### PR TITLE
feat(cli): record observed tool completions via host-side hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Host-side observation hooks close part of the durability gap (#207).**
+  Recovery depends on the agent voluntarily calling the recording tools, so a
+  kill between performing work and reporting it left the next session a
+  contract that understated what had landed on disk (observed live with Claude
+  Code on 2026-08-22: an artifact fully written, progress still 0/1, zero
+  checkpoints). Two new CLI commands convert that voluntary recording into
+  mandatory interception for Claude Code: `continuum observe` reads one
+  PostToolUse hook payload from stdin (or `--payload-file`) and appends a
+  `TOOL_COMPLETED` event carrying the tool name, mutated path, byte count and
+  SHA-256 of the file as it exists right now; `continuum hooks install
+  claude-code` wires file-mutating tool completions to it by editing
+  `.claude/settings.json` in place (preserving unrelated settings,
+  self-healing a stale baked-in binary path, refusing to touch a settings file
+  that is not valid JSON), with `continuum hooks remove claude-code` to undo.
+  Observations target the explicit `--run-id`, else the most recently active
+  non-terminal run; with no run active they are dropped with exit 0 so hooks
+  never disturb unrelated sessions. Events are sourced `EXTERNAL_AGENT`: they
+  are evidence a resumed session can weigh, not a laundering path to trusted
+  state. Tests in `tests/test_cli_observe.py` include driving the exact
+  command string baked into settings.json through a real shell.
+
+### Added
+
 - **`scoped_to_run=False` now enforces global uniqueness (#34).** An unscoped
   idempotency key claims store-global identity but the ledger only replayed its
   own run's log, so two runs could each open a fresh slot for the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,6 @@ All notable changes to this project are documented here. The format follows
   state. Tests in `tests/test_cli_observe.py` include driving the exact
   command string baked into settings.json through a real shell.
 
-### Added
-
 - **`scoped_to_run=False` now enforces global uniqueness (#34).** An unscoped
   idempotency key claims store-global identity but the ledger only replayed its
   own run's log, so two runs could each open a fresh slot for the same

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -33,6 +33,13 @@ from continuum.actions import ActionLedger
 from continuum.checkpoint import CheckpointError, CheckpointManager
 from continuum.cli.colour import Palette
 from continuum.cli.exitcodes import ExitCode, exit_code_for
+from continuum.clienthooks import (
+    DEFAULT_MATCHER,
+    install_claude_code_hook,
+    observe_command,
+    observe_event_payload,
+    remove_claude_code_hook,
+)
 from continuum.environment import StaticProvider, capture
 from continuum.events import EventType
 from continuum.models import (
@@ -607,6 +614,108 @@ def cmd_checkpoint(args: argparse.Namespace, storage: Storage, out: Any, err: An
     return ExitCode.OK
 
 
+def cmd_observe(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Record one observed tool completion as durable evidence (issue #207).
+
+    Reads a Claude Code PostToolUse hook payload (JSON on stdin, or from
+    ``--payload-file``) and appends a ``TOOL_COMPLETED`` event to the target
+    run: the explicit ``--run-id``, else the most recently active non-terminal
+    run. This is what closes part of the durability gap: the recording happens
+    in a host-side hook after every file-mutating tool call, outside the
+    model's control, so work that landed on disk is never invisible to
+    recovery even when no checkpoint was ever taken.
+
+    With no active run the observation is dropped with exit 0 rather than an
+    error: hooks fire for every Claude Code session in this directory,
+    including ones with nothing to do with CONTINUUM, and a wall of failures
+    would pressure the user into uninstalling the instrumentation. The note on
+    stderr keeps the drop visible.
+    """
+    if args.payload_file:
+        raw_text = Path(args.payload_file).read_text(encoding="utf-8")
+    else:
+        raw_text = sys.stdin.read()
+    try:
+        raw = json.loads(raw_text) if raw_text.strip() else None
+    except json.JSONDecodeError as exc:
+        print(f"error: observe payload is not valid JSON: {exc}", file=err)
+        return ExitCode.ERROR
+
+    run_id = args.run_id
+    if not run_id:
+        active = storage.get_active_run()
+        run_id = active.run_id if active else None
+    if not run_id:
+        print("No active CONTINUUM run; observation not recorded.", file=err)
+        return ExitCode.OK
+
+    storage.get_run(run_id)  # raises RunNotFound -> NOT_FOUND by the dispatcher
+
+    payload = observe_event_payload(raw if isinstance(raw, dict) else {})
+    event = storage.append_event(
+        run_id,
+        EventType.TOOL_COMPLETED,
+        payload,
+        source=Origin.EXTERNAL_AGENT,
+    )
+    _emit(
+        {
+            "run_id": run_id,
+            "sequence": event.sequence,
+            "event_id": event.event_id,
+            **payload,
+        },
+        f"Observed {payload.get('tool')} -> {run_id} (seq {event.sequence})",
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
+
+
+def cmd_hooks_install(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Wire file-mutating tool completions of a coding CLI into observe."""
+    settings_path = Path(args.settings)
+    command = observe_command(db=args.db)
+    status = install_claude_code_hook(settings_path, command)
+    verb = {"installed": "Installed", "updated": "Updated", "present": "Already present"}[status]
+    _emit(
+        {
+            "client": args.client,
+            "settings": str(settings_path),
+            "matcher": DEFAULT_MATCHER,
+            "command": command,
+            "status": status,
+        },
+        f"{verb} observation hook in {settings_path}\n"
+        f"  matcher: {DEFAULT_MATCHER}\n"
+        f"  command: {command}",
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
+
+
+def cmd_hooks_remove(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Remove the observation hook previously installed for a coding CLI."""
+    settings_path = Path(args.settings)
+    removed = remove_claude_code_hook(settings_path)
+    text = (
+        f"Removed observation hook from {settings_path}"
+        if removed
+        else f"No observation hook found in {settings_path}"
+    )
+    _emit(
+        {"client": args.client, "settings": str(settings_path), "removed": removed},
+        text,
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
+
+
 def cmd_verify(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Re-audit the event chain for tampering."""
     # A run that does not exist has an empty, trivially valid chain. Reporting
@@ -993,6 +1102,43 @@ def build_parser() -> argparse.ArgumentParser:
     checkpoint.add_argument("--trigger", default="manual")
     checkpoint.add_argument("--reason", default="")
 
+    observe = add("observe", cmd_observe, "Record one observed tool completion. Mutates storage.")
+    observe.add_argument(
+        "--run-id",
+        default=None,
+        help="target run (default: the most recently active non-terminal run)",
+    )
+    observe.add_argument(
+        "--payload-file",
+        default=None,
+        help="read the hook payload from this file instead of stdin",
+    )
+
+    hooks = add("hooks", cmd_hooks_install, "Manage host-side observation hooks.")
+    hooks_sub = hooks.add_subparsers(dest="hooks_command", metavar="ACTION CLIENT", required=True)
+
+    def hooks_client(p: argparse.ArgumentParser, func: Any) -> None:
+        p.add_argument("client", choices=("claude-code",), help="which client to configure")
+        p.add_argument(
+            "--settings",
+            default=".claude/settings.json",
+            help="path to the client's settings file (default: .claude/settings.json)",
+        )
+        p.set_defaults(func=func)
+
+    install = hooks_sub.add_parser(
+        "install", help="Install the observation hook. Mutates settings."
+    )
+    install.add_argument(
+        "--db",
+        default=None,
+        help="bake a specific database path into the hook command",
+    )
+    hooks_client(install, cmd_hooks_install)
+
+    remove = hooks_sub.add_parser("remove", help="Remove the observation hook.")
+    hooks_client(remove, cmd_hooks_remove)
+
     with_run(add("verify", cmd_verify, "Re-audit the event chain."))
     with_run(add("actions", cmd_actions, "List external side effects."))
     with_env(with_run(add("show-contract", cmd_contract, "Print the recovery contract.")))
@@ -1073,7 +1219,9 @@ def main(
         parser.print_help(file=out)
         return ExitCode.OK
 
-    if args.command in ("benchmark", "attest-keygen", "serve"):
+    # hooks never touches a run, so it must not create an empty database as a
+    # side effect of editing a settings file.
+    if args.command in ("benchmark", "attest-keygen", "serve", "hooks"):
         return int(args.func(args, None, out, err))
 
     try:

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -83,12 +83,24 @@ def observe_event_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
         return payload
 
     payload["path"] = path
+    # Read in bounded chunks rather than whole: the hook runs after every
+    # file-mutating tool call, and a multi-gigabyte artifact must not be held
+    # in memory just to hash it. Size and digest are only recorded after the
+    # read completes, so a mid-read failure records neither.
+    digest = hashlib.sha256()
+    size = 0
     try:
-        data = Path(path).read_bytes()
+        with Path(path).open("rb") as source:
+            while True:
+                chunk = source.read(1024 * 1024)
+                if not chunk:
+                    break
+                size += len(chunk)
+                digest.update(chunk)
     except OSError:
         return payload
-    payload["bytes"] = len(data)
-    payload["sha256"] = hashlib.sha256(data).hexdigest()
+    payload["bytes"] = size
+    payload["sha256"] = digest.hexdigest()
     return payload
 
 

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -1,0 +1,241 @@
+"""Host-side observation hooks for coding CLIs (issue #207).
+
+CONTINUUM's recovery guarantees depend on the agent voluntarily calling
+``continuum_record_progress`` / ``continuum_checkpoint``, which leaves an
+unbounded window in which real work exists on disk but the event log knows
+nothing about it. A kill inside that window hands the next session a contract
+that understates what actually happened (observed live on 2026-08-22: a Claude
+Code session wrote ``tic-tac-toe.html`` and was killed before any recording
+call, so resume reported progress 0/1 with zero checkpoints).
+
+The durable-execution literature (Temporal, Restate, LangGraph checkpointers,
+the Crab sandbox paper) closes this by making recording mandatory at the
+runtime layer rather than voluntary at the model layer. CONTINUUM cannot wrap
+an external CLI's agent loop, but Claude Code exposes something nearly as
+good: PostToolUse hooks fire after every Write/Edit completion, outside the
+model's control. This module turns those hook events into durable evidence.
+
+Two pieces live here:
+
+- :func:`observe_event_payload` extracts the durable facts (tool, path, byte
+  count, content digest) from one hook payload.
+- :func:`install_claude_code_hook` / :func:`remove_claude_code_hook` manage the
+  entry in ``.claude/settings.json`` that wires file-mutating tool completions
+  to ``continuum observe``.
+
+Provenance note: an observation is recorded ``Origin.EXTERNAL_AGENT``
+deliberately. The fact it captures ("this tool call completed") is asserted by
+the client harness, not verified by CONTINUUM, so it must never launder
+self-reported state into trusted state. What it buys is independent *evidence*
+a resumed session can weigh against the log.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shlex
+import shutil
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "DEFAULT_MATCHER",
+    "observe_event_payload",
+    "observe_command",
+    "install_claude_code_hook",
+    "remove_claude_code_hook",
+]
+
+#: Tool names whose completions carry a file path worth observing. Kept as one
+#: matcher expression so the installed settings stay a single entry.
+DEFAULT_MATCHER = "Write|Edit|MultiEdit|NotebookEdit"
+
+#: Keys of ``tool_input`` that hold the primary file path, in priority order.
+_PATH_KEYS = ("file_path", "notebook_path")
+
+
+def observe_event_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract the durable facts from one PostToolUse payload.
+
+    Returns a JSON-native dict suitable for a ``TOOL_COMPLETED`` event:
+    ``{"tool": ..., "path": ..., "bytes": ..., "sha256": ...}``. The path keys
+    are read from the hook's own report; size and digest come from reading the
+    file *now*, because the observation is only useful to recovery if it
+    describes what is actually on disk. A missing or unreadable file records
+    the path without size or digest: the absence is itself evidence, and
+    guessing values would poison it.
+    """
+    tool = str(raw.get("tool_name") or "unknown")
+    payload: dict[str, Any] = {"tool": tool}
+
+    tool_input = raw.get("tool_input")
+    path: str | None = None
+    if isinstance(tool_input, Mapping):
+        for key in _PATH_KEYS:
+            value = tool_input.get(key)
+            if isinstance(value, str) and value:
+                path = value
+                break
+    if path is None:
+        return payload
+
+    payload["path"] = path
+    try:
+        data = Path(path).read_bytes()
+    except OSError:
+        return payload
+    payload["bytes"] = len(data)
+    payload["sha256"] = hashlib.sha256(data).hexdigest()
+    return payload
+
+
+def observe_command(*, db: str | None = None) -> str:
+    """Build the shell command the hook will run.
+
+    The absolute path of the ``continuum`` executable is resolved at install
+    time and baked into the settings: hook processes may not inherit the PATH
+    that found the binary originally. When no executable is on PATH (editable
+    installs inside environments that expose only the interpreter), the
+    interpreter-plus-module form is used instead. An explicit ``db`` is baked
+    in too, since the default resolves relative to the working directory and
+    hook processes run with the project root as cwd.
+    """
+    executable = shutil.which("continuum")
+    parts = [executable] if executable else [sys.executable, "-m", "continuum.cli"]
+    if db:
+        parts += ["--db", db]
+    parts.append("observe")
+    return " ".join(shlex.quote(part) for part in parts)
+
+
+def _is_observe_hook(hook: Mapping[str, Any]) -> bool:
+    """True when a hook entry routes to ``continuum observe``."""
+    command = hook.get("command")
+    if not isinstance(command, str):
+        return False
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    return len(tokens) >= 1 and tokens[-1] == "observe"
+
+
+def install_claude_code_hook(
+    settings_path: Path,
+    command: str,
+    *,
+    matcher: str = DEFAULT_MATCHER,
+) -> str:
+    """Add the observe hook to a Claude Code settings file.
+
+    Existing settings are preserved; only the ``hooks.PostToolUse`` list gains
+    (or updates) our single entry. Returns ``"installed"`` when the entry was
+    added, ``"updated"`` when an existing observe entry pointed somewhere else
+    (a moved virtualenv, say) and was repointed, ``"present"`` when nothing
+    needed to change.
+
+    A settings file that exists but is unreadable raises rather than being
+    overwritten: a file someone edited by hand is a statement of intent, and
+    silently replacing it would destroy work to save a typo.
+    """
+    if settings_path.exists():
+        try:
+            settings: dict[str, Any] = json.loads(settings_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"{settings_path} is not valid JSON ({exc}); refusing to edit it"
+            ) from exc
+        if not isinstance(settings, dict):
+            raise ValueError(f"{settings_path} does not contain a JSON object")
+    else:
+        settings = {}
+
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        raise ValueError(f"{settings_path}: 'hooks' is not an object")
+
+    post_tool_use: list[Any] = hooks.setdefault("PostToolUse", [])
+    if not isinstance(post_tool_use, list):
+        raise ValueError(f"{settings_path}: 'hooks.PostToolUse' is not a list")
+
+    status = "installed"
+    entry_found = False
+    for group in post_tool_use:
+        if not isinstance(group, dict) or group.get("matcher") != matcher:
+            continue
+        entries = group.get("hooks")
+        if not isinstance(entries, list):
+            continue
+        for hook in entries:
+            if isinstance(hook, dict) and _is_observe_hook(hook):
+                entry_found = True
+                if hook.get("command") != command:
+                    hook["command"] = command
+                    status = "updated"
+                else:
+                    status = "present"
+
+    if not entry_found:
+        post_tool_use.append(
+            {
+                "matcher": matcher,
+                "hooks": [{"type": "command", "command": command}],
+            }
+        )
+
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    return status
+
+
+def remove_claude_code_hook(settings_path: Path, *, matcher: str = DEFAULT_MATCHER) -> bool:
+    """Remove the observe hook. Returns True when anything was removed.
+
+    Only entries this module's shape recognises are touched: a hand-written
+    PostToolUse entry pointing elsewhere survives untouched, as does every
+    other key in the file.
+    """
+    if not settings_path.exists():
+        return False
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{settings_path} is not valid JSON ({exc}); refusing to edit it") from exc
+    if not isinstance(settings, dict):
+        return False
+
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    post_tool_use = hooks.get("PostToolUse")
+    if not isinstance(post_tool_use, list):
+        return False
+
+    removed = False
+    kept_groups: list[Any] = []
+    for group in post_tool_use:
+        if (
+            isinstance(group, dict)
+            and group.get("matcher") == matcher
+            and isinstance(group.get("hooks"), list)
+            and any(isinstance(h, dict) and _is_observe_hook(h) for h in group["hooks"])
+        ):
+            removed = True
+            continue
+        kept_groups.append(group)
+
+    if not removed:
+        return False
+
+    if kept_groups:
+        hooks["PostToolUse"] = kept_groups
+    else:
+        del hooks["PostToolUse"]
+        if not hooks:
+            del settings["hooks"]
+
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    return True

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -253,9 +253,7 @@ def remove_claude_code_hook(settings_path: Path, *, matcher: str = DEFAULT_MATCH
         # the whole group would delete configuration this command never
         # installed.
         kept_hooks = [
-            h
-            for h in group["hooks"]
-            if not (isinstance(h, dict) and _is_observe_hook(h))
+            h for h in group["hooks"] if not (isinstance(h, dict) and _is_observe_hook(h))
         ]
         if len(kept_hooks) != len(group["hooks"]):
             removed = True

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -112,7 +112,15 @@ def observe_command(*, db: str | None = None) -> str:
 
 
 def _is_observe_hook(hook: Mapping[str, Any]) -> bool:
-    """True when a hook entry routes to ``continuum observe``."""
+    """True when a hook entry is one this module would have installed.
+
+    Deliberately narrow: a command that merely ends in ``observe`` could
+    belong to an unrelated tool, and treating it as ours would let install
+    repoint or remove delete someone else's configuration. Two shapes are
+    recognised, matching :func:`observe_command` exactly: a resolved
+    ``continuum`` executable path (its stem is ``continuum``), and the
+    interpreter fallback form ``<python> -m continuum.cli ... observe``.
+    """
     command = hook.get("command")
     if not isinstance(command, str):
         return False
@@ -120,7 +128,11 @@ def _is_observe_hook(hook: Mapping[str, Any]) -> bool:
         tokens = shlex.split(command)
     except ValueError:
         return False
-    return len(tokens) >= 1 and tokens[-1] == "observe"
+    if len(tokens) < 2 or tokens[-1] != "observe":
+        return False
+    if Path(tokens[0]).stem == "continuum":
+        return True
+    return tokens[1] == "-m" and len(tokens) >= 4 and tokens[2] == "continuum.cli"
 
 
 def install_claude_code_hook(
@@ -217,14 +229,27 @@ def remove_claude_code_hook(settings_path: Path, *, matcher: str = DEFAULT_MATCH
     removed = False
     kept_groups: list[Any] = []
     for group in post_tool_use:
-        if (
+        if not (
             isinstance(group, dict)
             and group.get("matcher") == matcher
             and isinstance(group.get("hooks"), list)
-            and any(isinstance(h, dict) and _is_observe_hook(h) for h in group["hooks"])
         ):
-            removed = True
+            kept_groups.append(group)
             continue
+        # Drop only the hook entries this module recognises as its own. A
+        # matcher group can hold unrelated user hooks alongside ours; removing
+        # the whole group would delete configuration this command never
+        # installed.
+        kept_hooks = [
+            h
+            for h in group["hooks"]
+            if not (isinstance(h, dict) and _is_observe_hook(h))
+        ]
+        if len(kept_hooks) != len(group["hooks"]):
+            removed = True
+        if not kept_hooks:
+            continue
+        group["hooks"] = kept_hooks
         kept_groups.append(group)
 
     if not removed:

--- a/tests/test_cli_observe.py
+++ b/tests/test_cli_observe.py
@@ -93,11 +93,18 @@ def test_observe_reads_stdin_when_no_payload_file_is_given(
 
 
 def test_observe_targets_the_requested_run_not_the_active_one(
-    db: str, tmp_path: Path, written_file: Path
+    tmp_path: Path, written_file: Path
 ) -> None:
+    """The explicit flag must win over active-run fallback selection.
+
+    A second, more recently started run stays in the same database so the
+    fallback would pick *it* if the flag were ignored; asserting it received
+    nothing is what makes this test discriminate.
+    """
     other = str(tmp_path / "other.db")
     with SQLiteStorage(other) as store:
         store.create_run_started(Run(run_id="run_2", goal="Another thing"))
+        store.create_run_started(Run(run_id="run_z", goal="Active run"))
 
     payload_file = tmp_path / "hook.json"
     payload_file.write_text(json.dumps(payload_for(written_file)))
@@ -108,7 +115,9 @@ def test_observe_targets_the_requested_run_not_the_active_one(
 
     with SQLiteStorage(other) as store:
         events = store.read_events("run_2")
-    assert events[-1].type is EventType.TOOL_COMPLETED
+        assert events[-1].type is EventType.TOOL_COMPLETED
+        # The fallback target must have been left untouched.
+        assert store.last_sequence("run_z") == 1
 
 
 def test_observe_with_no_active_run_drops_the_observation_without_failing(

--- a/tests/test_cli_observe.py
+++ b/tests/test_cli_observe.py
@@ -1,0 +1,276 @@
+"""Host-side observation hooks: ``continuum observe`` and ``continuum hooks``.
+
+These exist because of issue #207: a Claude Code session wrote its artifact and
+was killed before any voluntary recording call, so recovery reported progress
+0/1 with zero checkpoints. The observe path makes the recording happen in a
+PostToolUse hook, outside the model's control, so work that landed on disk is
+never invisible to the next session.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from continuum.cli import ExitCode, main
+from continuum.clienthooks import (
+    DEFAULT_MATCHER,
+    install_claude_code_hook,
+    remove_claude_code_hook,
+)
+from continuum.events import EventType
+from continuum.models import Origin, Run
+from continuum.storage import SQLiteStorage
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+def payload_for(path: Path) -> dict[str, object]:
+    return {"tool_name": "Write", "tool_input": {"file_path": str(path)}}
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "demo.db")
+    with SQLiteStorage(path) as store:
+        store.create_run_started(Run(run_id="run_1", goal="Write the thing"))
+    yield path
+
+
+@pytest.fixture
+def written_file(tmp_path: Path) -> Path:
+    target = tmp_path / "artifact.txt"
+    target.write_text("hello")
+    return target
+
+
+# --- observe ----------------------------------------------------------------- #
+
+
+def test_an_observation_is_recorded_as_tool_completed_with_file_facts(
+    db: str, tmp_path: Path, written_file: Path
+) -> None:
+    payload_file = tmp_path / "hook.json"
+    payload_file.write_text(json.dumps(payload_for(written_file)))
+
+    code, out, err = run("--db", db, "observe", "--payload-file", str(payload_file))
+    assert code == ExitCode.OK, err
+
+    with SQLiteStorage(db) as store:
+        events = store.read_events("run_1")
+    assert [e.type for e in events] == [EventType.RUN_STARTED, EventType.TOOL_COMPLETED]
+    recorded = events[-1]
+    assert recorded.source is Origin.EXTERNAL_AGENT
+    assert recorded.payload["tool"] == "Write"
+    assert recorded.payload["path"] == str(written_file)
+    assert recorded.payload["bytes"] == 5  # len(b"hello")
+    assert isinstance(recorded.payload["sha256"], str)
+    assert len(recorded.payload["sha256"]) == 64
+
+
+def test_observe_reads_stdin_when_no_payload_file_is_given(
+    db: str,
+    tmp_path: Path,
+    written_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload_for(written_file))))
+    code, _, err = run("--db", db, "observe")
+    assert code == ExitCode.OK, err
+
+    with SQLiteStorage(db) as store:
+        assert store.last_sequence("run_1") == 2
+
+
+def test_observe_targets_the_requested_run_not_the_active_one(
+    db: str, tmp_path: Path, written_file: Path
+) -> None:
+    other = str(tmp_path / "other.db")
+    with SQLiteStorage(other) as store:
+        store.create_run_started(Run(run_id="run_2", goal="Another thing"))
+
+    payload_file = tmp_path / "hook.json"
+    payload_file.write_text(json.dumps(payload_for(written_file)))
+    code, _, err = run(
+        "--db", other, "observe", "--run-id", "run_2", "--payload-file", str(payload_file)
+    )
+    assert code == ExitCode.OK, err
+
+    with SQLiteStorage(other) as store:
+        events = store.read_events("run_2")
+    assert events[-1].type is EventType.TOOL_COMPLETED
+
+
+def test_observe_with_no_active_run_drops_the_observation_without_failing(
+    db: str, tmp_path: Path, written_file: Path
+) -> None:
+    """Hooks fire for every session in the directory, including ones with no
+    CONTINUUM run. Failing them would pressure the user into uninstalling the
+    instrumentation, so the drop exits 0 with a visible stderr note."""
+    empty = str(tmp_path / "empty.db")
+
+    payload_file = tmp_path / "hook.json"
+    payload_file.write_text(json.dumps(payload_for(written_file)))
+    code, out, err = run("--db", empty, "observe", "--payload-file", str(payload_file))
+    assert code == ExitCode.OK
+    assert "No active CONTINUUM run" in err
+    assert out == ""
+
+    with SQLiteStorage(empty) as store:
+        assert store.list_runs() == []
+
+
+def test_observe_rejects_an_unknown_run_id(db: str, tmp_path: Path, written_file: Path) -> None:
+    payload_file = tmp_path / "hook.json"
+    payload_file.write_text(json.dumps(payload_for(written_file)))
+    code, _, err = run(
+        "--db", db, "observe", "--run-id", "typo", "--payload-file", str(payload_file)
+    )
+    assert code == ExitCode.NOT_FOUND
+    assert "typo" in err
+
+
+def test_observe_rejects_a_payload_that_is_not_json(db: str, tmp_path: Path) -> None:
+    payload_file = tmp_path / "hook.json"
+    payload_file.write_text("{not json")
+    code, _, err = run("--db", db, "observe", "--payload-file", str(payload_file))
+    assert code == ExitCode.ERROR
+    assert "not valid JSON" in err
+
+    with SQLiteStorage(db) as store:
+        assert store.last_sequence("run_1") == 1
+
+
+# --- hooks install / remove -------------------------------------------------- #
+
+
+def test_install_writes_a_single_post_tool_use_entry(tmp_path: Path) -> None:
+    settings = tmp_path / ".claude" / "settings.json"
+    command = "/bin/continuum observe"
+
+    status = install_claude_code_hook(settings, command)
+    assert status == "installed"
+
+    data = json.loads(settings.read_text())
+    entry = data["hooks"]["PostToolUse"]
+    assert entry == [
+        {
+            "matcher": DEFAULT_MATCHER,
+            "hooks": [{"type": "command", "command": command}],
+        }
+    ]
+
+    assert install_claude_code_hook(settings, command) == "present"
+
+
+def test_install_preserves_unrelated_settings_and_entries(tmp_path: Path) -> None:
+    settings = tmp_path / "settings.json"
+    settings.write_text(
+        json.dumps({"model": "opus", "hooks": {"PreToolUse": [{"matcher": "Bash"}]}})
+    )
+
+    install_claude_code_hook(settings, "/bin/continuum observe")
+    data = json.loads(settings.read_text())
+    assert data["model"] == "opus"
+    assert data["hooks"]["PreToolUse"] == [{"matcher": "Bash"}]
+    assert len(data["hooks"]["PostToolUse"]) == 1
+
+
+def test_install_repoints_a_stale_command(tmp_path: Path) -> None:
+    """A moved virtualenv must self-heal rather than leave a dead binary wired."""
+    settings = tmp_path / "settings.json"
+    install_claude_code_hook(settings, "/old/venv/bin/continuum observe")
+
+    status = install_claude_code_hook(settings, "/new/venv/bin/continuum observe")
+    assert status == "updated"
+    data = json.loads(settings.read_text())
+    assert data["hooks"]["PostToolUse"][0]["hooks"][0]["command"] == (
+        "/new/venv/bin/continuum observe"
+    )
+
+
+def test_install_refuses_to_overwrite_hand_edited_settings(tmp_path: Path) -> None:
+    settings = tmp_path / "settings.json"
+    settings.write_text("{broken")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        install_claude_code_hook(settings, "/bin/continuum observe")
+    # The file survives untouched: a file someone edited by hand is a
+    # statement of intent.
+    assert settings.read_text() == "{broken"
+
+
+def test_remove_deletes_only_the_observe_entry(tmp_path: Path) -> None:
+    settings = tmp_path / "settings.json"
+    install_claude_code_hook(settings, "/bin/continuum observe")
+
+    assert remove_claude_code_hook(settings) is True
+    data = json.loads(settings.read_text())
+    assert "hooks" not in data or "PostToolUse" not in data.get("hooks", {})
+    assert remove_claude_code_hook(settings) is False
+
+
+def test_cli_hooks_commands_round_trip(tmp_path: Path) -> None:
+    settings = tmp_path / "settings.json"
+
+    code, out, err = run("--json", "hooks", "install", "claude-code", "--settings", str(settings))
+    assert code == ExitCode.OK, err
+    installed = json.loads(out)
+    assert installed["status"] == "installed"
+    assert json.loads(settings.read_text())["hooks"]["PostToolUse"]
+
+    code, out, _ = run("--json", "hooks", "install", "claude-code", "--settings", str(settings))
+    assert code == ExitCode.OK
+    assert json.loads(out)["status"] == "present"
+
+    code, out, _ = run("--json", "hooks", "remove", "claude-code", "--settings", str(settings))
+    assert code == ExitCode.OK
+    assert json.loads(out)["removed"] is True
+
+
+def test_installed_command_actually_records_through_the_real_entrypoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The string baked into settings.json must work as-is: this drives the
+    real `continuum` executable (or interpreter fallback) through a shell,
+    exactly as Claude Code would."""
+    project = tmp_path / "proj"
+    (project / ".claude").mkdir(parents=True)
+    monkeypatch.chdir(project)
+
+    subprocess.run(["python", "-m", "continuum.cli", "init"], check=True, capture_output=True)
+    subprocess.run(
+        ["python", "-m", "continuum.cli", "start", "demo", "--goal", "write things"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["python", "-m", "continuum.cli", "hooks", "install", "claude-code"],
+        check=True,
+        capture_output=True,
+    )
+    artifact = project / "out.txt"
+    artifact.write_text("done")
+
+    # The command baked into the settings must work as-is through a shell,
+    # exactly as Claude Code would run it.
+    settings = json.loads((project / ".claude" / "settings.json").read_text())
+    command = settings["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+    hook_input = json.dumps(payload_for(artifact))
+    result = subprocess.run(command, input=hook_input, capture_output=True, text=True, shell=True)
+    assert result.returncode == ExitCode.OK, result.stderr
+
+    with SQLiteStorage(str(project / "continuum.db")) as store:
+        events = store.read_events("demo")
+    assert events[-1].type is EventType.TOOL_COMPLETED
+    assert events[-1].payload["path"] == str(artifact)
+    assert shlex.split(command)[-1] == "observe"


### PR DESCRIPTION
## Description

Recovery depended on the agent voluntarily calling the recording tools, so a kill between performing work and reporting it left the next session a contract that understated what had landed on disk. Observed live with Claude Code (issue #207): a session wrote its artifact and was hard-killed before any recording call, leaving progress 0/1 and zero checkpoints.

This PR converts voluntary recording into mandatory interception for hooked clients:

- `continuum observe`: reads one tool-call payload from stdin (or `--payload-file`) and appends a `TOOL_COMPLETED` event carrying the tool name, mutated path, byte count and SHA-256 of the file as it exists right now. Targets `--run-id` or the most recently active non-terminal run; with no run active it drops the observation with exit 0 so hooks never disturb unrelated sessions.
- `continuum hooks install claude-code` / `remove`: edits `.claude/settings.json` in place, wiring file-mutating tool completions to observe. Preserves unrelated settings, self-heals a stale baked-in command, refuses to touch a settings file that is not valid JSON, bakes absolute paths resolved at install time.

The observe contract itself is client-agnostic (one JSON object on stdin); only the installer is client-specific. Observations are sourced `EXTERNAL_AGENT` deliberately: they are evidence a resumed session can weigh, never a laundering path from self-reported state to trusted state. Surfacing them inside the recovery contract is follow-up #208; installers for other clients are #209.

## Related issues

Fixes #207

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest                      # 1098 passed, 12 skipped
ruff check src tests                  # clean
mypy src                              # Success: no issues found in 86 source files
```

New tests in `tests/test_cli_observe.py` cover: event recording with correct size/hash facts, stdin vs payload-file input, explicit run targeting, no-active-run drop with exit 0, unknown-run NOT_FOUND, malformed payload rejection, installer idempotency/unrelated-settings preservation/self-heal/refusal-on-invalid-JSON, removal, and an end-to-end test driving the exact settings.json command string through a real shell.

Also verified live against a real Claude Code session in a scratch directory: two files written by the agent appeared as `TOOL_COMPLETED` events with correct SHA-256 digests despite zero MCP calls and zero voluntary recording calls; a `kill -9` mid-task still left the partial work (`f1.txt`) durably recorded.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Known limitation, stated explicitly: observations prove a tool call completed and what the file looked like at observation time; they do not authenticate the caller (a local process could append events directly, which is already true of every writer to the SQLite store) and they do not by themselves upgrade self-reported progress in the validator (#208 keeps provenance conservative). The hook fires after Write/Edit/MultiEdit/NotebookEdit completions; Bash side effects are not yet observed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code observation hooks that record completed tool activity, including relevant file metadata.
  * Added commands to install and remove the observation hook while preserving existing settings.
  * Added support for targeting a specific run or the latest active run.
* **Bug Fixes**
  * Invalid or inactive observations are handled safely without creating unnecessary records or databases.
* **Documentation**
  * Documented observation commands, hook management, and external-agent provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->