### PR TITLE
feat(observability): metrics collector and Phase 14 recovery dashboard (A2)

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -36,6 +36,7 @@ from continuum.cli.exitcodes import ExitCode, exit_code_for
 from continuum.environment import StaticProvider, capture
 from continuum.events import EventType
 from continuum.models import ActionStatus, EnvironmentSnapshot, EnvResource, Origin, RecoveryMode
+from continuum.observability import render_dashboard
 from continuum.recovery import RecoveryEngine, render_contract
 from continuum.security.attestation import (
     generate_keypair,
@@ -343,6 +344,10 @@ def cmd_validate(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
         current_environment=_environment(args, args.run_id),
         expected_model=args.model,
     )
+    if getattr(args, "dashboard", False):
+        out.write(render_dashboard(decision) + "\n")
+        out.flush()
+        return exit_code_for(decision.mode)
     payload = {
         "run_id": decision.run_id,
         "mode": decision.mode.value,
@@ -819,6 +824,9 @@ def build_parser() -> argparse.ArgumentParser:
     validate = with_env(with_run(add("validate", cmd_validate, "Validate state. Read-only.")))
     validate.add_argument("--model", help="model that will run the resumed agent")
     validate.add_argument("--tolerate-unknown", action="store_true")
+    validate.add_argument(
+        "--dashboard", action="store_true", help="render the Phase 14 recovery dashboard"
+    )
 
     resume = with_env(with_run(add("resume", cmd_resume, "Decide how a run may resume.")))
     resume.add_argument("--model", help="model that will run the resumed agent")

--- a/src/continuum/environment/snapshot.py
+++ b/src/continuum/environment/snapshot.py
@@ -276,7 +276,5 @@ class GitProvider(EnvironmentProvider):
             }
         commit = result.stdout.strip()
         return {
-            key: EnvResource(
-                name=key, kind="git", version=commit[:16], metadata={"commit": commit}
-            )
+            key: EnvResource(name=key, kind="git", version=commit[:16], metadata={"commit": commit})
         }

--- a/src/continuum/observability.py
+++ b/src/continuum/observability.py
@@ -1,0 +1,202 @@
+"""Observability and the Phase 14 recovery dashboard.
+
+This module is additive. It provides a process-wide metrics collector that core
+modules can emit to without taking a hard dependency on storage or the recovery
+engine, plus a read-only renderer for the Phase 14 recovery dashboard built
+from an existing :class:`~continuum.recovery.engine.RecoveryDecision`.
+"""
+
+from __future__ import annotations
+
+import time
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from typing import Any
+
+from continuum.models import StateStatus
+from continuum.recovery.engine import RecoveryDecision
+
+__all__ = [
+    "Metrics",
+    "get_metrics",
+    "set_metrics",
+    "reset_metrics",
+    "render_dashboard",
+    "collect_from_decision",
+    "CHECKPOINTS_CREATED",
+    "VALIDATIONS_RUN",
+    "ACTIONS_CLAIMED",
+    "ACTIONS_COMPLETED",
+    "UNKNOWN_SIDE_EFFECTS",
+    "RECOVERIES_RESUMED",
+    "RECOVERIES_BLOCKED",
+]
+
+
+# Standard counter names --------------------------------------------------- #
+CHECKPOINTS_CREATED = "checkpoints.created"
+VALIDATIONS_RUN = "validations.run"
+ACTIONS_CLAIMED = "actions.claimed"
+ACTIONS_COMPLETED = "actions.completed"
+UNKNOWN_SIDE_EFFECTS = "actions.unknown_side_effects"
+RECOVERIES_RESUMED = "recoveries.resumed"
+RECOVERIES_BLOCKED = "recoveries.blocked"
+
+
+class _Timer:
+    """Context manager that records elapsed seconds into a :class:`Metrics`."""
+
+    def __init__(self, metrics: Metrics, name: str) -> None:
+        self._metrics = metrics
+        self._name = name
+        self._started: float | None = None
+
+    def __enter__(self) -> _Timer:
+        self._started = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
+        assert self._started is not None
+        self._metrics.record_time(self._name, time.perf_counter() - self._started)
+
+
+@dataclass
+class Metrics:
+    """A process-wide accumulator for recovery signals.
+
+    Counters are monotonic; timers accumulate elapsed seconds per name. The
+    collector is intentionally dependency-free so core modules can emit metrics
+    without importing storage or the recovery engine.
+    """
+
+    counters: dict[str, int] = field(default_factory=dict)
+    timers: dict[str, float] = field(default_factory=dict)
+    gauges: dict[str, float] = field(default_factory=dict)
+
+    def increment(self, name: str, by: int = 1) -> None:
+        if by < 0:
+            raise ValueError("counters may only increase")
+        self.counters[name] = self.counters.get(name, 0) + by
+
+    def set_gauge(self, name: str, value: float) -> None:
+        self.gauges[name] = value
+
+    def record_time(self, name: str, seconds: float) -> None:
+        if seconds < 0:
+            raise ValueError("elapsed time may not be negative")
+        self.timers[name] = self.timers.get(name, 0.0) + seconds
+
+    def timer(self, name: str) -> _Timer:
+        return _Timer(self, name)
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "counters": dict(self.counters),
+            "timers": dict(self.timers),
+            "gauges": dict(self.gauges),
+        }
+
+    def reset(self) -> None:
+        self.counters.clear()
+        self.timers.clear()
+        self.gauges.clear()
+
+
+_DEFAULT_METRICS: ContextVar[Metrics | None] = ContextVar("continuum_metrics", default=None)
+
+
+def get_metrics() -> Metrics:
+    """Return the active collector, creating a default one if none is set."""
+    metrics = _DEFAULT_METRICS.get()
+    if metrics is None:
+        metrics = Metrics()
+        _DEFAULT_METRICS.set(metrics)
+    return metrics
+
+
+def set_metrics(metrics: Metrics) -> Token[Metrics | None]:
+    """Install ``metrics`` as the active collector for this context."""
+    return _DEFAULT_METRICS.set(metrics)
+
+
+def reset_metrics() -> None:
+    """Replace the active collector with a fresh one."""
+    _DEFAULT_METRICS.set(Metrics())
+
+
+_STATUS_SYMBOL = {
+    StateStatus.VALID: "[ok]",
+    StateStatus.STALE: "[--]",
+    StateStatus.CONFLICTED: "[xx]",
+    StateStatus.UNKNOWN: "[??]",
+    StateStatus.INVALID: "[!!]",
+    StateStatus.REQUIRES_REVIEW: "[??]",
+    StateStatus.EXPIRED: "[--]",
+}
+
+
+def render_dashboard(decision: RecoveryDecision) -> str:
+    """Render the Phase 14 recovery dashboard for ``decision``.
+
+    Read-only over the existing :class:`RecoveryDecision`; emits no state.
+    """
+    lines: list[str] = []
+    lines.append("=" * 64)
+    lines.append("CONTINUUM RECOVERY DASHBOARD")
+    lines.append("=" * 64)
+    lines.append(f"run_id:            {decision.run_id}")
+    lines.append(f"checkpoint:        v{decision.contract.checkpoint_version}")
+    lines.append(f"recovery mode:     {decision.mode.value}")
+    lines.append(f"safe to resume:     {'yes' if decision.safe else 'no'}")
+    lines.append(f"next allowed:      {decision.next_allowed_action or 'continue'}")
+
+    lines.append("")
+    lines.append("STATE COMPONENTS")
+    lines.append("-" * 64)
+    if decision.validation.report.statuses:
+        for entry in decision.validation.report.statuses:
+            symbol = _STATUS_SYMBOL.get(entry.status, "[??]")
+            label = entry.component.value.replace("_", " ")
+            identifier = f" {entry.component_id}" if entry.component_id else ""
+            detail = f" -- {entry.detail}" if entry.detail else ""
+            lines.append(f"  {symbol} {label}{identifier}: {entry.status.value}{detail}")
+    else:
+        lines.append("  (no components validated)")
+
+    if decision.uncertain_actions:
+        lines.append("")
+        lines.append("UNCERTAIN SIDE EFFECTS")
+        lines.append("-" * 64)
+        for action in decision.uncertain_actions:
+            lines.append(f"  [??] {action.action_type} ({action.status.value})")
+
+    if decision.plan and decision.plan.steps:
+        lines.append("")
+        lines.append("REPAIRS REQUIRED")
+        lines.append("-" * 64)
+        lines.append(decision.plan.render())
+
+    if decision.rationale:
+        lines.append("")
+        lines.append("RATIONALE")
+        lines.append("-" * 64)
+        for reason in decision.rationale:
+            lines.append(f"  - {reason}")
+
+    lines.append("")
+    lines.append("=" * 64)
+    return "\n".join(lines)
+
+
+def collect_from_decision(decision: RecoveryDecision) -> None:
+    """Update the active metrics collector from a recovery ``decision``."""
+    metrics = get_metrics()
+    metrics.increment(VALIDATIONS_RUN)
+    statuses = decision.validation.report.statuses
+    metrics.set_gauge("validation.components", len(statuses))
+    metrics.set_gauge(
+        "validation.invalid",
+        sum(1 for e in statuses if e.status is not StateStatus.VALID),
+    )
+    metrics.increment(RECOVERIES_RESUMED if decision.safe else RECOVERIES_BLOCKED)
+    metrics.increment(UNKNOWN_SIDE_EFFECTS, len(decision.uncertain_actions))

