### PR TITLE
feat: register continuum-mcp with Claude Code via .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "continuum": {
+      "command": "continuum-mcp",
+      "args": ["--db", "continuum.db"],
+      "env": {
+        "CONTINUUM_MCP_MUTATING_CLIENTS": "claude-code"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a project `.mcp.json` so Claude Code automatically connects to the CONTINUUM MCP server (`continuum-mcp`) and every agent action is durably captured (checkpoints, progress, side-effect interception) without embedding any CONTINUUM code. This realises the "Claude Code should automatically use it and save everything" goal: the server is registered on launch, the `claude-code` client is pre-allowed to mutate runs, and read-only tools stay open.

For shared or exposed deployments, add `CONTINUUM_MCP_TOKEN` (or `CONTINUUM_MCP_CLIENT_TOKENS`) to the server env to turn on authentication (see #7).

## Verification

- `.mcp.json` is valid JSON and references the registered `continuum-mcp` console script.
- The MCP server was smoke-tested over stdio (10 tools served: record_progress, checkpoint, intercept/complete/fail/reconcile action, confirm, validate, resume, list_actions).
- `CONTINUUM_MCP_MUTATING_CLIENTS` is the exact env var `load_policy` reads (`authz.py:76`), so the pre-allowed client name matches.