### PR TITLE
docs(bench): reflect 5 implemented scenarios after #58

### DIFF
--- a/references/bench.md
+++ b/references/bench.md
@@ -16,7 +16,7 @@ Implemented (minimal harness):
 
 Remaining Phase 12 goals (see STATUS.md):
 
-- Expand from the 3 shipped scenarios to the full scenario suite below.
+- Expand from the 5 shipped scenarios to the full scenario suite below.
 - Publish baselines from real agent runs, not just the simulated harness.
 - Add a dashboard view of results.
 
@@ -27,6 +27,8 @@ Remaining Phase 12 goals (see STATUS.md):
 | process_crash        | The agent dies mid-run; measures duplicate work   |
 | dataset_change       | The environment version changes while the agent is down |
 | unknown_side_effect  | An external side effect is interrupted mid-flight |
+| partial_completion   | Task mostly finished before the crash (late crash) |
+| early_crash          | Agent crashes almost immediately; full replay wastes the most work |
 
 ### Implemented methods (baselines)
 
@@ -45,22 +47,28 @@ Remaining Phase 12 goals (see STATUS.md):
 | compression_ratio            | full log tokens / resume briefing tokens       |
 | elapsed_seconds              | Time to run the (scenario, method) measurement |
 
-### Target scenario suite (not yet implemented)
+The harness currently emits the six metrics above. The original Phase 12 issue
+(#9) asked for a broader measurement contract; coverage is partial. Remaining
+measurements such as recovery correctness, recovery latency, validation
+accuracy, and cost are tracked under the remaining Phase 12 goals and are not
+yet emitted by the harness.
 
-The full spec calls for ten controlled-failure scenarios:
+### Target scenario suite (remaining not yet implemented)
+
+The original spec called for ten controlled-failure scenarios. Five are now
+shipped (see Implemented scenarios above: `process_crash`, `dataset_change`,
+`unknown_side_effect`, `partial_completion`, `early_crash`). The remaining
+seven are:
 
 | Scenario             | Description                           |
 |:---------------------|:--------------------------------------|
-| Process crash        | Mid-task termination                  |
 | Context compaction   | Context window overflow               |
 | Tool failure         | External tool becomes unavailable     |
 | API timeout          | Session expires mid-task              |
-| Dataset change       | External data version changes         |
 | File modification    | Working files modified externally     |
 | Permission change    | Access revoked during execution       |
 | Model switch         | LLM provider changes mid-task        |
 | Stale decision       | Previously valid decision invalidated |
-| Partial completion   | Task partially finished before crash  |
 
 ### Sample results
 
@@ -76,7 +84,16 @@ From `continuum benchmark --total 30` (illustrative, not the published baseline)
     unknown_side_effect continuum              0.000         0  False       57     13.86
     unknown_side_effect replay                 0.233         1  False      516       1.0
     unknown_side_effect naive_checkpoint       0.000         0  False        3      None
+    partial_completion continuum              0.000         0  False       57     14.16
+    partial_completion replay                 0.800         1  False      778       1.0
+    partial_completion naive_checkpoint       0.000         0  False        4      None
+    early_crash       continuum              0.000         0  False       57     14.16
+    early_crash       replay                 0.200         1  False      778       1.0
+    early_crash       naive_checkpoint       0.000         0  False        4      None
 
 Reading: continuum resumes with no duplicate work and exactly one side effect,
 and is the only method that detects the dataset change. Full replay reprocesses
 everything (wasteful but ends correct). Naive checkpoint is efficient but blind.
+Full-replay waste also scales with crash timing: `early_crash` replays the least
+and `partial_completion` the most, while continuum stays at zero duplicate work
+in every scenario.


### PR DESCRIPTION
Follow-up to #57. When #58 added partial_completion and early_crash, the shipped CONTINUUM-Bench suite grew from three to five scenarios, but references/bench.md still listed only three. This updates the Implemented scenarios table, sample results, remaining-goals count, and target-suite list to match the current shipped state, and notes that Issue #9's full seven-measurement contract is only partially covered by the six emitted metrics.

The earlier squash merge of #57 did not include these edits (they were left uncommitted), so main still showed three scenarios. This PR sets the record straight. Doc-only change, no code or tests affected.