### PR TITLE
fix(serve): let a sidecar client resume without a memorized id or task file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,29 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **The `continuum serve` sidecar's `resume` had drifted from the MCP tool it
+  mirrors, so a non-Python client could not resume hands-free (issue #91).** The
+  module docstring promises "the protocol mirrors the MCP tool surface so the two
+  stay in sync", but two capabilities added to `continuum_resume` never reached
+  the sidecar: the run `goal` in the payload (PR #80) and an optional `run_id`
+  that targets the most recently active run (PR #75). A sidecar client therefore
+  learned `mode` and `completed/total` but never what the task *was*, and
+  `_h_resume` raised `bad_params` on the omitted `run_id` that an interrupted
+  session has no way to supply. The sidecar is the boundary intended for clients
+  that cannot embed Python or the `mcp` extra, so it was the one surface still
+  requiring an external task file and a memorized id, the exact overhead those
+  two changes removed for the MCP and CLI paths. `resume` now returns `goal` and
+  accepts an absent `run_id`, reporting `mode: "no_active_run"` (matching
+  `continuum_resume`) rather than a protocol error when there is nothing to
+  resume. Additive: no existing key changed, and the serve-only diagnostics
+  (`checkpoint_version`, `validation_reason`, `environment_changes`) are
+  untouched. Trust behaviour is unchanged, since returning a self-reported goal
+  confirms nothing and a self-certified run still resolves to `request_human`.
+  `tests/test_serve.py` gains four regression tests, including one that diffs the
+  sidecar's `resume` keys against the live `continuum_resume` payload so the next
+  field added on one side and forgotten on the other fails CI instead of being
+  found by hand.
+
 - **MCP server was not found at cold start because its name did not match the
   configured name (issue #87).** `.mcp.json` registered the server under the key
   `continuum`, and `build_server` advertised `MCPServer(name="continuum")`, while

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -260,12 +260,13 @@ def _write(stream: TextIO, payload: dict[str, Any]) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def _decision_payload(decision: Any) -> dict[str, Any]:
+def _decision_payload(decision: Any, *, goal: str) -> dict[str, Any]:
     report = decision.validation.report
     return {
         "checkpoint_version": report.checkpoint_version,
         "validation_reason": report.reason,
         "run_id": decision.state.run_id,
+        "goal": goal,
         "mode": decision.mode.value,
         "safe": decision.safe,
         "next_allowed_action": decision.next_allowed_action,
@@ -374,13 +375,34 @@ def _h_validate(server: SidecarServer, params: dict[str, Any]) -> dict[str, Any]
 
 
 def _h_resume(server: SidecarServer, params: dict[str, Any]) -> dict[str, Any]:
-    run_id = _require(params, "run_id")
+    # run_id is optional, exactly as it is on continuum_resume: a session that
+    # was interrupted and restarted has no id to send, so an omitted one means
+    # "the run that was interrupted". Reported as a mode rather than a protocol
+    # error, so a client branches on mode alone across both transports.
+    run_id = params.get("run_id")
+    if not run_id:
+        active = server.storage.get_active_run()
+        if active is None:
+            return {
+                "run_id": None,
+                "mode": "no_active_run",
+                "safe": False,
+                "message": (
+                    "No active run to resume. Start one with "
+                    "record_progress(run_id, completed, total, goal=...)."
+                ),
+            }
+        run_id = active.run_id
     decision = server.adapter.resume(
         run_id,
         current_environment=_environment(run_id, params.get("env")),
         expected_model=params.get("expected_model"),
     )
-    return _decision_payload(decision)
+    # The goal travels with the decision so a resumed client knows what to
+    # continue without keeping its own task file. Read-only: returning the
+    # self-reported goal confirms nothing, so a self-certified run still comes
+    # back as request_human.
+    return _decision_payload(decision, goal=server.storage.get_run(run_id).goal)
 
 
 def _h_confirm(server: SidecarServer, params: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -69,6 +69,114 @@ def test_checkpoint_and_resume_round_trip() -> None:
     assert decision["progress"]["completed"] == 1
 
 
+# --- resume mirrors the MCP surface (issue #91) ------------------------------
+
+
+def test_resume_returns_the_run_goal() -> None:
+    """A resumed client must learn what the task was, not just how far it got.
+
+    Without this the sidecar is the one boundary that still needs an external
+    task file to answer "what was I doing", which is the overhead the goal was
+    added to continuum_resume to remove.
+    """
+    srv = make_server()
+    srv.dispatch(
+        "record_progress",
+        {"run_id": "r1", "completed": 3, "total": 10, "goal": "migrate the billing module"},
+    )
+    srv.dispatch("checkpoint", {"run_id": "r1"})
+
+    decision = srv.dispatch("resume", {"run_id": "r1"})
+    assert decision["goal"] == "migrate the billing module"
+
+
+def test_resume_without_run_id_targets_the_active_run() -> None:
+    """An interrupted session has no id to send, so omitting it must work.
+
+    This is the whole point of the capability: a fresh process that lost its
+    memory of the run can still ask what to continue.
+    """
+    srv = make_server()
+    srv.dispatch(
+        "record_progress",
+        {"run_id": "r1", "completed": 3, "total": 10, "goal": "migrate the billing module"},
+    )
+    srv.dispatch("checkpoint", {"run_id": "r1"})
+
+    decision = srv.dispatch("resume", {})
+    assert decision["run_id"] == "r1"
+    assert decision["goal"] == "migrate the billing module"
+    assert decision["progress"]["completed"] == 3
+
+
+def test_resume_without_run_id_reports_no_active_run() -> None:
+    """Nothing to resume is a verdict, not a protocol error.
+
+    Reported as a mode so a client can branch on ``mode`` alone and get the
+    same answer from the sidecar as from continuum_resume.
+    """
+    srv = make_server()
+    decision = srv.dispatch("resume", {})
+    assert decision["mode"] == "no_active_run"
+    assert decision["safe"] is False
+    assert decision["run_id"] is None
+
+
+def test_resume_still_requires_review_for_a_self_reported_run() -> None:
+    """Returning the goal must not confirm it.
+
+    The goal is a self-report from a remote caller, so surfacing it is
+    read-only and the run stays behind the human-review gate.
+    """
+    srv = make_server()
+    srv.dispatch("record_progress", {"run_id": "r1", "completed": 1, "total": 10, "goal": "g"})
+    srv.dispatch("checkpoint", {"run_id": "r1"})
+
+    assert srv.dispatch("resume", {"run_id": "r1"})["mode"] == "request_human"
+
+
+async def test_resume_payload_covers_the_mcp_resume_surface() -> None:
+    """Every field continuum_resume returns must also come back from the sidecar.
+
+    Compared against the live MCP payload rather than a hardcoded key list,
+    because a field added there and forgotten here is exactly how ``goal`` went
+    missing. Skipped without the ``mcp`` extra, which ``continuum serve`` is
+    designed not to need.
+    """
+    pytest.importorskip("mcp")
+    from continuum.mcp.authz import AuthorizationPolicy
+    from continuum.mcp.server import build_server
+    from continuum.storage.sqlite import SQLiteStorage
+    from tests.mcp_helpers import fake_context
+
+    caller = "pytest-client"
+    server, ctx = build_server(
+        storage=SQLiteStorage(":memory:"), policy=AuthorizationPolicy([caller])
+    )
+    try:
+
+        async def call(name: str, **arguments: object) -> dict:
+            result = await server.call_tool(name, arguments, context=fake_context(caller))
+            return dict(json.loads(result.content[0].text))
+
+        await call("continuum_record_progress", run_id="r1", completed=3, total=10, goal="g")
+        await call("continuum_checkpoint", run_id="r1")
+        expected = await call("continuum_resume", run_id="r1")
+    finally:
+        ctx.close()
+
+    srv = make_server()
+    srv.dispatch("record_progress", {"run_id": "r1", "completed": 3, "total": 10, "goal": "g"})
+    srv.dispatch("checkpoint", {"run_id": "r1"})
+    actual = srv.dispatch("resume", {"run_id": "r1"})
+
+    missing = sorted(set(expected) - set(actual))
+    assert not missing, f"sidecar resume omits MCP fields: {missing}"
+
+    missing_progress = sorted(set(expected["progress"]) - set(actual["progress"]))
+    assert not missing_progress, f"sidecar progress omits MCP fields: {missing_progress}"
+
+
 def test_checkpointing_with_env_makes_drift_block_resume() -> None:
     """The sidecar must not disagree with the MCP surface about drift.
 
@@ -152,6 +260,37 @@ def test_stdio_loop_reads_jsonl_and_answers() -> None:
     assert json.loads(lines[0])["result"]["completed"] == 2
     assert json.loads(lines[1])["result"]["mode"]
     assert json.loads(lines[2])["error"]["type"] == "method_not_found"
+
+
+def test_stdio_resume_needs_no_params_at_all() -> None:
+    """The wire shape a restarted foreign client actually sends (issue #91).
+
+    Such a client knows the method and nothing else, so ``params`` may be absent
+    entirely rather than merely lacking ``run_id``. It must still come back with
+    the active run and its goal instead of a ``bad_params`` error.
+    """
+    srv = make_server()
+    requests = (
+        "\n".join(
+            [
+                json_line(
+                    0,
+                    "record_progress",
+                    {"run_id": "r1", "completed": 3, "total": 10, "goal": "migrate billing"},
+                ),
+                json_line(1, "checkpoint", {"run_id": "r1"}),
+                '{"id": 2, "method": "resume"}',
+            ]
+        )
+        + "\n"
+    )
+    out = io.StringIO()
+    srv.serve_stdio(io.StringIO(requests), out)
+
+    last = json.loads([line for line in out.getvalue().splitlines() if line.strip()][-1])
+    assert "error" not in last, last
+    assert last["result"]["run_id"] == "r1"
+    assert last["result"]["goal"] == "migrate billing"
 
 
 # --- authentication (fail-closed) ------------------------------------------


### PR DESCRIPTION
## Checklist

- [x] Tests added or updated for the change
- [x] Documentation updated, if the change affects it
- [x] CI is passing (Lint & Type-check, and Test on Python 3.11 / 3.12 / 3.13, all green. The Vercel check reports `Authorization required to deploy`, which is a deploy-preview permission on your side rather than anything in this diff.)
- [x] For security-relevant changes, the PR description states any known limitations explicitly

## What does this PR do?

Brings the `continuum serve` sidecar's `resume` back in line with the
`continuum_resume` MCP tool it is documented to mirror. Two changes in
`src/continuum/serve/server.py`:

1. The payload now includes the run `goal`.
2. `run_id` is optional. Omitted, it targets the most recently active run;
   when there is none, it returns `mode: "no_active_run"` (the same shape
   `continuum_resume` returns) instead of a `bad_params` error.

Before and after, same run, through the sidecar:

```
# before
keys: [..., 'mode', 'next_allowed_action', 'progress', ...]   # no 'goal'
resume without run_id -> BadParams: missing parameter 'run_id'

# after
goal -> 'migrate the billing module to the new API'
resume without run_id -> run_id: guide | goal: 'migrate the billing module to the new API'
```

Additive by construction: no existing key changed value or type, so a current
client keeps working untouched. The serve-only diagnostics
(`checkpoint_version`, `validation_reason`, `environment_changes`) are
deliberately left alone; parity in the direction that matters is "the sidecar
exposes everything the MCP tool does".

Five regression tests in `tests/test_serve.py`, each verified failing on the
unfixed source first:

| test | what it pins |
| --- | --- |
| `test_resume_returns_the_run_goal` | `goal` is in the payload |
| `test_resume_without_run_id_targets_the_active_run` | omitted id resolves the active run |
| `test_resume_without_run_id_reports_no_active_run` | empty database reports the mode, not an error |
| `test_resume_still_requires_review_for_a_self_reported_run` | trust gate unchanged |
| `test_stdio_resume_needs_no_params_at_all` | the wire shape a restarted client sends |

The fourth is the parity guard: rather than asserting a hardcoded key list, it
diffs the sidecar's `resume` keys against the *live* `continuum_resume` payload
and asserts the MCP surface is a subset. A field added on one side and
forgotten on the other now fails CI instead of being found by hand, which is
how `goal` went missing. It skips when the `mcp` extra is absent, since
`continuum serve` is designed not to need it.

Docs: `CHANGELOG.md` under `[Unreleased] / Fixed`. No other doc changes, because
there is no per-method sidecar reference page; the module docstring is the spec
and already promises the parity this restores, so it needed no edit.

## Why is this change needed?

Fixes #91.

The sidecar's module docstring states the invariant plainly:

> The protocol mirrors the MCP tool surface so the two stay in sync.

and `tests/test_serve.py` is written around the same property ("the same
operations the MCP server exposes are reachable ... from any process"). Two
capabilities added on the MCP side never reached it: the run `goal` (#80) and
the optional `run_id` (#75). Both landed on `continuum_resume` and on the CLI,
and neither on the sidecar. I diffed the payload keys of every paired method to
check the blast radius, and `resume` is the only one that had drifted, with
`goal` the only missing field:

```
record_progress  in MCP only: []
checkpoint       in MCP only: []
resume           in MCP only: ['goal']      <-- the gap
validate         in MCP only: []
list_actions     in MCP only: []
```

What makes this worth fixing rather than a cosmetic inconsistency is *which*
client it hurt. The sidecar is the boundary for processes that cannot embed
Python or the `mcp` extra, and those two capabilities are precisely what makes
a resume hands-free. `CLAUDE.md` now states the intended contract as a rule:

> Do not read or write any task file, the task is the run's `goal`, which
> `continuum_resume` returns, so a resumed session already knows what to
> continue.

A non-Python agent could not honour that. It had to remember the `run_id`
across the very interruption it was recovering from, and keep its own task file
to recall the goal, which is the exact overhead #75 and #80 removed everywhere
else. So the one surface built for foreign-language clients was the one surface
that still could not do the thing those clients most need.

## Known limitations

Flagging these explicitly since `resume` sits next to the trust boundary:

- **Trust behaviour is unchanged.** Returning the goal is read-only and
  confirms nothing, so a self-certified (agent-reported) run still resolves to
  `request_human` and still needs `confirm`. `test_resume_still_requires_review_for_a_self_reported_run`
  pins that. This PR deliberately does not touch the auto-confirm question in
  #84 and takes no position on it.
- **`goal` is a self-report** from a remote caller, recorded with
  `Origin.EXTERNAL_AGENT` like every other sidecar write. Surfacing it in the
  resume payload does not make it verified, and a client should not treat it as
  such. This matches what `continuum_resume` already does.
- **The no-active-run branch returns a short payload** (`run_id`, `mode`,
  `safe`, `message`) with no `progress` or `contract`, mirroring
  `continuum_resume`. A client must branch on `mode` before indexing the rest.
  The alternative would have been a protocol-level error, which the sidecar can
  express and the MCP tool cannot; I chose parity so one client path works
  across both transports, and raised it as an open question on #91 in case you
  would rather have the error.
- **Auth is untouched.** `resume` is not in `MUTATING`, and `dispatch` already
  verifies the shared secret for every method regardless, so the optional
  `run_id` does not widen what an unauthenticated caller can reach.

## Verification

```
843 passed, 4 skipped
ruff check src/ tests/          All checks passed!
ruff format --check src/ tests/ 97 files already formatted
mypy src/continuum              Success: no issues found in 55 source files
```

One unrelated failure on my machine,
`tests/test_mcp_server.py::test_main_reports_an_unopenable_database_instead_of_a_traceback`,
is pre-existing and Windows-only: the assertion compares a `WindowsPath` string
against a message whose backslashes have been escaped, so it cannot match. It
fails identically with my changes stashed, so it is out of scope here. Happy to
open a separate issue for it if it is not already known.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Resume responses now include the active run’s goal.
  - Resume can be called without specifying a run ID; it automatically targets the active run.
  - When no active run exists, the response clearly reports `no_active_run` instead of returning an error.

- **Bug Fixes**
  - Improved consistency between sidecar and MCP resume responses.
  - Preserved review requirements for runs that still need human confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
