### PR TITLE
feat: resume returns goal; drop CONTINUUM_TASK.md overhead (#6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,36 @@
 # CONTINUUM durable agent
 
-This project ships a CONTINUUM MCP server (`continuum-mcp`, registered in
-`.mcp.json` and enabled in `.claude/settings.local.json`). Use it so your work
-survives being interrupted: a run killed mid-task can be resumed by a brand-new
-session with no memory of the old `run_id` and no manual confirmation.
+This project ships a CONTINUUM MCP server (`continuum-mcp`, in `.mcp.json`). Use
+it so your work survives interruption: a run killed mid-task can be resumed by a
+new session with no memorized id and no manual confirmation. That is the only
+extra step — keep everything else normal and fast.
 
 ## On session start, detect and ask
 
-Your very first action, before any other work, is to call `continuum_resume`
-with **no `run_id`** to check for an interrupted run.
+Your **first action** is to call `continuum_resume` with **no `run_id`**.
 
-- If a run is returned and `progress.completed >= progress.total`: tell the user
-  the saved task is already complete, and ask whether to start a new one.
-- If a run is returned with `mode == "repair"` (the environment genuinely
-  drifted): report the blocker and ask how to proceed.
-- If a run is returned and it is still in progress: **stop and ask the user**.
-  Surface what you found — `run_id`, the progress (`completed/total`), and a
-  one-line summary of the task (read `CONTINUUM_TASK.md`, or the run's `goal`) —
-  then ask:
+- If an in-progress run is returned: show its `run_id`, progress
+  (`completed/total`) and `goal`, then **ask the user**:
 
-  > I found an unfinished task saved in CONTINUUM — run `<run_id>` at
-  > `<completed>/<total>`: "<task summary>". Resume it, or start a new task?
+  > I found an unfinished task in CONTINUUM — run `<run_id>` at `<c>/<t>`:
+  > "<goal>". Resume it, or start a new task?
 
-  Then **wait** for the answer.
-  - If the user says resume / yes: if `mode == "request_human"` (almost always
-    self-reported progress not yet confirmed), call `continuum_confirm(run_id)`
-    first, then read `CONTINUUM_TASK.md` and **continue automatically from the
-    recorded progress**. Tell the user you are resuming at `<completed>/<total>`.
-  - If the user says new / no: overwrite `CONTINUUM_TASK.md` and **start a fresh
-    run** (record_progress with `completed=0`).
-- If `no_active_run`: proceed with whatever the user asked. If they gave you a
-  task, start a fresh run (overwrite `CONTINUUM_TASK.md` with it first).
+  Then wait.
+  - **resume**: if `mode == "request_human"`, call `continuum_confirm(run_id)`
+    first, then continue from the recorded progress.
+  - **new**: start a fresh run.
+- If `no_active_run`: just do what the user asked.
 
-This is what makes a kill-and-reopen recoverable in milliseconds: the new session
-detects the interrupted run on its first tool call and offers to continue.
+Do **not** read or write any task file — the task is the run's `goal`, which
+`continuum_resume` returns, so a resumed session already knows what to continue.
 
-## Persist the task so a restart can recover it
+## While working, record every step (cheap, no extra files)
 
-Whenever you are given a task, write (or overwrite) `CONTINUUM_TASK.md` in this
-directory with that task spec first, then execute it. This way a restarted
-session that resumes can read `CONTINUUM_TASK.md` to recover what remains to be
-done — an explicit task from the user always overrides the file. Use a single
-stable `run_id` (e.g. `guide`) for the whole task.
+After each meaningful unit of work, call:
 
-## While working, record every step
+- `continuum_record_progress(run_id, completed, total, goal="<the task>")`
+- `continuum_checkpoint(run_id)`
 
-After each meaningful unit of work:
-
-- `continuum_record_progress(run_id, completed, total, goal=...)` — call often;
-  it is cheap and makes progress durable.
-- `continuum_checkpoint(run_id)` — call at meaningful milestones.
-
-## External side effects go through the ledger
-
-Before performing anything with effects outside this session (deploy, send,
-write a file the user cares about), route it through
-`continuum_intercept_action` and, once done, `continuum_complete_action` (or
-`continuum_fail_action`). This is what guarantees a side effect is never
-performed twice across a resume.
+That is all the durable state CONTINUUM needs. Never spawn exploration or write
+side files to "track" the task — the goal string and the progress counter are
+enough for a resumed session to pick up the next unit.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -20,7 +20,7 @@ continuum --json <command>      # machine-readable output
 | `events <run_id>` | Dump the raw event log for a run. |
 | `diff <run_id>` | Show the environment/state diff since the last checkpoint. |
 | `validate <run_id>` | Check state against the current environment. |
-| `resume [run_id]` | Assess and describe how the run may resume. Omit `run_id` to resume the most recently active run. |
+| `resume [run_id]` | Assess and describe how the run may resume. Omit `run_id` to resume the most recently active run. Prints the run's `goal` so you know what to continue. |
 | `confirm <run_id>` | Confirm a human-approved recovery step. |
 | `checkpoint <run_id>` | Force a state checkpoint. |
 | `verify <run_id>` | Re-audit the event chain for tampering. |

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -32,7 +32,7 @@ tools are gated by the allowlist (see Security).
 | `continuum_reconcile_action` | mutate | Resolve an uncertain side effect from outside evidence. |
 | `continuum_confirm` | mutate | Confirm a human-approved recovery step. |
 | `continuum_validate` | read | Check state against the current environment. |
-| `continuum_resume` | read | Assess and describe how the run may resume. Omit `run_id` to target the most recently active (interrupted) run. |
+| `continuum_resume` | read | Assess and describe how the run may resume. Omit `run_id` to target the most recently active (interrupted) run. Returns the run's `goal` so a resumed session knows what to continue. |
 | `continuum_list_actions` | read | List recorded side effects and their outcomes. |
 
 ## build_server

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -390,6 +390,7 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
 
     payload = {
         "run_id": decision.run_id,
+        "goal": storage.get_run(run_id).goal,
         "mode": decision.mode.value,
         "safe": decision.safe,
         "next_allowed_action": decision.next_allowed_action,

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -547,9 +547,14 @@ def build_server(
             current_environment=_environment(run_id, env),
             expected_model=expected_model,
         )
+        # Return the goal so a resumed session knows what to continue without
+        # any external task file. The run's goal is the single source of truth
+        # for "what was this task?" across interruptions.
+        goal = ctx.storage.get_run(run_id).goal
         return _json(
             {
                 "run_id": run_id,
+                "goal": goal,
                 "mode": decision.mode.value,
                 "safe": decision.safe,
                 "next_allowed_action": decision.next_allowed_action,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -491,6 +491,9 @@ async def test_resume_without_run_id_targets_the_active_run(server_ctx: tuple[An
     resumed = await call(server, "continuum_resume")
     assert resumed["run_id"] == "run_active"
     assert resumed["progress"]["completed"] == 30
+    # The goal comes back so a resumed session knows what to continue, with no
+    # external task file.
+    assert resumed["goal"] == "Analyze 100 documents"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
continuum_resume now returns the run goal, removing the need for a CONTINUUM_TASK.md file. CLAUDE.md is slimmed to detect-and-ask + checkpoint, killing the file-write/repo-research/clarifying-question overhead that delayed real work. Regression test for the goal field.