### PR TITLE
perf(adapters): resolve optional SDK adapters lazily (PEP 562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Lazy adapter imports (#214).** `continuum.adapters` sits on the critical
+  path of every entry point, but eagerly imported the optional SDK adapters,
+  so opening the MCP server cost roughly 3s before answering its first
+  request, and every `continuum observe` hook subprocess paid it again. The
+  dependency-free adapters stay eager; browser/container/kubernetes and the
+  langchain/langgraph/openai names now resolve through module
+  `__getattr__` (PEP 562) on first access, in both `continuum.adapters` and
+  the top-level `continuum` package. The public import surface is unchanged.
+  Measured on this machine: MCP server spawn-to-first-response drops from
+  about 3s to about 0.1s, and importing either package leaves none of
+  langgraph, langchain or openai in `sys.modules`. The full test suite also
+  gets faster for the same reason. Tests in `tests/test_adapters_lazy.py`
+  run their key assertions in subprocesses so earlier imports cannot mask a
+  regression.
+
 - **Host-side observation hooks close part of the durability gap (#207).**
   Recovery depends on the agent voluntarily calling the recording tools, so a
   kill between performing work and reporting it left the next session a

--- a/src/continuum/__init__.py
+++ b/src/continuum/__init__.py
@@ -7,6 +7,10 @@ runtime (``Continuum``), storage engines, validation, action ledger and CLI
 arrive in later phases; nothing here imports an LLM provider.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from continuum.actions import (
     ActionLedger,
     ActionOutcome,
@@ -25,9 +29,6 @@ from continuum.adapters import (
     AdapterRegistry,
     AgentAdapter,
     GenericAgentAdapter,
-    LangChainAgentAdapter,
-    LangGraphAgentAdapter,
-    OpenAIAgentAdapter,
     get_adapter,
     list_adapters,
     recover,
@@ -164,6 +165,38 @@ from continuum.storage import (
 )
 
 __version__ = "0.1.0"
+
+# Framework-adapter names resolve lazily (PEP 562, issue #214): importing the
+# package must not pay for openai/langgraph/langchain, because every entry
+# point imports this package, including processes that never touch an
+# adapter. Type-checkers see the real definitions here; runtime resolves them
+# through __getattr__ below.
+if TYPE_CHECKING:
+    from continuum.adapters.langchain import LangChainAgentAdapter
+    from continuum.adapters.langgraph import LangGraphAgentAdapter
+    from continuum.adapters.openai import OpenAIAgentAdapter
+
+_LAZY_TOP_LEVEL: dict[str, str] = {
+    "LangChainAgentAdapter": "langchain",
+    "LangGraphAgentAdapter": "langgraph",
+    "OpenAIAgentAdapter": "openai",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _LAZY_TOP_LEVEL.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    value = getattr(importlib.import_module(f"continuum.adapters.{module_name}"), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_LAZY_TOP_LEVEL))
+
 
 __all__ = [
     "__version__",

--- a/src/continuum/adapters/__init__.py
+++ b/src/continuum/adapters/__init__.py
@@ -1,4 +1,22 @@
-"""Framework adapters for CONTINUUM."""
+"""Framework adapters for CONTINUUM.
+
+Import-cost discipline (issue #214): this package is on the critical path of
+every entry point, including processes that never touch a framework adapter
+(the MCP server, and each ``continuum observe`` hook subprocess). The optional
+SDK adapters pull in heavyweight dependencies (openai ~1.3s, langgraph ~0.8s
+cumulative, measured with ``-X importtime``), so their names resolve lazily
+through module ``__getattr__`` (PEP 562) and are only imported when actually
+requested. The dependency-free adapters stay eager.
+
+The public surface is unchanged: ``from continuum.adapters import X`` works
+for every name in ``__all__``, because ``from`` imports fall back to
+``__getattr__`` when module attribute lookup misses.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
 
 from continuum.adapters.actions import (
     AdapterAction,
@@ -6,14 +24,8 @@ from continuum.adapters.actions import (
     run_action,
 )
 from continuum.adapters.base import AgentAdapter
-from continuum.adapters.browser import BrowserAdapter
-from continuum.adapters.container import ContainerAdapter
 from continuum.adapters.filesystem import FilesystemSandboxAdapter
 from continuum.adapters.generic import GenericAgentAdapter
-from continuum.adapters.kubernetes import KubernetesAdapter
-from continuum.adapters.langchain import LangChainAgentAdapter, langchain_available
-from continuum.adapters.langgraph import LangGraphAgentAdapter, langgraph_available
-from continuum.adapters.openai import ContinuumContext, OpenAIAgentAdapter, openai_agents_available
 from continuum.adapters.python_inproc import PythonInProcAdapter
 from continuum.adapters.registry import (
     AdapterRegistry,
@@ -22,6 +34,35 @@ from continuum.adapters.registry import (
     recover,
     register_adapter,
 )
+
+if TYPE_CHECKING:
+    # Type-checkers see the real definitions; runtime resolves them lazily
+    # through __getattr__ below.
+    from continuum.adapters.browser import BrowserAdapter
+    from continuum.adapters.container import ContainerAdapter
+    from continuum.adapters.kubernetes import KubernetesAdapter
+    from continuum.adapters.langchain import LangChainAgentAdapter, langchain_available
+    from continuum.adapters.langgraph import LangGraphAgentAdapter, langgraph_available
+    from continuum.adapters.openai import (
+        ContinuumContext,
+        OpenAIAgentAdapter,
+        openai_agents_available,
+    )
+
+#: Lazy name -> submodule under :mod:`continuum.adapters`. Every name here is
+#: provided by a module whose import pulls an optional third-party SDK.
+_LAZY_EXPORTS: dict[str, str] = {
+    "BrowserAdapter": "browser",
+    "ContainerAdapter": "container",
+    "KubernetesAdapter": "kubernetes",
+    "LangChainAgentAdapter": "langchain",
+    "langchain_available": "langchain",
+    "LangGraphAgentAdapter": "langgraph",
+    "langgraph_available": "langgraph",
+    "ContinuumContext": "openai",
+    "OpenAIAgentAdapter": "openai",
+    "openai_agents_available": "openai",
+}
 
 __all__ = [
     "AdapterAction",
@@ -47,3 +88,18 @@ __all__ = [
     "register_adapter",
     "run_action",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve a lazy export on first access and cache it as a module attr."""
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_LAZY_EXPORTS))

--- a/tests/test_adapters_lazy.py
+++ b/tests/test_adapters_lazy.py
@@ -73,9 +73,15 @@ def test_unknown_attribute_raises_attribute_error() -> None:
         continuum.adapters.definitely_not_an_adapter  # noqa: B018
 
 
-def test_repeated_access_is_cached_not_reimported() -> None:
-    import continuum.adapters
-
-    first = continuum.adapters.langgraph_available
-    second = continuum.adapters.langgraph_available
-    assert first is second
+def test_repeated_access_is_cached_in_the_module_dict() -> None:
+    """Caching means __getattr__ runs once: the name must be absent from the
+    module dict before first access and present afterwards. Identity alone
+    cannot prove this, because Python's import cache returns the same object
+    even when __getattr__ fires every time."""
+    result = _run(
+        "import continuum.adapters\n"
+        "assert 'langgraph_available' not in vars(continuum.adapters)\n"
+        "_ = continuum.adapters.langgraph_available\n"
+        "assert 'langgraph_available' in vars(continuum.adapters)\n"
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_adapters_lazy.py
+++ b/tests/test_adapters_lazy.py
@@ -1,0 +1,81 @@
+"""Lazy adapter imports (issue #214).
+
+``continuum.adapters`` sits on the critical path of every entry point,
+including the MCP server and each ``continuum observe`` hook subprocess.
+Importing it must not pay for the optional SDKs (openai, langgraph,
+langchain), while ``from continuum.adapters import LangGraphAgentAdapter``
+must keep working unchanged.
+
+Most assertions run in a subprocess: an in-process test would see modules
+imported by earlier tests and prove nothing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_OPTIONAL_SDK_ROOTS = ("langgraph", "langchain", "openai", "agents", "playwright")
+
+
+def _run(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+
+
+def test_importing_the_package_does_not_import_optional_sdks() -> None:
+    result = _run(
+        "import continuum.adapters, sys\n"
+        "polluted = [m for m in sys.modules if m.split('.')[0] in "
+        f"{_OPTIONAL_SDK_ROOTS!r}]\n"
+        "assert not polluted, polluted\n"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_importing_the_top_level_package_does_not_import_optional_sdks() -> None:
+    """``import continuum`` pulls in adapters via its own re-exports; the
+    framework names must resolve lazily there too."""
+    result = _run(
+        "import continuum, sys\n"
+        "polluted = [m for m in sys.modules if m.split('.')[0] in "
+        f"{_OPTIONAL_SDK_ROOTS!r}]\n"
+        "assert not polluted, polluted\n"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_from_import_resolves_lazy_names() -> None:
+    result = _run(
+        "from continuum.adapters import (LangChainAgentAdapter, langchain_available,\n"
+        "    LangGraphAgentAdapter, langgraph_available, OpenAIAgentAdapter,\n"
+        "    ContinuumContext, openai_agents_available)\n"
+        "from continuum import LangGraphAgentAdapter as TopLevel\n"
+        "assert TopLevel is LangGraphAgentAdapter\n"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_dir_lists_the_full_export_surface() -> None:
+    result = _run(
+        "import continuum.adapters\n"
+        "missing = set(continuum.adapters.__all__) - set(dir(continuum.adapters))\n"
+        "assert not missing, missing\n"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    import pytest
+
+    import continuum.adapters
+
+    with pytest.raises(AttributeError, match="definitely_not_an_adapter"):
+        continuum.adapters.definitely_not_an_adapter  # noqa: B018
+
+
+def test_repeated_access_is_cached_not_reimported() -> None:
+    import continuum.adapters
+
+    first = continuum.adapters.langgraph_available
+    second = continuum.adapters.langgraph_available
+    assert first is second


### PR DESCRIPTION
## Description

`continuum.adapters` is on the critical path of every entry point: the MCP server imports it at startup and every `continuum observe` hook subprocess imports it per file write. Until now its `__init__` eagerly imported all adapters, including the optional SDK ones (openai ~1.3s, langgraph ~0.8s cumulative import time), so an MCP server took roughly 3s to answer its first request.

This PR keeps the dependency-free adapters eager and resolves browser/container/kubernetes plus the langchain/langgraph/openai names lazily via module `__getattr__` (PEP 562), in both `continuum.adapters` and the top-level `continuum` package (which re-exported the framework names). The public import surface is unchanged; `from continuum.adapters import LangGraphAgentAdapter` works exactly as before because `from` imports fall back to `__getattr__`.

## Related issues

Fixes #214

## Types of changes

- Type: `performance`

## Breaking changes

No

## How has this been tested?

```
python -m pytest            # 1104 passed, 12 skipped
ruff check src tests        # clean
ruff format --check src tests   # clean
mypy src                    # Success: no issues found in 86 source files
```

Measured on this machine:

- MCP server spawn-to-first-response over a real stdio handshake: ~0.1s (STATUS.md documented ~3s)
- `python -X importtime -c "import continuum.adapters"`: adapter package cost drops from ~2.1s to near zero
- `import continuum.adapters` / `import continuum` leave zero langgraph/langchain/openai/agents/playwright modules in `sys.modules`

New tests in `tests/test_adapters_lazy.py`: subprocess-isolated pollution checks for both packages, from-import compatibility, top-level re-export identity, `dir()` completeness, unknown-name AttributeError, and access caching. A side effect of the same fix: the full suite runs in ~21s instead of ~52s, since tests no longer import the heavy SDKs transitively.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Phase 0a of the enforced-durability roadmap (#213). The lazy pattern intentionally mirrors what the adapters already do internally for their own optional dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Optional framework and platform adapters now load only when first accessed.
  - Existing adapter imports and public exports remain unchanged.
  - Dependency-free adapters continue to be available immediately.

- **Bug Fixes**
  - Reduced unnecessary loading of optional SDKs during package import.

- **Tests**
  - Added coverage for lazy loading, exports, repeated access, directory listings, and unknown attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->