### PR TITLE
docs: new task never resumes an unrelated old run (#6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,27 +5,27 @@ This project ships a CONTINUUM MCP server (`continuum-mcp`, registered in
 survives being interrupted: a run killed mid-task can be resumed by a brand-new
 session with no memory of the old `run_id` and no manual confirmation.
 
-## On session start, resume automatically
+## On session start, decide new task vs resume
 
-Before doing anything else, call `continuum_resume` with **no `run_id`**. It
-returns the most recently active (interrupted) run, or `mode: "no_active_run"`.
+Before doing anything else, call `continuum_resume` with **no `run_id`** to learn
+the active run. Then act on the user's intent **this session**:
 
-- If a run is returned and `progress.completed >= progress.total`: the task is
-  already finished — tell the user and stop, do not restart it.
-- If a run is returned and it is **safe to resume** (`mode == "resume"`): read
-  `CONTINUUM_TASK.md` (in this directory) to recover the task spec, then
-  **continue automatically from the recorded progress** — do not stop to ask.
-  Tell the user you are resuming run `<run_id>` at `<completed>/<total>`.
-- If a run is returned with `mode == "request_human"` (almost always because its
-  progress was self-reported by an agent and not yet confirmed): you are the
-  operator resuming your own run, so call `continuum_confirm(run_id)` to confirm
-  the self-reported state, then call `continuum_resume` again and continue
-  automatically as above.
-- If a run is returned with `mode == "repair"` (the environment genuinely
-  drifted): report the blocker and stop for the user.
-- If `no_active_run`: if you were just given a task in this session, persist it
-  (see below) and execute it, checkpointing as you go. Otherwise, if
-  `CONTINUUM_TASK.md` exists, execute it. If neither, ask the user for a task.
+- If the user's first message **describes new work to do** (a task): it
+  supersedes any interrupted run. Overwrite `CONTINUUM_TASK.md` with that task,
+  then **start a fresh run** (record_progress with `completed=0`) and execute it,
+  checkpointing as you go. Do **not** continue the interrupted run.
+- If the user's first message only asks to **resume / continue / recover** (no new
+  task described): continue the active run —
+  - if `progress.completed >= progress.total`: finished — tell the user and stop.
+  - if `mode == "resume"`: read `CONTINUUM_TASK.md` to recover the spec, then
+    **continue automatically from the recorded progress** — do not stop to ask.
+    Tell the user you are resuming run `<run_id>` at `<completed>/<total>`.
+  - if `mode == "request_human"` (almost always self-reported progress not yet
+    confirmed): you are the operator resuming your own run, so call
+    `continuum_confirm(run_id)`, then `continuum_resume` again and continue.
+  - if `mode == "repair"` (the environment genuinely drifted): report the blocker
+    and stop.
+- If `no_active_run` and the user gave a task: start fresh as above.
 
 This is what makes a kill-and-reopen recoverable in milliseconds and hands-free:
 the new session detects and continues the old run on its very first tool call.
@@ -34,9 +34,9 @@ the new session detects and continues the old run on its very first tool call.
 
 Whenever you are given a task, write (or overwrite) `CONTINUUM_TASK.md` in this
 directory with that task spec first, then execute it. This way a restarted
-session that finds an interrupted run can read `CONTINUUM_TASK.md` to recover what
-remains to be done — an explicit task from the user always overrides the file.
-Use a single stable `run_id` (e.g. `guide`) for the whole task.
+session that resumes can read `CONTINUUM_TASK.md` to recover what remains to be
+done — an explicit task from the user always overrides the file. Use a single
+stable `run_id` (e.g. `guide`) for the whole task.
 
 ## While working, record every step
 


### PR DESCRIPTION
CLAUDE.md distinguishes a new-task message (start fresh) from a resume request (continue active run). Fixes the case where a stale interrupted run hijacked a new task.