### PR TITLE
docs: add a separate API reference (#23)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,48 @@
+# CONTINUUM API Reference
+
+This is the programmatic API reference for CONTINUUM. The `docs/` root holds the
+marketing site; this folder documents the library and CLI that you integrate
+with. Everything here is generated from the public surface of the `continuum`
+package.
+
+CONTINUUM gives a long-running agent a durable, tamper-evident recovery layer:
+it checkpoints semantic state, records side effects in an idempotent ledger,
+validates a run against its environment, and decides how (and whether) the agent
+may resume. The integration points, in order of most to least common, are:
+
+- **Adapters** (`continuum.adapters`) wrap your agent loop or framework so
+  checkpointing, interception, and resume happen automatically.
+- **Action ledger** (`continuum.actions.ledger`) records side effects so a
+  restarted agent never repeats an effect it already performed.
+- **Checkpoints** (`continuum.checkpoint`) persist state on a policy.
+- **Recovery engine** (`continuum.recovery`) decides the safe resume mode.
+- **Validator** (`continuum.state.validator`) checks state against the live
+  environment.
+- **MCP server** (`continuum.mcp`) exposes the same operations to any MCP client
+  (for example Claude Code) over stdio, SSE, or HTTP.
+- **Security** (`continuum.security`, `continuum.mcp.authz`) signs chain
+  attestations and authenticates callers.
+- **CLI** (`continuum`) is the command line surface, also usable in scripts.
+
+## Modules
+
+- [Adapters](adapters.md) - GenericAgentAdapter, LangGraph, OpenAI, LangChain
+- [Action ledger](ledger.md) - ActionLedger, ActionOutcome
+- [Checkpoints](checkpoints.md) - CheckpointManager, RestoredRun
+- [Recovery](recovery.md) - RecoveryEngine, RecoveryDecision
+- [Validation](validation.md) - StateValidator, validate_state, ValidationOutcome
+- [MCP server](mcp.md) - continuum-mcp, the ten tools, build_server
+- [Security](security.md) - attestation and caller authentication
+- [CLI](cli.md) - the `continuum` command reference
+
+## Install
+
+```bash
+pip install continuum-agent          # core, no optional dependencies
+pip install continuum-agent[attest]  # adds cryptographic attestation
+pip install continuum-agent[mcp]     # adds the MCP server
+pip install continuum-agent[langgraph]  # adds the LangGraph adapter
+pip install continuum-agent[openai]  # adds the OpenAI Agents SDK adapter
+```
+
+All imports below assume `import continuum` and the relevant submodule.

--- a/docs/api/adapters.md
+++ b/docs/api/adapters.md
@@ -1,0 +1,89 @@
+# Adapters
+
+Adapters wrap an agent loop or framework so that checkpointing, side-effect
+interception, and resume happen through CONTINUUM without you reimplementing
+them. All adapters share the public surface of `GenericAgentAdapter`.
+
+```python
+from continuum.adapters import GenericAgentAdapter
+from continuum.storage import SQLiteStorage
+
+adapter = GenericAgentAdapter(SQLiteStorage("continuum.db"))
+```
+
+## GenericAgentAdapter
+
+`continuum.adapters.GenericAgentAdapter(storage, *, engine=None)`
+
+The concrete adapter for standard Python agent loops. Construct it with a
+`Storage` implementation; it owns a `CheckpointManager` and a `RecoveryEngine`.
+
+### `start_run(goal, *, run_id=None, metadata=None) -> Run`
+
+Create and initialize a new task run. Pass a stable `run_id` to make the run
+resumable across processes.
+
+### `capture_state(run_id, state, *, environment=None, reason="") -> StateCheckpoint`
+
+Create and store a semantic state checkpoint for a run. When `environment` is
+given, the pinned resources are declared as run dependencies so that a later
+environment drift is detected on resume (this is what makes
+`resume()` report unsafe after the world moved).
+
+### `restore_state(run_id, *, replay=True) -> SemanticState`
+
+Restore the latest semantic state for a run, optionally replaying events
+recorded after the checkpoint.
+
+### `intercept_action(run_id, action_type, action_fn, arguments=None, *, volatile=(), scoped_to_run=True, on_unknown=None, key=None) -> Any`
+
+Intercept and safely execute an external side effect. The effect is claimed in
+the ledger first; if it is already known to have happened, the recorded outcome
+is returned instead of running `action_fn` again. `volatile` names arguments
+that must not participate in identity. `key` supplies a stable idempotency key
+directly. `on_unknown` is called when the ledger cannot decide the outcome.
+
+### `resume(run_id, *, current_environment=None, expected_model=None, replay=True) -> RecoveryDecision`
+
+Assess recovery safety and return a `RecoveryDecision` for the run, without
+changing anything. The decision's `mode` is one of `RESUME`, `REPLAY`,
+`REQUEST_HUMAN`, or `ABORT`.
+
+## LangGraphAgentAdapter
+
+`continuum.adapters.LangGraphAgentAdapter(storage, *, engine=None)`
+
+Subclass of `GenericAgentAdapter` for LangGraph `StateGraph` workflows. Adds:
+
+### `revalidate_environment(run_id, *, current_environment=None, expected_model=None) -> RecoveryDecision`
+
+Re-assess recovery against the current environment without forcing a new
+checkpoint. Returns the same `RecoveryDecision` shape as `resume()`; use it to
+confirm that an existing checkpointer's run is still safe to continue after the
+environment changed (issue #25).
+
+## OpenAIAgentAdapter
+
+`continuum.adapters.OpenAIAgentAdapter(storage, *, engine=None)`
+
+Subclass of `GenericAgentAdapter` for the OpenAI Agents SDK. Wraps
+`function_tool` so tool arguments are bound and idempotency is preserved, and
+exposes `ContinuumContext` to tools.
+
+### `ContinuumContext`
+
+Passed to OpenAI tools; carries `run_id`, `storage`, and the adapter so a tool
+can capture state or intercept its own side effects.
+
+## LangChainAgentAdapter
+
+`continuum.adapters.LangChainAgentAdapter(storage, *, engine=None)`
+
+Subclass of `GenericAgentAdapter` wrapping LCEL runnable pipelines and the
+`langchain.agents.create_agent` tool-calling loop.
+
+## Availability flags
+
+`langgraph_available`, `openai_agents_available`, and `langchain_available` are
+booleans reflecting whether the optional dependency is importable. Importing an
+adapter whose dependency is missing raises at construction, not at import.

--- a/docs/api/checkpoints.md
+++ b/docs/api/checkpoints.md
@@ -1,0 +1,59 @@
+# Checkpoints
+
+Checkpoints persist a run's semantic state so a later session can resume from a
+known-good point instead of replaying the whole event log.
+
+```python
+from continuum.checkpoint.manager import CheckpointManager
+
+mgr = CheckpointManager(storage)
+cp = mgr.checkpoint(run_id, state=state, reason="milestone", environment=env)
+restored = mgr.restore(run_id)
+```
+
+## CheckpointManager
+
+`continuum.checkpoint.manager.CheckpointManager(storage, *, policy=None)`
+
+### `checkpoint(run_id, *, state=None, trigger="manual", reason="", environment=None) -> StateCheckpoint`
+
+Create, seal, and persist a checkpoint unconditionally. `environment` pins the
+resources the state depends on; those resources are declared as run dependencies
+so a later drift is reported by the validator.
+
+### `maybe_checkpoint(run_id, *, state=None, explicit=False, context_tokens=None, environment=None, now=None) -> StateCheckpoint | None`
+
+Checkpoint only if the policy agrees. Returns `None` when the policy declines, so
+call it on every step without paying for a checkpoint each time.
+
+### `evaluate(run_id, *, state=None, explicit=False, context_tokens=None, now=None) -> CheckpointDecision`
+
+Ask the policy whether a checkpoint is warranted right now, without writing
+anything.
+
+### `restore(run_id, *, replay=True) -> RestoredRun`
+
+Load the newest checkpoint and catch it up to the log. `replay=True` replays
+events recorded after the checkpoint so the returned state reflects all work.
+
+### `project_current(run_id) -> SemanticState`
+
+Fold the run's full event history into state, ignoring checkpoints.
+
+### `history(run_id) -> Sequence[StateCheckpoint]`
+
+Every checkpoint recorded for the run, in order.
+
+## RestoredRun
+
+`continuum.checkpoint.manager.RestoredRun(run_id, state, checkpoint, pending_events, replayed)`
+
+The value returned by `restore`. `state` is the resumed state, `checkpoint` the
+checkpoint it was based on, and `pending_events` the number of events replayed
+after it.
+
+## Policy
+
+The default `CheckpointPolicy` honors triggers (manual, interval, event,
+semantic, context-pressure, hybrid). Supply a custom `policy` to `CheckpointManager`
+to tune when checkpoints are taken.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,53 @@
+# CLI
+
+The `continuum` command is the command-line surface, also usable in scripts. Exit
+codes are a safety contract: only a verified-safe run exits `0`, so
+`continuum resume "$RUN" && ./start-agent.sh` cannot launch onto stale state.
+
+```bash
+continuum --db continuum.db <command> [args]
+continuum --json <command>      # machine-readable output
+```
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `init` | Initialize storage for a new database. |
+| `runs` | List runs and their status. |
+| `inspect <run_id>` | Show a run's goal, progress, and metadata. |
+| `history <run_id>` | List checkpoints for a run. |
+| `events <run_id>` | Dump the raw event log for a run. |
+| `diff <run_id>` | Show the environment/state diff since the last checkpoint. |
+| `validate <run_id>` | Check state against the current environment. |
+| `resume <run_id>` | Assess and describe how the run may resume. |
+| `confirm <run_id>` | Confirm a human-approved recovery step. |
+| `checkpoint <run_id>` | Force a state checkpoint. |
+| `verify <run_id>` | Re-audit the event chain for tampering. |
+| `actions <run_id>` | List recorded side effects and flag uncertain outcomes. |
+| `show-contract <run_id>` | Print the recovery contract for the run. |
+| `replay <run_id>` | Replay events and verify the stored state version. |
+| `benchmark` | Run the CONTINUUM-Bench harness. |
+| `attest-keygen` | Generate an Ed25519 signer key pair (PEM files). |
+| `attest <run_id>` | Sign a run's event chain into an attestation document. |
+| `attest-verify <run_id> --attest <file>` | Verify a signed attestation against the live chain. |
+| `serve` | Run the Tier 0 newline-delimited JSON sidecar (no MCP dependency). |
+
+## Examples
+
+```bash
+# Is it safe to continue?
+continuum resume run_42
+
+# What changed since the last checkpoint?
+continuum diff run_42
+
+# Prove the chain is untampered, then capture a signed attestation
+continuum verify run_42
+continuum attest run_42 --key signer.pem --out run_42.attest.json
+continuum attest-verify run_42 --attest run_42.attest.json
+```
+
+Most commands accept `--db` (storage path or URL) and `--json`. Colour is
+TTY-aware and respects `NO_COLOR`; piped output is byte-identical to uncoloured
+output.

--- a/docs/api/ledger.md
+++ b/docs/api/ledger.md
@@ -1,0 +1,76 @@
+# Action ledger
+
+The action ledger records side effects so a restarted or resumed agent never
+repeats an effect it already performed. It is the durability layer behind
+`adapter.intercept_action`.
+
+```python
+from continuum.actions.ledger import ActionLedger
+
+ledger = ActionLedger(storage, run_id)
+outcome = ledger.claim("email.send", {"to": "alice"})
+if outcome.fresh:
+    send_email("alice")
+    ledger.complete(outcome.key, result={"sent": True})
+```
+
+## ActionLedger
+
+`continuum.actions.ledger.ActionLedger(storage, run_id)`
+
+### `claim(action_type, arguments=None, *, volatile=(), scoped_to_run=True, key=None, on_unknown=None) -> ActionOutcome`
+
+Register intent to perform an action, or report that it already happened.
+Returns an `ActionOutcome` whose `fresh` flag is `False` when the ledger
+recognizes the action as already completed. `volatile` names arguments excluded
+from identity. `key` is a stable idempotency key (for example
+`invoice:INV-001`). `on_unknown` is invoked when an uncertain action is claimed
+and lets the caller decide inline.
+
+### `complete(key, *, external_id=None, result=None) -> Action`
+
+Record that the effect succeeded. `external_id` is the resource the effect
+produced (an invoice id, a file path); it is excluded from identity matching so a
+richer re-claim is not mistaken for a new action.
+
+### `fail(key, error, *, certain=True) -> Action`
+
+Record that the effect did not happen. `certain=False` records a timeout, which
+is treated as unknown rather than absent.
+
+### `reconcile(key, *, occurred, external_id=None, result=None, note="") -> Action`
+
+Resolve an uncertain action using evidence from the outside world. `occurred`
+says whether the effect in fact happened; the ledger then marks the action
+completed or cleared accordingly and, if `occurred` is false, removes the
+recorded effect.
+
+### `compensate(key, *, note="", by=None) -> Action`
+
+Record that a completed effect was deliberately undone (for example a refund).
+
+### `flag_for_review(key, reason) -> Action`
+
+Escalate an action a human must judge.
+
+### `get(key) -> Action | None`
+
+Return the recorded action for a key, if any.
+
+### `pending() -> Sequence[Action]`
+
+Actions whose real-world outcome is not known (interrupted or timed out). These
+are what recovery refuses to guess about.
+
+### `all() -> Sequence[Action]`
+
+Every recorded action for the run.
+
+## ActionOutcome
+
+`continuum.actions.ledger.ActionOutcome(key, action, fresh)`
+
+The value returned by `claim`. `fresh` is `True` when the effect should still be
+performed; `False` when the ledger already has a recorded outcome and
+`action` carries it. `key` is the idempotency key to pass to `complete`, `fail`,
+or `reconcile`.

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -1,0 +1,50 @@
+# MCP server
+
+CONTINUUM ships an MCP server so any MCP client (for example Claude Code) can use
+its durability layer without embedding Python. The server is `continuum-mcp`,
+built from `continuum.mcp.server.build_server`.
+
+```bash
+# stdio (the transport Claude Code uses)
+continuum-mcp --db continuum.db
+
+# or over the network
+continuum-mcp --transport sse
+continuum-mcp --transport streamable-http
+```
+
+With the project's `.mcp.json` present, Claude Code registers the server
+automatically and every agent action is checkpointed, validated, and recorded as
+it happens.
+
+## Tools
+
+All tools take a `run_id`. Read-only tools stay open to every caller; mutating
+tools are gated by the allowlist (see Security).
+
+| Tool | Kind | Purpose |
+|------|------|---------|
+| `continuum_record_progress` | mutate | Record goal progress (completed/total). |
+| `continuum_checkpoint` | mutate | Force a state checkpoint. |
+| `continuum_intercept_action` | mutate | Claim a side effect; returns whether to proceed. |
+| `continuum_complete_action` | mutate | Record a side effect succeeded. |
+| `continuum_fail_action` | mutate | Record a side effect did not happen. |
+| `continuum_reconcile_action` | mutate | Resolve an uncertain side effect from outside evidence. |
+| `continuum_confirm` | mutate | Confirm a human-approved recovery step. |
+| `continuum_validate` | read | Check state against the current environment. |
+| `continuum_resume` | read | Assess and describe how the run may resume. |
+| `continuum_list_actions` | read | List recorded side effects and their outcomes. |
+
+## build_server
+
+`continuum.mcp.server.build_server(database=None, *, policy=None, auth=None) -> tuple[Server, Storage]`
+
+Construct the MCP server and its storage. `policy` defaults to `load_policy()`
+(allowlist from env or `.continuum/mcp-policy.json`); `auth` defaults to
+`load_auth()` (shared secret or per-client tokens from env). Call `server.run(transport=...)`
+to serve.
+
+## main
+
+`continuum.mcp.server.main(argv=None)` is the `continuum-mcp` console entry
+point. It parses `--db` and `--transport` and runs the server.

--- a/docs/api/recovery.md
+++ b/docs/api/recovery.md
@@ -1,0 +1,53 @@
+# Recovery
+
+The recovery engine decides how, and whether, a run may resume. It combines the
+validator's environment check, the action ledger's uncertain outcomes, and the
+checkpoint state into a single `RecoveryDecision`.
+
+```python
+from continuum.recovery.engine import RecoveryEngine
+
+engine = RecoveryEngine(storage)
+decision = engine.assess(run_id, current_environment=env)
+print(decision.mode)        # RESUME | REPLAY | REQUEST_HUMAN | ABORT
+if decision.permits("resume"):
+    ...
+```
+
+## RecoveryEngine
+
+`continuum.recovery.engine.RecoveryEngine(storage, *, validator=None, strict_unknown=True)`
+
+### `assess(run_id, *, current_environment=None, expected_model=None, replay=True) -> RecoveryDecision`
+
+Decide how `run_id` may resume, without changing anything. `current_environment`
+is the live environment to compare against the checkpoint's declared dependencies;
+`expected_model` pins the model the run was built for. The engine takes the
+maximum on a severity ordering, so the most cautious signal wins regardless of
+evaluation order.
+
+## RecoveryDecision
+
+`continuum.recovery.engine.RecoveryDecision(run_id, mode, contract, plan, validation, restored, uncertain_actions=(), rationale=())`
+
+### `mode`
+
+One of `RESUME` (safe to continue from the checkpoint), `REPLAY` (re-run from a
+recorded plan), `REQUEST_HUMAN` (a human must adjudicate an uncertain side
+effect), or `ABORT` (the run cannot be trusted to continue).
+
+### `permits(action) -> bool`
+
+Whether `action` is the single step the contract currently allows. For
+`REQUEST_HUMAN` this is typically `confirm`; for `RESUME` it is `resume`.
+
+### `render() -> str`
+
+A human-readable explanation of the decision and its rationale, suitable for
+printing or handing to an operator.
+
+### `validation`, `restored`, `uncertain_actions`, `plan`, `contract`, `rationale`
+
+The underlying `ValidationOutcome`, the `RestoredRun`, any actions whose outcome
+is unknown, the repair `RepairPlan`, the `RecoveryContract`, and the textual
+reasons for the decision.

--- a/docs/api/security.md
+++ b/docs/api/security.md
@@ -1,0 +1,83 @@
+# Security
+
+CONTINUUM's core is dependency-free, but two optional security features live
+behind extras: cryptographic attestation of the event chain, and authentication of
+MCP callers.
+
+## Attestation
+
+`continuum.security.attestation` signs a run's event chain so a third party can
+verify it was not altered. Requires `continuum-agent[attest]` (the `cryptography`
+package).
+
+```python
+from continuum.security.attestation import (
+    generate_keypair, sign_chain, verify_attestation, Attestation,
+)
+
+priv_pem, pub_pem = generate_keypair()
+attest = sign_chain(priv_pem, run_id, trusted_through_seq, chain_hash, signer="ci")
+verify_attestation(attest)                              # True
+verify_attestation(attest, expected_chain_hash=chain_hash)  # True
+```
+
+### `generate_keypair() -> tuple[str, str]`
+
+Return `(private_pem, public_pem)` as PEM text for the signer to keep.
+
+### `sign_chain(private_pem, run_id, trusted_through_seq, chain_hash, *, signer=None, timestamp=None) -> Attestation`
+
+Sign a claim that `run_id` is intact through `trusted_through_seq`, whose head
+hash is `chain_hash`. The signature covers every field except `signature`
+itself, using `ed25519+sha256`.
+
+### `verify_attestation(attestation, *, expected_chain_hash=None) -> bool`
+
+Return `True` iff the signature is valid and (optionally) the chain hash matches.
+Callers should also compare `chain_hash` against the run's live head and check
+`public_key` against a known signer.
+
+### `Attestation`
+
+A frozen dataclass with `run_id`, `trusted_through_seq`, `chain_hash`, `signer`,
+`timestamp`, `public_key`, `algorithm`, and `signature`. Serialize with
+`to_dict()`.
+
+The CLI exposes the same flow: `continuum attest-keygen`, `continuum attest
+<run_id>`, and `continuum attest-verify <run_id> --attest <file>`.
+
+## MCP caller authentication
+
+`continuum.mcp.authz` decides who may change a run. It is a security boundary only
+when authentication is on; by default `clientInfo` is a name the client asserts
+and is never verified.
+
+### `load_auth(expected=None, *, tokens=None, env=None) -> AuthPolicy`
+
+Resolve the auth policy. Precedence: explicit `tokens` (per-client secrets), then
+`CONTINUUM_MCP_CLIENT_TOKENS` (env, `name:secret` pairs), then explicit
+`expected` (single shared secret), then `CONTINUUM_MCP_TOKEN` (env), then
+disabled. An empty secret refuses rather than opening the door.
+
+### `AuthPolicy(expected=None, *, tokens=None, source="default")`
+
+Verifies possession of the expected secret. In per-client mode (`tokens` set), a
+caller's secret is bound to the name it claims, so a token issued to one client
+cannot be replayed by another. `verify(caller, token)` raises `NotAuthenticated`
+on any failure. `disabled` is `True` only when no secret is configured.
+
+### `CONTINUUM_MCP_CLIENT_TOKENS`
+
+`"claude-code:tok-a,kilo:tok-k"` form. Each caller presents its secret in the
+handshake's `_meta.authToken`; a replayed or unknown secret is refused.
+
+### `load_policy(allow=None, *, root=None, env=None) -> AuthorizationPolicy`
+
+Resolve the allowlist: explicit argument, then `CONTINUUM_MCP_MUTATING_CLIENTS`
+(or its alias), then `.continuum/mcp-policy.json`, then deny. Only listed callers
+may use mutating tools; read-only tools stay open.
+
+### `AuthorizationPolicy`, `NotAuthorized`, `UnknownCaller`, `NotAuthenticated`
+
+The policy object and the errors raised when a caller is not permitted, did not
+identify itself, or failed authentication.

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -1,0 +1,47 @@
+# Validation
+
+The validator checks a run's projected state against the live environment and
+against the model it was built for. Staleness propagates from a dependency to the
+evidence resting on it, to the finding, to the final decision.
+
+```python
+from continuum.state.validator import StateValidator, validate_state
+
+outcome = validate_state(state, current_environment=env, expected_model="gpt-4o")
+print(outcome.report.status)   # VALID | STALE | CONFLICTED | UNKNOWN
+```
+
+## StateValidator
+
+`continuum.state.validator.StateValidator(*, strict_unknown=True, confirmed=False)`
+
+### `validate(state, *, current_environment=None, checkpoint_environment=None, checkpoint_version=0, expected_model=None, confirmed=False) -> ValidationOutcome`
+
+Validate `state` against the current environment and the model. `strict_unknown`
+makes an unconfirmed, unknown outcome block a safe resume; `confirmed` records
+that a human has vouched for the state.
+
+## validate_state
+
+`continuum.state.validator.validate_state(state, *, current_environment=None, checkpoint_environment=None, expected_model=None) -> ValidationOutcome`
+
+Module-level convenience that builds a default `StateValidator` and validates.
+
+## ValidationOutcome
+
+`continuum.state.validator.ValidationOutcome(state, report, environment_diff)`
+
+### `report`
+
+The `StateValidationResult`: per-component statuses, the overall `status`, and any
+findings. A component whose status is not `VALID` is what makes the run unsafe to
+resume. External dependencies that have drifted report `CONFLICTED`.
+
+### `environment_diff`
+
+The `EnvironmentDiff` between the checkpoint's declared dependencies and the
+current environment: which resources changed, and how.
+
+### `render() -> str`
+
+A human-readable validation report.

--- a/docs/index.html
+++ b/docs/index.html
@@ -176,6 +176,7 @@
       <a href="#mcp" class="nav-link">MCP</a>
       <a href="#mcp-intro" class="nav-link">Safety</a>
       <a href="https://github.com/Cyrax321/CONTINUUM/blob/main/README.md" target="_blank" rel="noopener" class="nav-link">Docs</a>
+      <a href="api/README.md" class="nav-link">API</a>
       <a href="mailto:cyrax8590@gmail.com" class="nav-link nav-contact">Contact</a>
     </div>
 


### PR DESCRIPTION
## Summary

Resolves #23. The docs/ root is a marketing site with no API reference. This adds a separate, version-controllable Markdown API reference under docs/api/:

- README.md (index + module map + install matrix)
- adapters.md (GenericAgentAdapter + LangGraph/OpenAI/LangChain subclasses, ContinuumContext)
- ledger.md (ActionLedger, ActionOutcome)
- checkpoints.md (CheckpointManager, RestoredRun, policy)
- recovery.md (RecoveryEngine, RecoveryDecision)
- validation.md (StateValidator, validate_state, ValidationOutcome)
- mcp.md (continuum-mcp, the ten tools, build_server)
- security.md (attestation + per-client MCP auth)
- cli.md (the 18 continuum commands)

Content is sourced from the actual public signatures (introspected from the
installed package), so it matches the shipped API. The marketing index nav now
links to api/README.md, keeping the reference separate from the marketing copy.