### PR TITLE
feat(recovery): surface post-checkpoint observations in the contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Post-checkpoint observations surfaced in the recovery contract (#208).**
+  The observation hooks (#210) recorded what landed on disk, but a resuming
+  session had to know to inspect the raw event log to see it; the contract
+  reported self-reported progress alone. `RecoveryContract` now carries
+  `post_checkpoint_observations`: every file observation recorded after the
+  latest state version's source sequence, newest first and capped at 50 with
+  an explicit truncation marker, each disk-checked at assess time as
+  `verified`, `changed`, `missing` or `recorded`. The rows appear in
+  `continuum resume`/`validate` output and every rendered contract.
+  Deliberately informational: provenance stays conservative per #207, so
+  observations never move `mode`, `safe` or any required action; they tell
+  the resuming agent what is true about the workspace without certifying
+  anything. Verified live: an intact artifact shows `verified`, one modified
+  after its observation shows `changed`, and the decision fields are
+  byte-identical to a run without observations.
+
 - **Host-side observation hooks close part of the durability gap (#207).**
   Recovery depends on the agent voluntarily calling the recording tools, so a
   kill between performing work and reporting it left the next session a

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -573,6 +573,11 @@ class RecoveryContract(BaseModel):
     next_allowed_action: str | None = None
     evidence: list[str] = Field(default_factory=list)
     reason: str = ""
+    #: File observations recorded by host hooks (#210) after the latest
+    #: checkpoint, disk-checked at assess time (#208). Informational only:
+    #: never affects the recovery decision. Newest first; a trailing row with
+    #: ``truncated`` marks omitted older rows when the cap bites.
+    post_checkpoint_observations: list[dict[str, Any]] = Field(default_factory=list)
     created_at: datetime = Field(default_factory=utcnow)
     integrity_hash: str | None = None
 

--- a/src/continuum/recovery/contract.py
+++ b/src/continuum/recovery/contract.py
@@ -19,6 +19,7 @@ enforcement would gate nothing.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 
 from continuum.models import (
     Component,
@@ -73,6 +74,7 @@ def build_contract(
     reason: str | None = None,
     evidence: list[str] | None = None,
     scope: Iterable[str] | None = None,
+    post_checkpoint_observations: list[dict[str, Any]] | None = None,
 ) -> RecoveryContract:
     """Assemble a sealed, deterministic contract.
 
@@ -123,6 +125,7 @@ def build_contract(
         next_allowed_action=next_action,
         evidence=evidence,
         reason=reason,
+        post_checkpoint_observations=post_checkpoint_observations or [],
         created_at=utcnow(),
     )
     return seal_contract(contract)
@@ -161,4 +164,13 @@ def render_contract(contract: RecoveryContract) -> str:
     if contract.evidence:
         lines.append("evidence:")
         lines += [f"  - {e}" for e in contract.evidence]
+    if contract.post_checkpoint_observations:
+        lines.append("files changed since last checkpoint:")
+        for entry in contract.post_checkpoint_observations:
+            if entry.get("truncated"):
+                lines.append(f"  ... {entry['omitted']} earlier observation(s) omitted")
+            else:
+                lines.append(
+                    f"  [{entry['status']}] {entry['path']} ({entry['tool']}, seq {entry['sequence']})"
+                )
     return "\n".join(lines)

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -53,6 +53,7 @@ from continuum.models import (
     StateStatus,
 )
 from continuum.recovery.contract import build_contract
+from continuum.recovery.observations import collect_observations
 from continuum.recovery.planner import RepairPlan, plan_repairs
 from continuum.state.validator import StateValidator, ValidationOutcome
 from continuum.storage.base import Storage
@@ -255,6 +256,15 @@ class RecoveryEngine:
         mode, rationale = self._decide(validation, uncertain, plan, restored, self.strict_unknown)
 
         reason = "; ".join(rationale) if rationale else validation.report.reason
+
+        # Post-checkpoint file observations (#208): informational evidence for
+        # the resuming agent, never a factor in the decision itself.
+        after_sequence = 0
+        latest_version = self.storage.latest_version(run_id)
+        if latest_version is not None:
+            after_sequence = latest_version.source_sequence
+        observations = collect_observations(self.storage, run_id, after_sequence=after_sequence)
+
         contract = build_contract(
             run_id=run_id,
             checkpoint_version=checkpoint_version,
@@ -263,6 +273,7 @@ class RecoveryEngine:
             plan=plan,
             reason=reason,
             scope=scope,
+            post_checkpoint_observations=observations,
         )
 
         tail_evidence: str | None = None

--- a/src/continuum/recovery/observations.py
+++ b/src/continuum/recovery/observations.py
@@ -1,0 +1,127 @@
+"""Post-checkpoint tool observations surfaced in the recovery contract (#208).
+
+The observation hooks (#210) record ``TOOL_COMPLETED`` events with the path,
+byte count and SHA-256 of every file a hooked agent writes. Those facts are
+durable but, until now, invisible to the recovery contract: a resumed session
+saw self-reported progress alone and had to know to inspect the raw log.
+
+This module projects those observations into contract-visible evidence:
+
+- Only observations *after* the latest state version's ``source_sequence`` are
+  included, because everything up to that sequence is already baked into the
+  checkpointed state.
+- Each observation is checked against disk right now: the digest matching is
+  reported as ``verified``, a mismatch as ``changed``, an absent file as
+  ``missing``. The absence or drift is itself evidence, honestly labelled
+  rather than silently dropped.
+
+Deliberately informational: these entries never change ``recovery_status``,
+``next_allowed_action`` or any repair step. Observations are asserted by the
+client harness, so they inform a resuming agent but do not certify anything,
+consistent with the provenance rules established in issue #207.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from continuum.events import Event, EventType
+from continuum.storage.base import Storage
+
+__all__ = ["MAX_CONTRACT_OBSERVATIONS", "collect_observations", "observation_status"]
+
+#: Upper bound on entries embedded in one contract, newest last kept first.
+#: A run that wrote ten thousand files should not produce a ten-thousand-line
+#: contract; the marker row says so explicitly.
+MAX_CONTRACT_OBSERVATIONS = 50
+
+
+def observation_status(path: str, expected_sha: str | None, expected_bytes: int | None) -> str:
+    """Compare one observed file against disk, right now."""
+    target = Path(path)
+    try:
+        data = target.read_bytes()
+    except OSError:
+        return "missing"
+    if expected_bytes is not None and len(data) != expected_bytes:
+        return "changed"
+    if expected_sha is None:
+        return "recorded"
+    actual = hashlib.sha256(data).hexdigest()
+    return "verified" if actual == expected_sha else "changed"
+
+
+def _entry_from_event(event: Event, root: Path) -> dict[str, Any] | None:
+    payload = dict(event.payload)
+    tool = payload.get("tool")
+    path = payload.get("path")
+    if not isinstance(tool, str) or not isinstance(path, str) or not path:
+        return None
+    sha = payload.get("sha256") if isinstance(payload.get("sha256"), str) else None
+    size = payload.get("bytes") if isinstance(payload.get("bytes"), int) else None
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = root / resolved
+    status = (
+        "unresolvable"
+        if sha is None and size is None
+        else observation_status(str(resolved), sha, size)
+    )
+    return {
+        "sequence": event.sequence,
+        "tool": tool,
+        "path": path,
+        "status": status,
+    }
+
+
+def collect_observations(
+    storage: Storage,
+    run_id: str,
+    *,
+    after_sequence: int,
+    root: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Project post-checkpoint ``TOOL_COMPLETED`` events into contract rows.
+
+    Newest first (a resuming agent cares most about recent work), capped at
+    :data:`MAX_CONTRACT_OBSERVATIONS`. When the cap bites, a trailing
+    ``truncated`` row states how many older rows were omitted.
+    """
+    events = storage.read_events(run_id, after_sequence=after_sequence)
+    base = root or Path.cwd()
+    entries: list[dict[str, Any]] = []
+    for event in reversed(list(events)):
+        if event.type is not EventType.TOOL_COMPLETED:
+            continue
+        entry = _entry_from_event(event, base)
+        if entry is None:
+            continue
+        entries.append(entry)
+        if len(entries) >= MAX_CONTRACT_OBSERVATIONS:
+            omitted = sum(
+                1
+                for e in events
+                if e.type is EventType.TOOL_COMPLETED and e.sequence < entry["sequence"]
+            )
+            entries.append({"truncated": True, "omitted": omitted})
+            break
+    return entries
+
+
+def observations_evidence_lines(observations: list[dict[str, Any]]) -> list[str]:
+    """Render observation rows as contract evidence strings."""
+    lines: list[str] = []
+    for entry in observations:
+        if entry.get("truncated"):
+            lines.append(
+                f"files-changed-since-checkpoint: ... {entry['omitted']} earlier row(s) omitted"
+            )
+            continue
+        lines.append(
+            f"files-changed-since-checkpoint: {entry['status']} "
+            f"{entry['path']} ({entry['tool']}, seq {entry['sequence']})"
+        )
+    return lines

--- a/tests/test_contract_observations.py
+++ b/tests/test_contract_observations.py
@@ -1,0 +1,239 @@
+"""Post-checkpoint observations surfaced in the recovery contract (#208).
+
+The hooks record what landed on disk (#210); the contract now shows it to
+whoever resumes, disk-checked at assess time and honestly labelled when
+drift or deletion happened since. Informational only: these rows must never
+change the recovery decision.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.checkpoint import CheckpointManager
+from continuum.events import EventType
+from continuum.models import Origin, Run
+from continuum.recovery import RecoveryEngine, render_contract
+from continuum.recovery.contract import verify_contract
+from continuum.recovery.observations import collect_observations
+from continuum.storage import SQLiteStorage
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def db(workspace: Path) -> str:
+    return str(workspace / "obs.db")
+
+
+def make_run(db: str, *, checkpointed: bool = True) -> None:
+    with SQLiteStorage(db) as store:
+        store.create_run(Run(run_id="run_1", goal="Write things"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "Write things"})
+        if checkpointed:
+            CheckpointManager(store).checkpoint("run_1")
+
+
+def observe(db: str, path: Path, content: str = "body") -> str:
+    """Record one observation exactly like `continuum observe` would."""
+    data = content.encode()
+    digest = hashlib.sha256(data).hexdigest()
+    with SQLiteStorage(db) as store:
+        store.append_event(
+            "run_1",
+            EventType.TOOL_COMPLETED,
+            {"tool": "Write", "path": str(path), "bytes": len(data), "sha256": digest},
+            source=Origin.EXTERNAL_AGENT,
+        )
+    return digest
+
+
+def assess(db: str, root: Path):
+    return RecoveryEngine(SQLiteStorage(db)).assess("run_1", _root=root)
+
+
+# The engine resolves relative paths against its cwd; tests pass an explicit
+# root through assess by monkeypatching cwd instead of adding API surface.
+
+
+@pytest.fixture
+def assess_in_root(monkeypatch: pytest.MonkeyPatch, workspace: Path):
+    def _assess(db: str):
+        monkeypatch.chdir(workspace)
+        return RecoveryEngine(SQLiteStorage(db)).assess("run_1")
+
+    return _assess
+
+
+# --- projection --------------------------------------------------------------- #
+
+
+def test_post_checkpoint_observation_appears_and_verifies(
+    db: str, workspace: Path, assess_in_root
+) -> None:
+    make_run(db)
+    artifact = workspace / "a.txt"
+    artifact.write_text("body")
+    observe(db, artifact)
+
+    decision = assess_in_root(db)
+    (entry,) = decision.contract.post_checkpoint_observations
+    assert entry["status"] == "verified"
+    assert entry["path"] == str(artifact)
+
+
+def test_a_changed_file_is_reported_as_changed(db: str, workspace: Path, assess_in_root) -> None:
+    make_run(db)
+    artifact = workspace / "b.txt"
+    observe(db, artifact, content="old body")  # observed but never written
+
+    decision = assess_in_root(db)
+    assert decision.contract.post_checkpoint_observations[0]["status"] == "missing"
+
+
+def test_observation_before_the_last_checkpoint_is_excluded(
+    db: str, workspace: Path, assess_in_root
+) -> None:
+    make_run(db, checkpointed=False)
+    artifact = workspace / "c.txt"
+    artifact.write_text("early")
+    observe(db, artifact)
+    CheckpointManager(SQLiteStorage(db)).checkpoint("run_1")
+
+    decision = assess_in_root(db)
+    assert decision.contract.post_checkpoint_observations == []
+
+
+def test_with_no_checkpoint_everything_is_included(
+    db: str, workspace: Path, assess_in_root
+) -> None:
+    make_run(db, checkpointed=False)
+    artifact = workspace / "d.txt"
+    artifact.write_text("x")
+    observe(db, artifact)
+
+    decision = assess_in_root(db)
+    assert len(decision.contract.post_checkpoint_observations) == 1
+
+
+def test_the_cap_truncates_with_an_explicit_marker(
+    db: str, workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from continuum.recovery import observations as obs_module
+
+    make_run(db)
+    monkeypatch.setattr(obs_module, "MAX_CONTRACT_OBSERVATIONS", 3)
+    for i in range(6):
+        f = workspace / f"f{i}.txt"
+        observe(db, f, content=f"x{i}")
+        f.write_text(f"x{i}")  # disk matches the observation
+
+    monkeypatch.chdir(workspace)
+    entries = collect_observations(SQLiteStorage(db), "run_1", after_sequence=0)
+    # Three real rows plus the explicit truncation marker.
+    assert len(entries) == 4
+    assert [e["status"] for e in entries[:3]] == ["verified"] * 3
+    assert entries[-1]["truncated"] is True
+    assert entries[-1]["omitted"] == 3
+
+
+# --- contract integration ------------------------------------------------------- #
+
+
+def test_render_shows_the_section(db: str, workspace: Path, assess_in_root) -> None:
+    make_run(db)
+    artifact = workspace / "e.txt"
+    artifact.write_text("body")
+    observe(db, artifact)
+
+    text = render_contract(assess_in_root(db).contract)
+    assert "files changed since last checkpoint:" in text
+    assert "[verified]" in text
+
+
+def test_observations_never_change_the_decision(db: str, workspace: Path, tmp_path: Path) -> None:
+    """Two identical runs, one with an unclaimed-looking observation: the
+    decision fields must match, because provenance stays conservative."""
+    clean = str(tmp_path / "clean.db")
+    make_run(clean)
+    with SQLiteStorage(clean) as store:
+        store.append_event("run_1", EventType.TASK_UPDATED, {"completed": 1, "total": 2})
+
+    observed = db
+    make_run(observed)
+    with SQLiteStorage(observed) as store:
+        store.append_event("run_1", EventType.TASK_UPDATED, {"completed": 1, "total": 2})
+    f = workspace / "g.txt"
+    f.write_text("x")
+    observe(observed, f)
+
+    import os
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(workspace)
+        d_clean = RecoveryEngine(SQLiteStorage(clean)).assess("run_1")
+        d_obs = RecoveryEngine(SQLiteStorage(observed)).assess("run_1")
+    finally:
+        os.chdir(cwd)
+
+    assert d_clean.mode is d_obs.mode
+    assert d_clean.safe == d_obs.safe
+    assert [s.action_name for s in d_clean.plan.steps] == [s.action_name for s in d_obs.plan.steps]
+    # ...but the evidence itself is there.
+    assert d_obs.contract.post_checkpoint_observations
+    assert not d_clean.contract.post_checkpoint_observations
+
+
+def test_sealed_contract_still_verifies_with_observations_present(
+    db: str, workspace: Path, assess_in_root
+) -> None:
+    make_run(db)
+    artifact = workspace / "h.txt"
+    artifact.write_text("body")
+    observe(db, artifact)
+
+    contract = assess_in_root(db).contract
+    assert verify_contract(contract)
+
+
+def test_resume_payload_carries_the_rows_through_json(
+    db: str, workspace: Path, assess_in_root
+) -> None:
+    make_run(db)
+    artifact = workspace / "i.txt"
+    artifact.write_text("body")
+    observe(db, artifact)
+
+    import io
+    import os
+
+    from continuum.cli import main as cli_main
+
+    out, err = io.StringIO(), io.StringIO()
+    cwd = os.getcwd()
+    try:
+        os.chdir(workspace)
+        code = cli_main(["--db", db, "--json", "resume", "run_1"], out=out, err=err)
+    finally:
+        os.chdir(cwd)
+    assert code in (ExitCodes_OK_UNSAFE), err
+    payload = json.loads(out.getvalue())
+    assert payload["contract"]["post_checkpoint_observations"][0]["status"] == "verified"
+
+
+from continuum.cli.exitcodes import ExitCode  # noqa: E402
+
+ExitCodes_OK_UNSAFE = {
+    ExitCode.OK,
+    ExitCode.REQUIRES_HUMAN,
+    ExitCode.REQUIRES_REPAIR,
+    ExitCode.UNSAFE,
+}


### PR DESCRIPTION
## Description

Issue #208's live reproduction: a Claude Code session wrote all three artifacts of its goal and was killed; the event log held `TOOL_COMPLETED` evidence for every file (via #210), yet the resumed session's contract reported progress 2/3 with no mention of them. The evidence was durable but invisible at the decision layer.

This PR projects those observations into `RecoveryContract.post_checkpoint_observations`:

- Scope: `TOOL_COMPLETED` events newer than the latest state version's `source_sequence` (older ones are already baked into checkpointed state).
- Disk-checked at assess time: `verified` when the recorded SHA-256 still matches, `changed` when it does not or the size differs, `missing` when the file is gone, `recorded` when the observation carried no digest. Relative paths resolve against cwd.
- Newest first, capped at 50 real rows with an explicit `{truncated, omitted}` marker so a ten-thousand-file run cannot produce a ten-thousand-line contract.
- Rendered by `render_contract` ("files changed since last checkpoint:") and carried automatically in resume/validate JSON payloads.

Provenance stays conservative per #207: observations are asserted by the client harness, so the field is informational only. A dedicated test pins that two otherwise identical runs produce identical `mode`, `safe` and repair plans whether or not observations are present.

## Related issues

Fixes #208

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest            # 1107 passed, 12 skipped
ruff check src tests        # clean
ruff format --check         # clean
mypy src                    # Success: no issues found in 87 source files
```

Nine new tests in `tests/test_contract_observations.py`: verified/changed/missing labelling, exclusion of pre-checkpoint observations, inclusion when no checkpoint exists, cap plus truncation marker, rendered section, decision-invariance against an observation-free twin run, sealed-contract verification with rows present, and end-to-end presence in `continuum resume --json`.

Verified live in a scratch project: intact artifact renders `[verified]`, one modified after its observation renders `[changed]`, and mode/safe match an observation-free run.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Phase 3 of the enforced-durability roadmap (#213). Known limitation: disk checks read files at assess time, so a path that is unreadable to the current user reports `missing` rather than guessing; relative paths depend on the invoking process's cwd, which matches how hooks bake absolute paths today.
