### PR TITLE
fix(adapters): keep a result dict holding the envelope key intact on cache hit (closes #44)

### DIFF
--- a/src/continuum/adapters/generic.py
+++ b/src/continuum/adapters/generic.py
@@ -17,7 +17,13 @@ from continuum.models import (
 from continuum.recovery.engine import RecoveryDecision, RecoveryEngine
 from continuum.storage.base import Storage
 
-__all__ = ["GenericAgentAdapter"]
+#: Key under which a non-dict action result is stored, since the ledger records
+#: results as mappings. A caller's own dict is wrapped in the same envelope when
+#: it contains this key, so the presence of the key in a stored result always
+#: means "envelope" and never "caller data".
+RESULT_ENVELOPE_KEY = "__return_value__"
+
+__all__ = ["GenericAgentAdapter", "RESULT_ENVELOPE_KEY"]
 
 
 class GenericAgentAdapter(AgentAdapter):
@@ -115,8 +121,12 @@ class GenericAgentAdapter(AgentAdapter):
 
         if not outcome.fresh:
             res = outcome.result
-            if isinstance(res, dict) and "__return_value__" in res:
-                return res["__return_value__"]
+            # One level of unwrapping, matching the one level the fresh path
+            # below applies. A stored dict that carries the key is always an
+            # envelope, never a caller's own dict, because the fresh path wraps
+            # those too.
+            if isinstance(res, dict) and RESULT_ENVELOPE_KEY in res:
+                return res[RESULT_ENVELOPE_KEY]
             return res
 
         try:
@@ -128,7 +138,13 @@ class GenericAgentAdapter(AgentAdapter):
             ledger.fail(outcome.key, f"{type(exc).__name__}: {exc}", certain=False)
             raise
 
-        result_dict = val if isinstance(val, dict) else {"__return_value__": val}
+        # A non-dict has to be wrapped to be stored. So does a dict that happens
+        # to contain the envelope key: storing that one as-is would make the
+        # cached path unwrap the caller's own dict and return only that member,
+        # so a completed action would return a different value on its second
+        # call than on its first.
+        needs_envelope = not isinstance(val, dict) or RESULT_ENVELOPE_KEY in val
+        result_dict = {RESULT_ENVELOPE_KEY: val} if needs_envelope else val
         ledger.complete(outcome.key, result=result_dict)
         return val
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -94,6 +94,82 @@ def test_intercept_action_handles_scalar_return_value(store: SQLiteStorage) -> N
     assert call_count == 1  # Deduplicated
 
 
+def test_a_result_dict_holding_the_envelope_key_survives_the_cache(
+    store: SQLiteStorage,
+) -> None:
+    """A completed action must return the same value on every call.
+
+    The cached path unwraps the envelope key; if a caller's own dict carried
+    that key and were stored as-is, the second call would return only that
+    member and silently drop the rest.
+    """
+    adapter = GenericAgentAdapter(store)
+    adapter.start_run(goal="Collide", run_id="run_110")
+
+    call_count = 0
+
+    def action() -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        return {"__return_value__": 42, "other": "payload"}
+
+    first = adapter.intercept_action("run_110", "act.collide", action, arguments={"k": 1})
+    second = adapter.intercept_action("run_110", "act.collide", action, arguments={"k": 1})
+
+    assert call_count == 1  # the second call is a pure cache hit
+    assert first == {"__return_value__": 42, "other": "payload"}
+    assert second == first
+
+
+def test_a_result_dict_that_is_only_the_envelope_key_survives_the_cache(
+    store: SQLiteStorage,
+) -> None:
+    """The degenerate case: the caller's dict is indistinguishable from an envelope."""
+    adapter = GenericAgentAdapter(store)
+    adapter.start_run(goal="Collide", run_id="run_111")
+
+    def action() -> dict[str, object]:
+        return {"__return_value__": "mine"}
+
+    first = adapter.intercept_action("run_111", "act.bare", action, arguments={"k": 1})
+    second = adapter.intercept_action("run_111", "act.bare", action, arguments={"k": 1})
+
+    assert first == {"__return_value__": "mine"}
+    assert second == first
+
+
+def test_a_nested_envelope_key_survives_the_cache(store: SQLiteStorage) -> None:
+    """Only one level is ever wrapped, so only one level is ever unwrapped."""
+    adapter = GenericAgentAdapter(store)
+    adapter.start_run(goal="Collide", run_id="run_112")
+
+    payload = {"__return_value__": {"__return_value__": "deep"}}
+
+    first = adapter.intercept_action("run_112", "act.nested", lambda: payload, arguments={"k": 1})
+    second = adapter.intercept_action("run_112", "act.nested", lambda: payload, arguments={"k": 1})
+
+    assert first == payload
+    assert second == payload
+
+
+def test_an_ordinary_dict_result_is_still_stored_unwrapped(store: SQLiteStorage) -> None:
+    """The envelope must not start wrapping dicts that never needed it."""
+    from continuum.actions.ledger import ActionLedger
+
+    adapter = GenericAgentAdapter(store)
+    adapter.start_run(goal="Plain", run_id="run_113")
+
+    adapter.intercept_action(
+        "run_113",
+        "act.plain",
+        lambda: {"transaction_id": "tx_1"},
+        arguments={"k": 1},
+    )
+
+    stored = ActionLedger(store, "run_113").all()
+    assert stored[-1].result == {"transaction_id": "tx_1"}
+
+
 def test_a_raised_action_leaves_the_side_effect_uncertain(store: SQLiteStorage) -> None:
     """An exception from an external call does not prove nothing happened.
 


### PR DESCRIPTION
Closes #44.

`intercept_action` stores a non-dict result as `{"__return_value__": val}` because the ledger records results as mappings, and the cached path unwraps that key. A caller whose real result was a dict **already containing** the key was stored as-is — so the fresh call returned the whole dict and the cached call returned only that one member, silently discarding the rest.

## Fix

The fresh path wraps such a dict too:

```python
needs_envelope = not isinstance(val, dict) or RESULT_ENVELOPE_KEY in val
result_dict = {RESULT_ENVELOPE_KEY: val} if needs_envelope else val
```

The presence of the key in a *stored* result now always means "envelope" and never "caller data", so both paths agree and exactly one level is ever unwrapped.

The issue's repro before and after:

```
first : {'__return_value__': 42, 'other': 'payload'}
second: {'__return_value__': 42, 'other': 'payload'}
equal : True | calls: 1
```

## Why this shape and not the two the issue offers

**"The cached path should return the entire stored result."** That breaks the scalar wrapping the envelope exists for — `42` would come back as `{"__return_value__": 42}` on the second call. It fixes one divergence by creating another.

**"The reserved key should be forbidden."** Validation could only run *after* `action_fn` has executed, since that's when the result exists. The side effect would already have happened and we'd raise instead of returning its result — for an action ledger whose whole purpose is not losing track of effects that occurred, that's worse than the bug.

The chosen fix also leaves **already-stored ledgers meaning exactly what they meant before**: nothing changes about how an ordinary dict or a wrapped scalar is persisted, only the previously-ambiguous case. That matters for a durable log.

The literal is now a named `RESULT_ENVELOPE_KEY`, exported alongside the adapter, since the invariant lives in two places that have to agree — them drifting apart is precisely this bug.

## Tests

4 added to `tests/test_adapters.py`. **Three fail against pristine `generic.py`:**

```
FAILED test_a_result_dict_holding_the_envelope_key_survives_the_cache
FAILED test_a_result_dict_that_is_only_the_envelope_key_survives_the_cache
FAILED test_a_nested_envelope_key_survives_the_cache
```

- the issue's exact reproduction
- the degenerate case where the caller's dict is *only* the envelope key, so it's indistinguishable from an envelope by shape alone
- a nested `{"__return_value__": {"__return_value__": "deep"}}`, proving exactly one level unwraps

The fourth is a **regression guard**: an ordinary dict is still stored unwrapped. It asserts against the *ledger record* rather than the return value, because the return value would look right either way — that's the assertion that stops the envelope quietly starting to wrap everything.

## Gate

Windows / Python 3.12, all three CI checks:

- `pytest` — **681 passed**, 4 skipped
- `ruff check` / `ruff format --check` — clean
- `mypy src/continuum` (strict) — no issues in 44 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)