--- a/src/continuum/plugins/seams.py
+++ b/src/continuum/plugins/seams.py
@@ -40,8 +40,7 @@ class StateExtractor(Protocol):
 
     def extract(
         self, trajectory: Any, environment: EnvironmentSnapshot | None = None
-    ) -> SemanticState:
-        ...
+    ) -> SemanticState: ...
 
 
 @runtime_checkable
@@ -50,8 +49,7 @@ class ActionReconciler(Protocol):
 
     name: str
 
-    def reconcile(self, action: Action) -> Reconciliation:
-        ...
+    def reconcile(self, action: Action) -> Reconciliation: ...
 
 
 @runtime_checkable
@@ -62,8 +60,7 @@ class ValidationRule(Protocol):
 
     def evaluate(
         self, state: SemanticState, environment: EnvironmentSnapshot | None = None
-    ) -> list[ComponentValidationEntry]:
-        ...
+    ) -> list[ComponentValidationEntry]: ...
 
 
 __all__ = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,6 +295,21 @@ def test_the_contract_can_be_printed(db: str) -> None:
     assert "next_allowed:" in out
 
 
+def test_validate_with_dashboard_renders_the_phase_14_dashboard(db: str) -> None:
+    code, out, _ = run("--db", db, "validate", "run_1", "--env", "dataset=v3", "--dashboard")
+    assert code == ExitCode.OK
+    assert "CONTINUUM RECOVERY DASHBOARD" in out
+    assert "run_1" in out
+    assert "safe to resume:" in out
+
+
+def test_validate_without_dashboard_stays_machine_friendly(db: str) -> None:
+    code, out, _ = run("--db", db, "validate", "run_1", "--env", "dataset=v3")
+    assert code == ExitCode.OK
+    assert "CONTINUUM RECOVERY DASHBOARD" not in out
+    assert "RESUME" in out or "REPAIR" in out
+
+
 def test_replay_rederives_state_from_events(db: str) -> None:
     _, out, _ = run("--db", db, "replay", "run_1")
     assert "60 completed" in out

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,154 @@
+"""Tests for the observability module (metrics collector + Phase 14 dashboard)."""
+
+from __future__ import annotations
+
+from continuum.checkpoint.manager import RestoredRun
+from continuum.environment.diff import EnvironmentDiff
+from continuum.models import (
+    Action,
+    ActionStatus,
+    Component,
+    ComponentValidationEntry,
+    Goal,
+    RecoveryContract,
+    RecoveryMode,
+    RecoverySafety,
+    SemanticState,
+    StateStatus,
+    StateValidationResult,
+)
+from continuum.observability import (
+    CHECKPOINTS_CREATED,
+    RECOVERIES_BLOCKED,
+    RECOVERIES_RESUMED,
+    UNKNOWN_SIDE_EFFECTS,
+    VALIDATIONS_RUN,
+    Metrics,
+    collect_from_decision,
+    get_metrics,
+    render_dashboard,
+    reset_metrics,
+    set_metrics,
+)
+from continuum.recovery.engine import RecoveryDecision
+from continuum.recovery.planner import RepairKind, RepairPlan, RepairStep
+from continuum.state.validator import ValidationOutcome
+
+
+def _decision(can_resume: bool, uncertain: tuple[Action, ...] = ()) -> RecoveryDecision:
+    """Build a minimal RecoveryDecision for dashboard/metrics tests."""
+    state = SemanticState(run_id="run_x", goal=Goal(description="recover"))
+    contract = RecoveryContract(
+        run_id="run_x",
+        checkpoint_version=3,
+        recovery_status=RecoverySafety.SAFE_TO_RESUME if can_resume else RecoverySafety.BLOCKED,
+        verified=["goal"],
+        invalidated=["external_dependency dataset (CONFLICTED)"],
+        required_actions=[],
+        next_allowed_action=None,
+    )
+    plan = RepairPlan(
+        steps=[
+            RepairStep(
+                kind=RepairKind.REVALIDATE_DEPENDENCY,
+                target="dataset",
+                reason="version drift",
+            )
+        ]
+    )
+    validation = ValidationOutcome(
+        state=state,
+        report=StateValidationResult(
+            run_id="run_x",
+            checkpoint_version=3,
+            statuses=[
+                ComponentValidationEntry(component=Component.GOAL, status=StateStatus.VALID),
+                ComponentValidationEntry(
+                    component=Component.EXTERNAL_DEPENDENCY,
+                    component_id="dataset",
+                    status=StateStatus.CONFLICTED,
+                    detail="v3 vs v4",
+                ),
+            ],
+            safe_to_resume=can_resume,
+        ),
+        environment_diff=EnvironmentDiff(),
+    )
+    restored = RestoredRun(
+        run_id="run_x", state=state, checkpoint=None, pending_events=0, replayed=True
+    )
+    return RecoveryDecision(
+        run_id="run_x",
+        mode=RecoveryMode.RESUME if can_resume else RecoveryMode.WAIT,
+        contract=contract,
+        plan=plan,
+        validation=validation,
+        restored=restored,
+        uncertain_actions=uncertain,
+        rationale=("dataset version drift",),
+    )
+
+
+def test_metrics_counter_is_monotonic_and_rejects_negative() -> None:
+    m = Metrics()
+    m.increment(CHECKPOINTS_CREATED, 3)
+    m.increment(CHECKPOINTS_CREATED)
+    assert m.counters[CHECKPOINTS_CREATED] == 4
+    try:
+        m.increment(CHECKPOINTS_CREATED, -1)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("negative increment should raise")
+
+
+def test_metrics_timer_accumulates() -> None:
+    m = Metrics()
+    with m.timer("validate"):
+        pass
+    assert "validate" in m.timers
+    assert m.timers["validate"] >= 0.0
+
+
+def test_get_metrics_returns_active_collector() -> None:
+    reset_metrics()
+    before = get_metrics()
+    token = set_metrics(Metrics())
+    try:
+        assert get_metrics() is not before
+    finally:
+        token.var.reset(token)
+
+
+def test_collect_from_decision_counts_resumed() -> None:
+    reset_metrics()
+    collect_from_decision(_decision(can_resume=True))
+    snap = get_metrics().snapshot()
+    assert snap["counters"][VALIDATIONS_RUN] == 1
+    assert snap["counters"][RECOVERIES_RESUMED] == 1
+    assert snap["counters"].get(RECOVERIES_BLOCKED, 0) == 0
+    assert snap["gauges"]["validation.invalid"] == 1
+
+
+def test_collect_from_decision_counts_blocked_and_unknown() -> None:
+    reset_metrics()
+    action = Action(run_id="run_x", action_type="github.create_issue", status=ActionStatus.UNKNOWN)
+    collect_from_decision(_decision(can_resume=False, uncertain=(action,)))
+    snap = get_metrics().snapshot()
+    assert snap["counters"][RECOVERIES_BLOCKED] == 1
+    assert snap["counters"][UNKNOWN_SIDE_EFFECTS] == 1
+
+
+def test_render_dashboard_contains_state_components_and_plan() -> None:
+    out = render_dashboard(_decision(can_resume=False))
+    assert "CONTINUUM RECOVERY DASHBOARD" in out
+    assert "run_x" in out
+    assert "external dependency dataset: conflicted" in out
+    assert "REPAIRS REQUIRED" in out
+    assert "revalidate_dependency dataset" in out
+    assert "RATIONALE" in out
+
+
+def test_render_dashboard_marks_resume() -> None:
+    out = render_dashboard(_decision(can_resume=True))
+    assert "safe to resume:     yes" in out


