### PR TITLE
fix(extractor): fall back to deterministic state on malformed LLM proposal

### DIFF
--- a/src/continuum/state/extractor.py
+++ b/src/continuum/state/extractor.py
@@ -132,11 +132,10 @@ class LLMExtractor:
 
         try:
             proposal = self._llm(context, state)
+            return self._merge(state, proposal)
         except Exception as exc:  # noqa: BLE001 - enrichment must never break recovery
             self.last_error = exc
             return state
-
-        return self._merge(state, proposal)
 
     def _merge(self, state: SemanticState, proposal: LLMProposal) -> SemanticState:
         provenance = Provenance(origin=Origin.LLM, extractor=self.name)

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -98,6 +98,19 @@ def test_a_failing_llm_degrades_to_the_deterministic_state() -> None:
     assert isinstance(extractor.last_error, RuntimeError)
 
 
+def test_a_malformed_proposal_degrades_to_the_deterministic_state() -> None:
+    log = build_log()
+
+    def malformed(ctx: ExtractionContext, state: object) -> LLMProposal:
+        return LLMProposal(findings=[{"finding_id": "f1", "confidence": "high"}])
+
+    extractor = LLMExtractor(malformed)
+    state = extractor.extract(context(log))
+
+    assert state == project("run_1", log.events("run_1"))
+    assert isinstance(extractor.last_error, ValueError)
+
+
 def test_a_disabled_llm_extractor_never_calls_out() -> None:
     calls: list[int] = []
 


### PR DESCRIPTION
## Checklist

- [x] Tests added or updated for the change
- [x] Documentation updated, if the change affects it
- [x] CI is passing
- [x] For security-relevant changes, the PR description states any known limitations explicitly

## What does this PR do?

Moves the `self._merge(state, proposal)` call inside the existing `try/except` in `LLMExtractor.extract` (`src/continuum/state/extractor.py`) so a successfully-returned but malformed `LLMProposal` falls back to the deterministic result instead of raising out of `extract`.

## Why is this change needed?

Fixes #40. The `LLMExtractor` docstring and the `# noqa: BLE001` on the `_llm` call guarantee enrichment "must never break recovery": "If it raises, extraction falls back to the deterministic result rather than failing the run." The `try/except` only wrapped `self._llm(context, state)`, so a proposal that passed the call but failed during `_merge` (e.g. `confidence: "high"`, or any failure in `Decision`/`Finding`/`PendingWork` construction) propagated a `ValueError` out of `extract` and aborted recovery. Wrapping `_merge` in the same guard records the error in `self.last_error` and returns the base state.

## Tests

- Added `test_a_malformed_proposal_degrades_to_the_deterministic_state` in `tests/test_extractor.py`, reproducing the reported repro (a `Finding` whose `confidence` is the string `"high"`), asserting `extract()` returns the deterministic state and `last_error` is a `ValueError`.

## Verification

- `pytest tests/test_extractor.py` — 12 passed
- `ruff check src/continuum/state/extractor.py tests/test_extractor.py` — clean

Note: `mypy src/continuum` cannot run in this environment (a third-party `numpy` stub fails to parse under Python 3.13 against the repo's `python_version = "3.11"` setting); the change is a re-indent with no type-surface change.
