### PR TITLE
docs(changelog): correct the serve resume test count to six

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,7 @@ All notable changes to this project are documented here. The format follows
   (`checkpoint_version`, `validation_reason`, `environment_changes`) are
   untouched. Trust behaviour is unchanged, since returning a self-reported goal
   confirms nothing and a self-certified run still resolves to `request_human`.
-  `tests/test_serve.py` gains four regression tests, including one that diffs the
+  `tests/test_serve.py` gains six regression tests, including one that diffs the
   sidecar's `resume` keys against the live `continuum_resume` payload so the next
   field added on one side and forgotten on the other fails CI instead of being
   found by hand.


### PR DESCRIPTION
## Checklist

- [x] Tests pass locally (`pytest`)
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy src/continuum` passes
- [x] CHANGELOG.md updated under the Unreleased section

## What does this PR do?

Corrects one word in the CHANGELOG entry for the sidecar `resume` parity fix:
`tests/test_serve.py` gained **six** regression tests, not four.

```
$ git diff --stat
 CHANGELOG.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

The six, as merged in #92:

```
$ git diff upstream/main~1 upstream/main -- tests/test_serve.py | grep "^+\(async \)\?def test_"
+def test_resume_returns_the_run_goal() -> None:
+def test_resume_without_run_id_targets_the_active_run() -> None:
+def test_resume_without_run_id_reports_no_active_run() -> None:
+def test_resume_still_requires_review_for_a_self_reported_run() -> None:
+async def test_resume_payload_covers_the_mcp_resume_surface() -> None:
+def test_stdio_resume_needs_no_params_at_all() -> None:
```

No other wording changed, and no code is touched.

## Why is this change needed?

The miscount is mine, from #92. CodeRabbit raised it on that PR, but the review
landed after the merge, so there is no branch left to amend and it is now
inaccurate on `main`. The CHANGELOG is the record a reader trusts to know what a
release actually verified, so a wrong count there is worth one commit to fix.

Not using a closing keyword: there is no issue for this, and #92 is already
merged.

## Verification

```
$ ruff check src/ tests/ examples/
All checks passed!

$ ruff format --check src/ tests/ examples/
107 files already formatted

$ mypy src/continuum
Success: no issues found in 55 source files

$ python -m pytest tests/test_serve.py -q
....................                                                     [100%]
```

Full-suite note, unchanged from #92 and unrelated to this diff: on Windows
`tests/test_mcp_server.py::test_main_reports_an_unopenable_database_instead_of_a_traceback`
fails on a clean checkout of `main`. I have now filed that separately as #94.
