### PR TITLE
feat: auto-detect and resume the active interrupted run (#6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CONTINUUM durable agent
+
+This project ships a CONTINUUM MCP server (`continuum-mcp`, registered in
+`.mcp.json` and enabled in `.claude/settings.local.json`). Use it so your work
+survives being interrupted: a run that is killed mid-task can be resumed by a
+brand-new session with no memory of the old `run_id`.
+
+## On session start, resume first
+
+Before doing anything else, call `continuum_resume` with **no `run_id`**. It
+returns the most recently active (interrupted) run, or `mode: "no_active_run"`
+when there is nothing to resume.
+
+- If a run is returned, immediately tell the user:
+
+  > I found an interrupted run `<run_id>` at `<completed>/<total>` progress
+  > (`<rationale>`). Resume where you left off?
+
+  Then **stop and wait** for the user to say yes. Do not invent new work. If they
+  agree, continue that same `run_id` with the CONTINUUM tools below.
+- If `no_active_run`, start a new run with `continuum_record_progress(run_id,
+  completed=0, total=N, goal=...)` and proceed.
+
+This is what makes a kill-and-reopen recoverable in milliseconds: the new session
+detects the old run on its very first tool call.
+
+## While working, record every step
+
+After each meaningful unit of work:
+
+- `continuum_record_progress(run_id, completed, total, goal=...)` — call often;
+  it is cheap and makes progress durable.
+- `continuum_checkpoint(run_id)` — call at meaningful milestones so a resumed
+  session knows exactly where it stopped.
+
+## External side effects go through the ledger
+
+Before performing anything with effects outside this session (deploy, send,
+write a file the user cares about), route it through
+`continuum_intercept_action` and, once done, `continuum_complete_action` (or
+`continuum_fail_action`). This is what guarantees a side effect is never
+performed twice across a resume.
+
+## When done
+
+Record final progress with `completed == total`. The run then drops out of
+`continuum_resume`'s active set and will not be offered for resume again.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,28 @@
+# Unscripted autonomous agent test (issue #6)
+
+This directory holds a reproducible harness for issue #6: an *unscripted* run of
+an independent LLM agent (Claude Code, the same CLI already wired to this project
+via `.mcp.json`) against the `continuum-mcp` server, with no step-by-step
+instructions. We record the tool-call sequence so we can verify the agent
+autonomously checkpoints, validates, and resumes.
+
+## Run it
+
+```bash
+export ANTHROPIC_API_KEY=sk-...      # required; the agent needs a real LLM
+bash benchmarks/unscripted_resume.sh
+```
+
+The script:
+
+1. Creates a fresh `continuum.db` and an MCP-connected Claude Code session.
+2. Phase 1: hands the agent `task.md` (a goal, not a script) and lets it drive
+   the `continuum_*` MCP tools however it sees fit.
+3. Phase 2: opens a *fresh* session on the same `RUN_ID` and asks it to resume,
+   checking whether it calls `continuum_resume` before acting.
+4. Records both the agent's tool calls (`run1.stream.jsonl`, `run2.stream.jsonl`)
+   and CONTINUUM's own view of what happened (`agent_trail.txt`, captured from
+   the event log, which is the ground-truth record).
+
+The deliverable for #6 is the captured sequence plus the deviations noted in the
+issue, not a passing unit test.

--- a/benchmarks/task.md
+++ b/benchmarks/task.md
@@ -1,0 +1,19 @@
+You are responsible for rolling out 5 microservices (auth, billing, search,
+notify, gateway) in a way that is safe to interrupt and resume.
+
+Use ONLY the CONTINUUM MCP tools available to you. Do not use any other tool.
+Manage the process however you see fit, but design it so that if your process
+were killed mid-rollout, another agent could resume at exactly the right point
+and never redeploy an already-deployed service.
+
+Concrete requirements:
+
+- The run id is RUN_ID. Use it for every tool call.
+- Make the rollout durable and resumable: if you are interrupted and a new
+  session starts, it must be able to tell what is already done.
+- Never record or re-attempt a side effect (a "deploy") that has already
+  happened.
+
+Decide the order and the cadence of checkpoints yourself. There is no prescribed
+sequence; just make it correct and resumable. When you are finished, report a
+short summary of what you deployed and the final state.

