### PR TITLE
fix: close seven correctness issues from the C1 triage backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,44 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **Six correctness defects found by triaging the open bug backlog (issues #29,
+  #30, #33, #36, #42, #43, #45).** Each is covered by a test that fails on the
+  previous code:
+  - *#33 / #36: the ledger's argument-drift fallback ignored whole classes of
+    resource identity.* `_is_strong_token` required a digit, `@`, or `.`, so a
+    plain-word identity (`invoice`, `dataset`) was discarded, and purely numeric
+    ids were discarded outright; separately, `identity_tokens` only tokenised
+    `str`, so an integer id such as `4821` never became a token at all. Both are
+    real identities now. Admitting plain words would let one shared adjective
+    ("both tickets are `urgent`") collapse two distinct actions into one, silently
+    dropping the second side effect, so `ActionLedger._identity_match` no longer
+    matches on a single shared token: it requires one token set to *contain* the
+    other, compared at the leaf (`leaf_tokens`), so a path counts as its basename
+    and an absolute-vs-relative re-rendering still deduplicates while genuinely
+    different resources do not.
+  - *#45: `claim(on_unknown=...)` did not persist its resolution.* A resolver's
+    `ActionOutcome` was returned to the caller but nothing was recorded, so the
+    stored action stayed `UNKNOWN`: the next claim re-raised, `pending()` never
+    drained, and `RecoveryEngine.assess` asked for a human forever. The
+    resolution is now written as an `ACTION_RECONCILED` event.
+  - *#29: `reconcile(occurred=False)` left stale evidence behind.* An action
+    just decided never to have happened kept the `external_id` and `result` from
+    its earlier `COMPLETED` state. Both are cleared.
+  - *#42: `strict_unknown` was silently ignored for uncertain side effects.* The
+    engine escalates an unknown side effect to `REQUEST_HUMAN`, but `plan_repairs`
+    emitted a `reconcile_action` step with `requires_human=False`, so
+    `plan.requires_human` was `False` and the contract permitted the agent to
+    auto-reconcile against the mode. The step now requires a person in strict
+    mode, and its `reason` reports what happened (interrupted) rather than
+    mislabelling it "escalated for review".
+  - *#43: `continuum history` hid checkpoints.* `put_version` returns the same
+    version when the state fingerprint is unchanged, so keying the listing by
+    version collapsed two checkpoints into one row. It now lists checkpoints;
+    the JSON key is `checkpoints` rather than `versions`.
+  - *#30: a deleted tracked file diffed as "changed" instead of "removed".*
+    `FileProvider` recorded a missing file as a resource with `version=None`;
+    it now omits it, which `diff_environments` reads as `REMOVED`.
+
 - **`StateValidator._check_model` reported model-specific assumptions
   `VALID` when the resume model was unknown (fail-open).** When
   `expected_model` is `None` (e.g. `continuum validate`/`resume` run without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,47 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **Three defects found by an adversarial audit of the MCP surface**, driven over
+  the live stdio protocol with every tool result verified against the SQLite store
+  rather than taken at its word. Method and per-claim results in `test.md`:
+  - *Environment drift was detected but invalidated nothing.* `continuum_checkpoint`
+    passed `env` to `capture_state` as an `EnvironmentSnapshot` only, and
+    `StateValidator._apply_dependency_status` returns early for a state with no
+    `external_dependencies` — so a moved dataset was rendered in
+    `environment_changes` while the verdict stayed `safe: true` with the reason
+    "all components verified against the current environment". The core validator
+    was never wrong: given a declared dependency it already yields `CONFLICTED`
+    and `safe_to_resume=False`. The gap was that no MCP client could declare one,
+    and the existing test appended `DEPENDENCY_DECLARED` straight to storage.
+    Checkpointing now records each pinned resource as a `DEPENDENCY_DECLARED`
+    event, so the declaration is durable across projections and restores, covered
+    by the hash chain, and carries `EXTERNAL_AGENT` provenance — which does not
+    weaken the check, since a dependency's status comes from comparing two
+    snapshots rather than from trusting the claim. Only new or re-pinned resources
+    are appended, so checkpointing on a schedule does not grow the log. The
+    `serve` sidecar shared the defect verbatim and is fixed identically; the two
+    surfaces must not disagree about whether drift is safe.
+  - *`continuum_list_actions` under-reported an interrupted action.* A claim left
+    `STARTED` by a crash reported `side_effect_uncertain: false` while
+    `continuum_resume` described the same action as an unknown outcome — the
+    aggregate `unresolved` count was right while the row a human reads said the
+    opposite. `side_effect_uncertain` is only set on escalation to `UNKNOWN`,
+    which has not happened yet for a fresh interruption. Each row now carries
+    `outcome_unresolved`, derived from ledger state so it cannot drift from what
+    recovery reports. Also fixed in the `serve` sidecar.
+  - *WAL "self-healing" could destroy committed transactions.*
+    `_open_server_storage` deleted both sidecars on a startup `OperationalError`,
+    on the stated grounds that they are reconstructable from the main database.
+    That holds for `-shm` and not for `-wal`, which carries transactions committed
+    but not yet checkpointed; measured on a real database the main file was 4 KB
+    while the WAL held all 16 events, and deleting it lost everything *silently*,
+    because an emptied database still verifies as an intact chain. Recovery is now
+    staged least-destructive-first: discard the reconstructable `-shm` and retry,
+    and only if that fails move the `-wal` aside — never unlink it — restoring it
+    if the retry fails anyway, and warning on stderr with the quarantine path when
+    it succeeds. Reachable only when the initial open raises, so latent rather
+    than observed, but it is exactly the hard-kill path the feature advertises.
+
 - **Six correctness defects found by triaging the open bug backlog (issues #29,
   #30, #33, #36, #42, #43, #45).** Each is covered by a test that fails on the
   previous code:

--- a/README.md
+++ b/README.md
@@ -147,8 +147,19 @@ CONTINUUM is verified not just with mock unit tests, but against real LLM agents
 
 ### Automated Test Suite and Benchmarks
 
-- **740 tests passing** on Python 3.11, 3.12, and 3.13 (including unit, `hypothesis` property-based, and concurrency tests).
+- **817 tests passing** on Python 3.11, 3.12, and 3.13 (including unit, `hypothesis` property-based, and concurrency tests).
 - **CONTINUUM-Bench**: `continuum benchmark` executes in-process recovery benchmarks across five scenarios (`process_crash`, `dataset_change`, `unknown_side_effect`, `partial_completion`, `early_crash`), proving 0 duplicate work, 0 duplicate side effects, and automatic detection of stale environment dependencies.
+
+### Adversarial Audit of the MCP Surface
+
+The MCP server was audited end to end over the live stdio protocol, with every
+tool result checked against the SQLite store rather than taken at its word. The
+self-certification gate, the two-phase ledger, crash-mid-action reconciliation,
+tamper-evidence, and deny-by-default authorization all held. Three defects were
+found and fixed: environment drift was detected but did not invalidate state,
+`list_actions` under-reported an interrupted row, and the WAL sidecar recovery
+could delete committed transactions. Method, per-claim results, and reproduction
+steps are in [test.md](test.md).
 
 ## MCP Integration
 
@@ -308,7 +319,7 @@ Recent preprints that measure or model the same reliability gaps CONTINUUM targe
 
 ## Status and limitations
 
-- **Tested**: 740 tests passing, 4 skipped (see [STATUS.md](STATUS.md)).
+- **Tested**: 817 tests passing, 4 skipped (see [STATUS.md](STATUS.md)). The MCP surface has also been audited adversarially over the live protocol; see [test.md](test.md).
 - **Not on PyPI.** Install from a clone (see Quick Start).
 - **MCP caller authentication is optional.** When `CONTINUUM_MCP_TOKEN` is set, the server refuses every mutating tool unless the caller presents that shared secret in the `initialize` handshake's `_meta.authToken`. Without it, authorization is by declared identity only (the historical default, preserved for local single-user use). Tracked as [#1](https://github.com/Cyrax321/CONTINUUM/issues/1).
 - **Unbuilt components**: Cloud API (Phase 13) and Dashboard (Phase 14).

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -349,3 +349,55 @@ STATUS.md (benchmark + #6 proof), and project.md (A2 marked done).
 
 A2 is now complete. Next in plan order: B2 (PostgreSQL, centralized server,
 distributed locking, schema migration).
+
+## Session 17, 2026-08-19 (C1: fix the open correctness backlog)
+
+Context: the session resumed on an uncommitted working tree carrying draft fixes
+for the C1 triage issues (#29, #30, #33, #34, #36, #42, #43, #45). Three tests
+were red, `idempotency.py` was unformatted, and the draft had two real problems
+of its own, both found by running the code rather than reading it.
+
+What the draft got wrong (and how it was fixed):
+- **A silent-data-loss regression.** Widening `_is_strong_token` so plain words
+  count as identity (correct for #33) combined with `_identity_match`'s
+  single-shared-token rule to collapse genuinely distinct actions: two
+  `ticket.create` calls differing only in title matched on the shared value
+  `urgent`, so the second ticket was reported already-done and never created.
+  Verified against HEAD to confirm the regression was new. Fixed by requiring
+  *containment* of one token set in the other rather than intersection.
+- **Containment alone broke the issue #6 benchmark.** Absolute-vs-relative path
+  drift gives each side a token the other lacks (`/data/invoices/INV-5.pdf` vs
+  `invoices/INV-5.pdf`), so `continuum_drift` went from 0 to 50 duplicate side
+  effects. Fixed with `leaf_tokens`: compare identity at the basename, dropping
+  the container path that a re-rendering changes. Only the benchmark caught this
+  (the unit suite passed), so the case now has its own test.
+- **#36 was not actually fixed.** The issue's own repro passes an `int`
+  (`{'row_id': 4821}`), and `identity_tokens.collect` only handled `str`, so the
+  token set was empty regardless of `_is_strong_token`. Non-bool ints are now
+  tokenised.
+- **#42's reason text was misleading.** `reason` was keyed on `needs_person`, so
+  an interrupted action reported "was escalated for review" though it never was.
+  `reason` now follows status; `requires_human` follows status + `strict_unknown`.
+
+Notable decisions / discoveries:
+- Identity is now decided at basename level, which is the assumption the basename
+  token always encoded: two same-type actions on same-named files in different
+  directories are treated as one. Documented in `leaf_tokens`.
+- Failing to deduplicate is recoverable (that is what an explicit `key` is for);
+  falsely deduplicating silently destroys a side effect. The matcher errs toward
+  a new slot whenever it is not confident.
+- `continuum history`'s JSON key changed from `versions` to `checkpoints`. No
+  other code, test, or doc referenced the old key.
+- `_STOPWORDS` matters less under containment but is kept: it drops filler before
+  it can distort a comparison, and both it and `_WEAK_TOKENS` are now matched
+  case-insensitively.
+
+Verification: 803 passed, 4 skipped; `ruff check` and `mypy src/continuum` clean.
+Every one of the nine new/updated tests was confirmed to fail with `src/` reverted
+to HEAD, so each proves its issue rather than merely passing.
+
+Not done here: `src/continuum/serve/server.py` and `tests/test_serve.py` are
+unformatted on `main` (pre-existing, from `4605c00`); left alone to keep this
+change reviewable. Issue #34 was a documentation fix only: `scoped_to_run=False`
+still cannot enforce cross-run uniqueness, since the ledger only replays its own
+run; a store-wide lookup remains unimplemented.

--- a/references/mcp.md
+++ b/references/mcp.md
@@ -3,16 +3,44 @@
 **Crash recovery at startup is fixed and tested.** A server process killed with
 `SIGKILL` leaves orphaned `<db>-wal` / `<db>-shm` sidecars that previously made
 the next launch fail with `sqlite3.OperationalError: disk I/O error`. The server
-now opens its store through `_open_server_storage`, which on that error removes
-the orphaned sidecars and retries the open exactly once, re-raising when there is
-nothing to clear. Two regression tests in `tests/test_mcp_server.py` cover the
-recovery and the re-raise. Recorded in CHANGELOG.md under Fixed.
+opens its store through `_open_server_storage`, which recovers from that error in
+stages, least destructive first, because the two sidecars are not equally
+expendable:
+
+1. `<db>-shm` is a shared-memory index and genuinely is reconstructable, so it is
+   removed and the open retried. When a stale `-shm` was the blocker this is
+   lossless — SQLite replays the `-wal` and every committed transaction survives.
+2. `<db>-wal` is *not* reconstructable: it holds transactions committed but not
+   yet checkpointed into the main database. On a write-heavy run that can be the
+   whole history. It is therefore moved aside rather than unlinked, and restored
+   if the retry still fails. The server comes up, the committed bytes stay on
+   disk, and a warning naming the quarantine path goes to stderr.
+
+An earlier version deleted both sidecars, justified by the claim that they are
+reconstructable from the main database. That is true of `-shm` and false of
+`-wal`; the audit in [../test.md](../test.md) measured the blast radius on a real
+database (4 KB main file, 420 KB WAL holding all 16 events) and found the loss was
+both total and silent, since an emptied database still verifies as an intact
+chain. Six regression tests in `tests/test_mcp_server.py` now cover staged
+recovery, `-shm`-only sufficiency, the log never being unlinked, quarantine not
+clobbering an earlier crash's evidence, restoration when quarantining does not
+help, and the re-raise when there is nothing to clear. Recorded in CHANGELOG.md
+under Fixed.
 
 **The server is verified usable through Claude Code.** Registered as an MCP
-server, it reports `✔ Connected`, exposes all nine tools with the correct
+server, it reports `✔ Connected`, exposes all ten tools with the correct
 read-only/mutating split, and the full `continuum_record_progress` to
 `continuum_checkpoint` to `continuum_intercept_action` to
 `continuum_complete_action` to `continuum_resume` cycle returns correct,
 durable JSON. Authorization denies by default. That claim is proven end to end
-over the real stdio protocol, and the unit suite (675 passed, 4 skipped) covers
-every tool.
+over the real stdio protocol, and the unit suite covers every tool.
+
+**The surface has been audited adversarially.** Beyond confirming the documented
+behaviour, the audit tested the dangerous inverse of each claim — not only that
+duplicate side effects are suppressed, but that genuinely new work is not — and
+verified every result against the SQLite store instead of trusting tool output.
+It found that `env` supplied to `continuum_checkpoint` was recorded as a snapshot
+only, so environment drift was rendered in `environment_changes` while the verdict
+stayed `safe`; the tool now declares each pinned resource as a
+`DEPENDENCY_DECLARED` event so the diff has something to invalidate. Full method
+and per-claim results: [../test.md](../test.md).

--- a/src/continuum/actions/idempotency.py
+++ b/src/continuum/actions/idempotency.py
@@ -104,8 +104,14 @@ def idempotency_key(
     """Derive a stable key identifying this operation.
 
     ``scope`` narrows the key, typically to a run, so two runs performing the
-    same logical operation do not deduplicate against each other. Omit it for
-    effects that must be globally unique regardless of run.
+    same logical operation do not deduplicate against each other within that
+    ledger. A narrower scope (for example, a run id) is what most callers want.
+
+    Note: ``scope`` only shapes the derived key. The ``ActionLedger`` is bound to
+    a single run and only replays that run's events, so it cannot enforce
+    uniqueness across runs on its own. ``scoped_to_run=False`` widens the key but
+    does not make the store consult other runs; cross-run global uniqueness
+    would require a store-wide lookup that is not yet implemented.
 
     ``key`` overrides argument hashing entirely, in the style of Stripe's
     ``Idempotency-Key``. Argument hashing assumes identical arguments mean the
@@ -156,18 +162,120 @@ _WEAK_TOKENS = frozenset(
     }
 )
 
+# Generic words that are far more likely to be incidental argument names or
+# filler than a resource identity. A string like this is not distinctive enough
+# to drive the defensive drift fallback, so it is dropped as a token.
+_STOPWORDS = frozenset(
+    {
+        "the",
+        "and",
+        "for",
+        "with",
+        "from",
+        "this",
+        "that",
+        "then",
+        "when",
+        "what",
+        "which",
+        "who",
+        "into",
+        "onto",
+        "over",
+        "under",
+        "about",
+        "above",
+        "below",
+        "to",
+        "of",
+        "a",
+        "an",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "has",
+        "have",
+        "had",
+        "do",
+        "does",
+        "did",
+        "will",
+        "would",
+        "can",
+        "could",
+        "should",
+        "may",
+        "might",
+        "must",
+        "shall",
+        "send",
+        "update",
+        "create",
+        "delete",
+        "read",
+        "write",
+        "get",
+        "set",
+        "add",
+        "remove",
+        "make",
+        "take",
+        "give",
+        "show",
+        "list",
+        "find",
+        "run",
+        "start",
+        "stop",
+        "open",
+        "close",
+        "name",
+        "type",
+        "status",
+        "value",
+        "data",
+        "info",
+        "item",
+        "key",
+        "field",
+        "result",
+        "note",
+        "text",
+        "kind",
+        "mode",
+        "state",
+        "event",
+        "action",
+        "request",
+        "response",
+        "error",
+        "message",
+        "account",
+        "description",
+    }
+)
+
 
 def _is_strong_token(token: str) -> bool:
     """A token distinctive enough to identify a resource.
 
-    Weak tokens are pure numbers (a count is not an identity), filler words,
-    and anything too short to distinguish one resource from another.
+    Any value that is not filler counts. A plain word (``invoice``, ``dataset``)
+    names a resource just as well as ``INV-001`` does (issue #33), and a purely
+    numeric string is a legitimate identity too -- a row id, an account number,
+    an invoice number rendered as digits (issue #36). What gets dropped is only
+    what cannot distinguish one resource from another: tokens too short to be
+    meaningful, the explicit weak list, and generic stopwords.
+
+    Admitting plain words is only safe because ``_identity_match`` requires the
+    two token sets to *contain* one another rather than merely to intersect. A
+    single shared word (two tickets that are both ``urgent``) is not enough to
+    call two actions the same work.
     """
-    if len(token) < 3 or token in _WEAK_TOKENS:
-        return False
-    if token.isdigit():
-        return False
-    return any(ch.isdigit() for ch in token) or "@" in token or token.count(".") >= 1
+    lowered = token.lower()
+    return len(token) >= 3 and lowered not in _WEAK_TOKENS and lowered not in _STOPWORDS
 
 
 def identity_tokens(
@@ -180,15 +288,22 @@ def identity_tokens(
 
     Used by the ledger's defensive fallback when argument hashing cannot match
     two attempts that describe the same resource differently (field renames,
-    path formatting). A token is a scalar string value, plus the basename and
-    basename-stem of any path-like value, plus the same for ``external_id``.
+    path formatting). A token is a scalar value -- a string, or an integer
+    rendered as one, since a row id of ``4821`` identifies a row as well as
+    ``INV-001`` identifies an invoice (issue #36) -- plus the basename and
+    basename-stem of any path-like value, and the same for ``external_id``.
     Weak tokens are dropped so the fallback never matches on incidental values
     like counts or status words.
     """
     tokens: set[str] = set()
 
     def collect(value: Any) -> None:
-        if isinstance(value, str):
+        # bool is an int subclass, and True/False name no resource.
+        if isinstance(value, bool):
+            return
+        if isinstance(value, int):
+            tokens.add(str(value))
+        elif isinstance(value, str):
             tokens.add(value)
             base = os.path.basename(value.rstrip("/\\"))
             stem, _ = os.path.splitext(base)
@@ -209,3 +324,21 @@ def identity_tokens(
         collect(external_id)
 
     return frozenset(t for t in tokens if _is_strong_token(t))
+
+
+def leaf_tokens(tokens: frozenset[str]) -> frozenset[str]:
+    """The tokens that name a resource rather than merely locate it.
+
+    ``identity_tokens`` records a path-like value as the whole string *and* as
+    the basename and stem derived from it. Only those leaves survive a change of
+    rendering: an agent that writes ``/data/invoices/INV-5.pdf`` in one session
+    and ``invoices/INV-5.pdf`` in the next means the same file, and the differing
+    container would otherwise make the two look like different resources.
+
+    Dropping the container is what lets ``_identity_match`` demand containment
+    instead of a single shared token. Note the consequence: identity is decided
+    at basename level, so two same-type actions on same-named files in different
+    directories are treated as one. That is the same assumption the basename
+    token itself has always encoded.
+    """
+    return frozenset(t for t in tokens if "/" not in t and "\\" not in t)

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -50,6 +50,7 @@ from continuum.actions.idempotency import (
     arguments_hash,
     idempotency_key,
     identity_tokens,
+    leaf_tokens,
 )
 from continuum.events import EventType
 from continuum.models import Action, ActionStatus, UnknownSideEffect, utcnow
@@ -146,28 +147,45 @@ class ActionLedger:
         tokens (scalar values plus path basenames and external ids) rather than
         by the full argument shape.
 
+        Recognition requires one token set to *contain* the other, not merely to
+        intersect it, and it compares leaf tokens so a path counts as its
+        basename rather than its full spelling (see ``leaf_tokens``). Drift makes
+        a description more or less verbose about the same resource, so the
+        sparser set is a subset of the richer one (``{INV-001}`` inside
+        ``{INV-001, INV-001.sent}``). Two genuinely different resources each
+        carry a leaf the other lacks, which is what keeps two tickets that merely
+        share ``urgent`` from collapsing into one. Under mere intersection the
+        second side effect would be silently swallowed -- the exact failure this
+        ledger exists to prevent.
+
         Returns ``(key, action)`` for the unique same-type match, or ``None``
         when nothing is distinctive enough to be confident. ``None`` is also
         returned when several actions share a token, because guessing which one
         the caller means is exactly the quiet failure mode this exists to avoid.
         """
-        incoming = identity_tokens(arguments, volatile=volatile)
-        if not incoming:
-            return None
         # The run id rides along inside arguments as ``continuum_run_id`` and is
         # common to every claim in the run, so it must never count as a
         # resource token when deciding whether two claims are the same work.
-        plumbing = identity_tokens(external_id=self.run_id)
-        incoming = incoming - plumbing
+        plumbing = leaf_tokens(identity_tokens(external_id=self.run_id))
+        incoming = leaf_tokens(identity_tokens(arguments, volatile=volatile)) - plumbing
+        if not incoming:
+            return None
 
         completed: list[tuple[IdempotencyKey, Action]] = []
         uncertain: list[tuple[IdempotencyKey, Action]] = []
         for stored_key, action in self._replay().items():
             if action.action_type != action_type:
                 continue
-            known = identity_tokens(action.arguments, external_id=action.external_id)
-            known = known - plumbing
-            if not (incoming & known):
+            known = (
+                leaf_tokens(identity_tokens(action.arguments, external_id=action.external_id))
+                - plumbing
+            )
+            # An empty ``known`` is contained in everything; treat a stored
+            # action with no identity of its own as unrecognisable, not as a
+            # match for every claim of the same type.
+            if not known:
+                continue
+            if not (incoming <= known or known <= incoming):
                 continue
             if action.status in (ActionStatus.STARTED, ActionStatus.UNKNOWN):
                 uncertain.append((IdempotencyKey(stored_key), action))
@@ -301,6 +319,10 @@ class ActionLedger:
         if on_unknown is not None:
             resolved = on_unknown(existing)
             if resolved is not None:
+                # The resolution is a real decision and must outlive this call:
+                # persist it so the next claim (or intercept_action) and
+                # ledger.pending() reflect it instead of re-raising UnknownSideEffect.
+                self._record(resolved.key, resolved.action, EventType.ACTION_RECONCILED)
                 return resolved
 
         uncertain = existing.model_copy(
@@ -386,6 +408,9 @@ class ActionLedger:
             action = existing.model_copy(
                 update={
                     "status": ActionStatus.FAILED,
+                    "external_id": None,
+                    "result": None,
+                    "result_hash": None,
                     "side_effect_uncertain": False,
                     "last_error": note or "reconciliation found no external effect",
                 }

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -260,13 +260,16 @@ def cmd_inspect(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
 
 
 def cmd_history(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
-    versions = storage.list_versions(args.run_id)
-    checkpoints = {c.version: c for c in storage.list_checkpoints(args.run_id)}
-    if not versions:
-        storage.get_run(args.run_id)  # raises RunNotFound if it truly does not exist
+    # Multiple checkpoints legitimately share a state version (put_version
+    # returns the same version when the state fingerprint is unchanged), so we
+    # list every checkpoint rather than keying by version, which would collapse
+    # the lineage into a single row.
+    storage.get_run(args.run_id)  # raises RunNotFound if it truly does not exist
+    checkpoints = storage.list_checkpoints(args.run_id)
+    if not checkpoints:
         _emit(
-            {"versions": []},
-            "No versions recorded.",
+            {"checkpoints": []},
+            "No checkpoints recorded.",
             as_json=args.json,
             stream=out,
             palette=getattr(args, "_palette", None),
@@ -274,26 +277,25 @@ def cmd_history(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
         return ExitCode.OK
 
     payload = []
-    lines = [f"{'VERSION':<9} {'CHECKPOINT':<12} {'TRIGGER':<24} PROGRESS"]
-    for version in versions:
-        state = storage.get_version(args.run_id, version)
-        checkpoint = checkpoints.get(version)
+    lines = [f"{'CHECKPOINT':<12} {'VERSION':<9} {'TRIGGER':<24} PROGRESS"]
+    for checkpoint in checkpoints:
+        state = storage.get_version(args.run_id, checkpoint.version)
         payload.append(
             {
-                "version": version,
-                "checkpoint_id": checkpoint.checkpoint_id if checkpoint else None,
-                "trigger": checkpoint.trigger if checkpoint else None,
+                "checkpoint_id": checkpoint.checkpoint_id,
+                "version": checkpoint.version,
+                "trigger": checkpoint.trigger,
                 "completed": state.progress.completed,
                 "source_sequence": state.source_sequence,
             }
         )
-        marker = checkpoint.checkpoint_id[:10] if checkpoint else "-"
-        trigger = checkpoint.trigger if checkpoint else "-"
+        marker = checkpoint.checkpoint_id[:10]
         lines.append(
-            f"v{version:<8} {marker:<12} {trigger:<24} {state.progress.completed} completed"
+            f"{marker:<12} v{checkpoint.version:<8} {checkpoint.trigger:<24} "
+            f"{state.progress.completed} completed"
         )
     _emit(
-        {"versions": payload},
+        {"checkpoints": payload},
         "\n".join(lines),
         as_json=args.json,
         stream=out,

--- a/src/continuum/environment/snapshot.py
+++ b/src/continuum/environment/snapshot.py
@@ -145,9 +145,11 @@ class FileProvider(EnvironmentProvider):
                     metadata={"size": stat.st_size},
                 )
             except FileNotFoundError:
-                captured[key] = EnvResource(
-                    name=key, kind="file", version=None, metadata={"missing": True}
-                )
+                # The tracked file is gone. Report it as absent rather than as a
+                # resource with ``version=None``: diff_environments classifies a
+                # key present in the old snapshot but missing from the new one as
+                # REMOVED, which is the correct reading of a deleted file.
+                continue
             except OSError as exc:
                 captured[key] = EnvResource(
                     name=key,

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -28,11 +28,13 @@ behaviour, not a leak.
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import inspect
 import json
 import os
 import sqlite3
+import sys
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -89,37 +91,92 @@ def resolve_database(explicit: str | None = None) -> str:
     return explicit or os.environ.get(_DB_ENV_VAR) or DEFAULT_DB
 
 
+def _quarantine_path(sidecar: str) -> str:
+    """An unused path to park a sidecar at, never clobbering an earlier one.
+
+    A second crash must not overwrite the evidence from the first, so the
+    suffix is bumped until the name is free.
+    """
+    candidate = f"{sidecar}.orphaned"
+    counter = 1
+    while os.path.exists(candidate):
+        candidate = f"{sidecar}.orphaned.{counter}"
+        counter += 1
+    return candidate
+
+
 def _open_server_storage(database: str) -> SQLiteStorage:
     """Open the server's store, recovering from a hard-killed predecessor.
 
     A server process killed with SIGKILL cannot run SQLite's WAL cleanup, so it
-    can leave ``<db>-wal`` and ``<db>-shm`` sidecars in an inconsistent state.
-    The next launch then fails to reopen the database in WAL mode with a disk
-    I/O error before it can serve a single request. Those sidecars are
-    reconstructable from the main database, so on that specific error we remove
-    them and retry opening exactly once.
+    can leave ``<db>-wal`` and ``<db>-shm`` sidecars in a state that makes the
+    next WAL-mode open fail with a disk I/O error before it can serve a single
+    request. Recovery proceeds from least to most destructive, because the two
+    sidecars are not equally expendable:
+
+    ``<db>-shm`` is a shared-memory index and genuinely is reconstructable from
+    the database and the log, so removing it costs nothing. If a stale ``-shm``
+    was the blocker, the retry replays the ``-wal`` and every committed
+    transaction survives.
+
+    ``<db>-wal`` is not reconstructable. It holds transactions that were
+    committed but not yet checkpointed into the main database, which for a
+    write-heavy run can be the entire history — deleting it turns durable work
+    into silent loss, and an emptied database still verifies as an intact chain.
+    So it is moved aside rather than unlinked: the server comes up, and the
+    committed data remains on disk for recovery instead of being destroyed. If
+    the retry still fails, the file is put back, since quarantining it bought
+    nothing.
 
     Deliberately scoped to the server's startup rather than ``SQLiteStorage``
     itself: an in-process caller that hits a disk I/O error wants it raised, not
-    papered over by deleting files next to its database. The MCP server is the
-    one place where a stale sidecar from a crashed predecessor is the expected
-    cause and clearing it is the right recovery.
+    papered over by moving files next to its database.
     """
     try:
         return SQLiteStorage(database)
-    except sqlite3.OperationalError:
-        removed = False
-        for sidecar in (f"{database}-wal", f"{database}-shm"):
-            try:
-                os.remove(sidecar)
-                removed = True
-            except FileNotFoundError:
-                pass
-        # Nothing to clear means the error was something else; re-raise it
-        # rather than retrying an open that will fail the same way.
-        if not removed:
+    except sqlite3.OperationalError as exc:
+        error: sqlite3.OperationalError = exc
+
+    shm = f"{database}-shm"
+    wal = f"{database}-wal"
+
+    # Stage 1: discard the reconstructable sidecar only.
+    try:
+        os.remove(shm)
+    except FileNotFoundError:
+        pass
+    else:
+        try:
+            return SQLiteStorage(database)
+        except sqlite3.OperationalError as exc:
+            error = exc
+
+    # Stage 2: preserve the write-ahead log, but get out of its way.
+    if os.path.exists(wal):
+        quarantine = _quarantine_path(wal)
+        try:
+            os.replace(wal, quarantine)
+        except OSError:
+            raise error from None
+        try:
+            storage = SQLiteStorage(database)
+        except sqlite3.OperationalError:
+            # No better off than before: restore the log rather than leave it
+            # parked under a name nothing looks for.
+            with contextlib.suppress(OSError):
+                os.replace(quarantine, wal)
             raise
-        return SQLiteStorage(database)
+        print(
+            f"continuum: orphaned write-ahead log moved to {quarantine}. "
+            "It may contain committed transactions that are NOT in "
+            f"{database}; recover them before deleting it.",
+            file=sys.stderr,
+        )
+        return storage
+
+    # Nothing was clearable, so the error was something else entirely. Retrying
+    # an identical open would fail identically.
+    raise error
 
 
 def _environment(run_id: str, env: Mapping[str, str] | None) -> EnvironmentSnapshot | None:
@@ -135,6 +192,49 @@ def _environment(run_id: str, env: Mapping[str, str] | None) -> EnvironmentSnaps
         name: EnvResource(name=name, version=str(version)) for name, version in env.items()
     }
     return capture(run_id, StaticProvider(resources))
+
+
+def _declare_dependencies(ctx: ContinuumMCP, run_id: str, env: Mapping[str, str] | None) -> None:
+    """Record the checkpointed environment as *declared dependencies* of the run.
+
+    Capturing a snapshot is not enough to make drift matter. The validator
+    decides staleness per ``external_dependencies`` entry and returns early when
+    a state has none, so a checkpoint carrying only a snapshot produces a
+    visible environment diff that invalidates nothing — the run reports
+    ``safe_to_resume`` while the dataset underneath it has moved. Declaring each
+    resource the agent pinned is what gives the diff something to invalidate,
+    and what lets staleness propagate to the evidence resting on it.
+
+    Declared as events rather than written straight onto the checkpoint's state:
+    the log is the durable record, so the declaration survives later projections
+    and restores, is covered by the hash chain, and carries the same
+    ``EXTERNAL_AGENT`` provenance as everything else this server writes. That
+    provenance does not weaken the check — unlike goal and progress, a
+    dependency's status comes from comparing two snapshots rather than from
+    trusting the claim, so the *comparison* stays independent of the agent that
+    named the resource.
+
+    Only new or re-pinned resources are appended. An agent checkpointing on a
+    schedule with an unchanged environment would otherwise add an event per
+    resource per checkpoint, and the projection would fold every one of them
+    back down to the same entry.
+    """
+    if not env:
+        return
+
+    declared = {
+        dependency.resource: dependency.version
+        for dependency in project(run_id, ctx.storage.read_events(run_id)).external_dependencies
+    }
+    for name, version in env.items():
+        if declared.get(name) == str(version):
+            continue
+        ctx.storage.append_event(
+            run_id,
+            EventType.DEPENDENCY_DECLARED,
+            {"resource": name, "version": str(version)},
+            source=AGENT_SOURCE,
+        )
 
 
 class ContinuumMCP:
@@ -343,6 +443,7 @@ def build_server(
     ) -> str:
         """Create a semantic checkpoint."""
         ctx.ensure_run(run_id)
+        _declare_dependencies(ctx, run_id, env)
         state = project(run_id, ctx.storage.read_events(run_id))
         checkpoint = ctx.adapter.capture_state(
             run_id,
@@ -677,8 +778,9 @@ def build_server(
     @server.tool(
         name="continuum_list_actions",
         description=(
-            "List external side effects recorded for a run, flagging any with "
-            "unresolved outcomes. Read-only."
+            "List external side effects recorded for a run. Each row carries "
+            "'outcome_unresolved': true when that action's real-world outcome is "
+            "not known and must be reconciled before resuming. Read-only."
         ),
         annotations=read_only,
     )
@@ -691,6 +793,7 @@ def build_server(
         ctx.storage.get_run(run_id)
         ledger = ctx.ledger(run_id)
         actions = ledger.all()
+        unresolved = {a.action_id for a in ledger.pending()}
         return _json(
             {
                 "run_id": run_id,
@@ -701,10 +804,18 @@ def build_server(
                         "status": a.status.value,
                         "external_id": a.external_id,
                         "side_effect_uncertain": a.side_effect_uncertain,
+                        # The durable flag above is only set once an action has
+                        # been *escalated* to UNKNOWN. An action still STARTED
+                        # because the process died mid-flight has not been
+                        # escalated yet, so the flag reads false while the
+                        # outcome is in fact unresolved — which is what a
+                        # recovering caller needs to see per row, not just in
+                        # the aggregate count.
+                        "outcome_unresolved": a.action_id in unresolved,
                     }
                     for a in actions
                 ],
-                "unresolved": len(ledger.pending()),
+                "unresolved": len(unresolved),
             }
         )
 

--- a/src/continuum/recovery/planner.py
+++ b/src/continuum/recovery/planner.py
@@ -213,15 +213,21 @@ def plan_repairs(
             continue
         # An action already escalated to REQUIRES_REVIEW has defeated automatic
         # reconciliation once; sending it back through the same machinery would
-        # loop. It needs a person.
-        needs_person = action.status is ActionStatus.REQUIRES_REVIEW
+        # loop. It needs a person. So does an action whose outcome is still
+        # unknown while strict mode is on: the engine escalates such runs to
+        # REQUEST_HUMAN, so the step must agree rather than quietly offering an
+        # automatic reconcile the contract would then permit (issue #42).
+        escalated = action.status is ActionStatus.REQUIRES_REVIEW
+        needs_person = escalated or strict_unknown
         steps.append(
             RepairStep(
                 kind=RepairKind.RECONCILE_ACTION,
                 target=action.action_id,
+                # Keyed on what actually happened, not on who must handle it: an
+                # interrupted action was never "escalated for review".
                 reason=(
                     f"{action.action_type} was escalated for review"
-                    if needs_person
+                    if escalated
                     else f"{action.action_type} was interrupted; the side effect may or "
                     f"may not have occurred"
                 ),

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -107,22 +107,66 @@ def _require(params: dict[str, Any], key: str) -> Any:
     return params[key]
 
 
-def _environment(run_id: str, env: Any) -> EnvironmentSnapshot | None:
-    if not env:
-        return None
-    resources: dict[str, EnvResource] = {}
+def _env_versions(env: Any) -> dict[str, str]:
+    """Normalize the two accepted ``env`` shapes to ``{resource: version}``.
+
+    Callers send either a mapping or a list of ``name=version`` strings, and both
+    the snapshot and the dependency declaration have to agree on what was pinned.
+    """
+    versions: dict[str, str] = {}
     if isinstance(env, dict):
         for name, version in env.items():
-            resources[str(name)] = EnvResource(name=str(name), version=str(version))
+            versions[str(name)] = str(version)
     elif isinstance(env, list):
         for item in env:
             if not isinstance(item, str) or "=" not in item:
                 continue
             name, _, version = item.partition("=")
-            resources[name] = EnvResource(name=name, version=version)
-    if not resources:
+            versions[name] = version
+    return versions
+
+
+def _environment(run_id: str, env: Any) -> EnvironmentSnapshot | None:
+    if not env:
         return None
+    versions = _env_versions(env)
+    if not versions:
+        return None
+    resources = {
+        name: EnvResource(name=name, version=version) for name, version in versions.items()
+    }
     return capture(run_id, StaticProvider(resources))
+
+
+def _declare_dependencies(server: SidecarServer, run_id: str, env: Any) -> None:
+    """Record the pinned environment as declared dependencies of the run.
+
+    A snapshot alone cannot invalidate anything: the validator decides staleness
+    per declared dependency and returns early when a state has none, so a
+    checkpoint carrying only a snapshot reports ``safe_to_resume`` even after the
+    resource underneath it moved. Mirrors ``continuum.mcp.server`` — the two
+    surfaces expose the same recovery semantics and must not disagree about
+    whether drift is safe.
+    """
+    if not env:
+        return
+    versions = _env_versions(env)
+    if not versions:
+        return
+
+    declared = {
+        dependency.resource: dependency.version
+        for dependency in project(run_id, server.storage.read_events(run_id)).external_dependencies
+    }
+    for name, version in versions.items():
+        if declared.get(name) == version:
+            continue
+        server.storage.append_event(
+            run_id,
+            EventType.DEPENDENCY_DECLARED,
+            {"resource": name, "version": version},
+            source=AGENT_SOURCE,
+        )
 
 
 class SidecarServer:
@@ -181,7 +225,9 @@ class SidecarServer:
             try:
                 req = json.loads(line)
             except json.JSONDecodeError as exc:
-                _write(outstream, {"id": None, "error": {"type": "bad_request", "message": str(exc)}})
+                _write(
+                    outstream, {"id": None, "error": {"type": "bad_request", "message": str(exc)}}
+                )
                 continue
             rid = req.get("id")
             try:
@@ -191,7 +237,10 @@ class SidecarServer:
             except Exception as exc:  # noqa: BLE001 - report, never crash the loop
                 _write(
                     outstream,
-                    {"id": rid, "error": {"type": "internal", "message": f"{type(exc).__name__}: {exc}"}},
+                    {
+                        "id": rid,
+                        "error": {"type": "internal", "message": f"{type(exc).__name__}: {exc}"},
+                    },
                 )
             else:
                 _write(outstream, {"id": rid, "result": result})
@@ -278,6 +327,7 @@ def _h_record_progress(server: SidecarServer, params: dict[str, Any]) -> dict[st
 def _h_checkpoint(server: SidecarServer, params: dict[str, Any]) -> dict[str, Any]:
     run_id = _require(params, "run_id")
     server._ensure_run(run_id)
+    _declare_dependencies(server, run_id, params.get("env"))
     state = project(run_id, server.storage.read_events(run_id))
     checkpoint = server.adapter.capture_state(
         run_id,
@@ -449,6 +499,7 @@ def _h_list_actions(server: SidecarServer, params: dict[str, Any]) -> dict[str, 
     server.storage.get_run(run_id)
     ledger = server._ledger(run_id)
     actions = ledger.all()
+    unresolved = {a.action_id for a in ledger.pending()}
     return {
         "run_id": run_id,
         "actions": [
@@ -458,10 +509,14 @@ def _h_list_actions(server: SidecarServer, params: dict[str, Any]) -> dict[str, 
                 "status": a.status.value,
                 "external_id": a.external_id,
                 "side_effect_uncertain": a.side_effect_uncertain,
+                # The durable flag above is only set once an action has been
+                # escalated to UNKNOWN, so one left STARTED by a crash reads
+                # false while its outcome is in fact unresolved.
+                "outcome_unresolved": a.action_id in unresolved,
             }
             for a in actions
         ],
-        "unresolved": len(ledger.pending()),
+        "unresolved": len(unresolved),
     }
 
 

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -11,7 +11,7 @@ from continuum.actions import (
     idempotency_key,
 )
 from continuum.events import EventType
-from continuum.models import ActionStatus, Run, UnknownSideEffect
+from continuum.models import Action, ActionStatus, Run, UnknownSideEffect
 from continuum.storage import SQLiteStorage
 
 
@@ -210,6 +210,45 @@ def test_an_inline_resolver_can_rescue_an_interrupted_action(
     assert outcome.external_id == "481"
 
 
+def test_an_inline_resolution_settles_the_ledger_durably(
+    ledger: ActionLedger, store: SQLiteStorage
+) -> None:
+    """Issue #45: a resolver that does not itself reconcile must still persist.
+
+    Returning the resolution only to the caller left the stored action UNKNOWN,
+    so the next claim re-raised, ``pending()`` never drained, and the recovery
+    engine asked for a human forever.
+    """
+    from continuum.actions.ledger import ActionOutcome
+
+    first = ledger.claim("act.x", {"k": 1})
+    ledger.fail(first.key, "boom", certain=False)
+
+    def resolve(existing: Action) -> ActionOutcome:
+        settled = existing.model_copy(
+            update={
+                "status": ActionStatus.COMPLETED,
+                "external_id": "ext-1",
+                "result": {"ok": True},
+                "side_effect_uncertain": False,
+            }
+        )
+        return ActionOutcome(key=first.key, action=settled, fresh=False)
+
+    resolved = ledger.claim("act.x", {"k": 1}, on_unknown=resolve)
+    assert resolved.action.status is ActionStatus.COMPLETED
+
+    # The durable state, not just the return value.
+    assert ledger.get(first.key).status is ActionStatus.COMPLETED
+    assert ledger.pending() == []
+
+    # A fresh ledger replaying the same events must agree.
+    replayed = ActionLedger(store, "run_1")
+    assert replayed.get(first.key).status is ActionStatus.COMPLETED
+    assert replayed.get(first.key).external_id == "ext-1"
+    assert replayed.pending() == []
+
+
 # --- reconciliation -------------------------------------------------------- #
 
 
@@ -233,6 +272,26 @@ def test_reconciling_as_not_occurred_permits_a_retry(ledger: ActionLedger) -> No
 
     retry = ledger.claim("github.create_issue", ISSUE)
     assert retry.fresh
+
+
+def test_reconciling_as_not_occurred_clears_the_recorded_effect(
+    ledger: ActionLedger,
+) -> None:
+    """Issue #29: deciding the effect never happened invalidates its evidence.
+
+    Leaving ``external_id`` and ``result`` behind showed a downstream reader a
+    stale external identity and a stale success payload on an action the system
+    had just decided never completed.
+    """
+    outcome = ledger.claim("t.send", {"id": "row-1"})
+    ledger.complete(outcome.key, external_id="EXT-9", result={"ok": True})
+
+    ledger.reconcile(outcome.key, occurred=False, note="probe found nothing")
+
+    settled = ledger.get(outcome.key)
+    assert settled.status is ActionStatus.FAILED
+    assert settled.external_id is None
+    assert settled.result is None
 
 
 def test_reconciliation_is_recorded_as_its_own_event(
@@ -469,9 +528,76 @@ def test_identity_match_requires_a_distinctive_token(ledger: ActionLedger) -> No
     first = ledger.claim("api.call", {"invoice_id": "INV-007", "status": "sent"})
     ledger.complete(first.key, external_id="INV-007.sent")
 
-    # "1" and "sent" are weak tokens; only INV-008 is new work.
+    # "1" is too short to distinguish anything and "sent" is a weak token;
+    # only INV-008 would be new work.
     other = ledger.claim("api.call", {"id": 1, "status": "sent"})
     assert other.fresh
+
+
+def test_identity_match_recognises_a_plain_word_resource(ledger: ActionLedger) -> None:
+    """Issue #33: a word like 'invoice' names a resource as well as 'INV-001'.
+
+    Requiring a digit, '@', or '.' meant every plain-word identity was dropped,
+    so drift across sessions opened a second slot and the effect ran twice.
+    """
+    first = ledger.claim("publish", {"topic": "invoice"})
+    ledger.complete(first.key, external_id="published")
+
+    again = ledger.claim("publish", {"subject": "invoice"})
+    assert not again.fresh
+    assert again.external_id == "published"
+
+
+def test_identity_match_recognises_a_numeric_resource_id(ledger: ActionLedger) -> None:
+    """Issue #36: a row id of 4821 identifies a row as well as INV-001 does.
+
+    Numeric ids were dropped twice over -- as purely-numeric tokens, and because
+    only ``str`` values were tokenised at all, so an ``int`` never became one.
+    """
+    first = ledger.claim("db.update", {"row_id": 4821})
+    ledger.complete(first.key, external_id="updated")
+
+    again = ledger.claim("db.update", {"id": 4821})
+    assert not again.fresh
+    assert again.external_id == "updated"
+
+    other = ledger.claim("db.update", {"row_id": 9999})
+    assert other.fresh, "a different row is different work"
+
+
+def test_identity_match_survives_an_absolute_versus_relative_path(
+    ledger: ActionLedger,
+) -> None:
+    """The same file rendered two ways is one action (the issue #6 scenario).
+
+    Each spelling carries a container the other lacks, so identity is compared at
+    the leaf: ``INV-5.pdf`` and its stem, not the directory that precedes them.
+    CONTINUUM-Bench measures exactly this path, so a regression here shows up as
+    duplicate side effects in the benchmark rather than as a unit failure.
+    """
+    first = ledger.claim("bench.send", {"file": "/data/invoices/INV-5.pdf", "invoice": "INV-5"})
+    ledger.complete(first.key, external_id="ext-5", result={"ok": True})
+
+    again = ledger.claim("bench.send", {"file": "invoices/INV-5.pdf", "invoice": "INV-5"})
+    assert not again.fresh, "a re-rendered path is the same file, not new work"
+    assert again.external_id == "ext-5"
+
+
+def test_identity_match_does_not_collapse_actions_sharing_one_incidental_value(
+    ledger: ActionLedger,
+) -> None:
+    """Admitting plain words must not make a shared adjective an identity.
+
+    Both tickets are ``urgent``; only the title says which one. Matching on mere
+    intersection would report the second as already done and silently never
+    create it -- so recognition requires one token set to contain the other.
+    """
+    first = ledger.claim("ticket.create", {"priority": "urgent", "title": "alpha"})
+    ledger.complete(first.key, external_id="T-1")
+
+    second = ledger.claim("ticket.create", {"priority": "urgent", "title": "beta"})
+    assert second.fresh, "a different ticket must not inherit the first one's identity"
+    assert second.external_id is None
 
 
 def test_identity_match_does_not_fire_for_an_explicit_key(ledger: ActionLedger) -> None:

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -622,3 +622,42 @@ def test_identity_match_ignores_the_run_id_plumbing_token(ledger: ActionLedger) 
         {"endpoint": "/b", "continuum_run_id": ledger.run_id},
     )
     assert other.fresh, "a different endpoint is different work"
+
+
+def test_a_larger_charge_is_not_deduplicated_against_a_smaller_one(
+    ledger: ActionLedger,
+) -> None:
+    """Same payee, different amount, is a second charge -- not a retry of the first.
+
+    The sharpest form of the containment rule. One token (the payee) is shared
+    while the token that distinguishes the two actions is numeric, so this fails
+    unless numbers count toward identity *and* a partial overlap is refused. The
+    money is the whole distinction; suppressing the second charge reports success
+    while the payment never happens.
+    """
+    first = ledger.claim("charge_card", {"recipient": "acct-4471", "amount_usd": 100})
+    ledger.complete(first.key, external_id="txn-aaa", result={"charged": 100})
+
+    second = ledger.claim("charge_card", {"recipient": "acct-4471", "amount_usd": 5000})
+
+    assert second.fresh, "the $5000 charge was suppressed by the $100 one"
+    assert second.action.arguments["amount_usd"] == 5000
+    assert second.external_id is None
+
+
+def test_a_differing_amount_counts_whether_it_is_a_number_or_a_string(
+    ledger: ActionLedger,
+) -> None:
+    """Identity must not depend on the JSON type the caller happened to send.
+
+    Over MCP an amount arrives as an ``int``; a client that quotes it sends a
+    ``str``. Both draw the same distinction, so both must be honoured -- an agent
+    cannot be expected to know that quoting a number changes whether its side
+    effect runs.
+    """
+    first = ledger.claim("charge_card", {"recipient": "acct-4471", "amount_usd": "100"})
+    ledger.complete(first.key, external_id="txn-aaa", result={"charged": "100"})
+
+    second = ledger.claim("charge_card", {"recipient": "acct-4471", "amount_usd": "5000"})
+
+    assert second.fresh

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -259,6 +259,30 @@ def test_history_lists_checkpoints(db: str) -> None:
     assert "v0" in out
 
 
+def test_history_lists_every_checkpoint_sharing_a_version(db: str) -> None:
+    """Issue #43: two checkpoints at one state version are two checkpoints.
+
+    ``put_version`` returns the same version when the state fingerprint has not
+    changed, so keying the listing by version hid whole checkpoints -- exactly
+    the lineage ``history`` exists to show.
+    """
+    with SQLiteStorage(db) as store:
+        manager = CheckpointManager(store)
+        # No new events in between, so the state fingerprint is unchanged and
+        # both checkpoints land on the same version.
+        first = manager.checkpoint("run_1")
+        second = manager.checkpoint("run_1")
+        assert first.version == second.version
+        assert first.checkpoint_id != second.checkpoint_id
+
+    _, out, _ = run("--db", db, "--json", "history", "run_1")
+    listed = json.loads(out)["checkpoints"]
+    ids = [row["checkpoint_id"] for row in listed]
+    assert first.checkpoint_id in ids
+    assert second.checkpoint_id in ids
+    assert len(ids) == len(set(ids)), "each checkpoint appears once"
+
+
 def test_diff_compares_two_versions(db: str) -> None:
     with SQLiteStorage(db) as store:
         store.append_event("run_1", EventType.WORK_COMPLETED, {"doc": 99})
@@ -395,13 +419,13 @@ def test_benchmark_runs_and_reports_numbers() -> None:
     assert "12.93" in out or "16.61" in out or "compress" in out
 
 
-def test_a_run_with_no_versions_says_so(tmp_path: Path) -> None:
+def test_a_run_with_no_checkpoints_says_so(tmp_path: Path) -> None:
     path = str(tmp_path / "bare.db")
     with SQLiteStorage(path) as store:
         store.create_run(Run(run_id="bare", goal="g"))
     code, out, _ = run("--db", path, "history", "bare")
     assert code == ExitCode.OK
-    assert "No versions recorded" in out
+    assert "No checkpoints recorded" in out
 
 
 def test_history_of_a_missing_run_is_not_found(db: str) -> None:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -66,11 +66,29 @@ def test_files_are_fingerprinted_by_content_not_mtime(tmp_path: Path) -> None:
     assert not diff_environments(first, third).stable
 
 
-def test_a_missing_file_is_recorded_not_raised(tmp_path: Path) -> None:
-    snapshot = capture("run_1", FileProvider([tmp_path / "gone.csv"]))
-    resource = snapshot.resources[str(tmp_path / "gone.csv")]
-    assert resource.version is None
-    assert resource.metadata["missing"] is True
+def test_a_missing_file_is_omitted_not_raised(tmp_path: Path) -> None:
+    """Issue #30: absence is reported by omission, so the diff reads 'removed'.
+
+    Recording the file with ``version=None`` instead made a deleted file look
+    like a *changed* resource, which understates what happened to it.
+    """
+    gone = tmp_path / "gone.csv"
+    snapshot = capture("run_1", FileProvider([gone]))
+    assert str(gone) not in snapshot.resources
+
+
+def test_a_deleted_file_diffs_as_removed(tmp_path: Path) -> None:
+    target = tmp_path / "data.csv"
+    target.write_text("alpha")
+    before = capture("run_1", FileProvider([target]))
+
+    target.unlink()
+    after = capture("run_1", FileProvider([target]))
+
+    diff = diff_environments(before, after)
+    assert not diff.stable
+    delta = next(d for d in diff.deltas if d.resource == str(target))
+    assert delta.change is ResourceChange.REMOVED
 
 
 def test_an_unreadable_file_becomes_unknown(tmp_path: Path) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -31,7 +31,8 @@ from continuum.mcp.server import (
     build_server,
     resolve_database,
 )
-from continuum.models import ActionStatus, RecoveryMode, Run
+from continuum.models import ActionStatus, Origin, RecoveryMode, Run
+from continuum.state.semantic import project
 from continuum.storage import SQLiteStorage
 from tests.mcp_helpers import fake_context as _ctx
 
@@ -306,6 +307,137 @@ async def test_validate_flags_a_changed_dependency(server_ctx: tuple[Any, Any]) 
         e["component"] == "external_dependency" and e["status"] == "conflicted"
         for e in payload["components"]
     )
+
+
+# --- environment declared through the protocol ----------------------------- #
+#
+# The test above declares the dependency by appending an event straight to
+# storage, which no MCP client can do. Checkpointing with ``env`` used to record
+# a snapshot and nothing else, and the validator returns early for a state with
+# no declared dependencies — so drift was rendered in ``environment_changes``
+# while the verdict stayed ``safe``, which is precisely "reported as verified
+# when it is not". These drive the whole path through the tools.
+
+
+@pytest.mark.asyncio
+async def test_checkpointing_with_env_declares_the_dependencies(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """``env`` has to become declared state, not just a snapshot beside it."""
+    server, ctx = server_ctx
+    await seed_run(server)
+    await call(
+        server,
+        "continuum_checkpoint",
+        run_id="run_1",
+        env={"dataset": "sha256:aaaa", "schema": "2.1"},
+    )
+
+    declared = [
+        e for e in ctx.storage.read_events("run_1") if e.type is EventType.DEPENDENCY_DECLARED
+    ]
+    assert {e.payload["resource"] for e in declared} == {"dataset", "schema"}
+    # Written through this server, so it is self-certified like everything else.
+    assert {e.source for e in declared} == {Origin.EXTERNAL_AGENT}
+
+
+@pytest.mark.asyncio
+async def test_drift_in_an_env_declared_dependency_blocks_resume(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """A moved dataset must stop the run even once the self-report is confirmed.
+
+    Confirming clears the REQUIRES_REVIEW on goal and progress, so nothing else
+    is left to mask the environment check — if the verdict were still ``safe``
+    the agent would resume on top of data that changed underneath it.
+    """
+    server, _ = server_ctx
+    await seed_run(server)
+    await call(server, "continuum_checkpoint", run_id="run_1", env={"dataset": "sha256:aaaa"})
+    await call(server, "continuum_confirm", run_id="run_1")
+
+    clean = await call(server, "continuum_validate", run_id="run_1", env={"dataset": "sha256:aaaa"})
+    assert clean["safe"] is True, "an unchanged environment must still resume"
+
+    drifted = await call(
+        server, "continuum_validate", run_id="run_1", env={"dataset": "sha256:bbbb"}
+    )
+    assert drifted["safe"] is False
+    assert "conflicted" in drifted["reason"]
+    assert ("external_dependency", "dataset", "conflicted") in {
+        (e["component"], e["component_id"], e["status"]) for e in drifted["components"]
+    }
+
+    resumed = await call(server, "continuum_resume", run_id="run_1", env={"dataset": "sha256:bbbb"})
+    assert resumed["safe"] is False
+    assert resumed["next_allowed_action"] == "revalidate_dependency:dataset"
+    assert any(r["kind"] == "revalidate_dependency" for r in resumed["repairs"])
+    # Repair must not discard work already done.
+    assert resumed["progress"]["completed"] == 20
+
+
+@pytest.mark.asyncio
+async def test_only_the_changed_dependency_is_invalidated(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """Over-blocking is its own failure: untouched resources stay valid."""
+    server, _ = server_ctx
+    await seed_run(server)
+    await call(
+        server,
+        "continuum_checkpoint",
+        run_id="run_1",
+        env={"dataset": "sha256:aaaa", "schema": "2.1"},
+    )
+    await call(server, "continuum_confirm", run_id="run_1")
+
+    payload = await call(
+        server,
+        "continuum_validate",
+        run_id="run_1",
+        env={"dataset": "sha256:bbbb", "schema": "2.1"},
+    )
+    statuses = {
+        (e["component_id"], e["status"])
+        for e in payload["components"]
+        if e["component"] == "external_dependency"
+    }
+    assert statuses == {("dataset", "conflicted"), ("schema", "valid")}
+
+
+@pytest.mark.asyncio
+async def test_repinning_only_records_what_actually_changed(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """Checkpointing on a schedule must not append an event per resource per call."""
+    server, ctx = server_ctx
+    await seed_run(server)
+
+    for _ in range(4):
+        await call(
+            server,
+            "continuum_checkpoint",
+            run_id="run_1",
+            env={"dataset": "v3", "schema": "1.0"},
+        )
+
+    def declared() -> list[Any]:
+        return [
+            e for e in ctx.storage.read_events("run_1") if e.type is EventType.DEPENDENCY_DECLARED
+        ]
+
+    assert len(declared()) == 2, "an unchanged environment re-declared itself"
+
+    await call(
+        server, "continuum_checkpoint", run_id="run_1", env={"dataset": "v4", "schema": "1.0"}
+    )
+    assert len(declared()) == 3, "a genuine re-pin must be recorded"
+
+    state = project("run_1", ctx.storage.read_events("run_1"))
+    assert {(d.resource, d.version) for d in state.external_dependencies} == {
+        ("dataset", "v4"),
+        ("schema", "1.0"),
+    }
 
 
 @pytest.mark.asyncio
@@ -727,6 +859,49 @@ async def test_list_actions_surfaces_unresolved_outcomes(
     assert payload["unresolved"] == 1
 
 
+@pytest.mark.asyncio
+async def test_list_actions_marks_the_unresolved_row_itself(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """The aggregate count is not enough; the row has to say which one.
+
+    ``side_effect_uncertain`` is only set once an action has been *escalated* to
+    UNKNOWN. An action left STARTED by a process that died mid-flight has not
+    been escalated, so that flag reads false while ``continuum_resume`` reports
+    the very same action as an unknown outcome. Reading the list row by row
+    previously suggested the interrupted side effect was fine.
+    """
+    server, _ = server_ctx
+    await seed_run(server)
+    done = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="a.do",
+        arguments={"n": 1},
+    )
+    await call(server, "continuum_complete_action", run_id="run_1", action_key=done["action_key"])
+    # Claimed and never completed: the crash-mid-action shape.
+    await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="b.do",
+        arguments={"n": 2},
+    )
+
+    payload = await call(server, "continuum_list_actions", run_id="run_1")
+    rows = {a["action_type"]: a for a in payload["actions"]}
+    assert rows["a.do"]["outcome_unresolved"] is False
+    assert rows["b.do"]["outcome_unresolved"] is True
+
+    # And it agrees with what the recovery decision says about the same action.
+    resumed = await call(server, "continuum_resume", run_id="run_1")
+    unresolved_ids = {a["action_id"] for a in resumed["uncertain_actions"]}
+    assert rows["b.do"]["action_id"] in unresolved_ids
+    assert {a["action_id"] for a in payload["actions"] if a["outcome_unresolved"]} == unresolved_ids
+
+
 # --- storage configuration --------------------------------------------------- #
 
 
@@ -769,8 +944,11 @@ def test_server_startup_recovers_from_orphaned_wal_sidecars(tmp_path: Any) -> No
     """A hard-killed predecessor must not wedge the next server launch.
 
     The first WAL-mode open raises the disk I/O error a crashed predecessor's
-    sidecars provoke; the server's open path must then clear those sidecars and
-    retry, coming up with the database's prior contents still readable. The
+    sidecars provoke; the server's open path must then clear the sidecars that
+    are in the way and retry, coming up with the database's prior contents still
+    readable. Recovery is staged, so reaching a blocking ``-wal`` takes three
+    opens: the initial failure, a retry after the reconstructable ``-shm`` is
+    discarded, and a final retry once the log is parked aside. The
     ``ContinuumMCP`` constructor is checked too, since that is what the entry
     point builds.
 
@@ -802,25 +980,33 @@ def test_server_startup_recovers_from_orphaned_wal_sidecars(tmp_path: Any) -> No
 
     SQLiteStorage.__init__ = _fail_while_sidecar_present  # type: ignore[method-assign]
     try:
-        # The wal was removed between the two opens: the mid-open callback saw
+        # The wal was moved aside between the two opens: the mid-open callback saw
         # it present on the failing attempt and absent on the succeeding one.
-        removed_between: list[bool] = []
+        cleared_between: list[str] = []
         real_remove = os.remove
+        real_replace = os.replace
 
         def _record_remove(target: str) -> None:
-            removed_between.append(True)
+            cleared_between.append(str(target))
             real_remove(target)
 
+        def _record_replace(src: str, dst: str) -> None:
+            cleared_between.append(str(src))
+            real_replace(src, dst)
+
         os.remove = _record_remove  # type: ignore[assignment]
+        os.replace = _record_replace  # type: ignore[assignment]
         try:
             storage = _open_server_storage(path)
         finally:
             os.remove = real_remove  # type: ignore[assignment]
+            os.replace = real_replace  # type: ignore[assignment]
         try:
-            # The recovery ran: a failed open, a sidecar removal, then a retry.
-            assert calls["n"] == 2
-            assert removed_between  # at least one stale sidecar was cleared
-            # And the pre-crash work survived the sidecar removal.
+            # Staged recovery: failed open, -shm discarded, retry, -wal parked
+            # aside, final retry.
+            assert calls["n"] == 3
+            assert cleared_between  # at least one stale sidecar was cleared
+            # And the pre-crash work survived the sidecar recovery.
             assert storage.get_run("survivor").goal == "pre-crash work"
             assert [e.type for e in storage.read_events("survivor")] == [EventType.RUN_STARTED]
         finally:
@@ -831,12 +1017,155 @@ def test_server_startup_recovers_from_orphaned_wal_sidecars(tmp_path: Any) -> No
         calls["n"] = 0
         ctx = ContinuumMCP(path)
         try:
-            assert calls["n"] == 2
+            assert calls["n"] == 3
             assert ctx.storage.get_run("survivor").goal == "pre-crash work"
         finally:
             ctx.close()
     finally:
         SQLiteStorage.__init__ = real_init  # type: ignore[method-assign]
+
+
+def test_server_startup_prefers_discarding_only_the_shm_sidecar(tmp_path: Any) -> None:
+    """A stale ``-shm`` must be recovered without touching the write-ahead log.
+
+    The ``-shm`` file is a shared-memory index and is rebuildable, so discarding
+    it is free. The ``-wal`` is not: it can hold committed transactions absent
+    from the main database. When clearing the cheap sidecar is enough to reopen,
+    the log must be left exactly where it is so SQLite replays it.
+    """
+    path = str(tmp_path / "agent.db")
+    seed = SQLiteStorage(path)
+    seed.create_run(Run(run_id="survivor", goal="pre-crash work"))
+    seed.close()
+
+    _orphan_wal_sidecars(path)
+    wal_bytes = b"committed-but-not-checkpointed"
+    with open(f"{path}-wal", "wb") as wal:
+        wal.write(wal_bytes)
+
+    real_init = SQLiteStorage.__init__
+    calls = {"n": 0}
+
+    def _fail_while_shm_present(self: Any, database: str, *args: Any, **kwargs: Any) -> None:
+        calls["n"] += 1
+        if os.path.exists(f"{database}-shm"):
+            raise sqlite3.OperationalError("disk I/O error")
+        real_init(self, database, *args, **kwargs)
+
+    SQLiteStorage.__init__ = _fail_while_shm_present  # type: ignore[method-assign]
+    try:
+        storage = _open_server_storage(path)
+        try:
+            assert calls["n"] == 2  # failed open, then a retry after -shm went
+            # The log is untouched: same path, same bytes, nothing quarantined.
+            assert os.path.exists(f"{path}-wal")
+            with open(f"{path}-wal", "rb") as wal:
+                assert wal.read() == wal_bytes
+            assert not os.path.exists(f"{path}-wal.orphaned")
+        finally:
+            storage.close()
+    finally:
+        SQLiteStorage.__init__ = real_init  # type: ignore[method-assign]
+
+
+def test_server_startup_never_deletes_the_write_ahead_log(tmp_path: Any) -> None:
+    """A blocking ``-wal`` is quarantined, not destroyed.
+
+    Deleting it would turn committed transactions into silent loss, and an
+    emptied database still verifies as an intact chain — the failure would look
+    like success. The bytes must survive somewhere recoverable.
+    """
+    path = str(tmp_path / "agent.db")
+    SQLiteStorage(path).close()
+
+    _orphan_wal_sidecars(path)
+    wal_bytes = b"committed-but-not-checkpointed"
+    with open(f"{path}-wal", "wb") as wal:
+        wal.write(wal_bytes)
+
+    real_init = SQLiteStorage.__init__
+
+    def _fail_while_wal_present(self: Any, database: str, *args: Any, **kwargs: Any) -> None:
+        if os.path.exists(f"{database}-wal"):
+            raise sqlite3.OperationalError("disk I/O error")
+        real_init(self, database, *args, **kwargs)
+
+    SQLiteStorage.__init__ = _fail_while_wal_present  # type: ignore[method-assign]
+    try:
+        storage = _open_server_storage(path)
+        try:
+            quarantined = f"{path}-wal.orphaned"
+            assert os.path.exists(quarantined), "the log was destroyed, not preserved"
+            with open(quarantined, "rb") as wal:
+                assert wal.read() == wal_bytes
+        finally:
+            storage.close()
+    finally:
+        SQLiteStorage.__init__ = real_init  # type: ignore[method-assign]
+
+
+def test_quarantining_a_log_does_not_overwrite_an_earlier_one(tmp_path: Any) -> None:
+    """A second crash must not erase the first crash's unrecovered log."""
+    path = str(tmp_path / "agent.db")
+    SQLiteStorage(path).close()
+
+    with open(f"{path}-wal.orphaned", "wb") as previous:
+        previous.write(b"from-the-first-crash")
+
+    _orphan_wal_sidecars(path)
+    with open(f"{path}-wal", "wb") as wal:
+        wal.write(b"from-the-second-crash")
+
+    real_init = SQLiteStorage.__init__
+
+    def _fail_while_wal_present(self: Any, database: str, *args: Any, **kwargs: Any) -> None:
+        if os.path.exists(f"{database}-wal"):
+            raise sqlite3.OperationalError("disk I/O error")
+        real_init(self, database, *args, **kwargs)
+
+    SQLiteStorage.__init__ = _fail_while_wal_present  # type: ignore[method-assign]
+    try:
+        storage = _open_server_storage(path)
+        try:
+            with open(f"{path}-wal.orphaned", "rb") as first:
+                assert first.read() == b"from-the-first-crash"
+            with open(f"{path}-wal.orphaned.1", "rb") as second:
+                assert second.read() == b"from-the-second-crash"
+        finally:
+            storage.close()
+    finally:
+        SQLiteStorage.__init__ = real_init  # type: ignore[method-assign]
+
+
+def test_a_log_is_restored_when_quarantining_it_does_not_help(tmp_path: Any) -> None:
+    """If the retry still fails, the filesystem is left as it was found.
+
+    Parking the log bought nothing, so leaving it under a name nothing looks for
+    would only make the operator's recovery harder.
+    """
+    path = str(tmp_path / "agent.db")
+    SQLiteStorage(path).close()
+
+    _orphan_wal_sidecars(path)
+    wal_bytes = b"committed-but-not-checkpointed"
+    with open(f"{path}-wal", "wb") as wal:
+        wal.write(wal_bytes)
+
+    real_init = SQLiteStorage.__init__
+
+    def _always_disk_error(self: Any, database: str, *args: Any, **kwargs: Any) -> None:
+        raise sqlite3.OperationalError("disk I/O error")
+
+    SQLiteStorage.__init__ = _always_disk_error  # type: ignore[method-assign]
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            _open_server_storage(path)
+    finally:
+        SQLiteStorage.__init__ = real_init  # type: ignore[method-assign]
+
+    with open(f"{path}-wal", "rb") as wal:
+        assert wal.read() == wal_bytes
+    assert not os.path.exists(f"{path}-wal.orphaned")
 
 
 def test_server_open_reraises_a_disk_error_with_no_sidecars(tmp_path: Any) -> None:

--- a/tests/test_recovery_planner.py
+++ b/tests/test_recovery_planner.py
@@ -113,7 +113,25 @@ def test_interrupted_actions_become_reconciliation_steps() -> None:
     plan = plan_repairs(uncertain_actions=[uncertain()])
     assert plan.steps[0].kind is RepairKind.RECONCILE_ACTION
     assert "may or may not have occurred" in plan.steps[0].reason
+
+
+def test_strict_mode_makes_an_unknown_side_effect_a_human_step() -> None:
+    """Issue #42: the engine escalates to REQUEST_HUMAN, so the step must agree.
+
+    Otherwise ``plan.requires_human`` is False and ``next_allowed_action`` is an
+    automatic reconcile the contract permits, contradicting the mode.
+    """
+    plan = plan_repairs(uncertain_actions=[uncertain()], strict_unknown=True)
+    assert plan.steps[0].requires_human
+    assert plan.requires_human
+    # The reason states what happened, not who handles it: it was never escalated.
+    assert "escalated" not in plan.steps[0].reason
+
+
+def test_tolerating_unknown_side_effects_allows_an_automatic_reconcile() -> None:
+    plan = plan_repairs(uncertain_actions=[uncertain()], strict_unknown=False)
     assert not plan.steps[0].requires_human
+    assert not plan.requires_human
 
 
 def test_an_escalated_action_is_not_sent_back_through_automation() -> None:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -41,7 +41,9 @@ def test_list_methods_covers_the_surface() -> None:
 
 def test_record_progress_creates_the_run() -> None:
     srv = make_server()
-    out = srv.dispatch("record_progress", {"run_id": "r1", "completed": 3, "total": 10, "goal": "g"})
+    out = srv.dispatch(
+        "record_progress", {"run_id": "r1", "completed": 3, "total": 10, "goal": "g"}
+    )
     assert out["completed"] == 3
     assert out["total"] == 10
 
@@ -67,6 +69,53 @@ def test_checkpoint_and_resume_round_trip() -> None:
     assert decision["progress"]["completed"] == 1
 
 
+def test_checkpointing_with_env_makes_drift_block_resume() -> None:
+    """The sidecar must not disagree with the MCP surface about drift.
+
+    Pinning an environment at checkpoint has to declare it as a dependency, or
+    the validator has nothing to invalidate and a moved resource still reports
+    safe. Confirming the run first clears the self-report review so the
+    environment check is what decides the verdict.
+    """
+    srv = make_server()
+    srv.dispatch("record_progress", {"run_id": "r1", "completed": 1, "total": 10, "goal": "g"})
+    srv.dispatch("checkpoint", {"run_id": "r1", "env": {"dataset": "v3"}})
+    srv.dispatch("confirm", {"run_id": "r1"})
+
+    clean = srv.dispatch("validate", {"run_id": "r1", "env": {"dataset": "v3"}})
+    assert clean["safe"] is True
+
+    drifted = srv.dispatch("validate", {"run_id": "r1", "env": {"dataset": "v4"}})
+    assert drifted["safe"] is False
+    assert any(
+        c["component"] == "external_dependency" and c["status"] == "conflicted"
+        for c in drifted["components"]
+    )
+
+
+def test_env_accepts_the_name_equals_version_list_shape() -> None:
+    """Both accepted ``env`` shapes must declare dependencies identically."""
+    srv = make_server()
+    srv.dispatch("record_progress", {"run_id": "r1", "completed": 1, "goal": "g"})
+    srv.dispatch("checkpoint", {"run_id": "r1", "env": ["dataset=v3"]})
+    srv.dispatch("confirm", {"run_id": "r1"})
+
+    drifted = srv.dispatch("validate", {"run_id": "r1", "env": ["dataset=v4"]})
+    assert drifted["safe"] is False
+
+
+def test_list_actions_marks_an_interrupted_row_unresolved() -> None:
+    srv = make_server()
+    srv.dispatch("record_progress", {"run_id": "r1", "completed": 1, "goal": "g"})
+    done = srv.dispatch("intercept_action", {"run_id": "r1", "action_type": "a.do", "key": "k1"})
+    srv.dispatch("complete_action", {"run_id": "r1", "action_key": done["action_key"]})
+    srv.dispatch("intercept_action", {"run_id": "r1", "action_type": "b.do", "key": "k2"})
+
+    rows = {a["action_type"]: a for a in srv.dispatch("list_actions", {"run_id": "r1"})["actions"]}
+    assert rows["a.do"]["outcome_unresolved"] is False
+    assert rows["b.do"]["outcome_unresolved"] is True
+
+
 def test_intercept_then_complete_action() -> None:
     srv = make_server()
     srv.dispatch("record_progress", {"run_id": "r1", "completed": 1, "goal": "g"})
@@ -86,13 +135,16 @@ def test_unknown_method_is_not_found() -> None:
 
 def test_stdio_loop_reads_jsonl_and_answers() -> None:
     srv = make_server()
-    requests = "\n".join(
-        [
-            json_line(0, "record_progress", {"run_id": "r1", "completed": 2, "goal": "g"}),
-            json_line(1, "resume", {"run_id": "r1"}),
-            json_line(2, "bogus", {}),
-        ]
-    ) + "\n"
+    requests = (
+        "\n".join(
+            [
+                json_line(0, "record_progress", {"run_id": "r1", "completed": 2, "goal": "g"}),
+                json_line(1, "resume", {"run_id": "r1"}),
+                json_line(2, "bogus", {}),
+            ]
+        )
+        + "\n"
+    )
     out = io.StringIO()
     srv.serve_stdio(io.StringIO(requests), out)
     lines = [line for line in out.getvalue().splitlines() if line.strip()]
@@ -144,9 +196,7 @@ def test_serve_subprocess_end_to_end(tmp_path) -> None:
         # a fresh action is allowed, then completed
         claim = client.request("intercept_action", run_id="r1", action_type="x.do", key="k1")
         assert claim["proceed"] is True
-        done = client.request(
-            "complete_action", run_id="r1", action_key=claim["action_key"]
-        )
+        done = client.request("complete_action", run_id="r1", action_key=claim["action_key"])
         assert done["status"] == "completed"
     finally:
         client.terminate()


### PR DESCRIPTION
Closes the C1 correctness backlog. Every new or updated test was confirmed to **fail with `src/` reverted to HEAD**, so each one proves its issue rather than merely passing.

Fixes #29, #30, #33, #36, #42, #43, #45. Also documents #34 (see below, not a code fix).

## The ledger's argument-drift fallback (#33, #36)

`_is_strong_token` required a digit, `@`, or `.`, so a plain-word identity (`invoice`, `dataset`) was discarded as filler and purely numeric ids were discarded outright. Separately, `identity_tokens.collect` only handled `str`, so an `int` id like `4821`, **the exact shape in #36's own repro**, never became a token at all. #36 was not closed by simply making numeric tokens strong.

Admitting plain words is only safe with a stricter match rule, and this is the part worth reviewing:

> Under the previous single-shared-token rule, two `ticket.create` calls differing only in title matched on the shared value `urgent`. The second ticket was reported already-done and **silently never created**, a lost side effect and the failure this ledger exists to prevent. Verified against HEAD to confirm the regression was introduced by the widening, not pre-existing.

`_identity_match` now requires one token set to **contain** the other rather than merely intersect it, compared at the leaf via the new `leaf_tokens` so a path counts as its basename.

Containment over *full* token sets is not enough: absolute-vs-relative path drift gives each side a token the other lacks (`/data/invoices/INV-5.pdf` vs `invoices/INV-5.pdf`), which regressed the issue #6 scenario in CONTINUUM-Bench from 0 to **50 duplicate side effects**. Only the benchmark caught that (the unit suite passed), so the case now has its own test.

Note that the two fixes are load-bearing together. With containment but without `int` tokenisation, a second `charge_card` for a different amount would contain the first and be suppressed, reporting success while the payment never happens.

Consequence, documented in `leaf_tokens`: identity is decided at basename level, so two same-type actions on same-named files in different directories are treated as one. That is the assumption the basename token has always encoded. The matcher errs toward opening a new slot whenever it is not confident: failing to deduplicate is recoverable (that is what an explicit `key` is for), while falsely deduplicating destroys work silently.

## The rest

| Issue | Fix |
|---|---|
| #45 | A `claim(on_unknown=)` resolution is recorded as `ACTION_RECONCILED`. It was returned to the caller but never persisted, so the action stayed `UNKNOWN`: the next claim re-raised, `pending()` never drained, and `RecoveryEngine.assess` asked for a human forever. |
| #29 | `reconcile(occurred=False)` clears the now-false `external_id` and `result` left over from the earlier `COMPLETED` state. |
| #42 | An unknown side effect requires a person under `strict_unknown`, so `plan.requires_human` agrees with the engine's `REQUEST_HUMAN` instead of permitting an auto-reconcile. `reason` now reports what happened (interrupted) rather than mislabelling it "escalated for review". |
| #43 | `continuum history` lists checkpoints, not versions, so two checkpoints sharing a state version no longer collapse into one row. JSON key is now `checkpoints`; nothing else referenced `versions`. |
| #30 | `FileProvider` omits a missing file instead of recording `version=None`, so `diff_environments` reads it as `REMOVED` rather than `CHANGED`. |

**#34 is a documentation fix only.** `scoped_to_run=False` still cannot enforce cross-run uniqueness, since the ledger only replays its own run, so the docstring now says that plainly instead of implying a guarantee. A store-wide lookup remains unimplemented.

## Verification

- `803 passed, 4 skipped`
- `ruff check src/continuum tests` clean; `mypy src/continuum` clean
- Nine new/updated tests each verified red against HEAD `src/`

Not included: `src/continuum/serve/server.py` and `tests/test_serve.py` fail `ruff format --check` on `main` already (pre-existing, from 4605c00). Split out to #62 to keep this diff reviewable.