### PR TITLE
feat(bench): expand CONTINUUM-Bench scenario suite with crash-timing scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,18 @@ All notable changes to this project are documented here. The format follows
   `tests/test_integration_langchain.py::TestLangChainArchitecture::test_explicit_key_deduplicates_against_argument_drift`
   and `test_key_fn_derives_key_from_call_arguments`, plus
   `tests/test_adapters_langgraph.py` and `tests/test_adapters_openai.py` key/key_fn
-  forwarding tests.
+   forwarding tests.
+
+- **CONTINUUM-Bench scenario suite expanded.** Added `partial_completion` and
+  `early_crash` scenarios to `src/continuum/benchmark/__init__.py`, bringing the
+  shipped suite to five controlled-failure scenarios. The new scenarios vary
+  crash timing: `partial_completion` crashes late (most work already done) and
+  `early_crash` crashes almost immediately (full replay wastes the most work).
+  `tests/test_benchmark.py` asserts continuum still recovers with zero duplicate
+  work and that full replay waste scales with crash timing. `model_switch` and
+  the remaining spec scenarios (context compaction, tool failure, API timeout,
+  file modification, permission change, stale decision) remain follow-up work
+  that needs deeper harness modelling of side effects and model or decision state.
 
 ### Changed
 

--- a/src/continuum/benchmark/__init__.py
+++ b/src/continuum/benchmark/__init__.py
@@ -70,6 +70,7 @@ class ScenarioSpec:
     side_frac: float
     interrupted: bool
     env_change: bool
+    description: str = ""
 
 
 SCENARIOS: dict[str, ScenarioSpec] = {
@@ -93,6 +94,22 @@ SCENARIOS: dict[str, ScenarioSpec] = {
         side_frac=0.25,
         interrupted=True,
         env_change=False,
+    ),
+    "partial_completion": ScenarioSpec(
+        name="partial_completion",
+        crash_frac=0.8,
+        side_frac=0.4,
+        interrupted=False,
+        env_change=False,
+        description="Task mostly finished before the crash; checks late-crash recovery.",
+    ),
+    "early_crash": ScenarioSpec(
+        name="early_crash",
+        crash_frac=0.2,
+        side_frac=0.1,
+        interrupted=False,
+        env_change=False,
+        description="Crash almost immediately; full replay wastes the most work.",
     ),
 }
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -28,6 +28,18 @@ def test_benchmark_runs_every_combination() -> None:
     assert by[("process_crash", "continuum")].compression_ratio is not None
     assert by[("process_crash", "continuum")].compression_ratio > 1.0
 
+    # Crash timing changes how much full replay wastes, while continuum stays clean.
+    assert by[("partial_completion", "continuum")].duplicate_work_ratio == 0.0
+    assert by[("early_crash", "continuum")].duplicate_work_ratio == 0.0
+    assert (
+        by[("early_crash", "replay")].duplicate_work_ratio
+        < by[("process_crash", "replay")].duplicate_work_ratio
+    )
+    assert (
+        by[("partial_completion", "replay")].duplicate_work_ratio
+        > by[("process_crash", "replay")].duplicate_work_ratio
+    )
+
 
 def test_benchmark_results_are_json_serialisable() -> None:
     import json
@@ -37,3 +49,13 @@ def test_benchmark_results_are_json_serialisable() -> None:
     assert "continuum" in text
     payload = json.dumps([r.as_dict() for r in results])
     assert json.loads(payload) == [r.as_dict() for r in results]
+
+
+def test_crash_timing_scenarios_recover_cleanly() -> None:
+    results = run_benchmark(total=20)
+    by = {(r.scenario, r.method): r for r in results}
+    for scen in ("partial_completion", "early_crash"):
+        cont = by[(scen, "continuum")]
+        assert cont.duplicate_work_ratio == 0.0
+        assert cont.side_effects_created == 1
+        assert cont.detected_stale is False


### PR DESCRIPTION
Expands the CONTINUUM-Bench harness from three to five controlled-failure scenarios by adding two crash-timing scenarios:

- `partial_completion` - crashes late (0.8 of the run done); checks late-crash recovery.
- `early_crash` - crashes almost immediately (0.2 done); full replay wastes the most work.

The harness is otherwise unchanged. `tests/test_benchmark.py` now asserts that continuum recovers with zero duplicate work for both new scenarios and that full-replay waste scales with crash timing (early_crash < process_crash < partial_completion).

`model_switch` and the remaining spec scenarios (context compaction, tool failure, API timeout, file modification, permission change, stale decision) are left as follow-up work because they need deeper harness modelling of side effects and model or decision state before the recovery model can differentiate them.

CHANGELOG updated under Unreleased / Added.

Part of Phase 12 (CONTINUUM-Bench). Builds on the doc correction in #57.