--- a/benchmarks/unscripted_resume.sh
+++ b/benchmarks/unscripted_resume.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Unscripted autonomous agent test for issue #6.
+#
+# Runs Claude Code (an independent LLM agent CLI) against the continuum-mcp
+# server with NO step-by-step instructions, only the goal in benchmarks/task.md.
+# Records the tool-call sequence so we can verify autonomous checkpoint / resume
+# behaviour. Requires ANTHROPIC_API_KEY and the `claude` CLI on PATH.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+DB="${CONTINUUM_DB:-continuum.db}"
+RUN_ID="${RUN_ID:-run_6_demo}"
+TASK_FILE="${TASK_FILE:-benchmarks/task.md}"
+MAX_TURNS="${MAX_TURNS:-30}"
+MODEL="${MODEL:-}"
+
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "ERROR: set ANTHROPIC_API_KEY before running this harness." >&2
+  exit 1
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "ERROR: claude CLI not found on PATH." >&2
+  exit 1
+fi
+
+CONTINUUM="${CONTINUUM:-continuum}"
+
+# Only the continuum MCP tools are auto-approved; everything else would prompt
+# and block in -p mode, keeping the run on-task and harmless.
+CLAUDE_ARGS=(--print --mcp-config .mcp.json --allowedTools 'mcp__continuum__*' --max-turns "$MAX_TURNS")
+[ -n "$MODEL" ] && CLAUDE_ARGS+=(--model "$MODEL")
+
+rm -f "$DB"
+"$CONTINUUM" --db "$DB" init >/dev/null
+
+echo "=== Phase 1: autonomous run (RUN_ID=$RUN_ID) ==="
+PROMPT="$(printf 'RUN_ID=%s\n\n%s' "$RUN_ID" "$(cat "$TASK_FILE")")"
+claude "${CLAUDE_ARGS[@]}" --output-format stream-json "$PROMPT" \
+  | tee "benchmarks/run1.stream.jsonl" \
+  | grep -oE '"name":"mcp__continuum__[a-z_]+"' | sort | uniq -c || true
+
+echo
+echo "=== Phase 2: resume in a fresh session ==="
+claude "${CLAUDE_ARGS[@]}" --output-format stream-json \
+  "RUN_ID=$RUN_ID Resume the run above and finish any incomplete steps, then call continuum_validate." \
+  | tee "benchmarks/run2.stream.jsonl" \
+  | grep -oE '"name":"mcp__continuum__[a-z_]+"' | sort | uniq -c || true
+
+echo
+echo "=== CONTINUUM's ground-truth record of what the agent did ==="
+"$CONTINUUM" --db "$DB" events "$RUN_ID" | tee "benchmarks/agent_trail.txt"
+echo
+echo "=== Resume assessment ==="
+"$CONTINUUM" --db "$DB" resume "$RUN_ID" || true

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -20,7 +20,7 @@ continuum --json <command>      # machine-readable output
 | `events <run_id>` | Dump the raw event log for a run. |
 | `diff <run_id>` | Show the environment/state diff since the last checkpoint. |
 | `validate <run_id>` | Check state against the current environment. |
-| `resume <run_id>` | Assess and describe how the run may resume. |
+| `resume [run_id]` | Assess and describe how the run may resume. Omit `run_id` to resume the most recently active run. |
 | `confirm <run_id>` | Confirm a human-approved recovery step. |
 | `checkpoint <run_id>` | Force a state checkpoint. |
 | `verify <run_id>` | Re-audit the event chain for tampering. |

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -32,7 +32,7 @@ tools are gated by the allowlist (see Security).
 | `continuum_reconcile_action` | mutate | Resolve an uncertain side effect from outside evidence. |
 | `continuum_confirm` | mutate | Confirm a human-approved recovery step. |
 | `continuum_validate` | read | Check state against the current environment. |
-| `continuum_resume` | read | Assess and describe how the run may resume. |
+| `continuum_resume` | read | Assess and describe how the run may resume. Omit `run_id` to target the most recently active (interrupted) run. |
 | `continuum_list_actions` | read | List recorded side effects and their outcomes. |
 
 ## build_server

--- a/docs/api/recovery.md
+++ b/docs/api/recovery.md
@@ -26,6 +26,12 @@ is the live environment to compare against the checkpoint's declared dependencie
 maximum on a severity ordering, so the most cautious signal wins regardless of
 evaluation order.
 
