### PR TITLE
fix(actions): only treat known file suffixes as stem-derived (#67)

### DIFF
--- a/src/continuum/actions/idempotency.py
+++ b/src/continuum/actions/idempotency.py
@@ -270,9 +270,11 @@ def _is_strong_token(token: str) -> bool:
     meaningful, the explicit weak list, and generic stopwords.
 
     Admitting plain words is only safe because ``_identity_match`` requires the
-    two token sets to *contain* one another rather than merely to intersect. A
-    single shared word (two tickets that are both ``urgent``) is not enough to
-    call two actions the same work.
+    two token sets to *contain* one another rather than merely to intersect (a
+    single shared word like ``urgent`` is not enough to call two actions the
+    same work), and because a containment match is only accepted when the extra
+    tokens are derived from the shared ones via the stem/suffix rule. Containment
+    alone is no longer sufficient after the derivation check was added.
     """
     lowered = token.lower()
     return len(token) >= 3 and lowered not in _WEAK_TOKENS and lowered not in _STOPWORDS

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -78,9 +78,78 @@ def _stem(token: str) -> str:
     return stem
 
 
+# Extensions accepted as genuine file suffixes for the stem-derivation rule
+# (issue #67, option 2). A dotted extra token is only treated as derived from
+# its basename when its extension looks like a real file suffix, so a handle
+# such as ``alice.smith`` is not collapsed into ``alice`` while legitimate
+# renderings like ``INV-001.sent`` or ``report.csv`` still deduplicate.
+_KNOWN_SUFFIXES = frozenset(
+    {
+        "csv",
+        "tsv",
+        "json",
+        "jsonl",
+        "ndjson",
+        "parquet",
+        "pq",
+        "avro",
+        "orc",
+        "xlsx",
+        "xls",
+        "pdf",
+        "txt",
+        "md",
+        "html",
+        "htm",
+        "xml",
+        "yaml",
+        "yml",
+        "toml",
+        "ini",
+        "cfg",
+        "conf",
+        "png",
+        "jpg",
+        "jpeg",
+        "gif",
+        "svg",
+        "webp",
+        "zip",
+        "gz",
+        "tar",
+        "tgz",
+        "bz2",
+        "rar",
+        "7z",
+        "db",
+        "sqlite",
+        "sql",
+        "arrow",
+        "feather",
+        "pkl",
+        "pickle",
+        "bin",
+        "log",
+        "dat",
+        "out",
+        "tmp",
+        "part",
+        "bak",
+        "old",
+        "eml",
+        "msg",
+        "wav",
+        "mp3",
+        "mp4",
+        "mov",
+        "sent",
+    }
+)
+
+
 def _superset_derives_from_subset(subset: frozenset[str], superset: frozenset[str]) -> bool:
     """True when every token present only in ``superset`` is a stem-extended form
-    of a token in ``subset``.
+    of a token in ``subset`` whose extension looks like a genuine file suffix.
 
     Containment alone is not enough: a completed action folds its ``external_id``
     and any optional descriptive argument into its token set, so the stored set
@@ -88,12 +157,24 @@ def _superset_derives_from_subset(subset: frozenset[str], superset: frozenset[st
     different work. The only safe superset is one whose extra tokens are derived
     from the shared ones (``INV-001.sent`` from ``INV-001``), never unrelated
     values like a one-off ``message`` or the effect's ``external_id``.
+
+    The derivation also requires the extension to be a known file suffix
+    (``_KNOWN_SUFFIXES``): ``alice.smith`` shares the stem ``alice`` but its
+    ``.smith`` extension is not a real suffix, so it is treated as distinct work
+    rather than a rendering of ``alice`` (issue #67).
     """
     extra = superset - subset
     if not extra:
         return True
     stems = {_stem(token).lower() for token in subset}
-    return all(_stem(token).lower() in stems for token in extra)
+    for token in extra:
+        stem = _stem(token).lower()
+        if stem not in stems:
+            return False
+        _, ext = os.path.splitext(token)
+        if ext.lstrip(".").lower() not in _KNOWN_SUFFIXES:
+            return False
+    return True
 
 
 class LedgerError(RuntimeError):

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -690,3 +690,30 @@ def test_sparse_then_rich_does_not_false_deduplicate(ledger: ActionLedger) -> No
 
     second = ledger.claim("slack.notify", {"channel": "ops", "message": "deploy failed"})
     assert second.fresh, "a richer re-claim is still different work"
+
+
+def test_stem_shaped_distinct_recipients(ledger: ActionLedger) -> None:
+    """Regression test for issue #67 (option 2).
+
+    A dotted recipient whose extension is not a real file suffix must not be
+    collapsed into its basename. ``alice.smith`` and ``alice`` are different
+    work, so the second send must run and not be swallowed as a repeat.
+    """
+    first = ledger.claim("email.send", {"to": "alice"})
+    ledger.complete(first.key, external_id="e1")
+
+    second = ledger.claim("email.send", {"to": "alice.smith"})
+    assert second.fresh, "alice.smith is not a rendering of alice"
+
+
+def test_file_extension_shape_still_deduplicates(ledger: ActionLedger) -> None:
+    """Option 2 must keep legitimate stem/suffix derivations (issue #67).
+
+    ``report`` and ``report.csv`` describe the same artifact rendered with and
+    without its export suffix, so the re-claim is recognised as already done.
+    """
+    first = ledger.claim("export.report", {"dataset": "report"})
+    ledger.complete(first.key, external_id="r1")
+
+    second = ledger.claim("export.report", {"dataset": "report.csv"})
+    assert not second.fresh, "report.csv is a known-suffix rendering of report"


### PR DESCRIPTION
## Summary

Implements option 2 from issue #67.

- The stem-derivation rule in `_superset_derives_from_subset` accepted any dotted extra token whose basename matched a shared token, so handles like `alice.smith` collapsed into `alice` and a distinct second send was swallowed as a repeat.
- Restrict derivation to extensions in `_KNOWN_SUFFIXES` (csv, parquet, sent, and other real file suffixes) so only genuine renderings like `INV-001.sent` or `report.csv` deduplicate, while `alice.smith` stays distinct.
- Correct the stale `_is_strong_token` docstring, which still described the pre-#65 containment-only safety.
- Two regression tests: `alice.smith` stays fresh; `report.csv` still deduplicates against `report`.

## Verification

- `test_stem_shaped_distinct_recipients` fails on the old behavior (fresh=False) and passes after the fix.
- Full suite: 823 passed, 4 skipped. ruff format --check and ruff check clean.