### PR TITLE
chore: apply ruff format to the serve sidecar files

### DIFF
--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -181,7 +181,9 @@ class SidecarServer:
             try:
                 req = json.loads(line)
             except json.JSONDecodeError as exc:
-                _write(outstream, {"id": None, "error": {"type": "bad_request", "message": str(exc)}})
+                _write(
+                    outstream, {"id": None, "error": {"type": "bad_request", "message": str(exc)}}
+                )
                 continue
             rid = req.get("id")
             try:
@@ -191,7 +193,10 @@ class SidecarServer:
             except Exception as exc:  # noqa: BLE001 - report, never crash the loop
                 _write(
                     outstream,
-                    {"id": rid, "error": {"type": "internal", "message": f"{type(exc).__name__}: {exc}"}},
+                    {
+                        "id": rid,
+                        "error": {"type": "internal", "message": f"{type(exc).__name__}: {exc}"},
+                    },
                 )
             else:
                 _write(outstream, {"id": rid, "result": result})

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -41,7 +41,9 @@ def test_list_methods_covers_the_surface() -> None:
 
 def test_record_progress_creates_the_run() -> None:
     srv = make_server()
-    out = srv.dispatch("record_progress", {"run_id": "r1", "completed": 3, "total": 10, "goal": "g"})
+    out = srv.dispatch(
+        "record_progress", {"run_id": "r1", "completed": 3, "total": 10, "goal": "g"}
+    )
     assert out["completed"] == 3
     assert out["total"] == 10
 
@@ -86,13 +88,16 @@ def test_unknown_method_is_not_found() -> None:
 
 def test_stdio_loop_reads_jsonl_and_answers() -> None:
     srv = make_server()
-    requests = "\n".join(
-        [
-            json_line(0, "record_progress", {"run_id": "r1", "completed": 2, "goal": "g"}),
-            json_line(1, "resume", {"run_id": "r1"}),
-            json_line(2, "bogus", {}),
-        ]
-    ) + "\n"
+    requests = (
+        "\n".join(
+            [
+                json_line(0, "record_progress", {"run_id": "r1", "completed": 2, "goal": "g"}),
+                json_line(1, "resume", {"run_id": "r1"}),
+                json_line(2, "bogus", {}),
+            ]
+        )
+        + "\n"
+    )
     out = io.StringIO()
     srv.serve_stdio(io.StringIO(requests), out)
     lines = [line for line in out.getvalue().splitlines() if line.strip()]
@@ -144,9 +149,7 @@ def test_serve_subprocess_end_to_end(tmp_path) -> None:
         # a fresh action is allowed, then completed
         claim = client.request("intercept_action", run_id="r1", action_type="x.do", key="k1")
         assert claim["proceed"] is True
-        done = client.request(
-            "complete_action", run_id="r1", action_key=claim["action_key"]
-        )
+        done = client.request("complete_action", run_id="r1", action_key=claim["action_key"])
         assert done["status"] == "completed"
     finally:
         client.terminate()


### PR DESCRIPTION
`src/continuum/serve/server.py` and `tests/test_serve.py` landed in 4605c00 without `ruff format`, so `ruff format --check` currently fails on `main`. This applies the formatter to both.

No behaviour change. `tests/test_serve.py` still passes (11), and the whole tree is now format-clean (`97 files already formatted`).

Split out of #61 to keep that review focused on the correctness fixes.