### PR TITLE
fix(cli,mcp): stop escaping the path in the cannot-open-storage error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,22 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **The `cannot open storage` message escaped the path, so on Windows it could
+  not be pasted back (issue #94).** Both entry points formatted the failing path
+  with `!r`, and `repr()` escapes backslashes, so a path the operator had typed
+  with single separators was reported with doubled ones
+  (`'C:\\Users\\me\\agent.db'`). That defeats the point of naming the path, which
+  is what #87 added the message for: the operator's next step is to paste it into
+  a shell or a config file. It also meant `pytest` was red on a clean checkout of
+  `main` on Windows, because `test_main_reports_an_unopenable_database_instead_of_a_traceback`
+  asserts the path appears verbatim. Both call sites now quote the path without
+  escaping it (`src/continuum/cli/main.py`, `src/continuum/mcp/server.py`); the
+  quotes still expose a stray leading or trailing space, which is the diagnostic
+  value `!r` was providing. Regression tests in `tests/test_cli.py` (which had no
+  coverage of this message at all) and `tests/test_mcp_server.py` use a path
+  containing a literal backslash, so they fail on the old code on every platform
+  rather than only on Windows, where CI does not run.
+
 - **The `continuum serve` sidecar's `resume` had drifted from the MCP tool it
   mirrors, so a non-Python client could not resume hands-free (issue #91).** The
   module docstring promises "the protocol mirrors the MCP tool surface so the two

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -954,7 +954,10 @@ def main(
     except sqlite3.Error as exc:
         # An unreadable or unwritable database is an ordinary operator mistake
         # (bad path, no permission). A traceback would bury the useful part.
-        print(f"error: cannot open storage at {args.db!r}: {exc}", file=err)
+        # Quoted, but not with !r: repr() escapes backslashes, so a Windows path
+        # comes back doubled and cannot be pasted back into a shell (issue #94).
+        # The quotes still expose a stray leading or trailing space.
+        print(f"error: cannot open storage at '{args.db}': {exc}", file=err)
         return ExitCode.ERROR
 
     try:

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -887,9 +887,12 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     except sqlite3.Error as exc:
         # resolve_database, not args.db, so the reported path is the one that
-        # was actually opened rather than None when --db was omitted.
+        # was actually opened rather than None when --db was omitted. Quoted,
+        # but not with !r: repr() escapes backslashes, so a Windows path comes
+        # back doubled and cannot be pasted back into a shell (issue #94). The
+        # quotes still expose a stray leading or trailing space.
         print(
-            f"error: cannot open storage at {resolve_database(args.db)!r}: {exc}",
+            f"error: cannot open storage at '{resolve_database(args.db)}': {exc}",
             file=sys.stderr,
         )
         return 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -393,6 +393,27 @@ def test_an_unopenable_database_reports_an_error_not_a_traceback(db: str) -> Non
     assert "Traceback" not in err
 
 
+def test_an_unopenable_database_reports_the_path_unescaped(tmp_path: Path) -> None:
+    """Regression for #94: the operator has to be able to paste the path back.
+
+    Naming the path is only useful if it survives intact. `repr()` escaped every
+    backslash, so a path typed with single separators was reported with doubled
+    ones. A literal backslash in the file name reproduces that on any platform,
+    which keeps this red on the old code under a Linux-only CI instead of only
+    on a Windows machine, where every separator hits it.
+    """
+    bad = os.path.join(str(tmp_path), "no-such-directory", "back\\slash.db")
+
+    code, _, err = run("--db", bad, "runs")
+
+    assert code == ExitCode.ERROR
+    assert "cannot open storage" in err
+    assert bad in err, err
+    # Two consecutive backslashes anywhere means the path was escaped.
+    assert "\\\\" not in err
+    assert "Traceback" not in err
+
+
 def test_an_empty_env_version_is_refused(db: str) -> None:
     """`--env dataset=` is nearly always an unexpanded shell variable.
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1277,6 +1277,28 @@ def test_main_reports_an_unopenable_database_instead_of_a_traceback(
     assert "Traceback" not in err
 
 
+def test_unopenable_database_message_does_not_escape_the_path(tmp_path: Any, capsys: Any) -> None:
+    """Regression for #94: the reported path was not copy-pasteable.
+
+    #87 got the failing path onto stderr, but `!r` escaped every backslash on the
+    way, so a path typed with single separators was reported with doubled ones and
+    could not be pasted back into a shell or a config file. A literal backslash in
+    the file name reproduces that on any platform, which keeps this red on the old
+    code under a Linux-only CI instead of only on Windows, where every separator
+    hits it.
+    """
+    missing = os.path.join(str(tmp_path), "no-such-directory", "back\\slash.db")
+
+    assert main(["--db", missing]) == 1
+
+    err = capsys.readouterr().err
+    assert "cannot open storage" in err
+    assert missing in err, err
+    # Two consecutive backslashes anywhere means the path was escaped.
+    assert "\\\\" not in err
+    assert "Traceback" not in err
+
+
 def test_main_reports_a_malformed_client_token_list(
     tmp_path: Any, capsys: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Checklist

- [x] Tests pass locally (`pytest`)
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy src/continuum` passes
- [x] CHANGELOG.md updated under the Unreleased section

## What does this PR do?

Stops `repr()` from mangling the path in the `cannot open storage` error, at both
call sites, and covers the behaviour with tests that are red on the old code on
every platform.

```
 CHANGELOG.md                | 16 ++++++++++++++++
 src/continuum/cli/main.py   |  5 ++++-
 src/continuum/mcp/server.py |  7 +++++--
 tests/test_cli.py           | 21 +++++++++++++++++++++
 tests/test_mcp_server.py    | 22 ++++++++++++++++++++++
```

The functional change is one character per site: `{path!r}` becomes `'{path}'`.

Before, on Windows:

```
$ continuum-mcp --db C:\Users\ASUS\no-such-dir\agent.db
error: cannot open storage at 'C:\Users\ASUS\no-such-dir\agent.db': unable to open database file
  copy-pasteable? -> False
```

After:

```
$ continuum-mcp --db C:\Users\ASUS\no-such-dir\agent.db
exit 1
error: cannot open storage at 'C:\Users\ASUS\no-such-dir\agent.db': unable to open database file
  copy-pasteable? -> True

$ continuum --db C:\Users\ASUS\no-such-dir\agent.db resume r1
exit 1
error: cannot open storage at 'C:\Users\ASUS\no-such-dir\agent.db': unable to open database file
  copy-pasteable? -> True
```

I kept the quotes rather than dropping them. They are what still exposes a stray
leading or trailing space, which is the diagnostic value `!r` was providing; only
the escaping is removed.

## Why is this change needed?

Fixes #94.

#87 put the failing path on stderr so the operator could act on it, and their next
step is to paste it into a shell or a config file. `repr()` escaping made the
reported path differ from the one they typed, so the message named a path that did
not exist. It also left `pytest` red on a clean checkout of `main` on Windows,
because `test_main_reports_an_unopenable_database_instead_of_a_traceback` asserts
the path appears verbatim. That test now passes, and the full suite is green here:

```
$ python -m pytest
846 passed, 4 skipped in 70.67s (0:01:10)
```

`tests/test_cli.py` had no coverage of this message at all, so the CLI half could
have regressed silently. It does now.

## On making the tests fail on CI, not just on Windows

The pre-existing assertion only breaks where the separator is a backslash, so a
`ubuntu-latest`-only CI cannot protect this fix. The new tests therefore use a
path with a *literal* backslash in the file name:

```python
missing = os.path.join(str(tmp_path), "no-such-directory", "back\slash.db")
```

`repr()` doubles a backslash regardless of platform, so both new tests fail on the
old code on Linux as well. Verified by reverting only the two source files and
re-running:

```
$ git stash push -- src/continuum/cli/main.py src/continuum/mcp/server.py
$ python -m pytest <the two new tests>
>       assert missing in err, err
E       assert '...\no-such-directory\back\slash.db' in "error: cannot open storage at '...\no-such-directory\back\slash.db': unable to open database file\n"
>       assert bad in err, err
E       assert '...\no-such-directory\back\slash.db' in "error: cannot open storage at '...\no-such-directory\back\slash.db': unable to open database file\n"
FAILED tests/test_mcp_server.py::test_unopenable_database_message_does_not_escape_the_path
FAILED tests/test_cli.py::test_an_unopenable_database_reports_the_path_unescaped
2 failed in 3.58s
```

And the same path shape rendered as a Linux runner sees it, confirming both
assertions are red there too rather than passing vacuously:

```
--db argument      : /tmp/pytest-of-run/pytest-0/test_x0/no-such-directory/back\slash.db

OLD (repr)   : error: cannot open storage at '/tmp/.../no-such-directory/back\slash.db': ...
               assert path in err      -> False
               assert no doubled slash -> False

NEW (quoted) : error: cannot open storage at '/tmp/.../no-such-directory/back\slash.db': ...
               assert path in err      -> True
               assert no doubled slash -> True
```

## Verification

```
$ ruff check src/ tests/ examples/
All checks passed!

$ ruff format --check src/ tests/ examples/
107 files already formatted

$ mypy src/continuum
Success: no issues found in 55 source files

$ python -m pytest
846 passed, 4 skipped in 70.67s (0:01:10)
```

## Note on scope

#94 offered two options and I implemented the first (quote without escaping)
rather than the second (keep `!r` and relax the test to compare normalised
paths). I went with this one because it fixes what the operator sees, whereas
relaxing the assertion would keep the mangled output and only quiet the test.
Happy to switch if you prefer the other.

Separately, this makes a Windows CI job worth considering: this is the second
Windows-only breakage after #81, and both were invisible to a `ubuntu-latest`
matrix. Not in this PR, since adding a runner is a maintainer decision about CI
minutes, but I am happy to open a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI and MCP storage-open errors to display database paths clearly, without doubling backslashes.
  * Preserved visibility of leading or trailing spaces in reported paths.
  * Error messages continue to avoid exposing a traceback.

* **Tests**
  * Added regression coverage for paths containing literal backslashes across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->