### PR DESCRIPTION
## Summary

Part of the roadmap in project.md section 7 (item A2, Observability and proof). Additive, self-contained, and does not touch the Registry/seam work from B1.

- `src/continuum/observability.py`: a dependency-free `Metrics` collector (monotonic counters, timers, gauges) backed by a contextvar so core modules can emit recovery signals without importing storage or the recovery engine. Plus `render_dashboard(decision)` (the Phase 14 recovery dashboard, read-only over an existing `RecoveryDecision`) and `collect_from_decision(decision)` to fold a verdict into the active metrics.
- `src/continuum/cli/main.py`: a `--dashboard` flag on `validate` that renders the Phase 14 dashboard.
- Tests: `tests/test_observability.py` (7) and CLI dashboard coverage in `tests/test_cli.py`.

## Verification

- `uv run --extra dev pytest tests/test_observability.py tests/test_cli.py` passes.
- `ruff check`, `ruff format --check`, and `mypy src/continuum` (53 files) all pass.
- Rebased onto current `main` (which now includes the B1 Registry/seams work); no conflicts, existing tests still green.

## Not in this PR

The CONTINUUM-Bench (#6) portion of A2 (LangGraph adapter revalidation, scenarios, baselines, real numbers) is a larger, adapter-adjacent slice and is left for a follow-up so this change stays reviewable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recovery dashboard for validation results, including run metadata, component status, uncertain side effects, required repairs, and rationale.
  * Added metrics tracking for validation, recovery actions, checkpoints, blocked recoveries, and unknown side effects.
  * Added `validate --dashboard` to display the dashboard directly and return an appropriate status code.

* **Bug Fixes**
  * Preserved the existing machine-readable and human-readable validation output when dashboard mode is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->