### PR TITLE
fix: stop _identity_match from falsely deduplicating distinct actions (#64)

### DIFF
--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -41,6 +41,7 @@ The distinction is documented rather than marketed away.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -63,6 +64,36 @@ __all__ = [
     "LedgerError",
     "DuplicateAction",
 ]
+
+
+def _stem(token: str) -> str:
+    """The basename-stem of a token, used to recognise derived spellings.
+
+    ``INV-001.sent`` and ``INV-001`` are the same resource rendered more or less
+    verbosely, so the matcher treats the former as derived from the latter. A
+    token without an extension returns itself, which keeps plain words and ids
+    self-derived.
+    """
+    stem, _ = os.path.splitext(token)
+    return stem
+
+
+def _superset_derives_from_subset(subset: frozenset[str], superset: frozenset[str]) -> bool:
+    """True when every token present only in ``superset`` is a stem-extended form
+    of a token in ``subset``.
+
+    Containment alone is not enough: a completed action folds its ``external_id``
+    and any optional descriptive argument into its token set, so the stored set
+    is a *superset* of a sparser re-claim even when the two are genuinely
+    different work. The only safe superset is one whose extra tokens are derived
+    from the shared ones (``INV-001.sent`` from ``INV-001``), never unrelated
+    values like a one-off ``message`` or the effect's ``external_id``.
+    """
+    extra = superset - subset
+    if not extra:
+        return True
+    stems = {_stem(token).lower() for token in subset}
+    return all(_stem(token).lower() in stems for token in extra)
 
 
 class LedgerError(RuntimeError):
@@ -158,6 +189,17 @@ class ActionLedger:
         second side effect would be silently swallowed -- the exact failure this
         ledger exists to prevent.
 
+        Containment on its own is still too loose: a completed action folds its
+        outcome ``external_id`` and any optional descriptive argument into its
+        token set, so the stored set is a *superset* of a sparser re-claim even
+        when the two are different work. The superset is therefore only accepted
+        when every token it carries beyond the subset is *derived* from the
+        subset -- a path stem (``INV-001.sent`` from ``INV-001``), not an
+        unrelated value such as a one-off ``message``. The outcome ``external_id``
+        is excluded from the comparison entirely, because it is recorded by
+        ``complete()`` and never present on the incoming claim, so it could only
+        ever manufacture a false superset (issue #64).
+
         Returns ``(key, action)`` for the unique same-type match, or ``None``
         when nothing is distinctive enough to be confident. ``None`` is also
         returned when several actions share a token, because guessing which one
@@ -176,16 +218,27 @@ class ActionLedger:
         for stored_key, action in self._replay().items():
             if action.action_type != action_type:
                 continue
-            known = (
-                leaf_tokens(identity_tokens(action.arguments, external_id=action.external_id))
-                - plumbing
-            )
+            # The ``external_id`` is an *outcome* recorded by ``complete()`` and
+            # is never present on the incoming claim, so folding it into ``known``
+            # would make the stored set a systematic superset of every sparser
+            # re-claim. It is therefore excluded from the comparison (issue #64).
+            known = leaf_tokens(identity_tokens(action.arguments)) - plumbing
             # An empty ``known`` is contained in everything; treat a stored
             # action with no identity of its own as unrecognisable, not as a
             # match for every claim of the same type.
             if not known:
                 continue
-            if not (incoming <= known or known <= incoming):
+            if incoming <= known:
+                # The stored action carries more tokens than the claim. That is
+                # only safe when the extra tokens are derived from the shared
+                # ones (a path stem, an ``external_id`` shape), never unrelated
+                # optional arguments.
+                if not _superset_derives_from_subset(incoming, known):
+                    continue
+            elif known <= incoming:
+                if not _superset_derives_from_subset(known, incoming):
+                    continue
+            else:
                 continue
             if action.status in (ActionStatus.STARTED, ActionStatus.UNKNOWN):
                 uncertain.append((IdempotencyKey(stored_key), action))

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -661,3 +661,32 @@ def test_a_differing_amount_counts_whether_it_is_a_number_or_a_string(
     second = ledger.claim("charge_card", {"recipient": "acct-4471", "amount_usd": "5000"})
 
     assert second.fresh
+
+
+def test_rich_then_sparse_does_not_false_deduplicate(ledger: ActionLedger) -> None:
+    """Regression test for issue #64.
+
+    A completed action with an optional descriptive argument (``message``) is
+    re-claimed without it. The stored token set is a superset of the sparser
+    claim only because of that unrelated optional value, not because the two are
+    the same work, so the second, genuinely different notify must run.
+    """
+    first = ledger.claim("slack.notify", {"channel": "ops", "message": "deploy failed"})
+    ledger.complete(first.key, external_id="msg_1")
+
+    second = ledger.claim("slack.notify", {"channel": "ops"})
+    assert second.fresh, "the second notify is distinct work, not a retry of the first"
+
+
+def test_sparse_then_rich_does_not_false_deduplicate(ledger: ActionLedger) -> None:
+    """Pin the call-order asymmetry from issue #64.
+
+    The reverse order (a sparse claim completed, then a richer re-claim) must
+    also stay distinct, exercising the ``known <= incoming`` branch of the
+    matcher.
+    """
+    first = ledger.claim("slack.notify", {"channel": "ops"})
+    ledger.complete(first.key, external_id="msg_1")
+
+    second = ledger.claim("slack.notify", {"channel": "ops", "message": "deploy failed"})
+    assert second.fresh, "a richer re-claim is still different work"


### PR DESCRIPTION
Closes #64.

The containment rule combined with the widened strong-token set let a completed action's stored token set become a superset of a sparser re-claim. That set folds in the outcome `external_id` (recorded by `complete()`, never present on the incoming claim) and any optional descriptive argument, so a genuinely different call was reported already-done and its side effect was silently dropped.

Fix:
- Exclude the outcome `external_id` from the comparison (it can only ever manufacture a false superset).
- Only accept a superset when every extra token is *derived* from the shared ones (a path stem such as `INV-001.sent` from `INV-001`), never an unrelated optional value. This keeps the issue #6 absolute-vs-relative path scenario deduplicating while refusing the `slack.notify` false-positive.

Verification:
- 819 passed, 4 skipped.
- The two new regression tests (`test_rich_then_sparse_does_not_false_deduplicate`, `test_sparse_then_rich_does_not_false_deduplicate`) were confirmed to fail against the pre-fix code and pass with the fix.
- ruff format and ruff check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action matching to prevent unrelated actions from being incorrectly treated as duplicates.
  * Ensured optional arguments and completed outcome identifiers do not cause false matches.
  * Preserved distinct notifications when their argument details differ, regardless of processing order.

* **Tests**
  * Added regression coverage for rich and sparse notification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->