### PR TITLE
fix(benchmark): close SQLiteStorage handles so continuum benchmark runs on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,19 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **`continuum benchmark` crashed on Windows from unclosed database handles
+  (issue #81).** `_run_one` and `run_idempotency_benchmark` constructed
+  `SQLiteStorage` without ever closing it, so the enclosing
+  `TemporaryDirectory()` still held open `.db` files at cleanup. POSIX allows
+  unlinking an open file, so this was an invisible resource leak on Linux and
+  macOS; Windows refuses it, and the whole command died on an unhandled
+  `PermissionError`. Both call sites now use `with SQLiteStorage(...) as store:`,
+  matching every other call site in the codebase. `tests/test_cli.py::_cli` also
+  replaced the subprocess environment with a hardcoded POSIX `PATH`, dropping
+  `SystemRoot` and leaving spawned interpreters unable to initialise Winsock on
+  Windows; it now inherits the parent environment and overrides only
+  `PYTHONPATH`. Together these fixed five tests that failed on Windows.
+
 - **Three defects found by an adversarial audit of the MCP surface**, driven over
   the live stdio protocol with every tool result verified against the SQLite store
   rather than taken at its word. Method and per-claim results in `test.md`:

--- a/src/continuum/benchmark/__init__.py
+++ b/src/continuum/benchmark/__init__.py
@@ -163,131 +163,134 @@ def _run_one(method: str, spec: ScenarioSpec, total: int, workdir: Path) -> Meth
     workdir.mkdir(parents=True, exist_ok=True)
     db = workdir / "agent.db"
     effects = workdir / "effects.log"
-    store = SQLiteStorage(str(db))
-    run_id = "run_bench"
-    env_v3 = capture_environment(run_id, StaticProvider(dataset="v3"))
+    with SQLiteStorage(str(db)) as store:
+        run_id = "run_bench"
+        env_v3 = capture_environment(run_id, StaticProvider(dataset="v3"))
 
-    # --- phase 1: first half of the run, up to the crash ------------------- #
-    crash_at = max(1, int(total * spec.crash_frac))
-    side_at = int(total * spec.side_frac)
-    side_at = crash_at if spec.interrupted else min(side_at, crash_at - 1)
+        # --- phase 1: first half of the run, up to the crash ------------------- #
+        crash_at = max(1, int(total * spec.crash_frac))
+        side_at = int(total * spec.side_frac)
+        side_at = crash_at if spec.interrupted else min(side_at, crash_at - 1)
 
-    store.create_run(Run(run_id=run_id, goal="Process documents"))
-    store.append_event(run_id, EventType.RUN_STARTED, {"goal": "Process documents", "total": total})
-    store.append_event(
-        run_id, EventType.DEPENDENCY_DECLARED, {"resource": "dataset", "version": "v3"}
-    )
-    store.append_event(
-        run_id,
-        EventType.EVIDENCE_ADDED,
-        {"evidence_id": "paper_128", "summary": "study", "source": "dataset"},
-    )
-    store.append_event(
-        run_id,
-        EventType.FINDING_ADDED,
-        {
-            "finding_id": "finding_17",
-            "claim": "X holds",
-            "evidence": ["paper_128"],
-            "confidence": 0.91,
-        },
-    )
-
-    ledger = ActionLedger(store, run_id)
-    manager = (
-        CheckpointManager(store, policy=SemanticPolicy(progress_stride=total))
-        if method == "continuum"
-        else None
-    )
-
-    for i in range(crash_at):
-        store.append_event(run_id, EventType.WORK_COMPLETED, {"doc": i})
-        if manager is not None:
-            manager.maybe_checkpoint(run_id, environment=env_v3)
-        if i == side_at and not spec.interrupted:
-            _attempt_side_effect(ledger, effects, spec)
-    if spec.interrupted:
-        # crash happens right after attempting the side effect
-        _attempt_side_effect(ledger, effects, spec)
-
-    if manager is not None:
-        manager.checkpoint(run_id, environment=env_v3)
-
-    env_after = (
-        capture_environment(run_id, StaticProvider(dataset="v4")) if spec.env_change else env_v3
-    )
-
-    # --- phase 2: recover, then continue to the end ---------------------- #
-    detected = False
-    restored_state = None
-    if method == "replay":
-        done = 0
-    elif method == "naive_checkpoint":
-        done = project(run_id, store.read_events(run_id)).progress.completed
-    else:  # continuum
-        assert manager is not None
-        restored = manager.restore(run_id)
-        restored_state = restored.state
-        done = restored_state.progress.completed
-        validation = validate_state(
-            restored_state, current_environment=env_after, checkpoint_environment=env_v3
+        store.create_run(Run(run_id=run_id, goal="Process documents"))
+        store.append_event(
+            run_id, EventType.RUN_STARTED, {"goal": "Process documents", "total": total}
         )
-        detected = not validation.safe
-        if ledger.pending():
-            reconcile_pending(
-                ledger, ProbeReconciler(lambda action: Resolution(occurred=True, external_id="481"))
+        store.append_event(
+            run_id, EventType.DEPENDENCY_DECLARED, {"resource": "dataset", "version": "v3"}
+        )
+        store.append_event(
+            run_id,
+            EventType.EVIDENCE_ADDED,
+            {"evidence_id": "paper_128", "summary": "study", "source": "dataset"},
+        )
+        store.append_event(
+            run_id,
+            EventType.FINDING_ADDED,
+            {
+                "finding_id": "finding_17",
+                "claim": "X holds",
+                "evidence": ["paper_128"],
+                "confidence": 0.91,
+            },
+        )
+
+        ledger = ActionLedger(store, run_id)
+        manager = (
+            CheckpointManager(store, policy=SemanticPolicy(progress_stride=total))
+            if method == "continuum"
+            else None
+        )
+
+        for i in range(crash_at):
+            store.append_event(run_id, EventType.WORK_COMPLETED, {"doc": i})
+            if manager is not None:
+                manager.maybe_checkpoint(run_id, environment=env_v3)
+            if i == side_at and not spec.interrupted:
+                _attempt_side_effect(ledger, effects, spec)
+        if spec.interrupted:
+            # crash happens right after attempting the side effect
+            _attempt_side_effect(ledger, effects, spec)
+
+        if manager is not None:
+            manager.checkpoint(run_id, environment=env_v3)
+
+        env_after = (
+            capture_environment(run_id, StaticProvider(dataset="v4")) if spec.env_change else env_v3
+        )
+
+        # --- phase 2: recover, then continue to the end ---------------------- #
+        detected = False
+        restored_state = None
+        if method == "replay":
+            done = 0
+        elif method == "naive_checkpoint":
+            done = project(run_id, store.read_events(run_id)).progress.completed
+        else:  # continuum
+            assert manager is not None
+            restored = manager.restore(run_id)
+            restored_state = restored.state
+            done = restored_state.progress.completed
+            validation = validate_state(
+                restored_state, current_environment=env_after, checkpoint_environment=env_v3
             )
+            detected = not validation.safe
+            if ledger.pending():
+                reconcile_pending(
+                    ledger,
+                    ProbeReconciler(lambda action: Resolution(occurred=True, external_id="481")),
+                )
 
-    t0 = time.perf_counter()
-    if method == "replay":
-        for i in range(total):
-            store.append_event(run_id, EventType.WORK_COMPLETED, {"doc": i})
-            if i == side_at:
-                _write_effect(effects)  # naive full replay redoes the side effect
-    else:
-        for i in range(done, total):
-            store.append_event(run_id, EventType.WORK_COMPLETED, {"doc": i})
-    elapsed = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        if method == "replay":
+            for i in range(total):
+                store.append_event(run_id, EventType.WORK_COMPLETED, {"doc": i})
+                if i == side_at:
+                    _write_effect(effects)  # naive full replay redoes the side effect
+        else:
+            for i in range(done, total):
+                store.append_event(run_id, EventType.WORK_COMPLETED, {"doc": i})
+        elapsed = time.perf_counter() - t0
 
-    # --- measure --------------------------------------------------------- #
-    events = store.read_events(run_id)
-    docs = [e.payload["doc"] for e in events if e.type.value == "WORK_COMPLETED"]
-    unique = len(set(docs))
-    attempts = len(docs)
-    duplicate_work = round((attempts - unique) / total, 4) if total else 0.0
-    side_effects = sum(1 for line in Path(effects).read_text().splitlines() if line.strip())
-    duplicate_side = max(0, side_effects - 1)
+        # --- measure --------------------------------------------------------- #
+        events = store.read_events(run_id)
+        docs = [e.payload["doc"] for e in events if e.type.value == "WORK_COMPLETED"]
+        unique = len(set(docs))
+        attempts = len(docs)
+        duplicate_work = round((attempts - unique) / total, 4) if total else 0.0
+        side_effects = sum(1 for line in Path(effects).read_text().splitlines() if line.strip())
+        duplicate_side = max(0, side_effects - 1)
 
-    if method == "continuum":
-        ctx = build_recovery_context(restored_state, token_budget=4000)  # type: ignore[arg-type]
-        context_tokens = estimate_tokens(ctx.render())
-    elif method == "replay":
-        context_tokens = estimate_tokens(_render_log(events))
-    else:
-        context_tokens = estimate_tokens(f"resume from {done}")
+        if method == "continuum":
+            ctx = build_recovery_context(restored_state, token_budget=4000)  # type: ignore[arg-type]
+            context_tokens = estimate_tokens(ctx.render())
+        elif method == "replay":
+            context_tokens = estimate_tokens(_render_log(events))
+        else:
+            context_tokens = estimate_tokens(f"resume from {done}")
 
-    full_log_tokens = estimate_tokens(_render_log(events))
-    if method == "naive_checkpoint":
-        # A bare progress count is not the actual information needed to resume,
-        # so a compression ratio here would overstate the method.
-        compression = None
-    else:
-        compression = round(full_log_tokens / context_tokens, 2) if context_tokens else None
+        full_log_tokens = estimate_tokens(_render_log(events))
+        if method == "naive_checkpoint":
+            # A bare progress count is not the actual information needed to resume,
+            # so a compression ratio here would overstate the method.
+            compression = None
+        else:
+            compression = round(full_log_tokens / context_tokens, 2) if context_tokens else None
 
-    return MethodResult(
-        method=method,
-        scenario=spec.name,
-        documents_total=total,
-        documents_processed_unique=unique,
-        duplicate_work_ratio=duplicate_work,
-        side_effects_created=side_effects,
-        duplicate_side_effects=duplicate_side,
-        detected_stale=detected,
-        context_tokens=context_tokens,
-        full_log_tokens=full_log_tokens,
-        compression_ratio=compression,
-        elapsed_seconds=round(elapsed, 6),
-    )
+        return MethodResult(
+            method=method,
+            scenario=spec.name,
+            documents_total=total,
+            documents_processed_unique=unique,
+            duplicate_work_ratio=duplicate_work,
+            side_effects_created=side_effects,
+            duplicate_side_effects=duplicate_side,
+            detected_stale=detected,
+            context_tokens=context_tokens,
+            full_log_tokens=full_log_tokens,
+            compression_ratio=compression,
+            elapsed_seconds=round(elapsed, 6),
+        )
 
 
 def run_benchmark(total: int = 200) -> list[MethodResult]:
@@ -372,26 +375,26 @@ def run_idempotency_benchmark(total: int = 50) -> list[IdempotencyResult]:
             db = base / f"idem_{method}.db"
             effects = base / f"idem_{method}.log"
             effects.write_text("")
-            store = SQLiteStorage(str(db))
-            run_id = "run_idem"
-            store.create_run(Run(run_id=run_id, goal="Send invoices"))
-            store.append_event(run_id, EventType.RUN_STARTED, {"goal": "Send invoices"})
-            ledger = ActionLedger(store, run_id)
-            attempted = 0
-            for i in range(total):
-                attempted += _try_idem_action(method, ledger, effects, i, abs_path=True)
-                attempted += _try_idem_action(method, ledger, effects, i, abs_path=False)
-            sent = {line for line in effects.read_text().splitlines() if line.strip()}
-            results.append(
-                IdempotencyResult(
-                    method=method,
-                    scenario="argument_drift",
-                    actions_total=total,
-                    attempts=attempted,
-                    distinct_side_effects=len(sent),
-                    duplicate_side_effects=attempted - len(sent),
+            with SQLiteStorage(str(db)) as store:
+                run_id = "run_idem"
+                store.create_run(Run(run_id=run_id, goal="Send invoices"))
+                store.append_event(run_id, EventType.RUN_STARTED, {"goal": "Send invoices"})
+                ledger = ActionLedger(store, run_id)
+                attempted = 0
+                for i in range(total):
+                    attempted += _try_idem_action(method, ledger, effects, i, abs_path=True)
+                    attempted += _try_idem_action(method, ledger, effects, i, abs_path=False)
+                sent = {line for line in effects.read_text().splitlines() if line.strip()}
+                results.append(
+                    IdempotencyResult(
+                        method=method,
+                        scenario="argument_drift",
+                        actions_total=total,
+                        attempts=attempted,
+                        distinct_side_effects=len(sent),
+                        duplicate_side_effects=attempted - len(sent),
+                    )
                 )
-            )
     return results
 
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -8,6 +8,12 @@ naive baselines do not.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from continuum import benchmark
 from continuum.benchmark import (
     METHODS,
     SCENARIOS,
@@ -16,6 +22,7 @@ from continuum.benchmark import (
     run_benchmark,
     run_idempotency_benchmark,
 )
+from continuum.storage import SQLiteStorage
 
 
 def test_recovery_benchmark_covers_every_scenario_and_method() -> None:
@@ -62,3 +69,41 @@ def test_idempotency_benchmark_proves_issue_6() -> None:
         r = results[method]
         assert r.attempts == 2 * total
         assert r.duplicate_side_effects == total
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        pytest.param(lambda: run_benchmark(total=4), id="run_benchmark"),
+        pytest.param(lambda: run_idempotency_benchmark(total=2), id="run_idempotency"),
+    ],
+)
+def test_benchmark_releases_every_storage_handle(
+    run: Callable[[], object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for #81: the benchmark must close every database it opens.
+
+    Both harnesses put their databases inside a ``TemporaryDirectory``. A handle
+    left open makes that cleanup raise ``PermissionError`` on Windows, which
+    took down the whole ``continuum benchmark`` command. This asserts the
+    handles are released rather than asserting on the platform error, so it also
+    fails on POSIX — where unlinking an open file quietly succeeds — if the
+    surrounding ``with`` blocks are ever dropped.
+    """
+    opened: list[_TrackedStorage] = []
+
+    class _TrackedStorage(SQLiteStorage):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            self.closed = False
+            opened.append(self)
+
+        def close(self) -> None:
+            super().close()
+            self.closed = True
+
+    monkeypatch.setattr(benchmark, "SQLiteStorage", _TrackedStorage)
+    run()
+
+    assert opened, "benchmark opened no database, so this test would prove nothing"
+    assert [s for s in opened if not s.closed] == []

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -86,9 +86,9 @@ def test_benchmark_releases_every_storage_handle(
     Both harnesses put their databases inside a ``TemporaryDirectory``. A handle
     left open makes that cleanup raise ``PermissionError`` on Windows, which
     took down the whole ``continuum benchmark`` command. This asserts the
-    handles are released rather than asserting on the platform error, so it also
-    fails on POSIX — where unlinking an open file quietly succeeds — if the
-    surrounding ``with`` blocks are ever dropped.
+    handles are released rather than asserting on the platform error, so it
+    fails on POSIX too if the surrounding ``with`` blocks are ever dropped,
+    even though unlinking an open file quietly succeeds there.
     """
     opened: list[_TrackedStorage] = []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -505,7 +505,7 @@ def test_a_model_switch_can_be_declared(db: str) -> None:
 
 def _cli(db: str, *argv: str) -> subprocess.CompletedProcess[str]:
     # Inherit the parent environment rather than replacing it. Only PYTHONPATH
-    # matters here — it makes the subprocess import continuum from src/ instead
+    # matters here. It makes the subprocess import continuum from src/ instead
     # of an installed copy. Passing a bare env= drops platform essentials: on
     # Windows, losing SystemRoot leaves the interpreter unable to initialise
     # Winsock, and every spawned process dies during startup on `import

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import subprocess
 import sys
 from collections.abc import Iterator
@@ -503,12 +504,16 @@ def test_a_model_switch_can_be_declared(db: str) -> None:
 
 
 def _cli(db: str, *argv: str) -> subprocess.CompletedProcess[str]:
+    # Inherit the parent environment rather than replacing it. Only PYTHONPATH
+    # matters here — it makes the subprocess import continuum from src/ instead
+    # of an installed copy. Passing a bare env= drops platform essentials: on
+    # Windows, losing SystemRoot leaves the interpreter unable to initialise
+    # Winsock, and every spawned process dies during startup on `import
+    # _overlapped` long before the CLI is reached.
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src")}
     return subprocess.run(
         [sys.executable, "-m", "continuum.cli", "--db", db, *argv],
-        env={
-            "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
-            "PATH": "/usr/bin:/bin",
-        },
+        env=env,
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Checklist

- [x] Tests added or updated for the change
- [x] Documentation updated, if the change affects it — `CHANGELOG.md` under `Unreleased` → `Fixed`
- [x] CI is passing
- [x] For security-relevant changes, the PR description states any known limitations explicitly — not security-relevant; limitations noted below

## What does this PR do?

Fixes two independent causes behind `continuum benchmark` crashing and five tests failing on Windows.

**1. Unclosed `SQLiteStorage` handles (`src/continuum/benchmark/__init__.py`)**

`_run_one` and `run_idempotency_benchmark` both did `store = SQLiteStorage(str(db))` and never closed it. Both write their databases inside a `TemporaryDirectory()`, so cleanup ran while the `.db` files were still open:

```
  File "src/continuum/benchmark/__init__.py", line 369, in run_idempotency_benchmark
    with TemporaryDirectory() as tmp:
PermissionError: [WinError 32] The process cannot access the file because it is
being used by another process: '...\Temp\tmpst4qqy1j\idem_replay.db'
```

Both call sites now use `with SQLiteStorage(...) as store:`. `Storage` already implements `__enter__`/`__exit__` (`src/continuum/storage/base.py:109`), and every other call site in the codebase already uses the context manager — these two were the only exceptions.

**2. Replaced subprocess environment (`tests/test_cli.py`)**

The `_cli` helper replaced the entire environment with a hardcoded POSIX `PATH`:

```python
env={"PYTHONPATH": ..., "PATH": "/usr/bin:/bin"}
```

Dropping `SystemRoot` leaves Windows unable to initialise Winsock, so every spawned interpreter died during startup — `OSError: [WinError 10106]` on `import _overlapped` — long before reaching the CLI. The assertions then saw empty stdout and exit code 1 rather than the behaviour under test. It now inherits the parent environment and overrides only `PYTHONPATH`, preserving the original intent (import continuum from `src/`, not an installed copy).

## Why is this change needed?

The leak is a genuine resource-management bug independent of platform — POSIX permits unlinking an open file, so it was invisible on Linux and macOS rather than absent. Windows refuses it, which turned a silent leak into a hard failure of a documented public command.

CI runs `ubuntu-latest` only (`.github/workflows/ci.yml:16`), which is why neither problem surfaced, even though `CONTRIBUTING.md` documents Windows setup (`.venv\Scripts\activate`). The practical cost is that a contributor on Windows cannot get a clean baseline, so their own regressions are indistinguishable from pre-existing failures.

Addresses #81.

## Tests / validation

Windows 11, Python 3.11.15, branched from `15ab5e6`.

| Check | Before | After |
| --- | --- | --- |
| `pytest` | `5 failed, 788 passed, 4 skipped` | **`835 passed, 4 skipped`** |
| `ruff check src/ tests/` | pass | **pass** |
| `ruff format --check src/ tests/` | pass | **pass** |
| `mypy src/continuum` | pass | **pass** |
| `continuum benchmark --total 10` | `PermissionError` traceback | **completes, prints results** |

The five previously-failing tests were `test_benchmark.py::test_idempotency_benchmark_proves_issue_6` and, in `test_cli.py`, `test_benchmark_runs_and_reports_numbers`, `test_the_cli_runs_as_a_module_without_warnings`, `test_the_shell_pipeline_short_circuits_on_unsafe_state`, and `test_report_and_hint_appear_in_the_right_order`.

The two totals are not directly comparable — the `788` baseline was measured before rebasing onto current `main`, which added tests of its own. The meaningful comparison is that the same five named failures are now passing and nothing regressed.

**New regression test:** `test_benchmark_releases_every_storage_handle`, parametrized over both harnesses. It asserts every opened handle was closed rather than asserting on the platform error, so it fails on POSIX too if the `with` blocks are ever dropped. I verified this rather than assuming — against the unfixed source it fails on both parametrizations; against the fixed source both pass.

## Reviewing the diff

Wrapping `_run_one` in `with` re-indents its body, so `src/continuum/benchmark/__init__.py` shows ~136 moved lines. **`git diff -w` collapses this to the two `with` statements plus two `ruff format` line wraps** that the extra indent pushed over the 100-char limit — those two are format-only and semantically identical. No logic changed.

## Limitations and follow-ups

- This fixes the two causes I could reproduce. I cannot verify macOS.
- It does **not** add Windows to the CI matrix, so this can silently regress. That felt like a separate decision about CI cost and is out of scope here — happy to open a follow-up issue, or add `windows-latest` to `ci.yml` in this PR if you'd prefer it bundled.
- `src/continuum/mcp/server.py` also constructs `SQLiteStorage` without a `with` (lines 136, 150, 162), but those hand the storage to a longer-lived caller rather than dropping it on the floor inside a temp directory, so they are not the same bug. I left them alone to keep this scoped.
- Happy to split this into two PRs (source leak vs. test harness) if you'd rather review them separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows benchmark issues by ensuring database resources are properly closed.
  - Improved command-line test environment handling across platforms.
- **Tests**
  - Added regression coverage verifying benchmark database resources are closed.
- **Documentation**
  - Documented the Windows benchmark and test environment fixes in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->