### PR TITLE
ci(release): migrate release workflow to uv (#27)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,18 +20,15 @@ jobs:
         uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
-          cache: pip
 
-      - name: Install build tools
-        run: pip install hatch
+      - name: Install uv
+        run: python -m pip install uv
 
       - name: Run tests before release
-        run: |
-          pip install -e ".[dev]"
-          pytest --tb=short -q
+        run: uv run --extra dev pytest --tb=short -q
 
       - name: Build wheel and sdist
-        run: hatch build
+        run: uv build
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7.0.1


### PR DESCRIPTION
## Summary

Migrates the PyPI release workflow from pip/hatch to uv (issue #27).

- Install uv with `python -m pip install uv`.
- Run the suite with `uv run --extra dev pytest` (the command CodeRabbit flagged on #63).
- Build with `uv build` (drop-in for `hatch build`; the backend is still hatchling, verified locally: wheel + sdist build cleanly).
- The PyPI trusted publisher step (`pypa/gh-action-pypi-publish@release/v1`) and `id-token: write` permission are unchanged, so OIDC trusted publishing is preserved.

## Verification

- YAML parses (yaml.safe_load) and `uv build` produces `continuum_agent-0.1.0-py3-none-any.whl` + `.tar.gz` locally.
- The release job only runs on tag push, so the pipeline itself is exercised at the next release; the publish mechanism is untouched from the previous workflow.
- Supersedes the contributor's fork PR #63.