### PR TITLE
fix(cli): make replay actually confirm the stored version (closes #31)

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -37,6 +37,7 @@ from continuum.models import ActionStatus, EnvironmentSnapshot, EnvResource, Ori
 from continuum.recovery import RecoveryEngine, render_contract
 from continuum.state.diff import diff_states, render_diff
 from continuum.state.semantic import ProjectionError, project
+from continuum.state.versioning import state_fingerprint
 from continuum.storage import (
     CheckpointNotFound,
     CorruptedRecord,
@@ -554,18 +555,58 @@ def cmd_replay(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
     storage.get_run(args.run_id)
     events = storage.read_events(args.run_id, upto=args.upto)
     state = project(args.run_id, events)
+
+    verified, verification = _verify_against_stored(args.run_id, storage)
+
     payload = {
         "run_id": args.run_id,
         "events_replayed": len(events),
         "completed": state.progress.completed,
         "source_sequence": state.source_sequence,
+        "verified": verified,
+        "verification": verification,
     }
     text = (
         f"Replayed {len(events)} events -> {state.progress.completed} completed, "
-        f"{len(state.decisions)} decision(s), {len(state.findings)} finding(s)"
+        f"{len(state.decisions)} decision(s), {len(state.findings)} finding(s)\n"
+        f"Verification: {verification}"
     )
     _emit(payload, text, as_json=args.json, stream=out, palette=getattr(args, "_palette", None))
+    if verified is False:
+        print(
+            f"replayed state does not match the stored version for run {args.run_id}",
+            file=err,
+        )
+        return ExitCode.CORRUPTED
     return ExitCode.OK
+
+
+def _verify_against_stored(run_id: str, storage: Storage) -> tuple[bool | None, str]:
+    """Re-derive the stored version's own prefix and check it still projects to it.
+
+    Returns (verified, human description). ``None`` means the comparison was not
+    attempted, which is reported rather than quietly counted as a pass — a
+    silent no-op that looks like a check is the bug this replaces.
+
+    The prefix matters. A stored version is the projection of events up to its
+    ``source_sequence``, and the log has usually grown since it was written, so
+    comparing it against a replay of the *whole* log would report corruption for
+    any run that simply did more work after its last checkpoint. Re-folding the
+    same prefix is the invariant SemanticState actually promises: "folding the
+    same prefix again must yield an equal state".
+
+    This is why verification does not depend on ``--upto``: the prefix is chosen
+    from the stored version, not from what the caller asked to display.
+    """
+    stored = storage.latest_version(run_id)
+    if stored is None:
+        return None, "skipped (no stored version to compare against)"
+    prefix = storage.read_events(run_id, upto=stored.source_sequence)
+    replayed = project(run_id, prefix)
+    where = f"version {stored.version} at sequence {stored.source_sequence}"
+    if state_fingerprint(replayed) == state_fingerprint(stored):
+        return True, f"matches stored {where}"
+    return False, f"DOES NOT match stored {where}"
 
 
 def cmd_benchmark(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ from continuum.cli import ExitCode, main
 from continuum.cli.exitcodes import exit_code_for
 from continuum.environment import StaticProvider, capture
 from continuum.events import EventType
-from continuum.models import RecoveryMode, Run
+from continuum.models import Finding, RecoveryMode, Run
 from continuum.storage import SQLiteStorage
 
 
@@ -491,3 +491,104 @@ def test_report_and_hint_appear_in_the_right_order(db: str) -> None:
     result = _cli(db, "resume", "run_1", "--env", "dataset=v4")
     assert "Next permitted action" in result.stdout
     assert "--repair" in result.stderr
+
+
+# --- replay actually verifies (issue #31) ---------------------------------- #
+
+
+def test_replay_confirms_the_state_matches_the_stored_version(db: str) -> None:
+    """The docstring's promise, now enforced: replay re-derives and compares."""
+    code, out, _ = run("--db", db, "replay", "run_1")
+    assert code == ExitCode.OK
+    assert "Verification: matches stored version" in out
+
+
+def test_replay_reports_verification_in_json(db: str) -> None:
+    code, out, _ = run("--db", db, "--json", "replay", "run_1")
+    payload = json.loads(out)
+    assert code == ExitCode.OK
+    assert payload["verified"] is True
+    assert "matches stored version" in payload["verification"]
+
+
+def test_replay_still_verifies_after_more_work_than_the_last_version(db: str) -> None:
+    """Events after the last checkpoint are normal, not corruption.
+
+    The stored version projects a prefix; the log keeps growing. Comparing a
+    full replay against it would flag every healthy run mid-flight.
+    """
+    with SQLiteStorage(db) as store:
+        for i in range(60, 70):
+            store.append_event("run_1", EventType.WORK_COMPLETED, {"doc": i})
+
+    code, out, _ = run("--db", db, "replay", "run_1")
+    assert code == ExitCode.OK
+    assert "matches stored version" in out
+
+
+def test_replay_detects_a_tampered_stored_version(db: str) -> None:
+    """A stored version the events do not project to must not exit 0."""
+    with SQLiteStorage(db) as store:
+        stored = store.latest_version("run_1")
+        assert stored is not None
+        # A phantom finding: structurally valid, so the storage layer's own
+        # integrity check still passes and only the replay comparison can
+        # catch it. (Nudging progress instead trips a model validator, which
+        # would be testing SemanticState rather than replay.)
+        tampered = stored.model_copy(
+            update={
+                "findings": [
+                    *stored.findings,
+                    Finding(finding_id="ghost", claim="never happened"),
+                ]
+            }
+        )
+        store.put_version(tampered, reason="tampered")
+
+    code, out, err = run("--db", db, "replay", "run_1")
+    assert code == ExitCode.CORRUPTED
+    assert "DOES NOT match stored version" in out
+    assert "run_1" in err
+
+
+def test_replay_reports_a_mismatch_in_json(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        stored = store.latest_version("run_1")
+        assert stored is not None
+        # A phantom finding: structurally valid, so the storage layer's own
+        # integrity check still passes and only the replay comparison can
+        # catch it. (Nudging progress instead trips a model validator, which
+        # would be testing SemanticState rather than replay.)
+        tampered = stored.model_copy(
+            update={
+                "findings": [
+                    *stored.findings,
+                    Finding(finding_id="ghost", claim="never happened"),
+                ]
+            }
+        )
+        store.put_version(tampered, reason="tampered")
+
+    code, out, _ = run("--db", db, "--json", "replay", "run_1")
+    payload = json.loads(out)
+    assert code == ExitCode.CORRUPTED
+    assert payload["verified"] is False
+
+
+def test_replay_says_so_when_there_is_no_stored_version(tmp_path: Path) -> None:
+    """Unverified must be reported, not silently counted as verified."""
+    path = str(tmp_path / "bare.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="bare", goal="G"))
+        store.append_event("bare", EventType.RUN_STARTED, {"goal": "G", "total": 1})
+
+    code, out, _ = run("--db", path, "replay", "bare")
+    assert code == ExitCode.OK
+    assert "skipped (no stored version" in out
+
+
+def test_replay_verification_is_independent_of_upto(db: str) -> None:
+    """--upto narrows what is displayed, not what is verified."""
+    code, out, _ = run("--db", db, "replay", "run_1", "--upto", "3")
+    assert code == ExitCode.OK
+    assert "matches stored version" in out


### PR DESCRIPTION
Closes #31.

`cmd_replay`'s docstring promised to "re-derive state from events and confirm it matches the stored version", but it never read `storage.latest_version` and never compared anything.

I took option (a) — implement the check — rather than dropping the claim, because `continuum replay` is the kind of thing that ends up in a pipeline, and the exit-code contract in this repo is treated as a safety guarantee.

## What it does now

Reports the verdict in text and JSON (new `verified` / `verification` keys) and exits `CORRUPTED` (3) on a mismatch — the code already defined for "stored data failed an integrity check".

```
Replayed 8 events -> 6 completed, 0 decision(s), 0 finding(s)
Verification: matches stored version 0 at sequence 4
```

## The part worth reviewing: which prefix gets compared

My first version compared the replayed state against `latest_version` directly. That reports corruption for **any healthy run that did work after its last checkpoint** — I hit it immediately:

```
stored version 0 source_sequence 4 completed 3
(3, '... 6 completed ...\nVerification: DOES NOT match stored version 0', 'replayed state does not match ...')
```

A stored version is the projection of events *up to its own `source_sequence`*, and the log keeps growing. So verification re-folds **that same prefix**:

```python
prefix = storage.read_events(run_id, upto=stored.source_sequence)
replayed = project(run_id, prefix)
```

That's the invariant `SemanticState` already documents — "folding the same prefix again must yield an equal state" — and `state_fingerprint` already excludes `version`, `created_at`, `updated_at` and `source_sequence`, so it compares meaning rather than bookkeeping.

A consequence worth stating: **verification is independent of `--upto`**, because the prefix comes from the stored version, not from what the caller asked to display. `--upto` narrows the report, not the check. (This also means there's no interaction with #32 / PR #39, which changes `--upto` handling — my diff doesn't touch that path.)

When there is no stored version, that's reported as `skipped (no stored version to compare against)` rather than quietly counted as a pass. Reporting "not checked" honestly is the whole point of the issue.

## Tests

7 added to `tests/test_cli.py`, all failing against pristine `main.py`:

- a consistent run reports a match, in text and in JSON
- **a run with 10 events appended after the last version still reports a match** — the regression that would make this feature worse than useless
- a tampered stored version is detected, in text and in JSON, with the run id on stderr
- no stored version is reported as skipped
- verification is unaffected by `--upto`

The tamper injects a phantom `Finding` rather than nudging `progress`. `Progress` has a cross-field validator (`completed + pending + failed exceeds total`), so a bad number is rejected by `SemanticState` on load and the test would be exercising the model's validator instead of this change — the CLI already exits 3 for that via `CorruptedRecord`, on a different path.

## Gate

Ran all three CI checks from CONTRIBUTING on Windows / Python 3.12:

- `pytest` — 684 passed, 4 skipped (677 before this branch)
- `ruff check src/ tests/` and `ruff format --check src/ tests/` — clean
- `mypy src/continuum` (strict) — no issues in 44 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)