+The MCP `continuum_resume` tool and the `continuum resume` CLI accept an
+*optional* `run_id`: when omitted they resolve the **active run** via
+`Storage.get_active_run()`, the most recently touched run not in a terminal state
+(`COMPLETED`/`CRASHED`/`ABORTED`/`FAILED`). That is what lets a fresh session
+resume an interrupted run without having remembered its id.
+
 ## RecoveryDecision
 
 `continuum.recovery.engine.RecoveryDecision(run_id, mode, contract, plan, validation, restored, uncertain_actions=(), rationale=())`

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -371,10 +371,20 @@ def cmd_validate(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
 
 def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Report how a run may resume. Read-only unless ``--repair`` is given."""
+    run_id = args.run_id
+    if not run_id:
+        active = storage.get_active_run()
+        if active is None:
+            print(
+                "No active run to resume. Start one with: continuum checkpoint <run_id>",
+                file=err,
+            )
+            return 2
+        run_id = active.run_id
     engine = RecoveryEngine(storage, strict_unknown=not args.tolerate_unknown)
     decision = engine.assess(
-        args.run_id,
-        current_environment=_environment(args, args.run_id),
+        run_id,
+        current_environment=_environment(args, run_id),
         expected_model=args.model,
     )
 
@@ -407,7 +417,7 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
 
     if args.repair and decision.plan:
         storage.append_event(
-            args.run_id,
+            run_id,
             EventType.RECOVERY_STARTED,
             {
                 "mode": decision.mode.value,
@@ -844,7 +854,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--dashboard", action="store_true", help="render the Phase 14 recovery dashboard"
     )
 
-    resume = with_env(with_run(add("resume", cmd_resume, "Decide how a run may resume.")))
+    resume = with_env(add("resume", cmd_resume, "Decide how a run may resume."))
+    resume.add_argument(
+        "run_id",
+        nargs="?",
+        default=None,
+        help="the run to resume; omit to resume the most recently active run",
+    )
     resume.add_argument("--model", help="model that will run the resumed agent")
     resume.add_argument("--tolerate-unknown", action="store_true")
     resume.add_argument("--repair", action="store_true", help="record the repair plan")

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -515,16 +515,33 @@ def build_server(
             "Ask whether it is safe to continue a run after any interruption, and "
             "what to do first. Call this BEFORE resuming work. Returns a mode: "
             "'resume' means proceed; anything else means stop and perform "
-            "'next_allowed_action' first. Read-only."
+            "'next_allowed_action' first. Read-only. If 'run_id' is omitted, targets "
+            "the most recently active (interrupted) run, so a fresh session can "
+            "resume without remembering the id."
         ),
         annotations=read_only,
     )
     def continuum_resume(
-        run_id: str,
+        run_id: str | None = None,
         env: dict[str, str] | None = None,
         expected_model: str | None = None,
     ) -> str:
         """Compute a recovery decision and contract."""
+        if not run_id:
+            active = ctx.storage.get_active_run()
+            if active is None:
+                return _json(
+                    {
+                        "run_id": None,
+                        "mode": "no_active_run",
+                        "safe": False,
+                        "message": (
+                            "No active run to resume. Start one with "
+                            "continuum_record_progress(run_id, completed, total, goal=...)."
+                        ),
+                    }
+                )
+            run_id = active.run_id
         decision = ctx.adapter.resume(
             run_id,
             current_environment=_environment(run_id, env),

--- a/src/continuum/storage/base.py
+++ b/src/continuum/storage/base.py
@@ -131,6 +131,17 @@ class Storage(ABC):
     @abstractmethod
     def list_runs(self, *, limit: int | None = None) -> Sequence[Run]: ...
 
+    @abstractmethod
+    def get_active_run(self) -> Run | None:
+        """Return the most recently active run that is not in a terminal state.
+
+        A terminal run (completed, crashed, aborted, failed) is finished and must
+        not be offered for resume. The rest are candidates for interruption:
+        the one touched most recently is the one a new session should resume
+        without the caller having to remember its id. Returns ``None`` when no
+        such run exists.
+        """
+
     # -- events ----------------------------------------------------------- #
 
     @abstractmethod

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -32,7 +32,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from continuum.events import Event, EventType, IntegrityReport, IntegrityViolation
-from continuum.models import Origin, Run, SemanticState, StateCheckpoint, utcnow
+from continuum.models import Origin, Run, RunStatus, SemanticState, StateCheckpoint, utcnow
 from continuum.security.hashing import make_id
 from continuum.state.versioning import state_fingerprint
 from continuum.storage.base import (
@@ -267,6 +267,21 @@ class SQLiteStorage(Storage):
         with self._read() as conn:
             rows = conn.execute(query, params).fetchall()
         return [self._row_to_run(row) for row in rows]
+
+    def get_active_run(self) -> Run | None:
+        terminal = (
+            RunStatus.COMPLETED.value,
+            RunStatus.CRASHED.value,
+            RunStatus.ABORTED.value,
+            RunStatus.FAILED.value,
+        )
+        with self._read() as conn:
+            rows = conn.execute(
+                "SELECT * FROM runs WHERE status NOT IN (?, ?, ?, ?) "
+                "ORDER BY updated_at DESC, run_id DESC LIMIT 1",
+                terminal,
+            ).fetchall()
+        return self._row_to_run(rows[0]) if rows else None
 
     @staticmethod
     def _row_to_run(row: sqlite3.Row) -> Run:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -477,6 +477,22 @@ async def test_resume_returns_a_contract_and_next_action(
     assert payload["progress"]["completed"] == 20
 
 
+async def test_resume_without_run_id_targets_the_active_run(server_ctx: tuple[Any, Any]) -> None:
+    """A fresh session need not remember the old run id to resume it."""
+    server, _ = server_ctx
+    # No runs yet -> explicit "no active run" signal.
+    none = await call(server, "continuum_resume")
+    assert none["mode"] == "no_active_run"
+    assert none["run_id"] is None
+    assert "continuum_record_progress" in none["message"]
+
+    # Seed a run; resume with no id should discover and assess it.
+    await seed_run(server, "run_active", completed=30)
+    resumed = await call(server, "continuum_resume")
+    assert resumed["run_id"] == "run_active"
+    assert resumed["progress"]["completed"] == 30
+
+
 @pytest.mark.asyncio
 async def test_deterministic_state_still_resumes_cleanly(
     server_ctx: tuple[Any, Any],

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -91,6 +91,25 @@ def test_run_metadata_survives(storage: SQLiteStorage) -> None:
     assert storage.get_run("run_m").metadata == {"owner": "sam", "retries": 2}
 
 
+def test_get_active_run_returns_none_when_there_are_no_runs(storage: SQLiteStorage) -> None:
+    assert storage.get_active_run() is None
+
+
+def test_get_active_run_excludes_terminal_runs(storage: SQLiteStorage) -> None:
+    storage.create_run(Run(run_id="c", goal="g", status=RunStatus.COMPLETED))
+    storage.create_run(Run(run_id="x", goal="g", status=RunStatus.ABORTED))
+    storage.create_run(Run(run_id="f", goal="g", status=RunStatus.FAILED))
+    assert storage.get_active_run() is None
+
+
+def test_get_active_run_returns_the_most_recent_non_terminal_run(storage: SQLiteStorage) -> None:
+    # A finished run touched more recently must still be excluded.
+    finished = storage.create_run(Run(run_id="done", goal="g", status=RunStatus.COMPLETED))
+    storage.update_run(finished.model_copy(update={"goal": "done again"}))
+    active = storage.create_run(Run(run_id="active", goal="g"))
+    assert storage.get_active_run().run_id == active.run_id
+
+
 # --- events ---------------------------------------------------------------- #
 
 


### PR DESCRIPTION
## Summary

Implements the auto-detect-and-resume glue from issue #6: a fresh agent session
can resume an interrupted run without remembering its id, and Claude Code is
wired to do so automatically on connect.

- `Storage.get_active_run()` returns the most recently touched run that is not
  in a terminal state (COMPLETED/CRASHED/ABORTED/FAILED).
- `continuum_resume` (MCP tool) and `continuum resume` (CLI) now take an
  optional `run_id`; omitted, they target the active run. The tool returns a
  clear `no_active_run` signal when nothing is interruptible.
- New project `CLAUDE.md` instructs Claude Code to, on session start, call
  `continuum_resume` with no id, offer to continue any interrupted run, and
  self-record progress/checkpoints as it works. Combined with the existing
  `.mcp.json` + `.claude/settings.local.json`, this yields the
  kill-terminal / open-new-terminal / resume-in-milliseconds flow.
- Regression tests for `get_active_run` and resume-with-no-run-id.
- `benchmarks/` harness that runs Claude Code unscripted against continuum-mcp
  (needs ANTHROPIC_API_KEY for the live two-terminal demo).

## Verification

`uv run pytest tests/test_storage.py tests/test_mcp_server.py` pass; full suite
green; `ruff format`/`ruff check` clean.

The live two-terminal unscripted demo (give task -> kill -> reopen -> auto-resume)
remains a manual step requiring an LLM key; the infrastructure it depends on is
delivered here.