### PR TITLE
fix(mcp): reject negative progress counters even when total is omitted

### DIFF
--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -287,13 +287,10 @@ def build_server(
         # is intact yet unprojectable would be poisoned permanently. The
         # `Progress` model enforces this at projection time; checking here keeps
         # the bad value out of the event log in the first place.
-        if total is not None:
-            if completed < 0 or failed < 0:
-                raise ValueError("progress counters must be non-negative")
-            if completed + failed > total:
-                raise ValueError(
-                    f"completed ({completed}) + failed ({failed}) exceeds total ({total})"
-                )
+        if completed < 0 or failed < 0:
+            raise ValueError("progress counters must be non-negative")
+        if total is not None and completed + failed > total:
+            raise ValueError(f"completed ({completed}) + failed ({failed}) exceeds total ({total})")
         ctx.storage.append_event(run_id, EventType.TASK_UPDATED, payload, source=AGENT_SOURCE)
 
         state = project(run_id, ctx.storage.read_events(run_id))

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -185,6 +185,36 @@ async def test_over_total_progress_is_rejected_before_being_written(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "negative_update",
+    [
+        {"completed": -5},
+        {"completed": 0, "failed": -1},
+    ],
+)
+async def test_negative_progress_is_rejected_before_being_written_without_total(
+    server_ctx: tuple[Any, Any],
+    negative_update: dict[str, int],
+) -> None:
+    """Negative counters must be rejected even when `total` is omitted, or the
+    bad event is written and every later projection/checkpoint/resume fails
+    permanently (issue #38)."""
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, ctx = server_ctx
+    ctx.storage.create_run(Run(run_id="run_1", goal="g"))
+    arguments = {"run_id": "run_1", "goal": "g", **negative_update}
+    with pytest.raises(ToolError, match="must be non-negative"):
+        await server.call_tool(
+            "continuum_record_progress",
+            arguments,
+            context=_ctx(TEST_CLIENT),
+        )
+    # Nothing beyond the start event was written: the log is not poisoned.
+    assert [e.type.value for e in ctx.storage.read_events("run_1")] == ["RUN_STARTED"]
+
+
+@pytest.mark.asyncio
 async def test_recording_progress_for_an_unknown_run_without_a_goal_fails(
     server_ctx: tuple[Any, Any],
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #38 — negative progress counters were not rejected before write when `total` was omitted, which let a `{'completed': -5, 'failed': 0}` event poison the run's event log and permanently break every later projection/checkpoint/resume.

## Change

In `continuum_record_progress`, the negative-counter guard (`completed < 0 or failed < 0`) was nested inside `if total is not None:`, so it was skipped when `total` was omitted. The check does not depend on `total`, so it is hoisted out; only the `completed + failed > total` check remains gated on `total`.

## Tests

- Added `test_negative_progress_is_rejected_before_being_written_without_total` in `tests/test_mcp_server.py`, parametrized over `completed=-5` and `failed=-1` with `total` omitted, asserting the tool raises and no `TASK_UPDATED` event is written.

## Verification

- `pytest tests/test_mcp_server.py` — 38 passed
- `pytest --no-cov` (full suite) — 679 passed, 4 skipped
- `ruff check src/ tests/` — clean
- `ruff format --check src/ tests/` — clean