### PR TITLE
fix(serve): delete the dead auth gate and pin the policy the sidecar really has (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,34 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **The `continuum serve` sidecar exported a `MUTATING` constant describing an
+  authentication policy it does not implement, and no test pinned the real one
+  (issue #95, reported by @abyyxhek).** `MUTATING` names seven of the ten
+  methods, and `_auth_check` gated the shared secret on membership in it — but
+  `_auth_check` had no call sites anywhere in the tree, and `dispatch` calls
+  `self.auth.verify` unconditionally, so `resume`, `validate` and `list_actions`
+  do require a token despite being absent from the set. `SidecarAuth`'s docstring
+  documented the same phantom rule ("every mutating call must present the
+  matching `auth_token`"). The behaviour is the correct one and the description
+  was wrong: unlike the MCP server — whose mutating-only policy is deliberate and
+  pinned by `test_read_only_tools_stay_open_to_anyone` — the sidecar is reachable
+  by any process that can speak to its pipe, and its reads are worth closing for
+  what they return (`resume` hands back the goal string, `list_actions` the
+  arguments and results of external side effects). Gating them costs nothing by
+  default, since an unset `CONTINUUM_SERVE_TOKEN` disables authentication
+  entirely. So the dead `_auth_check` is deleted, `MUTATING` keeps its export as
+  descriptive write-vs-read metadata with a docstring stating that it does not
+  govern authentication, and `SidecarAuth` and `dispatch` now document the real
+  policy and why it diverges from the MCP server's. The gap was not only
+  cosmetic: the existing auth tests all drove `record_progress`, so the suite was
+  consistent with *both* policies, and reinstating the mutating-only gate in
+  `dispatch` opened all three read-only methods to unauthenticated callers
+  without turning a single existing test red. `tests/test_serve.py` gains three
+  regression tests, twelve cases in all — every method in `list_methods()`
+  refused without the secret, the read-only methods refused although `MUTATING`
+  omits them, and a read-only method still succeeding with it — verified red
+  against that reintroduced gate.
+
 - **The `continuum serve` sidecar's `resume` had drifted from the MCP tool it
   mirrors, so a non-Python client could not resume hands-free (issue #91).** The
   module docstring promises "the protocol mirrors the MCP tool surface so the two

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -46,6 +46,15 @@ from continuum.storage import RunNotFound, Storage, open_storage
 #: about its own work, so it is recorded as self-certified.
 AGENT_SOURCE = Origin.EXTERNAL_AGENT
 
+#: Which methods write run state, as descriptive metadata for clients that want
+#: to treat a write differently from a read (confirm it, log it, retry it).
+#:
+#: This does **not** govern sidecar authentication, and never has: ``dispatch``
+#: verifies the shared secret for *every* method, read-only ones included. The
+#: name invites the opposite reading, so it is spelled out here -- a caller that
+#: gates its own token on this set will be refused on ``resume``. See
+#: ``SidecarServer.dispatch`` for why the sidecar is stricter than the MCP
+#: server, whose policy really is mutating-only.
 MUTATING = {
     "record_progress",
     "checkpoint",
@@ -81,10 +90,11 @@ class SidecarAuth:
     """Fail-closed shared-secret authentication for the sidecar.
 
     When ``expected`` is ``None`` (the default), authentication is disabled and
-    the sidecar behaves as before. When set, every mutating call must present
-    the matching ``auth_token`` parameter or it is refused. A missing or wrong
-    secret always refuses; an empty configured secret refuses rather than
-    opening the door.
+    the sidecar behaves as before. When set, every call must present the
+    matching ``auth_token`` parameter or it is refused -- reads as well as
+    writes, not only the methods in ``MUTATING``. A missing or wrong secret
+    always refuses; an empty configured secret refuses rather than opening the
+    door.
     """
 
     def __init__(self, expected: str | None = None) -> None:
@@ -202,11 +212,24 @@ class SidecarServer:
     def _ledger(self, run_id: str) -> ActionLedger:
         return ActionLedger(self.storage, run_id)
 
-    def _auth_check(self, method: str, params: dict[str, Any]) -> None:
-        if method in MUTATING:
-            self.auth.verify(params.get("auth_token"))
-
     def dispatch(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Authenticate, then route to the handler for ``method``.
+
+        The secret is required for every method, not just the ones in
+        ``MUTATING``. That is deliberate, and it is where the sidecar diverges
+        from the MCP server's mutating-only policy: the MCP server talks to a
+        client the user launched on their own machine, whereas any process that
+        can reach this pipe can speak the protocol. Reads are worth closing
+        because of what they return -- ``resume`` hands back the goal string,
+        ``list_actions`` the arguments and results of external side effects.
+        Gating those on the same secret costs nothing by default, since
+        ``CONTINUUM_SERVE_TOKEN`` unset disables authentication entirely.
+
+        A ``MUTATING``-only variant of this check used to exist here as an
+        unreferenced helper. Restoring it would open reads to unauthenticated
+        callers in exactly the deployments that bothered to set a secret, so the
+        policy is pinned by tests in ``tests/test_serve.py`` (issue #95).
+        """
         handler = _HANDLERS.get(method)
         if handler is None:
             raise MethodNotFound(method)

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -21,6 +21,7 @@ from continuum.serve import (
     list_methods,
     serve_subprocess,
 )
+from continuum.serve.server import MUTATING
 
 
 def make_server() -> SidecarServer:
@@ -317,6 +318,79 @@ def test_auth_disabled_by_default() -> None:
     auth = SidecarAuth()
     assert auth.disabled
     auth.verify(None)  # must not raise
+
+
+@pytest.mark.parametrize("method", list_methods())
+def test_every_method_requires_the_secret(monkeypatch, method: str) -> None:
+    """The sidecar's real policy, pinned exhaustively (issue #95).
+
+    The two token tests in this section both drive ``record_progress``, so
+    between them they only proved the policy for one mutating method -- which
+    left the suite consistent with a mutating-only policy that the sidecar does
+    not implement. Driving every entry in ``list_methods()`` closes that, and
+    keeps a method added later from landing unauthenticated by default.
+
+    ``dispatch`` verifies before it routes, so the missing ``run_id`` here
+    cannot be what raises: ``BadParams`` would mean auth had already been
+    skipped.
+    """
+    monkeypatch.setenv("CONTINUUM_SERVE_TOKEN", "secret")
+    srv = make_server()
+
+    with pytest.raises(NotAuthorized):
+        srv.dispatch(method, {"run_id": "r1"})
+
+
+def test_the_mutating_constant_does_not_govern_authentication(monkeypatch) -> None:
+    """Regression for #95: the exported constant is metadata, not the policy.
+
+    ``MUTATING`` omits the three read-only methods, and until this test the only
+    trace of a mutating-only rule was an unreferenced ``_auth_check`` helper.
+    Deleting the helper is not enough on its own -- someone reading the constant
+    can reintroduce the same gate in ``dispatch``, and every other test in this
+    file would still pass while ``resume``, ``validate`` and ``list_actions``
+    silently opened up to unauthenticated callers, in precisely the deployments
+    that bothered to set a secret. This is the test that goes red instead.
+    """
+    monkeypatch.setenv("CONTINUUM_SERVE_TOKEN", "secret")
+    srv = make_server()
+
+    read_only = [method for method in list_methods() if method not in MUTATING]
+    assert read_only == ["list_actions", "resume", "validate"], (
+        "the set of methods MUTATING leaves out has changed; "
+        "confirm the auth policy still covers them"
+    )
+
+    for method in read_only:
+        with pytest.raises(NotAuthorized):
+            srv.dispatch(method, {"run_id": "r1"})
+
+
+def test_a_read_only_method_succeeds_with_the_secret(monkeypatch) -> None:
+    """Closing reads must gate them, not break them.
+
+    Also shows what the gate is protecting: ``resume`` returns the goal string,
+    and ``list_actions`` the arguments and results of real side effects. That is
+    the argument for the sidecar being stricter than the MCP server -- anything
+    that can reach this pipe can ask for it.
+    """
+    monkeypatch.setenv("CONTINUUM_SERVE_TOKEN", "secret")
+    srv = make_server()
+    srv.dispatch(
+        "record_progress",
+        {
+            "run_id": "r1",
+            "completed": 1,
+            "total": 3,
+            "goal": "migrate billing",
+            "auth_token": "secret",
+        },
+    )
+
+    out = srv.dispatch("resume", {"run_id": "r1", "auth_token": "secret"})
+
+    assert out["goal"] == "migrate billing"
+    assert out["progress"]["completed"] == 1
 
 
 # --- real subprocess path (what an external client uses) --------------------


### PR DESCRIPTION
Fixes #95.

## The problem

`serve/server.py` exports a `MUTATING` set naming seven of the ten methods, and `_auth_check` gates the shared secret on membership in it:

```python
def _auth_check(self, method: str, params: dict[str, Any]) -> None:
    if method in MUTATING:
        self.auth.verify(params.get("auth_token"))
```

`_auth_check` has no call sites anywhere in the tree, and `dispatch` calls `self.auth.verify` unconditionally. So `resume`, `validate` and `list_actions` **do** require a token despite being absent from `MUTATING`. `SidecarAuth`'s docstring documented the policy that does not exist too — "every mutating call must present the matching `auth_token`".

Three artifacts describing one policy, and the code implements another.

## Which one is right

The behaviour, and the description was wrong — agreeing with the issue's conclusion.

The MCP server's mutating-only policy is deliberate and pinned by `test_read_only_tools_stay_open_to_anyone`: it talks to a client the user launched on their own machine. The sidecar is a different boundary — anything that can reach its pipe can speak the protocol — and its reads are worth closing for what they return. `resume` hands back the goal string; `list_actions` returns the arguments and results of external side effects. Gating those costs nothing by default, since an unset `CONTINUUM_SERVE_TOKEN` disables authentication entirely.

## The change

- **Delete `_auth_check`.** It implements a policy the sidecar does not have.
- **Keep `MUTATING` exported**, as the issue prefers, with a docstring saying what it is (descriptive write-vs-read metadata for clients) and that it does not govern authentication. It stays a submodule-level export; it is deliberately not added to the `continuum.serve` package `__all__`, since raising its prominence is the opposite of what it needs.
- **Correct `SidecarAuth`'s docstring** to say every call, reads included.
- **Document on `dispatch`** why the sidecar is stricter than the MCP server, so the next reader has the reason and not just the rule.

No behaviour change. This is dead code, two wrong docstrings, and the missing tests.

## Why it needed the tests, not just the deletion

Both existing token tests drive `record_progress`, so the suite was consistent with *either* policy. Putting the mutating-only gate back into `dispatch` is a one-line change that reads like tidying up dead code, and it opens all three read-only methods to unauthenticated callers — in precisely the deployments that bothered to set a secret:

```
--- shipped dispatch (verifies unconditionally) ---
  list_actions   -> NotAuthorized (fail-closed)
  resume         -> NotAuthorized (fail-closed)
  validate       -> NotAuthorized (fail-closed)

--- dispatch 'fixed' to use the dead _auth_check ---
  list_actions   -> reached the handler: RunNotFound
  resume         -> reached the handler: CheckpointError
  validate       -> reached the handler: CheckpointError
```

Every existing test stayed green through that.

Three new tests in `tests/test_serve.py` (twelve cases) close it:

- `test_every_method_requires_the_secret` — parametrized over `list_methods()`, so a method added later cannot land unauthenticated by default.
- `test_the_mutating_constant_does_not_govern_authentication` — the discriminating one: the read-only methods are refused *although* `MUTATING` omits them.
- `test_a_read_only_method_succeeds_with_the_secret` — the refusal is a gate, not blanket breakage.

Verified red against the reintroduced gate (exactly those four failures, every other test in the file passing) and green after.

## Checks

`860 passed, 4 skipped`; `ruff check`, `ruff format --check`, and `mypy src/continuum` all clean. Rebased onto `58756fc`.

## Credit

Reported by @abyyxhek, who diagnosed the orphaned helper, worked out which side was correct, and recommended this fix including the preference to keep `MUTATING` exported with a clarifying docstring. They offered to send the patch — happy to close this in favour of theirs if they would rather carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
