### PR TITLE
feat(cli): reconciler registry settles uncertain actions with probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Reconciler registry: probes settle uncertain side effects (#218).** An
+  uncertain action blocked resume until a person checked the external
+  system by hand, which does not scale past the first high-volume run.
+  Projects can now register one probe per action type in
+  `.continuum/reconcilers.json`; the probe receives the Action record as
+  JSON on stdin and prints a verdict (`occurred=true|false|unknown` or a
+  JSON object). `continuum reconcile <run>` runs the registered probes over
+  every pending action: definitive verdicts are applied through the ledger
+  and land as `ACTION_RECONCILED` events sourced `DETERMINISTIC` (local,
+  registered, auditable); probe errors, timeouts, unparseable output and
+  explicit unknowns leave actions untouched; types without a probe are
+  skipped. Auto-settlement therefore only shrinks the human queue, never
+  widens what an agent may certify itself. `--dry-run` reports without
+  writing. The command is deliberately separate from validate/resume so
+  those stay read-only under the exit-code safety contract. Verified live:
+  a claim committed then the MCP server killed leaves `REQUEST_HUMAN`;
+  after registering an outbox-checking probe, `reconcile` settles the
+  action and resume returns `RESUME`. Tests in `tests/test_reconcilers.py`
+  cover verdict parsing, the settle table, failure isolation, dry-run,
+  provenance and exit codes.
+
 - **Host-side observation hooks close part of the durability gap (#207).**
   Recovery depends on the agent voluntarily calling the recording tools, so a
   kill between performing work and reporting it left the next session a

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -716,6 +716,57 @@ def cmd_hooks_remove(args: argparse.Namespace, storage: Storage, out: Any, err: 
     return ExitCode.OK
 
 
+def cmd_reconcile_auto(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Settle uncertain actions with registered probes (issue #218).
+
+    Mutating by design (it appends ACTION_RECONCILED events through the
+    ledger), which is why it is its own command rather than something
+    `validate`/`resume` do implicitly: those stay read-only so the exit-code
+    safety contract holds. With no registered probe for an action's type,
+    that action is left exactly as the ledger holds it.
+    """
+    from continuum.actions.ledger import ActionLedger
+    from continuum.reconcilers import (
+        DEFAULT_RECONCILERS_PATH,
+        ReconcilerConfigError,
+        load_reconcilers,
+        settle_run,
+    )
+
+    storage.get_run(args.run_id)
+    try:
+        probes = load_reconcilers(
+            Path(args.config) if args.config else Path(DEFAULT_RECONCILERS_PATH)
+        )
+    except ReconcilerConfigError as exc:
+        print(f"error: {exc}", file=err)
+        return ExitCode.ERROR
+
+    pending = ActionLedger(storage, args.run_id).pending()
+    report = settle_run(storage, args.run_id, probes, dry_run=args.dry_run)
+    payload = {"run_id": args.run_id, "dry_run": args.dry_run, **report.as_dict()}
+    lines = [
+        f"pending actions: {len(pending)}, "
+        f"settled: {report.settled} "
+        f"(occurred {len(report.settled_true)}, not-occurred {len(report.settled_false)}), "
+        f"unresolved: {len(report.unresolved)}, "
+        f"no probe registered: {len(report.skipped_no_probe)}"
+    ]
+    for action_type, detail in report.unresolved:
+        lines.append(f"  [!!] {action_type}: {detail}")
+    if args.dry_run:
+        lines.append("dry run: nothing was written")
+    _emit(
+        payload,
+        "\n".join(lines),
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    remaining = len(pending) - report.settled
+    return ExitCode.OK if remaining <= 0 else ExitCode.REQUIRES_HUMAN
+
+
 def cmd_verify(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Re-audit the event chain for tampering."""
     # A run that does not exist has an empty, trivially valid chain. Reporting
@@ -1140,6 +1191,22 @@ def build_parser() -> argparse.ArgumentParser:
     hooks_client(remove, cmd_hooks_remove)
 
     with_run(add("verify", cmd_verify, "Re-audit the event chain."))
+
+    reconcile_auto = with_run(
+        add(
+            "reconcile",
+            cmd_reconcile_auto,
+            "Settle uncertain actions with registered probes. Mutates storage.",
+        )
+    )
+    reconcile_auto.add_argument(
+        "--dry-run", action="store_true", help="report what probes would settle, write nothing"
+    )
+    reconcile_auto.add_argument(
+        "--config",
+        default=None,
+        help="probe registry path (default: .continuum/reconcilers.json)",
+    )
     with_run(add("actions", cmd_actions, "List external side effects."))
     with_env(with_run(add("show-contract", cmd_contract, "Print the recovery contract.")))
 

--- a/src/continuum/reconcilers.py
+++ b/src/continuum/reconcilers.py
@@ -1,0 +1,219 @@
+"""Registered reconciliation probes for uncertain side effects (issue #218).
+
+An uncertain action blocks resume until something settles it, and until now
+that something was always a person. Most of the time the answer is
+mechanically checkable ("is the invoice in the outbox?"), so this module lets
+a project register one probe per action type:
+
+    .continuum/reconcilers.json
+    {"send_invoice": {"command": "check-outbox", "timeout": 10}}
+
+A probe receives the full Action record as JSON on stdin and prints exactly
+one verdict on its last stdout line: ``occurred=true``, ``occurred=false`` or
+``occurred=unknown`` (a JSON object with an ``occurred`` field also works,
+with true/false/null/unknown). The verdict is applied through
+:meth:`ActionLedger.reconcile`, so it lands in the log like any other
+reconciliation and is auditable there.
+
+Provenance stays conservative and deliberately narrower than what the ledger
+technically allows:
+
+- A definitive probe verdict is settled automatically; the event is sourced
+  ``DETERMINISTIC`` because a local, registered, auditable command produced
+  it.
+- Anything else, missing probe, non-zero exit, timeout, unparseable output,
+  explicit unknown, leaves the action untouched and the human queue intact.
+
+Auto-settlement therefore only ever shrinks the set of things a person must
+look at; it never widens what an agent may certify on its own.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from continuum.models import Action
+from continuum.storage.base import Storage
+
+__all__ = [
+    "DEFAULT_RECONCILERS_PATH",
+    "ReconcilerConfigError",
+    "load_reconcilers",
+    "probe_verdict",
+    "settle_run",
+]
+
+#: Where the registry lives relative to the project root a hook or CLI
+#: invocation runs in. JSON, matching gate.json and mcp-policy.json.
+DEFAULT_RECONCILERS_PATH = ".continuum/reconcilers.json"
+
+_DEFAULT_TIMEOUT = 10.0
+
+
+class ReconcilerConfigError(ValueError):
+    """The reconciler registry exists but cannot be honoured."""
+
+
+def load_reconcilers(path: Path) -> dict[str, dict[str, Any]]:
+    """Read the registry. Empty dict when absent; raise when malformed."""
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ReconcilerConfigError(f"{path} is not valid JSON ({exc})") from exc
+    if not isinstance(raw, dict) or not isinstance(raw.get("probes", {}), dict):
+        raise ReconcilerConfigError(f"{path}: expected {{'probes': {{...}}}}")
+    probes: dict[str, dict[str, Any]] = {}
+    for action_type, spec in (raw.get("probes") or {}).items():
+        if not isinstance(spec, dict) or not isinstance(spec.get("command"), str):
+            raise ReconcilerConfigError(f"{path}: probe {action_type!r} needs a string 'command'")
+        timeout = spec.get("timeout", _DEFAULT_TIMEOUT)
+        if not isinstance(timeout, (int, float)) or timeout <= 0:
+            raise ReconcilerConfigError(
+                f"{path}: probe {action_type!r} 'timeout' must be a positive number"
+            )
+        probes[action_type] = {"command": spec["command"], "timeout": float(timeout)}
+    return probes
+
+
+def _parse_verdict(text: str) -> bool | Literal["unknown"]:
+    """Parse a probe's final output line into occurred True/False/None."""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return "unknown"
+    last = lines[-1]
+    lowered = last.lower()
+    if lowered.startswith("occurred="):
+        value = lowered.split("=", 1)[1]
+        return {"true": True, "false": False}.get(value, "unknown")
+    try:
+        parsed = json.loads(last)
+    except json.JSONDecodeError:
+        return "unknown"
+    if isinstance(parsed, dict):
+        occurred = parsed.get("occurred")
+        if isinstance(occurred, bool):
+            return occurred
+        return "unknown"
+    elif isinstance(parsed, bool):
+        return parsed
+    return "unknown"
+
+
+def probe_verdict(
+    spec: Mapping[str, Any], action: Action
+) -> tuple[bool | None | Literal["error"], str]:
+    """Run one probe. Returns ``(verdict, detail)``.
+
+    The verdict is True, False, None (probe ran but could not tell) or the
+    string ``"error"`` (probe itself failed). ``detail`` carries whatever a
+    human would want to see next to the outcome.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S602 - operator-configured command
+            spec["command"],
+            input=json.dumps(action.model_dump(mode="json")),
+            capture_output=True,
+            text=True,
+            timeout=float(spec["timeout"]),
+            shell=True,
+        )
+    except subprocess.TimeoutExpired:
+        return (
+            "error",
+            f"probe for {action.action_type!r} timed out after {spec['timeout']}s",
+        )
+    except OSError as exc:
+        return "error", f"probe for {action.action_type!r} failed to run: {exc}"
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "").strip()[:200]
+        return "error", f"probe exited {completed.returncode}: {detail}"
+    verdict = _parse_verdict(completed.stdout)
+    if verdict == "unknown":
+        return None, (
+            f"probe could not determine the outcome from output "
+            f"{(completed.stdout or '').strip()[:120]!r}"
+        )
+    return verdict, (completed.stderr or "").strip()[:200]
+
+
+@dataclass
+class SettleReport:
+    """What automatic reconciliation did for one run."""
+
+    settled_true: list[str] = field(default_factory=list)
+    settled_false: list[str] = field(default_factory=list)
+    unresolved: list[tuple[str, str]] = field(default_factory=list)
+    skipped_no_probe: list[str] = field(default_factory=list)
+
+    @property
+    def settled(self) -> int:
+        return len(self.settled_true) + len(self.settled_false)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "settled_occurred": self.settled_true,
+            "settled_not_occurred": self.settled_false,
+            "unresolved": [{"action_type": t, "detail": d} for t, d in self.unresolved],
+            "no_probe_registered": self.skipped_no_probe,
+            "settled_total": self.settled,
+        }
+
+
+def settle_run(
+    storage: Storage,
+    run_id: str,
+    probes: dict[str, dict[str, Any]],
+    *,
+    dry_run: bool = False,
+) -> SettleReport:
+    """Probe every pending action of ``run_id`` and settle definitive ones."""
+    from continuum.actions import ActionLedger  # local import: avoids a cycle at module load
+
+    report = SettleReport()
+    ledger = ActionLedger(storage, run_id)
+    pending = ledger.pending()
+    for action in pending:
+        spec = probes.get(action.action_type)
+        if spec is None:
+            report.skipped_no_probe.append(action.action_id)
+            continue
+        verdict, detail = probe_verdict(spec, action)
+        if verdict == "error":
+            report.unresolved.append((action.action_type, detail))
+            continue
+        if verdict is None:
+            report.unresolved.append(
+                (action.action_type, detail or "probe could not determine the outcome")
+            )
+            continue
+        assert isinstance(verdict, bool), f"unexpected verdict {verdict!r}"
+        label = f"{action.action_type}:{action.external_id or action.action_id[:12]}"
+        if dry_run:
+            (report.settled_true if verdict else report.settled_false).append(label)
+            continue
+        ledger.reconcile(str(_key_for(storage, run_id, action)), occurred=verdict)
+        (report.settled_true if verdict else report.settled_false).append(label)
+    return report
+
+
+def _key_for(storage: Storage, run_id: str, action: Action) -> Any:
+    """Find the ledger key whose folded record is this action.
+
+    The fold is keyed by derived idempotency key while the Action record does
+    not carry it, so recover the key by matching action_id against the run's
+    folded ledger.
+    """
+    from continuum.actions.ledger import fold_action_events
+
+    folded = fold_action_events(storage.read_events(run_id))
+    for key, candidate in folded.items():
+        if candidate.action_id == action.action_id:
+            return key
+    raise LookupError(f"action {action.action_id} vanished from run {run_id} mid-reconcile")

--- a/tests/test_reconcilers.py
+++ b/tests/test_reconcilers.py
@@ -1,0 +1,240 @@
+"""Registered reconciliation probes (issue #218).
+
+A probe is an operator-configured command that checks the external system
+for one action type and prints a verdict. These tests pin the parsing
+contract, the settle loop against the real ledger, the provenance of
+auto-settled events, and the CLI's exit-code behaviour.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.cli import ExitCode, main
+from continuum.events import EventType
+from continuum.models import ActionStatus, Origin, Run
+from continuum.reconcilers import (
+    ReconcilerConfigError,
+    _parse_verdict,
+    load_reconcilers,
+    settle_run,
+)
+from continuum.storage import SQLiteStorage
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "rec.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    yield path
+
+
+def seed_pending(db: str, key: str = "invoice:1") -> str:
+    """Claim (and leave uncertain) one action; returns its action_id."""
+    with SQLiteStorage(db) as store:
+        outcome = ActionLedger(store, "run_1").claim(
+            "send_invoice", {}, key=key, scoped_to_run=True
+        )
+    assert outcome.fresh is True
+    return outcome.action.action_id
+
+
+# --- config loading ------------------------------------------------------------ #
+
+
+def test_missing_registry_loads_empty(tmp_path: Path) -> None:
+    assert load_reconcilers(tmp_path / "nope.json") == {}
+
+
+def test_broken_json_raises_instead_of_degrading(tmp_path: Path) -> None:
+    p = tmp_path / "r.json"
+    p.write_text("{")
+    with pytest.raises(ReconcilerConfigError, match="not valid JSON"):
+        load_reconcilers(p)
+
+
+def test_probe_requires_a_command_and_positive_timeout(tmp_path: Path) -> None:
+    p = tmp_path / "r.json"
+    p.write_text(json.dumps({"probes": {"send_invoice": {"timeout": 5}}}))
+    with pytest.raises(ReconcilerConfigError, match="command"):
+        load_reconcilers(p)
+    p.write_text(json.dumps({"probes": {"send_invoice": {"command": "x", "timeout": -1}}}))
+    with pytest.raises(ReconcilerConfigError, match="timeout"):
+        load_reconcilers(p)
+
+
+# --- verdict parsing -------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("occurred=true", True),
+        ("occurred=false", False),
+        ("OCCURRED=FALSE", False),
+        ('{"occurred": true}', True),
+        ('{"occurred": null}', "unknown"),
+        ("true", True),
+        ("garbage", "unknown"),
+        ("", "unknown"),
+    ],
+)
+def test_verdict_parsing(line: str, expected: bool | str) -> None:
+    assert (
+        _parse_verdict(line) is expected
+        if expected != "unknown"
+        else _parse_verdict(line) == "unknown"
+    )
+
+
+def test_last_line_wins() -> None:
+    assert _parse_verdict("noise\nmore noise\noccurred=false") is False
+
+
+# --- settle loop -------------------------------------------------------------------- #
+
+
+def registry(tmp_path: Path, entries: dict[str, str]) -> Path:
+    p = tmp_path / "reconcilers.json"
+    p.write_text(
+        json.dumps({"probes": {k: {"command": v, "timeout": 5} for k, v in entries.items()}})
+    )
+    return p
+
+
+def test_a_definitive_probe_settles_the_action(db: str, tmp_path: Path) -> None:
+    seed_pending(db, key="invoice:1")
+    probes = load_reconcilers(registry(tmp_path, {"send_invoice": "printf occurred=true"}))
+    report = settle_run(SQLiteStorage(db), "run_1", probes)
+    assert report.settled_true and report.settled == 1
+    with SQLiteStorage(db) as store:
+        from continuum.actions.ledger import fold_action_events
+
+        folded = fold_action_events(store.read_events("run_1"))
+    (action,) = folded.values()
+    assert action.status is ActionStatus.COMPLETED
+
+
+def test_false_frees_the_action_for_retry(db: str, tmp_path: Path) -> None:
+    seed_pending(db, key="invoice:2")
+    probes = load_reconcilers(registry(tmp_path, {"send_invoice": "printf occurred=false"}))
+    report = settle_run(SQLiteStorage(db), "run_1", probes)
+    assert report.settled_false
+    with SQLiteStorage(db) as store:
+        from continuum.actions.ledger import fold_action_events
+
+        (action,) = fold_action_events(store.read_events("run_1")).values()
+    assert action.status is ActionStatus.FAILED
+
+
+def test_an_unknown_verdict_leaves_the_action_untouched(db: str, tmp_path: Path) -> None:
+    seed_pending(db)
+    probes = load_reconcilers(registry(tmp_path, {"send_invoice": "printf occurred=unknown"}))
+    report = settle_run(SQLiteStorage(db), "run_1", probes)
+    assert not report.settled
+    assert len(report.unresolved) == 1
+    assert "could not determine" in report.unresolved[0][1]
+
+
+def test_probe_failures_never_settle(db: str, tmp_path: Path) -> None:
+    seed_pending(db)
+    cases = {
+        "nonzero": "exit 3",
+        "junk output": "printf hello",
+        "timeout": "sleep 30",
+    }
+    for name, command in cases.items():
+        entry = {} if name != "timeout" else {"command": command, "timeout": 0.2}
+        probes = {**load_reconcilers(registry(tmp_path, {"send_invoice": command}))}
+        if name == "timeout":
+            probes = {"send_invoice": {"command": command, "timeout": 0.2}}
+        report = settle_run(SQLiteStorage(db), "run_1", probes)
+        del entry
+        assert not report.settled, name
+        assert report.unresolved and report.unresolved[0][0] == "send_invoice", name
+
+
+def test_actions_without_registered_probes_are_skipped(db: str, tmp_path: Path) -> None:
+    seed_pending(db)
+    probes = load_reconcilers(registry(tmp_path, {"other_tool": "printf occurred=true"}))
+    report = settle_run(SQLiteStorage(db), "run_1", probes)
+    assert not report.settled
+    assert len(report.skipped_no_probe) == 1
+
+
+def test_dry_run_reports_without_writing(db: str, tmp_path: Path) -> None:
+    seed_pending(db)
+    probes = load_reconcilers(registry(tmp_path, {"send_invoice": "printf occurred=true"}))
+    report = settle_run(SQLiteStorage(db), "run_1", probes, dry_run=True)
+    assert report.settled == 1
+    with SQLiteStorage(db) as store:
+        (action,) = ActionLedger(store, "run_1").all()
+    assert action.status is ActionStatus.STARTED
+
+
+def test_settled_events_are_sourced_deterministic(db: str, tmp_path: Path) -> None:
+    seed_pending(db)
+    probes = load_reconcilers(registry(tmp_path, {"send_invoice": "printf occurred=true"}))
+    settle_run(SQLiteStorage(db), "run_1", probes)
+    with SQLiteStorage(db) as store:
+        events = store.read_events("run_1")
+    reconciled = [e for e in events if e.type is EventType.ACTION_RECONCILED]
+    assert reconciled, "expected an ACTION_RECONCILED event"
+    assert all(e.source is Origin.DETERMINISTIC for e in reconciled)
+
+
+# --- CLI ------------------------------------------------------------------------------ #
+
+
+def test_cli_reconcile_exits_zero_when_everything_settles(db: str, tmp_path: Path) -> None:
+    seed_pending(db, key="invoice:8")
+    cfg = registry(tmp_path, {"send_invoice": "printf occurred=true"})
+    code, out, err = run("--db", db, "--json", "reconcile", "run_1", "--config", str(cfg))
+    assert code == ExitCode.OK, err
+    payload = json.loads(out)
+    assert payload["settled_total"] == 1
+    assert payload["dry_run"] is False
+
+
+def test_cli_reconcile_requires_human_when_probes_cannot_settle(db: str, tmp_path: Path) -> None:
+    seed_pending(db)
+    cfg = registry(tmp_path, {"other_tool": "printf occurred=true"})
+    code, out, err = run("--db", db, "--json", "reconcile", "run_1", "--config", str(cfg))
+    assert code == ExitCode.REQUIRES_HUMAN
+    assert json.loads(out)["settled_total"] == 0
+
+
+def test_cli_dry_run_writes_nothing(db: str, tmp_path: Path) -> None:
+    seed_pending(db, key="invoice:9")
+    cfg = registry(tmp_path, {"send_invoice": "printf occurred=true"})
+    code, out, _ = run(
+        "--db", db, "--json", "reconcile", "run_1", "--config", str(cfg), "--dry-run"
+    )
+    assert code == ExitCode.OK
+    assert json.loads(out)["dry_run"] is True
+
+    # Still pending afterwards.
+    code, out, _ = run("--db", db, "--json", "actions", "run_1")
+    actions = json.loads(out)["actions"]
+    assert any(a["status"] == ActionStatus.STARTED.value for a in actions)
+
+
+def test_cli_reconcile_unknown_run_is_not_found(tmp_path: Path) -> None:
+    path = str(tmp_path / "empty.db")
+    with SQLiteStorage(path):
+        pass
+    code, _, _ = run("--db", path, "reconcile", "ghost")
+    assert code == ExitCode.NOT_FOUND


### PR DESCRIPTION
## Description

Uncertain side effects block resume until something reconciles them, and until now that something was always a person checking the external system by hand. This PR adds a reconciler registry so projects teach CONTINUUM how to check each action type itself:

```json
// .continuum/reconcilers.json
{"probes": {"send_invoice": {"command": "check-outbox", "timeout": 10}}}
```

`continuum reconcile <run>` runs registered probes over every pending action. A probe receives the full Action record as JSON on stdin and prints one verdict (`occurred=true|false|unknown`, or a JSON object). Definitive verdicts settle through `ActionLedger.reconcile` and land as `ACTION_RECONCILED` events sourced `DETERMINISTIC`: the probe ran locally against the operator's own configuration and its outcome is auditable in the hash-chained log. Everything else (missing probe, non-zero exit, timeout, unparseable output, explicit unknown) leaves the action exactly as it was, so auto-settlement only shrinks the human queue and never widens what agents may certify themselves. `--dry-run` reports what would settle without writing.

Design note: reconciliation is deliberately a separate mutating command rather than implicit behaviour inside validate/resume, preserving their read-only guarantee and exit-code safety contract.

## Related issues

Fixes #218

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest            # 1121 passed, 12 skipped
ruff check src tests        # clean
ruff format --check         # clean
mypy src                    # Success: no issues found in 87 source files
```

23 new tests in `tests/test_reconcilers.py`: registry loading and malformed-config refusal, verdict parsing (line form, JSON form, case, last-line-wins), the settle table (true/false/unknown/error/no-probe), failure isolation across probe kinds including timeout, dry-run writing nothing, `DETERMINISTIC` provenance of settled events, and CLI exit codes (OK when fully settled, REQUIRES_HUMAN when anything remains, NOT_FOUND for unknown runs).

Verified live end to end in a scratch project: claimed an action through the real stdio MCP server then hard-killed it before completion; resume reported REQUEST_HUMAN with the uncertain action; registered an outbox-checking probe (`test -f outbox/INV-42.sent && printf occurred=true || printf occurred=false`); `continuum reconcile batch` settled it; resume returned RESUME with the ACTION_RECONCILED event in the chain.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Phase 2 of the enforced-durability roadmap (#213). Security posture stated explicitly: probes run operator-configured shell commands locally, which is exactly as trusted as the operator editing the database directly; they never receive credentials from CONTINUUM and their verdicts are ordinary auditable events, not privileged writes.
