### PR TITLE
fix(adapter): declare captured environment so drift blocks resume (#25)

### DIFF
--- a/src/continuum/adapters/generic.py
+++ b/src/continuum/adapters/generic.py
@@ -8,13 +8,16 @@ from typing import Any
 from continuum.actions.ledger import ActionLedger, ActionOutcome
 from continuum.adapters.base import AgentAdapter
 from continuum.checkpoint.manager import CheckpointManager
+from continuum.events import EventType
 from continuum.models import (
     EnvironmentSnapshot,
+    Origin,
     Run,
     SemanticState,
     StateCheckpoint,
 )
 from continuum.recovery.engine import RecoveryDecision, RecoveryEngine
+from continuum.state.semantic import ProjectionError, project
 from continuum.storage.base import Storage
 
 #: Key under which a non-dict action result is stored, since the ledger records
@@ -61,12 +64,55 @@ class GenericAgentAdapter(AgentAdapter):
         environment: EnvironmentSnapshot | None = None,
         reason: str = "",
     ) -> StateCheckpoint:
+        # A snapshot alone cannot invalidate a checkpoint: the validator decides
+        # staleness per declared dependency and returns early when a state has
+        # none, so a checkpoint carrying only a snapshot would report
+        # safe_to_resume even after the resource underneath it moved. Declaring
+        # the pinned environment as dependencies is what gives drift something
+        # to invalidate. Mirrors the MCP server and serve sidecar (issue #25).
+        if environment is not None:
+            self._declare_dependencies(run_id, environment)
         return self.manager.checkpoint(
             run_id,
             state=state,
             reason=reason or "adapter state capture",
             environment=environment,
         )
+
+    def _declare_dependencies(self, run_id: str, environment: EnvironmentSnapshot) -> None:
+        """Record a captured environment as declared dependencies of the run.
+
+        Stored as ``DEPENDENCY_DECLARED`` events (not written onto the
+        checkpoint state) so the declaration survives projection and restore, is
+        covered by the hash chain, and carries the same external-agent provenance
+        as the rest of the adapter's writes. Only new or re-pinned resources are
+        appended, so a scheduled checkpoint with an unchanged environment adds
+        nothing.
+        """
+        env_map = {name: str(res.version) for name, res in environment.resources.items()}
+        if not env_map:
+            return
+        # Projecting prior declarations is an optimization (skip re-pinning the
+        # same version). If the run has no goal yet, projection is impossible, so
+        # fall back to declaring everything; project folds duplicates later.
+        try:
+            declared = {
+                dependency.resource: dependency.version
+                for dependency in project(
+                    run_id, self.storage.read_events(run_id)
+                ).external_dependencies
+            }
+        except ProjectionError:
+            declared = {}
+        for name, version in env_map.items():
+            if declared.get(name) == version:
+                continue
+            self.storage.append_event(
+                run_id,
+                EventType.DEPENDENCY_DECLARED,
+                {"resource": name, "version": version},
+                source=Origin.EXTERNAL_AGENT,
+            )
 
     def restore_state(
         self,

--- a/src/continuum/adapters/langgraph.py
+++ b/src/continuum/adapters/langgraph.py
@@ -367,6 +367,35 @@ class LangGraphAgentAdapter(GenericAgentAdapter):
             expected_model=expected_model,
         )
 
+    def revalidate_environment(
+        self,
+        run_id: str,
+        *,
+        current_environment: EnvironmentSnapshot | None = None,
+        expected_model: str | None = None,
+    ) -> RecoveryDecision:
+        """Revalidate a resumed checkpoint against the current environment.
+
+        This is the "keep your LangGraph checkpointer, add the validator" entry
+        point from issue #25. A LangGraph user keeps their own
+        ``SqliteSaver``/``PostgresSaver`` for faithful state replay; this method
+        adds CONTINUUM's staleness propagation on top of it, without replacing
+        the checkpointer. Call it before resuming a graph that was restored from
+        a checkpointer, passing the environment as it is *now*.
+
+        Staleness propagates ``dependency -> evidence -> finding -> decision``
+        and ``UNKNOWN`` degrades toward unsafe, so a resource that moved between
+        the checkpoint and the present surfaces as a non-RESUME decision rather
+        than a silent resume. The verdict is identical to :meth:`assess_graph_recovery`
+        (a read-only :class:`RecoveryDecision`); this name makes the
+        checkpointer-companion use case discoverable.
+        """
+        return self.engine.assess(
+            run_id,
+            current_environment=current_environment,
+            expected_model=expected_model,
+        )
+
 
 def _extract_run_id(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str | None:
     """Try to find a continuum_run_id from function arguments.

--- a/tests/test_adapters_langgraph.py
+++ b/tests/test_adapters_langgraph.py
@@ -19,6 +19,7 @@ from continuum.models import (
     Progress,
     RecoveryMode,
     SemanticState,
+    StateStatus,
 )
 from continuum.storage import SQLiteStorage
 
@@ -288,6 +289,37 @@ class TestWithMockedLangGraph:
         decision = adapter.assess_graph_recovery("run_lg_7", current_environment=env)
         assert not decision.safe
         assert decision.mode is not RecoveryMode.RESUME
+
+    def test_revalidate_environment_detects_drift_on_existing_checkpointer(
+        self, adapter: Any
+    ) -> None:
+        """Issue #25: revalidation must catch a moved resource before resume.
+
+        A LangGraph user keeps their own checkpointer for faithful replay, but
+        CONTINUUM should still ask "is this checkpoint still true against today's
+        world?" before resuming. A checkpoint pinned to one environment must not
+        resume against a drifted one: the verdict must be non-RESUME, not a
+        silent green light.
+        """
+        run_id = "run_lg_drift"
+        adapter.start_run(goal="Drift", run_id=run_id)
+
+        state = SemanticState(run_id=run_id, goal=Goal(description="Drift"))
+        env_v3 = capture(run_id, StaticProvider(dataset="v3"))
+        adapter.capture_state(run_id, state, environment=env_v3)
+
+        clean = adapter.revalidate_environment(run_id, current_environment=env_v3)
+        assert clean.safe
+        assert clean.mode is RecoveryMode.RESUME
+
+        drifted = capture(run_id, StaticProvider(dataset="v4"))
+        bad = adapter.revalidate_environment(run_id, current_environment=drifted)
+        assert not bad.safe
+        assert bad.mode is not RecoveryMode.RESUME
+        assert any(
+            e.component.value == "external_dependency" and e.status is not StateStatus.VALID
+            for e in bad.validation.report.statuses
+        )
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

- capture_state stored the environment snapshot but never declared it as run dependencies, so the recovery validator had nothing to invalidate. A drifted dataset (e.g. dataset v3 -> v4) still reported safe to resume.
- Declare the pinned environment as DEPENDENCY_DECLARED events (mirroring the MCP server and serve sidecar); the validator now conflicts the drifted resource and blocks resume.
- Add LangGraphAdapter.revalidate_environment to expose revalidation and a regression test (test_revalidate_environment_detects_drift_on_existing_checkpointer) that demonstrates drift is now detected.

Fixes #25.

## Verification

- New regression test fails on the old code path (verdict RESUME despite drift) and passes after the fix.
- Full suite: 821 passed, 4 skipped. ruff format --check and ruff check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment dependency tracking during state capture to improve checkpoint validation.
  * Added environment revalidation for LangGraph workflows without replacing existing checkpointing.
  * Recovery decisions now account for changed datasets and other environment differences.

* **Bug Fixes**
  * Prevented workflows from resuming when external dependencies have become invalid or stale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->