### PR TITLE
fix: report the failing storage path unescaped so it is copy-pasteable (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,23 @@ All notable changes to this project are documented here. The format follows
   field added on one side and forgotten on the other fails CI instead of being
   found by hand.
 
+- **The cannot-open-storage message escaped backslashes, so a Windows path was
+  not copy-pasteable (issue #94).** Both entry points formatted the failing path
+  with `!r`, and `repr()` escapes each backslash, so
+  `C:\Users\ASUS\no-such-dir\agent.db` came back as
+  `'C:\\Users\\ASUS\\no-such-dir\\agent.db'` — not the path the operator passed,
+  and useless pasted into a shell or a config file. POSIX paths were unaffected,
+  having no backslashes to escape, which is also why the MCP server's
+  `test_main_reports_an_unopenable_database_instead_of_a_traceback` was red on a
+  clean checkout of `main` on Windows: its `assert str(missing) in err` held only
+  on POSIX. The escaping broke the exact guarantee #87 was fixed to provide.
+  Both sites now use literal quote delimiters (`at '{path}'`), which still show
+  leading or trailing whitespace but do not escape: `src/continuum/cli/main.py`
+  and `src/continuum/mcp/server.py`. The regression test at each entry point puts
+  a backslash in the *filename*, which is legal on POSIX, so the ubuntu-only CI
+  can catch this class of Windows-only breakage rather than shipping it a third
+  time (#81 was the first). Reported with a full diagnosis by @abyyxhek.
+
 - **MCP server was not found at cold start because its name did not match the
   configured name (issue #87).** `.mcp.json` registered the server under the key
   `continuum`, and `build_server` advertised `MCPServer(name="continuum")`, while

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -954,7 +954,12 @@ def main(
     except sqlite3.Error as exc:
         # An unreadable or unwritable database is an ordinary operator mistake
         # (bad path, no permission). A traceback would bury the useful part.
-        print(f"error: cannot open storage at {args.db!r}: {exc}", file=err)
+        #
+        # Quoted with literal delimiters rather than !r (issue #94): repr()
+        # escapes each backslash, so a Windows path came back doubled and what
+        # was printed was not the path that was passed. The quotes are kept
+        # because they still reveal leading or trailing whitespace.
+        print(f"error: cannot open storage at '{args.db}': {exc}", file=err)
         return ExitCode.ERROR
 
     try:

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -933,8 +933,12 @@ def main(argv: list[str] | None = None) -> int:
     except sqlite3.Error as exc:
         # resolve_database, not args.db, so the reported path is the one that
         # was actually opened rather than None when --db was omitted.
+        #
+        # Quoted with literal delimiters rather than !r (issue #94), matching
+        # cli/main.py: repr() escapes each backslash, so a Windows path came
+        # back doubled and could not be copied into a shell or a config file.
         print(
-            f"error: cannot open storage at {resolve_database(args.db)!r}: {exc}",
+            f"error: cannot open storage at '{resolve_database(args.db)}': {exc}",
             file=sys.stderr,
         )
         return 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -393,6 +393,27 @@ def test_an_unopenable_database_reports_an_error_not_a_traceback(db: str) -> Non
     assert "Traceback" not in err
 
 
+def test_the_reported_path_is_not_backslash_escaped(tmp_path: Path) -> None:
+    """Regression for #94: the operator has to be able to copy the path back.
+
+    ``!r`` escapes each backslash, so a Windows path was reported with every
+    separator doubled -- not the path that was passed, and useless pasted into
+    a shell or a config file.
+
+    Pinned with a backslash in the *filename*, which is legal on POSIX, so the
+    ubuntu-only CI can catch a regression that otherwise only shows on Windows.
+    That blind spot is the reason this shipped: #81 was Windows-only for the
+    same reason.
+    """
+    missing = tmp_path / "no-such-dir" / "back\\slash.db"
+
+    code, _, err = run("--db", str(missing), "runs")
+
+    assert code == ExitCode.ERROR
+    assert str(missing) in err, "the path reported is not the path that was passed"
+    assert "\\\\" not in err, "repr()-style escaping is back"
+
+
 def test_an_empty_env_version_is_refused(db: str) -> None:
     """`--env dataset=` is nearly always an unexpanded shell variable.
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1279,6 +1279,23 @@ def test_main_reports_an_unopenable_database_instead_of_a_traceback(
     assert "Traceback" not in err
 
 
+def test_the_reported_path_is_not_backslash_escaped(tmp_path: Any, capsys: Any) -> None:
+    """Regression for #94, the same property as the CLI's identical test.
+
+    ``!r`` doubled every backslash, so on Windows the assertion above (``str(
+    missing) in err``) was red on a clean checkout of main -- the escaping broke
+    the very guarantee #87 was fixed to provide. A backslash in the filename is
+    legal on POSIX, so this reproduces on the ubuntu-only CI too.
+    """
+    missing = tmp_path / "no-such-dir" / "back\\slash.db"
+
+    assert main(["--db", str(missing)]) == 1
+
+    err = capsys.readouterr().err
+    assert str(missing) in err, "the path reported is not the path that was passed"
+    assert "\\\\" not in err, "repr()-style escaping is back"
+
+
 def test_main_reports_a_malformed_client_token_list(
     tmp_path: Any, capsys: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Fixes #94.

Credit to @abyyxhek, whose report already contained the whole diagnosis — both call sites, the POSIX/Windows asymmetry, and why CI cannot see it. They offered to send the patch pending your call on the output format; this implements their recommended option, and I'm happy to close this in favour of theirs if you'd rather.

## The bug

Both entry points formatted the failing path with `!r`, and `repr()` escapes each backslash. A Windows operator passing `C:\Users\ASUS\no-such-dir\agent.db` was shown:

```
error: cannot open storage at 'C:\\Users\\ASUS\\no-such-dir\\agent.db': unable to open database file
```

That is not the path they passed, and it cannot be pasted back into a shell or a config file — which defeats the point of the message. #90 added it precisely so an operator would get something actionable instead of a traceback.

POSIX paths were unaffected, having no backslashes to escape. That asymmetry is also why `tests/test_mcp_server.py::test_main_reports_an_unopenable_database_instead_of_a_traceback` is **red on a clean checkout of `main` on Windows**: its `assert str(missing) in err` holds only on POSIX. So the escaping broke the exact guarantee #87 was fixed to provide, and the test guarding that guarantee was the thing reporting it.

## The fix

Literal quote delimiters instead of `!r`, at both sites — `src/continuum/cli/main.py` and `src/continuum/mcp/server.py`:

```python
f"error: cannot open storage at '{args.db}': {exc}"
```

This is the option @abyyxhek recommended. I went with it over the alternative (keep `!r`, relax the test to compare normalised paths) because that alternative keeps an unusable message and changes the test to accept it — the assertion is not the thing that is wrong here.

The quotes are kept deliberately, not left over: they still reveal leading or trailing whitespace in a path, which was the only thing `!r` was actually buying at these call sites. Both comments now say so, so this doesn't get tidied back to `!r`.

Verified on macOS, both entry points:

```
path passed:  no-such-dir/back\slash.db

$ continuum-mcp --db 'no-such-dir/back\slash.db'
error: cannot open storage at 'no-such-dir/back\slash.db': unable to open database file

$ continuum --db 'no-such-dir/back\slash.db' resume r1
error: cannot open storage at 'no-such-dir/back\slash.db': unable to open database file
```

## Tests

One per entry point, both named `test_the_reported_path_is_not_backslash_escaped` (`tests/test_cli.py`, `tests/test_mcp_server.py`).

The load-bearing detail: they put the backslash in the **filename**, not in a directory separator. That is legal on POSIX, so the escaping reproduces on Linux and **the ubuntu-only CI can catch this Windows-only class of bug**. Proven red before the change and green after, on macOS:

```
E   AssertionError: the path reported is not the path that was passed
E   assert '.../no-such-dir/back\\slash.db' in "error: cannot open storage at '.../no-such-dir/back\\\\slash.db': ..."
```

Each test also asserts `"\\\\" not in err`, so a future `!r` fails loudly rather than only on someone's Windows box.

`tests/test_cli.py` previously had `test_an_unopenable_database_reports_an_error_not_a_traceback`, which asserts `"error:" in err` and no traceback but never asserts the path — that is the hole this fell through, and it is left as-is next to the new test.

Both CI jobs are `runs-on: ubuntu-latest`, so this is the second Windows-only breakage to reach `main` invisibly (#81 was the first, fixed in #89). A Windows CI job is the real fix for that gap and is out of scope here; writing path assertions that reproduce on Linux is the cheap part, and it is what these two tests do.

## Checks

| check | result |
|---|---|
| `pytest` | 840 passed, 4 skipped |
| `ruff check src/ tests/` | All checks passed |
| `ruff format --check src/ tests/` | 97 files already formatted |
| `mypy src/continuum` | no issues in 55 source files |

## Rebased onto current `main`

Originally branched off `dc400f5`; since then #92, #93 and #96 landed, so this is rebased onto `4f3ac25`. The only conflict was `CHANGELOG.md`, where #92's entry and mine were both added at the top of `### Fixed` — resolved by keeping both. The `mcp/server.py` and `tests/test_mcp_server.py` hunks auto-merged: my #93 added a `ModuleNotFoundError` handler *above* `main()`'s `sqlite3.Error` handler, and this changes the `print` *inside* it, so the two compose without interaction. All four checks re-run green on the new base (848 passed, 4 skipped — the count moved with the merged PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
