### PR TITLE
fix(attest): wire attestation into CI and correct stale docstring (#24)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dev = [
     "langgraph>=0.2",
     "openai-agents>=0.2",
     "langchain>=0.3",
+    # Attestation tests (continuum attest / attest-verify) exercise the optional
+    # Ed25519 signing path, so the crypto dependency is needed in the dev/test
+    # environment even though runtime installs stay dependency-free.
+    "cryptography>=45.0",
 ]
 # The MCP server is optional: the core library and CLI never import it, so
 # installing CONTINUUM does not pull in a server stack you may not want.

--- a/src/continuum/security/attestation.py
+++ b/src/continuum/security/attestation.py
@@ -11,10 +11,11 @@ Ed25519 key that "this run's chain, trusted through sequence ``N`` with root has
 integrity layer, it does not replace it, and it is deliberately optional so the
 core recovery path needs no crypto dependency.
 
-Nothing here is imported by the core library or CLI. ``continuum attest`` will
-wire these primitives to a real run's ``trusted_through`` head (see the design
-doc ``references/attestation.md``); that CLI surface is intentionally not built
-yet so the design can be reviewed first.
+Nothing here is imported by the core recovery path, which must need no crypto
+dependency. The CLI surfaces ``continuum attest`` and ``continuum attest-verify``
+(plus ``attest-keygen``) wire these primitives to a real run's live head and are
+covered by ``tests/test_attestation.py`` and the attest cases in
+``tests/test_cli.py`` (see the design doc ``references/attestation.md``).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Closes #24. The Ed25519 event-chain attestation (the `continuum attest`, `attest-verify`, and `attest-keygen` commands, backed by `continuum.security.attestation`) was already implemented and covered by `tests/test_attestation.py` and the attest cases in `tests/test_cli.py`.

The only gap was CI: `cryptography` lived only in the `attest` optional extra, so the CI command `uv run --extra dev pytest` could not import it and the attest tests never executed in CI. This adds `cryptography` to the `dev` extra so they run; the runtime install (`pip install continuum-agent`) stays dependency-free.

Also corrects the stale docstring in `attestation.py`, which claimed the CLI surface was intentionally not built yet.

## Verification

- `uv run pytest tests/test_attestation.py tests/test_cli.py -k attest` passes (7 tests): keygen, sign/verify round-trip, wrong-chain-hash rejection, tampered-payload rejection, substituted-public-key rejection, CLI round-trip, and altered-after-new-event detection.
- ruff format --check and ruff check clean.
- Full suite still green (823 passed).

This does not change the attested artifact or the signing algorithm (ed25519+sha256); it only makes the existing, tested feature actually execute in CI.