### PR TITLE
feat(cli): install observation hooks for Gemini CLI and Codex CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Lazy adapter imports (#214).** `continuum.adapters` sits on the critical
+  path of every entry point, but eagerly imported the optional SDK adapters,
+  so opening the MCP server cost roughly 3s before answering its first
+  request, and every `continuum observe` hook subprocess paid it again. The
+  dependency-free adapters stay eager; browser/container/kubernetes and the
+  langchain/langgraph/openai names now resolve through module
+  `__getattr__` (PEP 562) on first access, in both `continuum.adapters` and
+  the top-level `continuum` package. The public import surface is unchanged.
+  Measured on this machine: MCP server spawn-to-first-response drops from
+  about 3s to about 0.1s, and importing either package leaves none of
+  langgraph, langchain or openai in `sys.modules`. The full test suite also
+  gets faster for the same reason. Tests in `tests/test_adapters_lazy.py`
+  run their key assertions in subprocesses so earlier imports cannot mask a
+  regression.
+
 - **Host-side observation hooks close part of the durability gap (#207).**
   Recovery depends on the agent voluntarily calling the recording tools, so a
   kill between performing work and reporting it left the next session a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Client installers for Gemini CLI and Codex CLI (#209).** The observe and
+  gate commands were already client-agnostic; wiring them into new clients is
+  now data, not code. `CLIENT_PROFILES` describes each client's settings
+  path, hook event names and tool matchers, and `continuum hooks
+  install|remove` accepts all three clients: claude-code (PostToolUse/
+  PreToolUse on Write|Edit), gemini (AfterTool/BeforeTool on
+  write_file|replace, per the official hooks reference) and codex
+  (PostToolUse/PreToolUse, Bash-only today because Codex's documented hook
+  surface does not traverse apply_patch or MCP tools). Removal scans every
+  event list rather than hardcoded names, so it works across clients while
+  still touching only entries this tool installed. The installer surfaces
+  Codex's `[features].codex_hooks = true` requirement as an explicit hint
+  instead of hand-editing TOML. A regression test pins that each client's
+  default settings path comes from its profile, closing a gap found live:
+  every earlier test passed explicit paths, so a hardcoded CLI default was
+  silently writing all clients' hooks into Claude Code's settings file.
+
 - **Pre-action gate: host-enforced side-effect claims (#217).** The two-phase
   action protocol was a convention the model was asked to follow; nothing
   stopped an unclaimed side effect from firing, which degrades exactly-once

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Pre-action gate: host-enforced side-effect claims (#217).** The two-phase
+  action protocol was a convention the model was asked to follow; nothing
+  stopped an unclaimed side effect from firing, which degrades exactly-once
+  to at-least-once-with-nothing. `continuum gate` is a pre-tool-use hook that
+  makes the protocol physical: a call whose tool is registered in
+  `.continuum/gate.json` may proceed only when a live ledger claim already
+  exists for its derived key. Keys come from configuration templates
+  (`{"tools": {"send_invoice": {"key_template": "invoice:{customer}:{id}"}}}`
+  applied to the call's structured arguments), never from LLM-authored
+  strings. The decision table mirrors the ledger exactly: no claim denies
+  with instructions to route through `continuum_intercept_action`; a
+  COMPLETED record denies as a duplicate (the dedup verdict made physical);
+  UNKNOWN denies with reconcile instructions; closed attempts must be
+  reclaimed; only STARTED passes. Exit 2 feeds the reason back through the
+  harness so the model can comply on retry. `hooks install claude-code
+  --with-gate` wires PreToolUse alongside PostToolUse observe: claim before,
+  evidence after, both outside model control. Stated limitation: v1 gates
+  structured tool surfaces only, not shell commands run inside Bash.
+  Verified live over the real stdio MCP boundary: deny, claim via MCP,
+  allow, complete, duplicate denied, observation recorded in one hash chain.
+
 - **Lazy adapter imports (#214).** `continuum.adapters` sits on the critical
   path of every entry point, but eagerly imported the optional SDK adapters,
   so opening the MCP server cost roughly 3s before answering its first

--- a/src/continuum/__init__.py
+++ b/src/continuum/__init__.py
@@ -7,6 +7,10 @@ runtime (``Continuum``), storage engines, validation, action ledger and CLI
 arrive in later phases; nothing here imports an LLM provider.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from continuum.actions import (
     ActionLedger,
     ActionOutcome,
@@ -25,9 +29,6 @@ from continuum.adapters import (
     AdapterRegistry,
     AgentAdapter,
     GenericAgentAdapter,
-    LangChainAgentAdapter,
-    LangGraphAgentAdapter,
-    OpenAIAgentAdapter,
     get_adapter,
     list_adapters,
     recover,
@@ -164,6 +165,38 @@ from continuum.storage import (
 )
 
 __version__ = "0.1.0"
+
+# Framework-adapter names resolve lazily (PEP 562, issue #214): importing the
+# package must not pay for openai/langgraph/langchain, because every entry
+# point imports this package, including processes that never touch an
+# adapter. Type-checkers see the real definitions here; runtime resolves them
+# through __getattr__ below.
+if TYPE_CHECKING:
+    from continuum.adapters.langchain import LangChainAgentAdapter
+    from continuum.adapters.langgraph import LangGraphAgentAdapter
+    from continuum.adapters.openai import OpenAIAgentAdapter
+
+_LAZY_TOP_LEVEL: dict[str, str] = {
+    "LangChainAgentAdapter": "langchain",
+    "LangGraphAgentAdapter": "langgraph",
+    "OpenAIAgentAdapter": "openai",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _LAZY_TOP_LEVEL.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    value = getattr(importlib.import_module(f"continuum.adapters.{module_name}"), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_LAZY_TOP_LEVEL))
+
 
 __all__ = [
     "__version__",

--- a/src/continuum/adapters/__init__.py
+++ b/src/continuum/adapters/__init__.py
@@ -1,4 +1,22 @@
-"""Framework adapters for CONTINUUM."""
+"""Framework adapters for CONTINUUM.
+
+Import-cost discipline (issue #214): this package is on the critical path of
+every entry point, including processes that never touch a framework adapter
+(the MCP server, and each ``continuum observe`` hook subprocess). The optional
+SDK adapters pull in heavyweight dependencies (openai ~1.3s, langgraph ~0.8s
+cumulative, measured with ``-X importtime``), so their names resolve lazily
+through module ``__getattr__`` (PEP 562) and are only imported when actually
+requested. The dependency-free adapters stay eager.
+
+The public surface is unchanged: ``from continuum.adapters import X`` works
+for every name in ``__all__``, because ``from`` imports fall back to
+``__getattr__`` when module attribute lookup misses.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
 
 from continuum.adapters.actions import (
     AdapterAction,
@@ -6,14 +24,8 @@ from continuum.adapters.actions import (
     run_action,
 )
 from continuum.adapters.base import AgentAdapter
-from continuum.adapters.browser import BrowserAdapter
-from continuum.adapters.container import ContainerAdapter
 from continuum.adapters.filesystem import FilesystemSandboxAdapter
 from continuum.adapters.generic import GenericAgentAdapter
-from continuum.adapters.kubernetes import KubernetesAdapter
-from continuum.adapters.langchain import LangChainAgentAdapter, langchain_available
-from continuum.adapters.langgraph import LangGraphAgentAdapter, langgraph_available
-from continuum.adapters.openai import ContinuumContext, OpenAIAgentAdapter, openai_agents_available
 from continuum.adapters.python_inproc import PythonInProcAdapter
 from continuum.adapters.registry import (
     AdapterRegistry,
@@ -22,6 +34,35 @@ from continuum.adapters.registry import (
     recover,
     register_adapter,
 )
+
+if TYPE_CHECKING:
+    # Type-checkers see the real definitions; runtime resolves them lazily
+    # through __getattr__ below.
+    from continuum.adapters.browser import BrowserAdapter
+    from continuum.adapters.container import ContainerAdapter
+    from continuum.adapters.kubernetes import KubernetesAdapter
+    from continuum.adapters.langchain import LangChainAgentAdapter, langchain_available
+    from continuum.adapters.langgraph import LangGraphAgentAdapter, langgraph_available
+    from continuum.adapters.openai import (
+        ContinuumContext,
+        OpenAIAgentAdapter,
+        openai_agents_available,
+    )
+
+#: Lazy name -> submodule under :mod:`continuum.adapters`. Every name here is
+#: provided by a module whose import pulls an optional third-party SDK.
+_LAZY_EXPORTS: dict[str, str] = {
+    "BrowserAdapter": "browser",
+    "ContainerAdapter": "container",
+    "KubernetesAdapter": "kubernetes",
+    "LangChainAgentAdapter": "langchain",
+    "langchain_available": "langchain",
+    "LangGraphAgentAdapter": "langgraph",
+    "langgraph_available": "langgraph",
+    "ContinuumContext": "openai",
+    "OpenAIAgentAdapter": "openai",
+    "openai_agents_available": "openai",
+}
 
 __all__ = [
     "AdapterAction",
@@ -47,3 +88,18 @@ __all__ = [
     "register_adapter",
     "run_action",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve a lazy export on first access and cache it as a module attr."""
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_LAZY_EXPORTS))

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -34,8 +34,8 @@ from continuum.checkpoint import CheckpointError, CheckpointManager
 from continuum.cli.colour import Palette
 from continuum.cli.exitcodes import ExitCode, exit_code_for
 from continuum.clienthooks import (
-    DEFAULT_MATCHER,
-    install_claude_code_hook,
+    CLIENT_PROFILES,
+    install_client_hook,
     observe_command,
     observe_event_payload,
     remove_claude_code_hook,
@@ -682,42 +682,93 @@ def cmd_observe(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
 
 
 def cmd_hooks_install(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
-    """Wire file-mutating tool completions of a coding CLI into observe."""
-    settings_path = Path(args.settings)
+    """Wire a coding CLI's tool events into observe (and optionally gate).
+
+    Per-client wiring is data-driven (#209): the profile supplies the
+    settings-path default and the event/matcher names; the installed commands
+    are the same client-agnostic ``continuum observe`` / ``continuum gate``.
+    """
+    from continuum.clienthooks import CLIENT_PROFILES
+
+    profile = CLIENT_PROFILES[args.client]
+    settings_path = Path(args.settings or profile["settings"])
     command = observe_command(db=args.db)
-    status = install_claude_code_hook(settings_path, command)
-    entries = [(DEFAULT_MATCHER, "observe", status)]
+    gate_command = command[: -len("observe")] + "gate"
+
+    statuses = [
+        (
+            install_client_hook(
+                settings_path,
+                command,
+                event_name=profile["post_event"],
+                matcher=profile["write_matcher"],
+            ),
+            profile["write_matcher"],
+            "observe",
+            profile["post_event"],
+            command,
+        )
+    ]
     if getattr(args, "with_gate", False):
-        gate_command = observe_command(db=args.db)[: -len("observe")] + "gate"
-        gate_status = install_claude_code_hook(settings_path, gate_command, kind="gate")
-        entries.append(("*", "gate", gate_status))
+        statuses.append(
+            (
+                install_client_hook(
+                    settings_path,
+                    gate_command,
+                    event_name=profile["pre_event"],
+                    matcher=profile["any_matcher"],
+                ),
+                profile["any_matcher"],
+                "gate",
+                profile["pre_event"],
+                gate_command,
+            )
+        )
+
     lines = [f"Hook configuration written to {settings_path}"]
-    for matcher, kind, st in entries:
-        lines.append(f"  [{st}] {kind} (matcher {matcher})")
-        if kind == "observe":
-            lines.append(f"    command: {command}")
-        else:
-            lines.append(f"    command: {gate_command}")
+    for st, matcher, kind, event, cmd in statuses:
+        lines.append(f"  [{st}] {kind} on {event} (matcher {matcher})")
+        lines.append(f"    command: {cmd}")
+    payload: dict[str, Any] = {
+        "client": args.client,
+        "settings": str(settings_path),
+        "hooks": [
+            {"event": event, "matcher": m, "kind": k, "status": st, "command": cmd}
+            for st, m, k, event, cmd in statuses
+        ],
+    }
+    if args.client == "codex":
+        hint = _codex_feature_flag_hint()
+        if hint:
+            lines.append(hint)
+            payload["feature_flag_hint"] = hint
     _emit(
-        {
-            "client": args.client,
-            "settings": str(settings_path),
-            "hooks": [
-                {
-                    "matcher": m,
-                    "kind": k,
-                    "status": s,
-                    "command": command if k == "observe" else gate_command,
-                }
-                for m, k, s in entries
-            ],
-        },
+        payload,
         "\n".join(lines),
         as_json=args.json,
         stream=out,
         palette=getattr(args, "_palette", None),
     )
     return ExitCode.OK
+
+
+def _codex_feature_flag_hint() -> str:
+    """Codex gates its hook engine behind a config flag; without it hooks are
+    silent no-ops. We do not hand-edit TOML, so surface the exact line."""
+    config = Path.home() / ".codex" / "config.toml"
+    try:
+        text = config.read_text(encoding="utf-8")
+    except OSError:
+        return (
+            "note: Codex hooks are off by default. Add '[features]\\ncodex_hooks = true' "
+            f"to {config} (create it if needed), then restart Codex."
+        )
+    if "codex_hooks" not in text:
+        return (
+            f"note: 'codex_hooks' was not found in {config}; add "
+            "'[features]\\ncodex_hooks = true', then restart Codex."
+        )
+    return ""
 
 
 def cmd_hooks_remove(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
@@ -1255,11 +1306,15 @@ def build_parser() -> argparse.ArgumentParser:
     hooks_sub = hooks.add_subparsers(dest="hooks_command", metavar="ACTION CLIENT", required=True)
 
     def hooks_client(p: argparse.ArgumentParser, func: Any) -> None:
-        p.add_argument("client", choices=("claude-code",), help="which client to configure")
+        p.add_argument(
+            "client",
+            choices=tuple(CLIENT_PROFILES),
+            help="which client to configure (claude-code, gemini, codex)",
+        )
         p.add_argument(
             "--settings",
-            default=".claude/settings.json",
-            help="path to the client's settings file (default: .claude/settings.json)",
+            default=None,
+            help="path to the client's settings file (default: per client profile)",
         )
         p.set_defaults(func=func)
 

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -42,6 +42,14 @@ from continuum.clienthooks import (
 )
 from continuum.environment import StaticProvider, capture
 from continuum.events import EventType
+from continuum.gate import (
+    DEFAULT_GATE_CONFIG_PATH,
+    GateConfigError,
+    load_gate_config,
+)
+from continuum.gate import (
+    decide as gate_decide,
+)
 from continuum.models import (
     ActionStatus,
     EnvironmentSnapshot,
@@ -678,18 +686,33 @@ def cmd_hooks_install(args: argparse.Namespace, storage: Storage, out: Any, err:
     settings_path = Path(args.settings)
     command = observe_command(db=args.db)
     status = install_claude_code_hook(settings_path, command)
-    verb = {"installed": "Installed", "updated": "Updated", "present": "Already present"}[status]
+    entries = [(DEFAULT_MATCHER, "observe", status)]
+    if getattr(args, "with_gate", False):
+        gate_command = observe_command(db=args.db)[: -len("observe")] + "gate"
+        gate_status = install_claude_code_hook(settings_path, gate_command, kind="gate")
+        entries.append(("*", "gate", gate_status))
+    lines = [f"Hook configuration written to {settings_path}"]
+    for matcher, kind, st in entries:
+        lines.append(f"  [{st}] {kind} (matcher {matcher})")
+        if kind == "observe":
+            lines.append(f"    command: {command}")
+        else:
+            lines.append(f"    command: {gate_command}")
     _emit(
         {
             "client": args.client,
             "settings": str(settings_path),
-            "matcher": DEFAULT_MATCHER,
-            "command": command,
-            "status": status,
+            "hooks": [
+                {
+                    "matcher": m,
+                    "kind": k,
+                    "status": s,
+                    "command": command if k == "observe" else gate_command,
+                }
+                for m, k, s in entries
+            ],
         },
-        f"{verb} observation hook in {settings_path}\n"
-        f"  matcher: {DEFAULT_MATCHER}\n"
-        f"  command: {command}",
+        "\n".join(lines),
         as_json=args.json,
         stream=out,
         palette=getattr(args, "_palette", None),
@@ -714,6 +737,99 @@ def cmd_hooks_remove(args: argparse.Namespace, storage: Storage, out: Any, err: 
         palette=getattr(args, "_palette", None),
     )
     return ExitCode.OK
+
+
+def cmd_gate(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Decide whether one tool call may proceed (issue #217).
+
+    Designed as a pre-tool-use hook: exit 0 allows the call, exit 2 denies it
+    with an actionable reason on stderr that the harness feeds back to the
+    model. The decision is pure (:func:`continuum.gate.decide`); this command
+    only resolves the run, loads the ledger projection and renders the
+    verdict.
+
+    Exit codes deliberately reuse the CLI contract where they agree: OK
+    allows. Denial is reported as 2, which the CLI defines as NOT_FOUND but a
+    hook transport defines as "block this tool call"; in both readings the
+    caller must not proceed.
+    """
+    from continuum.actions.ledger import fold_action_events
+
+    if args.payload_file:
+        raw_text = Path(args.payload_file).read_text(encoding="utf-8")
+    else:
+        raw_text = sys.stdin.read()
+    try:
+        raw = json.loads(raw_text) if raw_text.strip() else None
+    except json.JSONDecodeError as exc:
+        # The payload cannot be matched against any pattern; there is nothing
+        # to enforce, and blocking every call over a protocol hiccup would
+        # make the harness unusable.
+        print(f"gate: payload is not valid JSON ({exc}); allowing", file=err)
+        return ExitCode.OK
+
+    run_id = args.run_id
+    if not run_id:
+        active = storage.get_active_run()
+        run_id = active.run_id if active else None
+
+    config_path = Path(args.config) if args.config else Path(DEFAULT_GATE_CONFIG_PATH)
+    try:
+        config = load_gate_config(config_path)
+    except GateConfigError as exc:
+        print(f"gate: {exc}; denying until it is fixed", file=err)
+        return 2
+
+    if not isinstance(raw, dict):
+        _emit(
+            {"allow": True, "reason": "no payload"},
+            "gate: no payload; allowing",
+            as_json=args.json,
+            stream=out,
+            palette=getattr(args, "_palette", None),
+        )
+        return ExitCode.OK
+
+    tool_name = str(raw.get("tool_name") or "")
+    tool_input_raw = raw.get("tool_input")
+    tool_input: dict[str, Any] = dict(tool_input_raw) if isinstance(tool_input_raw, dict) else {}
+
+    if config is not None and tool_name in config and run_id is None:
+        print(
+            f"gate: {tool_name} is gated but there is no active CONTINUUM run. "
+            f"Start or resume one (continuum start / continuum_record_progress) first.",
+            file=err,
+        )
+        return 2
+
+    actions_by_key = fold_action_events(storage.read_events(run_id)) if run_id is not None else {}
+    decision = gate_decide(
+        config,
+        tool_name,
+        tool_input,
+        run_id=run_id or "",
+        actions_by_key=actions_by_key,
+    )
+    if decision.allow:
+        _emit(
+            {"allow": True, "reason": decision.reason, "tool": tool_name},
+            f"[ok] allow: {decision.reason}",
+            as_json=args.json,
+            stream=out,
+            palette=getattr(args, "_palette", None),
+        )
+        return ExitCode.OK
+    # A hook transport feeds stderr back to the model on a blocking exit, so
+    # the actionable reason must live there; stdout keeps the machine view.
+    print(f"[!!] deny: {decision.reason}", file=err)
+    _emit(
+        {"allow": False, "reason": decision.reason, "tool": tool_name},
+        "",
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return 2
 
 
 def cmd_verify(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
@@ -1114,6 +1230,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="read the hook payload from this file instead of stdin",
     )
 
+    gate = add(
+        "gate",
+        cmd_gate,
+        "Decide whether a tool call may proceed (pre-tool-use hook). Read-only.",
+    )
+    gate.add_argument(
+        "--run-id",
+        default=None,
+        help="target run (default: the most recently active non-terminal run)",
+    )
+    gate.add_argument(
+        "--payload-file",
+        default=None,
+        help="read the hook payload from this file instead of stdin",
+    )
+    gate.add_argument(
+        "--config",
+        default=None,
+        help=f"gate registry path (default: {DEFAULT_GATE_CONFIG_PATH})",
+    )
+
     hooks = add("hooks", cmd_hooks_install, "Manage host-side observation hooks.")
     hooks_sub = hooks.add_subparsers(dest="hooks_command", metavar="ACTION CLIENT", required=True)
 
@@ -1133,6 +1270,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--db",
         default=None,
         help="bake a specific database path into the hook command",
+    )
+    install.add_argument(
+        "--with-gate",
+        action="store_true",
+        help="also install a PreToolUse gate that denies unclaimed side-effect calls",
     )
     hooks_client(install, cmd_hooks_install)
 

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -123,15 +123,15 @@ def observe_command(*, db: str | None = None) -> str:
     return " ".join(shlex.quote(part) for part in parts)
 
 
-def _is_observe_hook(hook: Mapping[str, Any]) -> bool:
+def _is_continuum_hook(hook: Mapping[str, Any], kind: str) -> bool:
     """True when a hook entry is one this module would have installed.
 
-    Deliberately narrow: a command that merely ends in ``observe`` could
+    Deliberately narrow: a command that merely ends in the kind word could
     belong to an unrelated tool, and treating it as ours would let install
     repoint or remove delete someone else's configuration. Two shapes are
     recognised, matching :func:`observe_command` exactly: a resolved
     ``continuum`` executable path (its stem is ``continuum``), and the
-    interpreter fallback form ``<python> -m continuum.cli ... observe``.
+    interpreter fallback form ``<python> -m continuum.cli ... <kind>``.
     """
     command = hook.get("command")
     if not isinstance(command, str):
@@ -140,31 +140,40 @@ def _is_observe_hook(hook: Mapping[str, Any]) -> bool:
         tokens = shlex.split(command)
     except ValueError:
         return False
-    if len(tokens) < 2 or tokens[-1] != "observe":
+    if len(tokens) < 2 or tokens[-1] != kind:
         return False
     if Path(tokens[0]).stem == "continuum":
         return True
     return tokens[1] == "-m" and len(tokens) >= 4 and tokens[2] == "continuum.cli"
 
 
+def _is_observe_hook(hook: Mapping[str, Any]) -> bool:
+    return _is_continuum_hook(hook, "observe")
+
+
 def install_claude_code_hook(
     settings_path: Path,
     command: str,
     *,
-    matcher: str = DEFAULT_MATCHER,
+    kind: str = "observe",
+    matcher: str | None = None,
 ) -> str:
-    """Add the observe hook to a Claude Code settings file.
+    """Add a continuum hook entry to a Claude Code settings file.
 
-    Existing settings are preserved; only the ``hooks.PostToolUse`` list gains
-    (or updates) our single entry. Returns ``"installed"`` when the entry was
-    added, ``"updated"`` when an existing observe entry pointed somewhere else
-    (a moved virtualenv, say) and was repointed, ``"present"`` when nothing
-    needed to change.
+    ``kind`` selects which hook this is ("observe" or "gate"); it must equal
+    the final word of ``command``. Existing settings are preserved; only the
+    matching list under ``hooks`` gains (or updates) our single entry.
+    Returns ``"installed"`` when the entry was added, ``"updated"`` when an
+    existing entry of the same kind pointed somewhere else (a moved
+    virtualenv, say) and was repointed, ``"present"`` when nothing needed to
+    change.
 
     A settings file that exists but is unreadable raises rather than being
     overwritten: a file someone edited by hand is a statement of intent, and
     silently replacing it would destroy work to save a typo.
     """
+    if matcher is None:
+        matcher = DEFAULT_MATCHER if kind == "observe" else "*"
     if settings_path.exists():
         try:
             settings: dict[str, Any] = json.loads(settings_path.read_text(encoding="utf-8"))
@@ -181,20 +190,21 @@ def install_claude_code_hook(
     if not isinstance(hooks, dict):
         raise ValueError(f"{settings_path}: 'hooks' is not an object")
 
-    post_tool_use: list[Any] = hooks.setdefault("PostToolUse", [])
-    if not isinstance(post_tool_use, list):
-        raise ValueError(f"{settings_path}: 'hooks.PostToolUse' is not a list")
+    event_name = "PostToolUse" if kind == "observe" else "PreToolUse"
+    hook_list: list[Any] = hooks.setdefault(event_name, [])
+    if not isinstance(hook_list, list):
+        raise ValueError(f"{settings_path}: 'hooks.{event_name}' is not a list")
 
     status = "installed"
     entry_found = False
-    for group in post_tool_use:
+    for group in hook_list:
         if not isinstance(group, dict) or group.get("matcher") != matcher:
             continue
         entries = group.get("hooks")
         if not isinstance(entries, list):
             continue
         for hook in entries:
-            if isinstance(hook, dict) and _is_observe_hook(hook):
+            if isinstance(hook, dict) and _is_continuum_hook(hook, kind):
                 entry_found = True
                 if hook.get("command") != command:
                     hook["command"] = command
@@ -203,7 +213,7 @@ def install_claude_code_hook(
                     status = "present"
 
     if not entry_found:
-        post_tool_use.append(
+        hook_list.append(
             {
                 "matcher": matcher,
                 "hooks": [{"type": "command", "command": command}],
@@ -215,12 +225,14 @@ def install_claude_code_hook(
     return status
 
 
-def remove_claude_code_hook(settings_path: Path, *, matcher: str = DEFAULT_MATCHER) -> bool:
-    """Remove the observe hook. Returns True when anything was removed.
+def remove_claude_code_hook(settings_path: Path) -> bool:
+    """Remove every continuum hook this module installed. True when anything
+    was removed.
 
-    Only entries this module's shape recognises are touched: a hand-written
-    PostToolUse entry pointing elsewhere survives untouched, as does every
-    other key in the file.
+    Only entries this module's shape recognises are touched (observe and gate,
+    any matcher): a hand-written entry pointing elsewhere survives untouched,
+    as does every other key in the file. A group holding unrelated hooks keeps
+    them.
     """
     if not settings_path.exists():
         return False
@@ -234,43 +246,50 @@ def remove_claude_code_hook(settings_path: Path, *, matcher: str = DEFAULT_MATCH
     hooks = settings.get("hooks")
     if not isinstance(hooks, dict):
         return False
-    post_tool_use = hooks.get("PostToolUse")
-    if not isinstance(post_tool_use, list):
-        return False
 
     removed = False
-    kept_groups: list[Any] = []
-    for group in post_tool_use:
-        if not (
-            isinstance(group, dict)
-            and group.get("matcher") == matcher
-            and isinstance(group.get("hooks"), list)
-        ):
+    for event_name in ("PostToolUse", "PreToolUse"):
+        hook_list = hooks.get(event_name)
+        if not isinstance(hook_list, list):
+            continue
+
+        kept_groups: list[Any] = []
+        for group in hook_list:
+            if not (isinstance(group, dict) and isinstance(group.get("hooks"), list)):
+                kept_groups.append(group)
+                continue
+            # Drop only the hook entries this module recognises as its own. A
+            # matcher group can hold unrelated user hooks alongside ours;
+            # removing the whole group would delete configuration this command
+            # never installed.
+            kept_hooks = [
+                h
+                for h in group["hooks"]
+                if not (
+                    isinstance(h, dict)
+                    and (_is_continuum_hook(h, "observe") or _is_continuum_hook(h, "gate"))
+                )
+            ]
+            if len(kept_hooks) != len(group["hooks"]):
+                removed = True
+            if not kept_hooks:
+                continue
+            group["hooks"] = kept_hooks
             kept_groups.append(group)
-            continue
-        # Drop only the hook entries this module recognises as its own. A
-        # matcher group can hold unrelated user hooks alongside ours; removing
-        # the whole group would delete configuration this command never
-        # installed.
-        kept_hooks = [
-            h for h in group["hooks"] if not (isinstance(h, dict) and _is_observe_hook(h))
-        ]
-        if len(kept_hooks) != len(group["hooks"]):
-            removed = True
-        if not kept_hooks:
-            continue
-        group["hooks"] = kept_hooks
-        kept_groups.append(group)
+
+        # Rewrite each list unconditionally: keeping only recognised-ours
+        # entries and surviving groups is idempotent whether or not this run
+        # removed anything.
+        if kept_groups:
+            hooks[event_name] = kept_groups
+        elif event_name in hooks:
+            del hooks[event_name]
 
     if not removed:
         return False
 
-    if kept_groups:
-        hooks["PostToolUse"] = kept_groups
-    else:
-        del hooks["PostToolUse"]
-        if not hooks:
-            del settings["hooks"]
+    if not hooks:
+        del settings["hooks"]
 
     settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
     return True

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -42,9 +42,11 @@ from pathlib import Path
 from typing import Any
 
 __all__ = [
+    "CLIENT_PROFILES",
     "DEFAULT_MATCHER",
     "observe_event_payload",
     "observe_command",
+    "install_client_hook",
     "install_claude_code_hook",
     "remove_claude_code_hook",
 ]
@@ -55,6 +57,37 @@ DEFAULT_MATCHER = "Write|Edit|MultiEdit|NotebookEdit"
 
 #: Keys of ``tool_input`` that hold the primary file path, in priority order.
 _PATH_KEYS = ("file_path", "notebook_path")
+
+#: Per-client wiring profiles (issue #209). Everything that differs between
+#: clients is data, not code: which settings file they read, which hook
+#: events exist, and which tools count as file-mutating there. The observe
+#: and gate commands stay client-agnostic because every profiled client
+#: speaks the same stdin contract (tool_name plus tool_input JSON).
+CLIENT_PROFILES: dict[str, dict[str, str]] = {
+    "claude-code": {
+        "settings": ".claude/settings.json",
+        "post_event": "PostToolUse",
+        "pre_event": "PreToolUse",
+        "write_matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "any_matcher": "*",
+    },
+    "gemini": {
+        "settings": ".gemini/settings.json",
+        "post_event": "AfterTool",
+        "pre_event": "BeforeTool",
+        "write_matcher": "write_file|replace",
+        "any_matcher": ".*",
+    },
+    "codex": {
+        "settings": ".codex/hooks.json",
+        "post_event": "PostToolUse",
+        "pre_event": "PreToolUse",
+        # Documented surface as of mid-2026: Codex hooks fire for shell/Bash
+        # calls only; apply_patch and MCP tools do not traverse them.
+        "write_matcher": "^Bash$|^shell$",
+        "any_matcher": "^Bash$|^shell$",
+    },
+}
 
 
 def observe_event_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
@@ -151,12 +184,43 @@ def _is_observe_hook(hook: Mapping[str, Any]) -> bool:
     return _is_continuum_hook(hook, "observe")
 
 
+def install_client_hook(
+    settings_path: Path,
+    command: str,
+    *,
+    event_name: str,
+    matcher: str,
+) -> str:
+    """Install one continuum hook entry into any client's settings file.
+
+    The client-agnostic core behind every installer (#209): add (or repoint,
+    or recognise as present) a single entry under ``hooks.<event_name>``.
+    Returns "installed", "updated" or "present", matching the claude-code
+    contract this was extracted from.
+    """
+    return _install_hook(settings_path, command, event_name=event_name, matcher=matcher)
+
+
 def install_claude_code_hook(
     settings_path: Path,
     command: str,
     *,
     kind: str = "observe",
     matcher: str | None = None,
+) -> str:
+    """Claude Code wrapper; see :func:`install_client_hook`."""
+    if matcher is None:
+        matcher = DEFAULT_MATCHER if kind == "observe" else "*"
+    event_name = "PostToolUse" if kind == "observe" else "PreToolUse"
+    return _install_hook(settings_path, command, event_name=event_name, matcher=matcher)
+
+
+def _install_hook(
+    settings_path: Path,
+    command: str,
+    *,
+    event_name: str,
+    matcher: str,
 ) -> str:
     """Add a continuum hook entry to a Claude Code settings file.
 
@@ -172,8 +236,6 @@ def install_claude_code_hook(
     overwritten: a file someone edited by hand is a statement of intent, and
     silently replacing it would destroy work to save a typo.
     """
-    if matcher is None:
-        matcher = DEFAULT_MATCHER if kind == "observe" else "*"
     if settings_path.exists():
         try:
             settings: dict[str, Any] = json.loads(settings_path.read_text(encoding="utf-8"))
@@ -190,7 +252,6 @@ def install_claude_code_hook(
     if not isinstance(hooks, dict):
         raise ValueError(f"{settings_path}: 'hooks' is not an object")
 
-    event_name = "PostToolUse" if kind == "observe" else "PreToolUse"
     hook_list: list[Any] = hooks.setdefault(event_name, [])
     if not isinstance(hook_list, list):
         raise ValueError(f"{settings_path}: 'hooks.{event_name}' is not a list")
@@ -204,7 +265,10 @@ def install_claude_code_hook(
         if not isinstance(entries, list):
             continue
         for hook in entries:
-            if isinstance(hook, dict) and _is_continuum_hook(hook, kind):
+            ours = isinstance(hook, dict) and (
+                _is_continuum_hook(hook, "observe") or _is_continuum_hook(hook, "gate")
+            )
+            if ours:
                 entry_found = True
                 if hook.get("command") != command:
                     hook["command"] = command
@@ -248,8 +312,10 @@ def remove_claude_code_hook(settings_path: Path) -> bool:
         return False
 
     removed = False
-    for event_name in ("PostToolUse", "PreToolUse"):
-        hook_list = hooks.get(event_name)
+    # Scan every event list, not just the Claude Code names: clients differ
+    # in what they call their hook points (Gemini uses AfterTool/BeforeTool).
+    for event_name in [k for k, v in hooks.items() if isinstance(v, list)]:
+        hook_list = hooks[event_name]
         if not isinstance(hook_list, list):
             continue
 

--- a/src/continuum/gate.py
+++ b/src/continuum/gate.py
@@ -1,0 +1,174 @@
+"""Pre-action gating for external side effects (issue #217).
+
+The two-phase action protocol is only as strong as the model's willingness to
+follow it. Observation (#210) records what happened; it cannot stop an
+unclaimed side effect from firing. Harnesses that support pre-tool-use hooks
+which can *deny* a call make enforcement possible at the host layer, outside
+the model's control.
+
+This module holds the pure decision logic so it can be tested exhaustively
+without a harness:
+
+- :func:`load_gate_config` reads ``.continuum/gate.json``, which registers
+  side-effect tools and the stable-key templates that identify their
+  operations.
+- :func:`render_key` derives the idempotency key from the call's structured
+  arguments using the configured template. Keys come from configuration, never
+  from LLM-authored strings.
+- :func:`decide` answers one question: may this tool call proceed?
+
+The decision rule mirrors the ledger's semantics exactly. A gated call is
+allowed only when a live claim (status ``STARTED``) already exists for its
+derived key. Anything else is denied with instructions: unclaimed calls are
+told how to claim, completed calls are told the effect already happened (this
+is the dedup verdict made physical), uncertain calls are told to reconcile,
+and closed attempts are told to claim again. When the config file exists but
+is malformed the gate fails closed: a file someone wrote is a statement of
+intent, and silently letting everything through would defeat it.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from continuum.actions.idempotency import idempotency_key
+from continuum.models import ActionStatus
+
+__all__ = [
+    "DEFAULT_GATE_CONFIG_PATH",
+    "Decision",
+    "load_gate_config",
+    "render_key",
+    "decide",
+]
+
+#: Where the gate configuration lives, relative to the project root the hook
+#: runs in. JSON, matching the existing ``.continuum/mcp-policy.json``
+#: convention.
+DEFAULT_GATE_CONFIG_PATH = ".continuum/gate.json"
+
+
+class GateConfigError(ValueError):
+    """The gate configuration exists but cannot be honoured."""
+
+
+@dataclass(frozen=True)
+class Decision:
+    """The outcome of one gate evaluation."""
+
+    allow: bool
+    reason: str
+
+
+def load_gate_config(path: Path) -> dict[str, dict[str, Any]] | None:
+    """Read the gate registry. Returns None when no configuration exists.
+
+    A missing file means "no gate configured", which is distinct from a file
+    that exists and is broken: the latter raises rather than degrading into
+    silently passing every call.
+    """
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise GateConfigError(f"{path} is not valid JSON ({exc})") from exc
+    if not isinstance(raw, dict) or not isinstance(raw.get("tools", {}), dict):
+        raise GateConfigError(f"{path}: expected {{'tools': {{...}}}}")
+    tools = raw.get("tools") or {}
+    for tool, spec in tools.items():
+        if not isinstance(spec, dict) or not isinstance(spec.get("key_template"), str):
+            raise GateConfigError(f"{path}: tool {tool!r} needs a string 'key_template'")
+        if spec.get("action_type") is not None and not isinstance(spec.get("action_type"), str):
+            raise GateConfigError(f"{path}: tool {tool!r} 'action_type' must be a string")
+    return tools
+
+
+def render_key(template: str, tool_input: Mapping[str, Any]) -> str:
+    """Substitute ``{field}`` placeholders from the call's arguments.
+
+    Only top-level argument fields are supported in v1. A placeholder with no
+    matching argument raises: a template the current call cannot satisfy is a
+    configuration problem worth surfacing, not something to paper over with a
+    weaker identity.
+    """
+    import string
+
+    fields = [name for _, name, _, _ in string.Formatter().parse(template) if name]
+    missing = [f for f in fields if f not in tool_input]
+    if missing:
+        raise GateConfigError(
+            f"key template {template!r} needs argument(s) {missing} "
+            f"but the call supplied {sorted(tool_input)!r}"
+        )
+    values = {f: tool_input[f] for f in fields}
+    return template.format(**values)
+
+
+def _expected_key(action_type: str, run_id: str, rendered: str) -> str:
+    """The exact ledger key a claim of this operation must have produced."""
+    return str(idempotency_key(action_type, None, scope=run_id, key=rendered))
+
+
+def decide(
+    config: Mapping[str, Mapping[str, Any]] | None,
+    tool_name: str,
+    tool_input: Mapping[str, Any],
+    *,
+    run_id: str,
+    actions_by_key: Mapping[str, Any],
+) -> Decision:
+    """Decide whether one tool call may proceed.
+
+    ``actions_by_key`` maps ledger keys to Action records (the output of
+    ``fold_action_events`` over the run's event log). Ungated tools pass
+    immediately without touching anything else.
+    """
+    if config is None:
+        return Decision(True, "no gate configured")
+    spec = config.get(tool_name)
+    if spec is None:
+        return Decision(True, "tool is not gated")
+
+    action_type = spec.get("action_type") or tool_name
+    try:
+        rendered = render_key(spec["key_template"], tool_input)
+        key = _expected_key(action_type, run_id, rendered)
+    except GateConfigError as exc:
+        return Decision(False, f"gate configuration error: {exc}")
+
+    action = actions_by_key.get(key)
+    if action is None or action.action_type != action_type:
+        return Decision(
+            False,
+            f"side effect {action_type!r} with key {rendered!r} has no ledger claim. "
+            f"Call the MCP tool continuum_intercept_action with run_id={run_id!r}, "
+            f"action_type={action_type!r}, key={rendered!r} first, then repeat this call.",
+        )
+
+    status = action.status
+    if status is ActionStatus.STARTED:
+        return Decision(True, f"live claim {rendered!r}")
+    if status is ActionStatus.COMPLETED:
+        return Decision(
+            False,
+            f"{action_type!r} with key {rendered!r} was already completed"
+            + (f" (external id {action.external_id!r})" if action.external_id else "")
+            + ". Do not repeat it.",
+        )
+    if status is ActionStatus.UNKNOWN:
+        return Decision(
+            False,
+            f"{action_type!r} with key {rendered!r} has an unknown outcome. Call "
+            f"continuum_reconcile_action for it before attempting anything further.",
+        )
+    return Decision(
+        False,
+        f"the previous attempt of {action_type!r} with key {rendered!r} is closed "
+        f"(status {status.value}). Claim it again through continuum_intercept_action "
+        f"before retrying.",
+    )

--- a/tests/test_adapters_lazy.py
+++ b/tests/test_adapters_lazy.py
@@ -1,0 +1,81 @@
+"""Lazy adapter imports (issue #214).
+
+``continuum.adapters`` sits on the critical path of every entry point,
+including the MCP server and each ``continuum observe`` hook subprocess.
+Importing it must not pay for the optional SDKs (openai, langgraph,
+langchain), while ``from continuum.adapters import LangGraphAgentAdapter``
+must keep working unchanged.
+
+Most assertions run in a subprocess: an in-process test would see modules
+imported by earlier tests and prove nothing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_OPTIONAL_SDK_ROOTS = ("langgraph", "langchain", "openai", "agents", "playwright")
+
+
+def _run(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+
+
+def test_importing_the_package_does_not_import_optional_sdks() -> None:
+    result = _run(
+        "import continuum.adapters, sys\n"
+        "polluted = [m for m in sys.modules if m.split('.')[0] in "
+        f"{_OPTIONAL_SDK_ROOTS!r}]\n"
+        "assert not polluted, polluted\n"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_importing_the_top_level_package_does_not_import_optional_sdks() -> None:
+    """``import continuum`` pulls in adapters via its own re-exports; the
+    framework names must resolve lazily there too."""
+    result = _run(
+        "import continuum, sys\n"
+        "polluted = [m for m in sys.modules if m.split('.')[0] in "
+        f"{_OPTIONAL_SDK_ROOTS!r}]\n"
+        "assert not polluted, polluted\n"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_from_import_resolves_lazy_names() -> None:
+    result = _run(
+        "from continuum.adapters import (LangChainAgentAdapter, langchain_available,\n"
+        "    LangGraphAgentAdapter, langgraph_available, OpenAIAgentAdapter,\n"
+        "    ContinuumContext, openai_agents_available)\n"
+        "from continuum import LangGraphAgentAdapter as TopLevel\n"
+        "assert TopLevel is LangGraphAgentAdapter\n"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_dir_lists_the_full_export_surface() -> None:
+    result = _run(
+        "import continuum.adapters\n"
+        "missing = set(continuum.adapters.__all__) - set(dir(continuum.adapters))\n"
+        "assert not missing, missing\n"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    import pytest
+
+    import continuum.adapters
+
+    with pytest.raises(AttributeError, match="definitely_not_an_adapter"):
+        continuum.adapters.definitely_not_an_adapter  # noqa: B018
+
+
+def test_repeated_access_is_cached_not_reimported() -> None:
+    import continuum.adapters
+
+    first = continuum.adapters.langgraph_available
+    second = continuum.adapters.langgraph_available
+    assert first is second

--- a/tests/test_cli_gate.py
+++ b/tests/test_cli_gate.py
@@ -1,0 +1,274 @@
+"""The pre-action gate (issue #217).
+
+The gate closes the enforcement half of the durability gap: a registered
+side-effect tool call is allowed only when a live ledger claim already exists
+for its derived key. These tests cover the decision table, the key-derivation
+contract against the real idempotency function, config failure modes, and the
+exit-code contract a hook transport depends on (0 allow, 2 deny).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.actions.idempotency import idempotency_key
+from continuum.cli import ExitCode, main
+from continuum.gate import (
+    GateConfigError,
+    decide,
+    load_gate_config,
+    render_key,
+)
+from continuum.models import Action, ActionStatus, Run
+from continuum.storage import SQLiteStorage
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+def payload(tool: str, **args: object) -> dict[str, object]:
+    return {"tool_name": tool, "tool_input": args}
+
+
+CONFIG = {
+    "tools": {
+        "send_invoice": {"key_template": "invoice:{customer}:{invoice_id}"},
+        "mcp__acme__charge": {"key_template": "charge:{id}", "action_type": "charge_card"},
+    }
+}
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "gate.db")
+    with SQLiteStorage(path) as store:
+        store.create_run_started(Run(run_id="run_1", goal="Do side effects"))
+    yield path
+
+
+# --- pure logic -------------------------------------------------------------- #
+
+
+def test_render_key_substitutes_top_level_fields() -> None:
+    assert render_key("invoice:{customer}:{invoice_id}", {"customer": "acme", "invoice_id": 7}) == (
+        "invoice:acme:7"
+    )
+
+
+def test_render_key_refuses_a_template_the_call_cannot_satisfy() -> None:
+    with pytest.raises(GateConfigError, match="needs argument"):
+        render_key("invoice:{invoice_id}", {"customer": "acme"})
+
+
+def test_load_gate_config_returns_none_when_absent(tmp_path: Path) -> None:
+    assert load_gate_config(tmp_path / "missing.json") is None
+
+
+def test_load_gate_config_fails_closed_on_broken_json(tmp_path: Path) -> None:
+    path = tmp_path / "gate.json"
+    path.write_text("{nope")
+    with pytest.raises(GateConfigError):
+        load_gate_config(path)
+
+
+def test_load_gate_config_requires_a_template_per_tool(tmp_path: Path) -> None:
+    path = tmp_path / "gate.json"
+    path.write_text(json.dumps({"tools": {"send_invoice": {}}}))
+    with pytest.raises(GateConfigError, match="key_template"):
+        load_gate_config(path)
+
+
+def test_decide_allows_ungated_tools_without_touching_the_ledger() -> None:
+    decision = decide(CONFIG["tools"], "Read", {"path": "x"}, run_id="r", actions_by_key={})
+    assert decision.allow is True
+
+
+def _decide(db: str, tool_input: dict[str, object], tool: str = "send_invoice"):
+    from continuum.actions.ledger import fold_action_events
+
+    with SQLiteStorage(db) as store:
+        folded = fold_action_events(store.read_events("run_1"))
+    return decide(CONFIG["tools"], tool, tool_input, run_id="run_1", actions_by_key=folded)
+
+
+def _seed(db: str, action_type: str, rendered: str, status: ActionStatus) -> None:
+    """Append ACTION_RECORDED events shaped exactly like the real writer."""
+    from continuum.events import EventType
+
+    key = str(idempotency_key(action_type, None, scope="run_1", key=rendered))
+    action = Action(run_id="run_1", action_type=action_type, status=status)
+    with SQLiteStorage(db) as store:
+        store.append_event(
+            "run_1",
+            EventType.ACTION_RECORDED,
+            {"key": key, "action": action.model_dump(mode="json")},
+        )
+
+
+# --- the decision table ------------------------------------------------------- #
+
+
+def test_unclaimed_side_effect_is_denied_with_claim_instructions(db: str) -> None:
+    decision = _decide(db, {"customer": "acme", "invoice_id": 7})
+    assert decision.allow is False
+    assert "continuum_intercept_action" in decision.reason
+    assert "invoice:acme:7" in decision.reason
+
+
+def test_a_live_claim_is_allowed(db: str) -> None:
+    _seed(db, "send_invoice", "invoice:acme:7", ActionStatus.STARTED)
+    assert _decide(db, {"customer": "acme", "invoice_id": 7}).allow is True
+
+
+def test_a_completed_call_is_denied_even_though_a_record_exists(db: str) -> None:
+    """This is the dedup verdict made physical: the model cannot re-fire an
+    effect the ledger knows already happened, claim or no claim."""
+    _seed(db, "send_invoice", "invoice:acme:7", ActionStatus.COMPLETED)
+    decision = _decide(db, {"customer": "acme", "invoice_id": 7})
+    assert decision.allow is False
+    assert "already completed" in decision.reason
+
+
+def test_an_uncertain_outcome_is_denied_with_reconcile_instructions(db: str) -> None:
+    _seed(db, "send_invoice", "invoice:acme:7", ActionStatus.UNKNOWN)
+    decision = _decide(db, {"customer": "acme", "invoice_id": 7})
+    assert decision.allow is False
+    assert "continuum_reconcile_action" in decision.reason
+
+
+def test_a_closed_attempt_must_be_reclaimed_before_retrying(db: str) -> None:
+    _seed(db, "send_invoice", "invoice:acme:7", ActionStatus.FAILED)
+    decision = _decide(db, {"customer": "acme", "invoice_id": 7})
+    assert decision.allow is False
+    assert "Claim it again" in decision.reason
+
+
+def test_a_different_key_of_the_same_tool_is_independently_gated(db: str) -> None:
+    _seed(db, "send_invoice", "invoice:acme:7", ActionStatus.STARTED)
+    other = _decide(db, {"customer": "acme", "invoice_id": 8})
+    assert other.allow is False
+    same = _decide(db, {"customer": "acme", "invoice_id": 7})
+    assert same.allow is True
+
+
+def test_action_type_override_matches_the_configured_type(db: str) -> None:
+    _seed(db, "charge_card", "charge:c1", ActionStatus.STARTED)
+    decision = decide(
+        CONFIG["tools"],
+        "mcp__acme__charge",
+        {"id": "c1"},
+        run_id="run_1",
+        actions_by_key={
+            str(idempotency_key("charge_card", None, scope="run_1", key="charge:c1")): (
+                Action(run_id="run_1", action_type="charge_card", status=ActionStatus.STARTED)
+            )
+        },
+    )
+    assert decision.allow is True
+
+
+# --- the CLI surface ------------------------------------------------------------ #
+
+
+def write_config(tmp_path: Path) -> str:
+    path = tmp_path / "gate.json"
+    path.write_text(json.dumps(CONFIG))
+    return str(path)
+
+
+def test_gate_denies_an_unclaimed_call_with_exit_two(db: str, tmp_path: Path) -> None:
+    code, out, err = run(
+        "--db",
+        db,
+        "--json",
+        "gate",
+        "--config",
+        write_config(tmp_path),
+        "--payload-file",
+        str(_payload_file(tmp_path, customer="acme", invoice_id=7)),
+    )
+    assert code == 2
+    assert json.loads(out)["allow"] is False
+    assert "continuum_intercept_action" in err
+
+
+def _payload_file(tmp_path: Path, **args: object) -> Path:
+    p = tmp_path / "payload.json"
+    p.write_text(json.dumps(payload("send_invoice", **args)))
+    return p
+
+
+def test_gate_allows_after_a_real_claim_via_the_ledger_api(db: str, tmp_path: Path) -> None:
+    from continuum.actions.ledger import ActionLedger
+
+    with SQLiteStorage(db) as store:
+        ActionLedger(store, "run_1").claim(
+            "send_invoice", {}, key="invoice:acme:9", scoped_to_run=True
+        )
+    code, out, err = run(
+        "--db",
+        db,
+        "--json",
+        "gate",
+        "--config",
+        write_config(tmp_path),
+        "--payload-file",
+        str(_payload_file(tmp_path, customer="acme", invoice_id=9)),
+    )
+    assert code == ExitCode.OK, err
+    assert json.loads(out)["allow"] is True
+
+
+def test_gate_fast_paths_when_no_config_exists(db: str, tmp_path: Path) -> None:
+    p = tmp_path / "p.json"
+    p.write_text(json.dumps(payload("send_invoice", customer="a", invoice_id=1)))
+    code, out, _ = run("--db", db, "--json", "gate", "--payload-file", str(p))
+    assert code == ExitCode.OK
+    assert json.loads(out)["reason"] == "no gate configured"
+
+
+def test_gate_denies_when_the_registry_is_corrupt(db: str, tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{")
+    p = tmp_path / "p.json"
+    p.write_text(json.dumps(payload("send_invoice", customer="a", invoice_id=1)))
+    code, _, err = run("--db", db, "--json", "gate", "--config", str(bad), "--payload-file", str(p))
+    assert code == 2
+    assert "denying until it is fixed" in err
+
+
+def test_gate_denies_a_gated_call_when_no_run_is_active(tmp_path: Path) -> None:
+    empty = str(tmp_path / "empty.db")
+    with SQLiteStorage(empty):
+        pass
+    p = tmp_path / "p.json"
+    p.write_text(json.dumps(payload("send_invoice", customer="a", invoice_id=1)))
+    code, _, err = run(
+        "--db",
+        empty,
+        "--json",
+        "gate",
+        "--config",
+        write_config(tmp_path),
+        "--payload-file",
+        str(p),
+    )
+    assert code == 2
+    assert "no active CONTINUUM run" in err
+
+
+def test_gate_tolerates_an_unparseable_payload(db: str, tmp_path: Path) -> None:
+    p = tmp_path / "p.json"
+    p.write_text("{junk")
+    code, _, err = run(
+        "--db", db, "--json", "gate", "--config", write_config(tmp_path), "--payload-file", str(p)
+    )
+    assert code == ExitCode.OK
+    assert "allowing" in err

--- a/tests/test_cli_observe.py
+++ b/tests/test_cli_observe.py
@@ -234,12 +234,12 @@ def test_cli_hooks_commands_round_trip(tmp_path: Path) -> None:
     code, out, err = run("--json", "hooks", "install", "claude-code", "--settings", str(settings))
     assert code == ExitCode.OK, err
     installed = json.loads(out)
-    assert installed["status"] == "installed"
+    assert installed["hooks"][0]["status"] == "installed"
     assert json.loads(settings.read_text())["hooks"]["PostToolUse"]
 
     code, out, _ = run("--json", "hooks", "install", "claude-code", "--settings", str(settings))
     assert code == ExitCode.OK
-    assert json.loads(out)["status"] == "present"
+    assert json.loads(out)["hooks"][0]["status"] == "present"
 
     code, out, _ = run("--json", "hooks", "remove", "claude-code", "--settings", str(settings))
     assert code == ExitCode.OK

--- a/tests/test_client_installers.py
+++ b/tests/test_client_installers.py
@@ -1,0 +1,158 @@
+"""Client installers beyond Claude Code (issue #209).
+
+Gemini CLI and Codex CLI expose hook surfaces with the same stdin contract
+(tool_name + tool_input JSON) but different settings layouts, event names
+and matchers. Wiring is data-driven from CLIENT_PROFILES; these tests pin
+each profile's installed shape, idempotency, removal, and the Codex feature
+flag hint.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from continuum.cli import ExitCode, main
+from continuum.clienthooks import CLIENT_PROFILES
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+import io  # noqa: E402
+
+
+@pytest.mark.parametrize("client", ("claude-code", "gemini", "codex"))
+def test_install_writes_the_profiled_shape(tmp_path: Path, client: str) -> None:
+    profile = CLIENT_PROFILES[client]
+    settings = tmp_path / "settings.json"
+
+    code, out, err = run("--json", "hooks", "install", client, "--settings", str(settings))
+    assert code == ExitCode.OK, err
+
+    data = json.loads(settings.read_text())
+    hooks_obj = data["hooks"]
+    post = hooks_obj[profile["post_event"]]
+    assert len(post) == 1
+    assert post[0]["matcher"] == profile["write_matcher"]
+    command = post[0]["hooks"][0]["command"]
+    assert command.split()[-1] == "observe"
+
+    payload = json.loads(out)
+    assert payload["hooks"][0]["event"] == profile["post_event"]
+    assert payload["settings"] == str(settings)
+
+
+@pytest.mark.parametrize("client", ("claude-code", "gemini", "codex"))
+def test_install_is_idempotent_per_client(tmp_path: Path, client: str) -> None:
+    settings = tmp_path / "settings.json"
+    for _ in range(2):
+        code, _, err = run("--json", "hooks", "install", client, "--settings", str(settings))
+        assert code == ExitCode.OK, err
+    data = json.loads(settings.read_text())
+    event = CLIENT_PROFILES[client]["post_event"]
+    assert len(data["hooks"][event]) == 1
+
+
+def test_gemini_gate_uses_before_tool(tmp_path: Path) -> None:
+    settings = tmp_path / "settings.json"
+    code, out, _ = run(
+        "--json", "hooks", "install", "gemini", "--with-gate", "--settings", str(settings)
+    )
+    assert code == ExitCode.OK
+    data = json.loads(settings.read_text())
+    assert data["hooks"]["AfterTool"][0]["matcher"] == "write_file|replace"
+    before = data["hooks"]["BeforeTool"]
+    assert before[0]["matcher"] == ".*"
+    assert before[0]["hooks"][0]["command"].split()[-1] == "gate"
+
+
+def test_remove_cleans_each_client(tmp_path: Path) -> None:
+    for client in ("claude-code", "gemini", "codex"):
+        settings = tmp_path / f"{client}.json"
+        run("--json", "hooks", "install", client, "--with-gate", "--settings", str(settings))
+        code, out, _ = run("--json", "hooks", "remove", client, "--settings", str(settings))
+        assert code == ExitCode.OK
+        assert json.loads(out)["removed"] is True
+        data = json.loads(settings.read_text())
+        # No continuum entries survive; unrelated content would.
+        assert "hooks" not in data or all(
+            not group.get("hooks") for group in data.get("hooks", {}).values()
+        )
+
+
+def test_codex_install_hints_when_feature_flag_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    settings = tmp_path / "settings.json"
+    code, out, _ = run("--json", "hooks", "install", "codex", "--settings", str(settings))
+    assert code == ExitCode.OK
+    payload = json.loads(out)
+    assert "codex_hooks" in payload["feature_flag_hint"]
+
+
+def test_codex_install_stays_silent_when_flag_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_home = tmp_path / "home"
+    codex_dir = fake_home / ".codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "config.toml").write_text("[features]\ncodex_hooks = true\n")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    settings = tmp_path / "settings.json"
+    code, out, _ = run("--json", "hooks", "install", "codex", "--settings", str(settings))
+    assert code == ExitCode.OK
+    assert "feature_flag_hint" not in json.loads(out)
+
+
+def test_gemini_payload_shape_matches_the_observation_contract() -> None:
+    """Gemini AfterTool payloads carry the same tool_name/tool_input fields;
+    prove `continuum observe` accepts one verbatim through the real CLI."""
+    import tempfile
+
+    project = Path(tempfile.mkdtemp())
+    subprocess.run(["python", "-m", "continuum.cli", "init"], cwd=project, capture_output=True)
+    subprocess.run(
+        ["python", "-m", "continuum.cli", "start", "g", "--goal", "gemini"],
+        cwd=project,
+        capture_output=True,
+    )
+    artifact = project / "out.txt"
+    artifact.write_text("written by gemini")
+    gemini_payload = json.dumps(
+        {
+            "hook_event_name": "AfterTool",
+            "tool_name": "write_file",
+            "tool_input": {"file_path": str(artifact), "content": "x"},
+        }
+    )
+    result = subprocess.run(
+        ["python", "-m", "continuum.cli", "--db", str(project / "continuum.db"), "observe"],
+        input=gemini_payload,
+        capture_output=True,
+        text=True,
+        cwd=project,
+    )
+    assert result.returncode == ExitCode.OK, result.stderr
+
+
+@pytest.mark.parametrize("client", ("claude-code", "gemini", "codex"))
+def test_default_settings_path_comes_from_the_profile(
+    tmp_path: Path, client: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Caught live: an explicit --settings was tested everywhere, so a
+    hardcoded CLI default silently sent every client's hooks to Claude
+    Code's settings file. The default must come from the profile."""
+    monkeypatch.chdir(tmp_path)
+    code, _, err = run("--json", "hooks", "install", client)
+    assert code == ExitCode.OK, err
+    expected = CLIENT_PROFILES[client]["settings"]
+    assert (tmp_path / expected).exists(), expected


### PR DESCRIPTION
## Description

Phase 3b of the enforced-durability roadmap (#213): the observation and gate commands already speak one client-agnostic stdin contract; this PR makes installing them onto other harnesses data-driven. `CLIENT_PROFILES` in `clienthooks.py` describes, per client, the settings path, hook event names and tool matchers:

| Client | Settings | Observe | Gate |
|---|---|---|---|
| claude-code | `.claude/settings.json` | PostToolUse, matcher `Write\|Edit\|MultiEdit\|NotebookEdit` | PreToolUse, `*` |
| gemini | `.gemini/settings.json` | AfterTool, `write_file\|replace` | BeforeTool, `.*` |
| codex | `.codex/hooks.json` | PostToolUse, Bash-only today | PreToolUse, Bash-only |

Gemini's shape follows the official hooks reference (events `BeforeTool`/`AfterTool`, same exit-code semantics, identical stdin fields). Codex's documented limitation is encoded honestly in the profile: as of mid-2026 its hook surface traverses shell/Bash calls only, not apply_patch or MCP tools, and the engine requires `[features].codex_hooks = true` in `~/.codex/config.toml`. The installer detects a missing flag and emits the exact line to add rather than hand-editing TOML.

Removal now scans every event list in the settings file instead of hardcoded Claude Code names, working across all three clients while still stripping only entries whose command matches the continuum shapes.

## Related issues

Fixes #209

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest            # 1137 passed, 12 skipped
ruff check src tests        # clean
ruff format --check         # clean
mypy src                    # Success: no issues found in 87 source files
```

New tests in `tests/test_client_installers.py`: profiled install shape for all three clients (event name, matcher, trailing observe/gate word), idempotency, Gemini BeforeTool gate placement, cross-client removal cleanliness, Codex feature-flag hint presence and silence, verbatim acceptance of a real Gemini AfterTool payload by `continuum observe` through a subprocess, and default-settings-path-per-profile regressions.

Also verified live in scratch directories: each client installs to its own settings file with the profiled events and matchers, and `claude mcp list`-style health remains untouched (hook files are inert to non-hook runs).

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Known limitations, stated up front: Codex coverage is Bash-only until OpenAI widens its hook surface (documented in the profile comment); the Codex feature flag is hinted at rather than auto-edited because hand-writing TOML risks corrupting operator config; Gemini's consumer CLI sunset (Antigravity migration) preserves the same settings layout per Google's migration notes, but the enterprise carveout means both spellings may exist in the wild.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hook installers for Claude Code, Gemini CLI, and Codex CLI.
  * Added optional pre-action gates that allow or deny side-effecting tool calls based on active claims.
  * Added the `gate` command and client-specific installation options.
* **Performance**
  * Optional integrations now load on demand, improving startup while preserving public imports.
* **Documentation**
  * Updated the unreleased changelog with installer, gate, configuration, and authentication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->