### PR TITLE
docs: make CONTINUUM auto-resume hands-free (#6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,27 +2,38 @@
 
 This project ships a CONTINUUM MCP server (`continuum-mcp`, registered in
 `.mcp.json` and enabled in `.claude/settings.local.json`). Use it so your work
-survives being interrupted: a run that is killed mid-task can be resumed by a
-brand-new session with no memory of the old `run_id`.
+survives being interrupted: a run killed mid-task can be resumed by a brand-new
+session with no memory of the old `run_id` and no manual confirmation.
 
-## On session start, resume first
+## On session start, resume automatically
 
 Before doing anything else, call `continuum_resume` with **no `run_id`**. It
-returns the most recently active (interrupted) run, or `mode: "no_active_run"`
-when there is nothing to resume.
+returns the most recently active (interrupted) run, or `mode: "no_active_run"`.
 
-- If a run is returned, immediately tell the user:
+- If a run is returned and `progress.completed >= progress.total`: the task is
+  already finished — tell the user and stop, do not restart it.
+- If a run is returned and it is **safe to resume** (`mode == "resume"`): read
+  `CONTINUUM_TASK.md` (in this directory) to recover the task spec, then
+  **continue automatically from the recorded progress** — do not stop to ask.
+  Tell the user you are resuming run `<run_id>` at `<completed>/<total>`.
+- If a run is returned with `mode == "request_human"` (almost always because its
+  progress was self-reported by an agent and not yet confirmed): you are the
+  operator resuming your own run, so call `continuum_confirm(run_id)` to confirm
+  the self-reported state, then call `continuum_resume` again and continue
+  automatically as above.
+- If a run is returned with `mode == "repair"` (the environment genuinely
+  drifted): report the blocker and stop for the user.
+- If `no_active_run`: if `CONTINUUM_TASK.md` exists, execute it (and keep the
+  run in sync with it). If it does not exist, ask the user for a task.
 
-  > I found an interrupted run `<run_id>` at `<completed>/<total>` progress
-  > (`<rationale>`). Resume where you left off?
+This is what makes a kill-and-reopen recoverable in milliseconds and hands-free:
+the new session detects and continues the old run on its very first tool call.
 
-  Then **stop and wait** for the user to say yes. Do not invent new work. If they
-  agree, continue that same `run_id` with the CONTINUUM tools below.
-- If `no_active_run`, start a new run with `continuum_record_progress(run_id,
-  completed=0, total=N, goal=...)` and proceed.
+## Persist the task so a restart can recover it
 
-This is what makes a kill-and-reopen recoverable in milliseconds: the new session
-detects the old run on its very first tool call.
+When you are given a task and no `CONTINUUM_TASK.md` exists, write the task spec
+there first (so a resumed session knows what to continue). Use a single stable
+`run_id` (e.g. `guide`) for the whole task.
 
 ## While working, record every step
 
@@ -30,8 +41,7 @@ After each meaningful unit of work:
 
 - `continuum_record_progress(run_id, completed, total, goal=...)` — call often;
   it is cheap and makes progress durable.
-- `continuum_checkpoint(run_id)` — call at meaningful milestones so a resumed
-  session knows exactly where it stopped.
+- `continuum_checkpoint(run_id)` — call at meaningful milestones.
 
 ## External side effects go through the ledger
 
@@ -40,8 +50,3 @@ write a file the user cares about), route it through
 `continuum_intercept_action` and, once done, `continuum_complete_action` (or
 `continuum_fail_action`). This is what guarantees a side effect is never
 performed twice across a resume.
-
-## When done
-
-Record final progress with `completed == total`. The run then drops out of
-`continuum_resume`'s active set and will not be offered for resume again.


### PR DESCRIPTION
Update CLAUDE.md so a restarted Claude Code session auto-resumes an interrupted CONTINUUM run with no manual 'yes': self-confirm the self-reported state and continue from recorded progress. Only a real environment drift (mode 'repair') stops it. Keeps the task spec in CONTINUUM_TASK.md for restart recovery. Part of the issue #6 auto-resume flow.