### PR TITLE
fix(extractor): collapse ids repeated within a single LLM proposal (closes #41)

### DIFF
--- a/src/continuum/state/extractor.py
+++ b/src/continuum/state/extractor.py
@@ -147,6 +147,10 @@ class LLMExtractor:
             decision_id = str(raw.get("decision_id", ""))
             if not decision_id or decision_id in known_decisions:
                 continue  # never overwrite a recorded fact
+            # Also guards against a repeat later in this same proposal: the set is
+            # seeded from the base state, so without this the second copy of an id
+            # the LLM emitted twice would not be recognised as already handled.
+            known_decisions.add(decision_id)
             decisions.append(
                 Decision(
                     decision_id=decision_id,
@@ -164,6 +168,7 @@ class LLMExtractor:
             finding_id = str(raw.get("finding_id", ""))
             if not finding_id or finding_id in known_findings:
                 continue
+            known_findings.add(finding_id)
             confidence = float(raw.get("confidence", 0.5))
             findings.append(
                 Finding(
@@ -182,6 +187,7 @@ class LLMExtractor:
             task_id = str(raw.get("task_id", ""))
             if not task_id or task_id in known_work:
                 continue
+            known_work.add(task_id)
             pending.append(
                 PendingWork(
                     task_id=task_id,

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -133,6 +133,103 @@ def test_proposals_without_ids_are_dropped() -> None:
 # --- composition ----------------------------------------------------------- #
 
 
+def test_a_repeated_decision_id_within_one_proposal_is_collapsed() -> None:
+    """The known-id set is seeded from the base state; it must also grow as we append."""
+    log = build_log()
+    extractor = LLMExtractor(
+        lambda ctx, state: LLMProposal(
+            decisions=[
+                {"decision_id": "X", "decision": "first"},
+                {"decision_id": "X", "decision": "second"},
+            ]
+        )
+    )
+    state = extractor.extract(context(log))
+    assert [d.decision_id for d in state.decisions].count("X") == 1
+
+
+def test_a_repeated_finding_id_within_one_proposal_is_collapsed() -> None:
+    log = build_log()
+    extractor = LLMExtractor(
+        lambda ctx, state: LLMProposal(
+            findings=[
+                {"finding_id": "Y", "claim": "a"},
+                {"finding_id": "Y", "claim": "b"},
+            ]
+        )
+    )
+    state = extractor.extract(context(log))
+    assert [f.finding_id for f in state.findings].count("Y") == 1
+
+
+def test_a_repeated_task_id_within_one_proposal_is_collapsed() -> None:
+    log = build_log()
+    extractor = LLMExtractor(
+        lambda ctx, state: LLMProposal(
+            pending_work=[
+                {"task_id": "T", "description": "a"},
+                {"task_id": "T", "description": "b"},
+            ]
+        )
+    )
+    state = extractor.extract(context(log))
+    assert [w.task_id for w in state.pending_work].count("T") == 1
+
+
+def test_the_first_occurrence_wins_within_a_proposal() -> None:
+    """Consistent with the base state winning over a proposal: earlier wins."""
+    log = build_log()
+    extractor = LLMExtractor(
+        lambda ctx, state: LLMProposal(
+            decisions=[
+                {"decision_id": "X", "decision": "first"},
+                {"decision_id": "X", "decision": "second"},
+            ]
+        )
+    )
+    decision = extractor.extract(context(log)).decision("X")
+    assert decision is not None
+    assert decision.decision == "first"
+
+
+def test_distinct_ids_in_one_proposal_are_all_kept() -> None:
+    """The de-dup guard must not collapse genuinely different components."""
+    log = build_log()
+    extractor = LLMExtractor(
+        lambda ctx, state: LLMProposal(
+            decisions=[
+                {"decision_id": "X", "decision": "one"},
+                {"decision_id": "Z", "decision": "two"},
+            ],
+            findings=[
+                {"finding_id": "Y", "claim": "a"},
+                {"finding_id": "W", "claim": "b"},
+            ],
+        )
+    )
+    state = extractor.extract(context(log))
+    assert {"X", "Z"} <= {d.decision_id for d in state.decisions}
+    assert {"Y", "W"} <= {f.finding_id for f in state.findings}
+
+
+def test_a_proposal_repeating_a_recorded_id_still_cannot_overwrite_it() -> None:
+    """d1 is recorded; repeating it twice must neither overwrite nor duplicate."""
+    log = build_log()
+    extractor = LLMExtractor(
+        lambda ctx, state: LLMProposal(
+            decisions=[
+                {"decision_id": "d1", "decision": "hijacked"},
+                {"decision_id": "d1", "decision": "hijacked again"},
+            ]
+        )
+    )
+    state = extractor.extract(context(log))
+    assert [d.decision_id for d in state.decisions].count("d1") == 1
+    decision = state.decision("d1")
+    assert decision is not None
+    assert decision.decision == "recorded"
+
+
 def test_composite_chains_without_double_applying_events() -> None:
     log = build_log()
     composite = CompositeExtractor(


### PR DESCRIPTION
Closes #41.

`_merge` seeds `known_decisions` / `known_findings` / `known_work` from the **base state** and never grows them, so an id the LLM emitted twice in one response passed the guard twice and was appended twice.

## Fix

One line per collection — add the accepted id to its set as it's appended:

```python
if not decision_id or decision_id in known_decisions:
    continue  # never overwrite a recorded fact
known_decisions.add(decision_id)
decisions.append(...)
```

That makes the guard that stops a proposal overwriting a recorded fact also stop it duplicating *itself*. All three collections had the same hole, so all three are fixed — `pending_work` isn't in the issue's repro but has identical code, and fixing two of three would leave the same bug behind under a different name.

**First occurrence wins.** That's the direction the existing semantics already run — the base state beats the proposal, so earlier beats later — and it's asserted rather than left implicit.

## Tests

6 added to `tests/test_extractor.py`.

**Three fail against pristine `extractor.py`:**

```
FAILED test_a_repeated_decision_id_within_one_proposal_is_collapsed
FAILED test_a_repeated_finding_id_within_one_proposal_is_collapsed
FAILED test_a_repeated_task_id_within_one_proposal_is_collapsed
```

**Three are regression guards** that must pass both before and after, and do:

- `test_the_first_occurrence_wins_within_a_proposal` — pins *which* copy survives, not just that one does
- `test_distinct_ids_in_one_proposal_are_all_kept` — the de-dup must not collapse genuinely different components, which is how this kind of fix usually goes wrong
- `test_a_proposal_repeating_a_recorded_id_still_cannot_overwrite_it` — `d1` is already recorded; repeating it twice must neither overwrite nor duplicate, i.e. the existing protection still holds through the new code path

## Gate

Windows / Python 3.12, all three CI checks from CONTRIBUTING:

- `pytest` — **683 passed**, 4 skipped (677 before this branch)
- `ruff check src/ tests/` and `ruff format --check src/ tests/` — clean
- `mypy src/continuum` (strict) — no issues in 44 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)