### PR TITLE
fix(mcp): make a failed cold start leak free and diagnosable (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,22 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **A failed MCP cold start leaked a database handle and reported itself as a
+  traceback (issue #87).** `build_server` opened storage on its first line but
+  resolved the authorization policy and auth token after it, and both loaders
+  reject malformed input with `ValueError`. A bad policy file or a
+  `CONTINUUM_MCP_CLIENT_TOKENS` entry without a colon therefore stranded an open
+  `SQLiteStorage` with no owner to close it, the same leak as issue #81 and fatal
+  on Windows for the same reason, and left an empty database behind for a server
+  that never started. Configuration is now resolved before storage is opened, so
+  nothing is acquired until it can be used. `main` also called `build_server`
+  outside any handler, so an ordinary operator mistake surfaced as a
+  `sqlite3.OperationalError` or `ValueError` traceback; over stdio that goes into
+  the protocol pipe, where the client reports only that the server never became
+  ready. It now prints the CLI's `error: ...` form to stderr and exits 1,
+  matching the rationale already documented in `cli/main.py`. Tests in
+  `tests/test_mcp_server.py`.
+
 - **`continuum benchmark` crashed on Windows from unclosed database handles
   (issue #81).** `_run_one` and `run_idempotency_benchmark` constructed
   `SQLiteStorage` without ever closing it, so the enclosing

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -318,9 +318,14 @@ def build_server(
     it is resolved from ``CONTINUUM_MCP_TOKEN`` and is disabled when that is
     unset, leaving the default local, no-account behavior unchanged.
     """
-    ctx = ContinuumMCP(database, storage=storage)
+    # Configuration is resolved before storage is opened, because both loaders
+    # reject malformed input with ValueError (a bad policy file, a token entry
+    # without a colon). Opening first would strand that handle with no owner to
+    # close it, and would also leave an empty database behind for a server that
+    # never started. Nothing here depends on the store, so the order is free.
     policy = load_policy() if policy is None else policy
     auth = load_auth() if auth is None else auth
+    ctx = ContinuumMCP(database, storage=storage)
     server = MCPServer(
         name="continuum",
         title="CONTINUUM",
@@ -869,7 +874,26 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    server, ctx = build_server(args.db)
+    try:
+        server, ctx = build_server(args.db)
+    except ValueError as exc:
+        # A malformed policy file or token list is an operator mistake, so it is
+        # reported the way the CLI reports the same class of failure (see
+        # cli/main.py): a traceback would bury the useful part. It matters more
+        # here than there, because a stdio server writes its traceback into the
+        # protocol pipe, where the client surfaces it only as "not ready" with
+        # no indication of what to fix.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except sqlite3.Error as exc:
+        # resolve_database, not args.db, so the reported path is the one that
+        # was actually opened rather than None when --db was omitted.
+        print(
+            f"error: cannot open storage at {resolve_database(args.db)!r}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
     try:
         server.run(transport=args.transport)
     finally:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -23,12 +23,13 @@ from continuum.actions.ledger import ActionLedger
 from continuum.checkpoint import CheckpointManager
 from continuum.environment import StaticProvider, capture
 from continuum.events import EventType
-from continuum.mcp.authz import AuthorizationPolicy
+from continuum.mcp.authz import CLIENT_TOKENS_ENV_VAR, AuthorizationPolicy
 from continuum.mcp.server import (
     DEFAULT_DB,
     ContinuumMCP,
     _open_server_storage,
     build_server,
+    main,
     resolve_database,
 )
 from continuum.models import ActionStatus, Origin, RecoveryMode, Run
@@ -1212,6 +1213,86 @@ def test_server_open_reraises_a_disk_error_with_no_sidecars(tmp_path: Any) -> No
 
     # One attempt, then re-raise: no retry when there was nothing to clear.
     assert calls["n"] == 1
+
+
+# --- cold start -------------------------------------------------------------- #
+
+
+def test_a_rejected_configuration_leaves_no_open_handle(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for #87: a failed build must not strand the store.
+
+    ``load_policy`` and ``load_auth`` reject malformed input with ValueError, so
+    a build that opens storage before resolving them has no owner left to close
+    the handle. That is the leak of #81 in the cold-start path, invisible on
+    POSIX and fatal on Windows, where the stranded file cannot be removed.
+
+    This asserts two things. No handle is left open, which any correct fix
+    satisfies, including closing it on the way out. And no database file is
+    created, which holds specifically because configuration is resolved before
+    anything is acquired: a server that never started has no business leaving a
+    database behind in the operator's working directory.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(CLIENT_TOKENS_ENV_VAR, "missing-the-colon")
+
+    live: list[Any] = []
+
+    class _TrackedStorage(SQLiteStorage):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            live.append(self)
+
+        def close(self) -> None:
+            super().close()
+            if self in live:
+                live.remove(self)
+
+    monkeypatch.setattr("continuum.mcp.server.SQLiteStorage", _TrackedStorage)
+
+    with pytest.raises(ValueError):
+        build_server("agent.db")
+
+    assert live == [], "the rejected build left a storage handle open"
+    assert not os.path.exists("agent.db"), "a server that never started created a database"
+
+
+def test_main_reports_an_unopenable_database_instead_of_a_traceback(
+    tmp_path: Any, capsys: Any
+) -> None:
+    """Regression for #87: a bad --db must be diagnosable by the operator.
+
+    Over stdio an unhandled exception is written into the protocol pipe, so the
+    client can only report that the server never became ready. The path that
+    failed has to reach stderr instead, as it already does for the CLI.
+    """
+    missing = tmp_path / "no-such-directory" / "agent.db"
+
+    assert main(["--db", str(missing)]) == 1
+
+    err = capsys.readouterr().err
+    assert "cannot open storage" in err
+    assert str(missing) in err
+    assert "Traceback" not in err
+
+
+def test_main_reports_a_malformed_client_token_list(
+    tmp_path: Any, capsys: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half of #87's cold start: configuration the loaders reject.
+
+    The message must name the offending variable, since the operator's only
+    other signal is that the server is not ready.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(CLIENT_TOKENS_ENV_VAR, "missing-the-colon")
+
+    assert main(["--db", "agent.db"]) == 1
+
+    err = capsys.readouterr().err
+    assert CLIENT_TOKENS_ENV_VAR in err
+    assert "Traceback" not in err
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Checklist

- [x] Tests added or updated for the change
- [x] Documentation updated, if the change affects it
- [ ] CI is passing
- [x] For security-relevant changes, the PR description states any known limitations explicitly

CI has not run yet at the time of opening, so that box is left unchecked rather than asserted. Locally, on macOS with Python 3.13.5, the checks CI runs are green: `pytest` 838 passed / 4 skipped, `ruff check src/ tests/ examples/`, `ruff format --check src/ tests/ examples/`, and `mypy src/continuum` all clean. I will confirm once the workflow reports.

## What does this PR do?

Two changes in the MCP cold-start path, plus three regression tests.

**1. `build_server` no longer opens storage before it can be used.** It opened the store on its first line and resolved the authorization policy and auth token afterwards. Both loaders reject malformed input with `ValueError` (`authz.py:171` for a `CONTINUUM_MCP_CLIENT_TOKENS` entry without a colon, `authz.py:305` for an unreadable policy file), so either one left an open `SQLiteStorage` with no owner to close it, and also left an empty database behind for a server that never started. Configuration is now resolved first. Neither loader touches the store, so the order is free.

I chose reordering over closing the handle in an `except` block because it keeps the acquisition next to its owner, prevents the stray database rather than merely releasing the handle, and avoids re-indenting the several hundred lines of tool registration that follow.

**2. `main` reports a failed startup instead of raising through.** It called `build_server` outside any handler, so an ordinary operator mistake surfaced as a `sqlite3.OperationalError` or `ValueError` traceback. It now prints the CLI's `error: ...` form to stderr and returns 1, following the rationale already recorded at `cli/main.py:954-957` ("A traceback would bury the useful part"). The reported path comes from `resolve_database` rather than `args.db`, so it names the file actually opened instead of `None` when `--db` was omitted.

Observed behaviour, before and after, from a scratch directory:

```
# before
$ continuum-mcp --db nested/dir/x.db
  ...
sqlite3.OperationalError: unable to open database file          # traceback, and exit status swallowed

# after
$ continuum-mcp --db nested/dir/x.db
error: cannot open storage at 'nested/dir/x.db': unable to open database file
$ echo $?
1

# after, malformed configuration
$ CONTINUUM_MCP_CLIENT_TOKENS=no-colon continuum-mcp --db ok.db
error: CONTINUUM_MCP_CLIENT_TOKENS entries must be 'name:secret', got 'no-colon'
$ ls            # no stray ok.db from the failed start
```

**Tests** (`tests/test_mcp_server.py`, new `cold start` section): the rejected build leaves no open handle and no database file, and each of the two failure modes produces a clean diagnostic rather than a traceback. Following the precedent set by the #81 regression test, the handle assertion tracks `SQLiteStorage` instances rather than asserting on a platform error, so it is meaningful on Linux and macOS and not only on Windows. All three fail on the unfixed source and pass on the fixed source:

```
$ git stash push src/continuum/mcp/server.py   # keep the tests, revert the fix
$ pytest tests/test_mcp_server.py -k "rejected_configuration or main_reports"
FAILED test_a_rejected_configuration_leaves_no_open_handle
  AssertionError: the rejected build left a storage handle open
FAILED test_main_reports_an_unopenable_database_instead_of_a_traceback
  sqlite3.OperationalError: unable to open database file
FAILED test_main_reports_a_malformed_client_token_list
  ValueError: CONTINUUM_MCP_CLIENT_TOKENS entries must be 'name:secret', got 'missing-the-colon'
3 failed
```

The successful path is unchanged. Verified with a real stdio handshake against the built server: `initialize` returns `serverInfo` `{"name": "continuum", "title": "CONTINUUM"}` and `tools/list` returns all ten tools.

## Why is this change needed?

Addresses #87. The issue asks why `continuum-mcp` sometimes reports not-ready at start and how the server should be hardened so it is reliably connected before the first tool call. This is the hardening half.

The leak is the same defect as #81, in a different call site: a `SQLiteStorage` acquired and never released, invisible on POSIX because unlinking an open file succeeds, and fatal on Windows because it does not. #81 was fatal at temp-directory cleanup; here it strands a handle on the process's own database during startup.

The diagnostics matter more for this entry point than for the CLI. A stdio server's traceback goes into the protocol pipe, so the client has nothing to report except that the server never became ready, which is exactly the symptom in the issue. Whatever the eventual answer to the configuration question, an operator who misconfigures the server should be told what to fix rather than being left with `ready: false`.

**Known limitations, stated explicitly.** This touches the path that loads the authorization policy and the auth token, so it is worth being precise about what does not change:

- No change to any authorization or authentication decision. The same policy and the same `AuthPolicy` are built from the same inputs; only the point at which they are resolved relative to opening the database moves. Fail-closed behaviour for an unconfigured or misconfigured server is untouched, and `tests/test_mcp_authz.py` passes unchanged.
- The reordering removes the leak for every failure the loaders raise, which are the reachable operator mistakes. A failure after the store is open (for example inside `MCPServer` construction) would still strand the handle. I left that alone deliberately: guarding it means wrapping the whole builder, and I have no reproduction for it.
- This does not resolve #87. It does not answer how `.mcp.json` should be configured so the server is reliably connected, so I have used "Addresses" rather than "Fixes" and left the issue open.

One separate observation from reproducing this, noted in the issue rather than acted on here: the server registers itself as `continuum` (`MCPServer(name="continuum")`, matching the `.mcp.json` key and confirmed by the handshake above), while the docs and CLAUDE.md refer to `continuum-mcp`, which is only the console script name. An operator waiting on `continuum-mcp` would get the "no MCP server with this name is configured" message quoted in the issue. That looks like a documentation fix and I am happy to send it separately if you agree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup validation to prevent invalid configurations from creating empty databases or leaving storage resources open.
  - Replaced startup tracebacks with concise error messages shown on standard error.
  - CLI now exits with status 1 when configuration or database initialization fails.
- **Tests**
  - Added coverage for invalid authorization settings, malformed token configuration, and unavailable databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->