### PR TITLE
feat(mcp): bind caller credentials to identity with per-client tokens (#7)

### DIFF
--- a/src/continuum/mcp/authz.py
+++ b/src/continuum/mcp/authz.py
@@ -15,16 +15,18 @@ time and injected server-side: a caller cannot elevate itself mid-session by
 passing a forged ``clientInfo`` in tool arguments. That is enough to separate
 cooperating agents, and not enough to stop a hostile one on its own.
 
-When ``CONTINUUM_MCP_TOKEN`` is set (or an ``AuthPolicy`` is supplied), the
-server additionally verifies a shared secret the client presents in the
-handshake's ``_meta.authToken``. A caller that cannot prove possession of the
-secret is refused every mutating tool regardless of the name it claims, which
-is what turns "cooperating agents kept apart" into "hostile caller stopped".
-The check is fail-closed: a missing or mismatched secret always refuses, and an
-unset secret leaves authentication disabled so the default local, single-user,
-no-account behavior is unchanged. A hostile process with direct filesystem
-access to the database can still edit it without the server, which is outside
-this layer's scope.
+When ``CONTINUUM_MCP_TOKEN`` is set, the server verifies one shared secret the
+client presents in the handshake's ``_meta.authToken``. Per-client credentials
+are available via ``CONTINUUM_MCP_CLIENT_TOKENS`` (``name:secret`` pairs): each
+caller's secret is bound to the identity it claims, so a token issued to one
+client cannot be replayed by another. A caller that cannot prove possession of
+the expected secret (for its own name, under per-client mode) is refused every
+mutating tool regardless of the name it claims, which is what turns "cooperating
+agents kept apart" into "hostile caller stopped". The check is fail-closed: a
+missing, empty, or mismatched secret always refuses, and an unset secret leaves
+authentication disabled so the default local, single-user, no-account behavior
+is unchanged. A hostile process with direct filesystem access to the database
+can still edit it without the server, which is outside this layer's scope.
 
 Read-only tools stay open
 -------------------------
@@ -61,6 +63,7 @@ __all__ = [
     "load_auth",
     "caller_name",
     "token_from",
+    "CLIENT_TOKENS_ENV_VAR",
 ]
 
 POLICY_ENV_VAR = "CONTINUUM_MCP_ALLOW"
@@ -151,21 +154,53 @@ class AuthPolicy:
 
 AUTH_ENV_VAR = "CONTINUUM_MCP_TOKEN"
 
+#: Per-client credentials: a ``name:secret`` mapping (whitespace or comma
+#: separated) that binds each caller's shared secret to the identity it claims,
+#: so a token issued to one client cannot be replayed by another (issue #7).
+CLIENT_TOKENS_ENV_VAR = "CONTINUUM_MCP_CLIENT_TOKENS"
+
+
+def _parse_client_tokens(value: str | None) -> dict[str, str] | None:
+    """Parse ``CONTINUUM_MCP_CLIENT_TOKENS`` into ``{name: secret}``."""
+    if not value:
+        return None
+    tokens: dict[str, str] = {}
+    for part in value.replace(",", " ").split():
+        name, sep, secret = part.partition(":")
+        if not sep:
+            raise ValueError(f"{CLIENT_TOKENS_ENV_VAR} entries must be 'name:secret', got {part!r}")
+        name, secret = name.strip(), secret.strip()
+        if not name or not secret:
+            raise ValueError(
+                f"{CLIENT_TOKENS_ENV_VAR} entry {part!r} needs a non-empty name and secret"
+            )
+        tokens[name] = secret
+    return tokens or None
+
 
 def load_auth(
     expected: str | None = None,
     *,
+    tokens: Mapping[str, str] | None = None,
     env: Mapping[str, str] | None = None,
 ) -> AuthPolicy:
     """Resolve the authentication policy.
 
-    Explicit argument wins, then the ``CONTINUUM_MCP_TOKEN`` environment
-    variable, then disabled. An empty variable is treated as unset, so a blank
-    configuration is the same as "no authentication".
+    Precedence: explicit ``tokens`` argument, then the
+    ``CONTINUUM_MCP_CLIENT_TOKENS`` environment variable (per-client secrets),
+    then the explicit ``expected`` argument, then the ``CONTINUUM_MCP_TOKEN``
+    environment variable (a single shared secret), then disabled. An empty
+    variable is treated as unset, so a blank configuration is the same as "no
+    authentication".
     """
+    if tokens is not None:
+        return AuthPolicy(None, tokens=tokens, source="argument")
     if expected is not None:
         return AuthPolicy(expected, source="argument")
     environ = os.environ if env is None else env
+    client_tokens = _parse_client_tokens(environ.get(CLIENT_TOKENS_ENV_VAR))
+    if client_tokens:
+        return AuthPolicy(None, tokens=client_tokens, source=CLIENT_TOKENS_ENV_VAR)
     value = environ.get(AUTH_ENV_VAR)
     if value:
         return AuthPolicy(value, source=AUTH_ENV_VAR)

--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -20,6 +20,7 @@ import pytest
 
 from continuum.mcp.authz import (
     AUTH_ENV_VAR,
+    CLIENT_TOKENS_ENV_VAR,
     POLICY_ENV_VAR,
     POLICY_ENV_VAR_ALIAS,
     POLICY_FILENAME,
@@ -401,6 +402,37 @@ def test_load_auth_is_disabled_without_a_secret() -> None:
     assert not load_auth("x", env={}).disabled
 
 
+def test_load_auth_reads_per_client_tokens_env() -> None:
+    auth = load_auth(env={CLIENT_TOKENS_ENV_VAR: "trusted-agent:tok-a,kilo:tok-k"})
+    assert not auth.disabled
+    assert auth.source == CLIENT_TOKENS_ENV_VAR
+    # Each caller's secret is bound to its own name.
+    auth.verify("trusted-agent", "tok-a")
+    auth.verify("kilo", "tok-k")
+    with pytest.raises(NotAuthenticated):
+        auth.verify("trusted-agent", "tok-k")  # another client's token
+    with pytest.raises(NotAuthenticated):
+        auth.verify("stranger", "tok-a")  # unregistered caller
+
+
+def test_load_auth_rejects_malformed_client_tokens() -> None:
+    with pytest.raises(ValueError, match="name:secret"):
+        load_auth(env={CLIENT_TOKENS_ENV_VAR: "no-colon-here"})
+
+
+def test_load_auth_per_client_tokens_win_over_shared_secret_env() -> None:
+    auth = load_auth(
+        env={
+            CLIENT_TOKENS_ENV_VAR: "trusted-agent:tok-a",
+            AUTH_ENV_VAR: "shared",
+        }
+    )
+    assert auth.source == CLIENT_TOKENS_ENV_VAR
+    auth.verify("trusted-agent", "tok-a")
+    with pytest.raises(NotAuthenticated):
+        auth.verify("trusted-agent", "shared")
+
+
 def test_token_from_reads_the_handshake_meta() -> None:
     assert token_from(fake_context(ALLOWED, auth_token="tok")) == "tok"
     assert token_from(fake_context(ALLOWED)) is None
@@ -487,6 +519,86 @@ async def test_read_only_tools_do_not_require_the_secret(
         "continuum_resume", {"run_id": "run_1"}, context=fake_context(STRANGER)
     )
     assert not result.is_error
+
+
+@pytest.mark.asyncio
+async def test_load_auth_wires_per_client_tokens_into_the_server(
+    store: SQLiteStorage,
+) -> None:
+    """The env-driven per-client policy must reach the running server (issue #7)."""
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    srv, _ = build_server(
+        storage=store,
+        policy=AuthorizationPolicy([ALLOWED, "kilo"]),
+        auth=load_auth(env={CLIENT_TOKENS_ENV_VAR: f"{ALLOWED}:tok-a,kilo:tok-k"}),
+    )
+    # The right caller with its own token succeeds.
+    result = await srv.call_tool(
+        "continuum_record_progress",
+        {"run_id": "run_1", "completed": 3, "total": 10, "goal": "g"},
+        context=fake_context(ALLOWED, auth_token="tok-a"),
+    )
+    assert json.loads(result.content[0].text)["completed"] == 3
+    # Replaying another client's token against this name is refused.
+    with pytest.raises(ToolError, match="shared secret|not registered"):
+        await srv.call_tool(
+            "continuum_record_progress",
+            {"run_id": "run_1", "completed": 1, "goal": "g"},
+            context=fake_context(ALLOWED, auth_token="tok-k"),
+        )
+
+
+@pytest.fixture
+def per_client_server(store: SQLiteStorage) -> Any:
+    """A server that issues a distinct secret to each allowed caller (issue #7)."""
+    srv, _ = build_server(
+        storage=store,
+        policy=AuthorizationPolicy([ALLOWED, "kilo"]),
+        auth=AuthPolicy(tokens={ALLOWED: "tok-a", "kilo": "tok-k"}),
+    )
+    return srv
+
+
+@pytest.mark.asyncio
+async def test_per_client_secret_is_bound_to_its_name(per_client_server: Any) -> None:
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    # Correct caller and its own token: allowed.
+    result = await per_client_server.call_tool(
+        "continuum_record_progress",
+        {"run_id": "run_1", "completed": 3, "total": 10, "goal": "g"},
+        context=fake_context(ALLOWED, auth_token="tok-a"),
+    )
+    assert json.loads(result.content[0].text)["completed"] == 3
+    # A different client's token replayed under this name is refused.
+    with pytest.raises(ToolError, match="shared secret|not registered"):
+        await per_client_server.call_tool(
+            "continuum_record_progress",
+            {"run_id": "run_1", "completed": 1, "goal": "g"},
+            context=fake_context(ALLOWED, auth_token="tok-k"),
+        )
+    # The other client succeeds with its own token.
+    result = await per_client_server.call_tool(
+        "continuum_record_progress",
+        {"run_id": "run_1", "completed": 5, "total": 10, "goal": "g"},
+        context=fake_context("kilo", auth_token="tok-k"),
+    )
+    assert json.loads(result.content[0].text)["completed"] == 5
+
+
+@pytest.mark.asyncio
+async def test_an_unregistered_caller_is_refused_even_with_a_token(
+    per_client_server: Any,
+) -> None:
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    with pytest.raises(ToolError, match="shared secret|not registered"):
+        await per_client_server.call_tool(
+            "continuum_record_progress",
+            {"run_id": "run_1", "completed": 1, "goal": "g"},
+            context=fake_context(STRANGER, auth_token="tok-a"),
+        )
 
 
 # --- every tool must be classified ------------------------------------------ #


### PR DESCRIPTION
## Summary

Closes #7. Adds per-client caller authentication to the MCP server so a credential is bound to the identity it asserts, not just proven to exist.

- `CONTINUUM_MCP_CLIENT_TOKENS` (whitespace/comma separated `name:secret` pairs) feeds `AuthPolicy.tokens`; a token issued to one client is refused when replayed by another.
- `load_auth` now sources per-client tokens from the environment, taking precedence over the single shared secret (`CONTINUUM_MCP_TOKEN`). The running server picks this up automatically because `build_server` calls `load_auth()` by default.
- Malformed entries and empty names/secrets raise rather than silently degrading.
- Transport-level (UDS peer credential) identity is noted as a separate, platform-dependent option and is not implemented here.

## Verification

- New tests: env parsing, malformed-entry rejection, per-client precedence over shared secret, env-driven policy reaching the live server, server-level token/name binding, and unregistered-caller refusal. All MCP authz tests pass; full suite 829 passed, 4 skipped.
- ruff format --check and ruff check clean.