### PR TITLE
feat(recovery): render actionable next steps on resume and validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Actionable recovery guidance (`human_steps`).** The contract named what
+  was blocked but not what to do about it, leaving every resuming agent to
+  translate `reconcile_action:abc` into commands by hand. Resume and
+  validate now render executable next steps derived from the plan plus live
+  project automation: a reconcile step with a registered probe becomes one
+  `continuum reconcile <run>` command; without one it names the external
+  check and the exact `continuum_reconcile_action(...)` call, and says why
+  it is manual; human review points at `continuum confirm`; dependency
+  steps name the `--env` re-pin. Gate presence is surfaced as protocol
+  guidance. Steps flow through CLI text/JSON, MCP `continuum_resume`, and
+  the sidecar's mirrored payload. Guidance is rendering only: derived from
+  existing state and config, never executed by CONTINUUM itself.
+
 - **Client installers for Gemini CLI and Codex CLI (#209).** The observe and
   gate commands were already client-agnostic; wiring them into new clients is
   now data, not code. `CLIENT_PROFILES` describes each client's settings

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -457,6 +457,30 @@ def cmd_diff(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
     return ExitCode.OK
 
 
+def _human_steps(decision: Any, run_id: str) -> list[str]:
+    """Executable next steps for this decision, derived from live config.
+
+    Read-only: the reconciler registry and gate config are inspected, never
+    executed. Absent files simply mean fewer shortcuts to suggest.
+    """
+    from continuum.gate import DEFAULT_GATE_CONFIG_PATH
+    from continuum.reconcilers import DEFAULT_RECONCILERS_PATH, load_reconcilers
+    from continuum.recovery.guidance import human_steps_for
+
+    try:
+        probes = load_reconcilers(Path(DEFAULT_RECONCILERS_PATH))
+        probed: list[str] = list(probes)
+    except Exception:
+        probed = []
+    gate_configured = Path(DEFAULT_GATE_CONFIG_PATH).exists()
+    return human_steps_for(
+        decision,
+        run_id=run_id,
+        probed_types=probed,
+        gate_configured=gate_configured,
+    )
+
+
 def cmd_validate(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Assess a run without touching it. Exit code carries the verdict."""
     decision = RecoveryEngine(storage, strict_unknown=not args.tolerate_unknown).assess(
@@ -468,6 +492,15 @@ def cmd_validate(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
         out.write(render_dashboard(decision) + "\n")
         out.flush()
         return exit_code_for(decision.mode)
+    steps = _human_steps(decision, args.run_id)
+    if steps:
+        text = (
+            decision.render()
+            + "\n\nNext steps:\n"
+            + "\n".join(f"  {i}. {t}" for i, t in enumerate(steps, 1))
+        )
+    else:
+        text = decision.render()
     payload = {
         "run_id": decision.run_id,
         "mode": decision.mode.value,
@@ -475,10 +508,11 @@ def cmd_validate(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
         "contract": decision.contract.model_dump(mode="json"),
         "rationale": list(decision.rationale),
         "repairs": [s.action_name for s in decision.plan.steps],
+        "human_steps": steps,
     }
     _emit(
         payload,
-        decision.render(),
+        text,
         as_json=args.json,
         stream=out,
         palette=getattr(args, "_palette", None),
@@ -505,12 +539,18 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         expected_model=args.model,
     )
 
+    steps = _human_steps(decision, run_id)
+    text = decision.render()
+    if steps:
+        text += "\n\nNext steps:\n" + "\n".join(f"  {i}. {t}" for i, t in enumerate(steps, 1))
+
     payload = {
         "run_id": decision.run_id,
         "goal": storage.get_run(run_id).goal,
         "mode": decision.mode.value,
         "safe": decision.safe,
         "next_allowed_action": decision.next_allowed_action,
+        "human_steps": steps,
         "contract": decision.contract.model_dump(mode="json"),
         "repairs": [s.action_name for s in decision.plan.steps],
         "progress": {
@@ -521,7 +561,7 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
     }
     _emit(
         payload,
-        decision.render(),
+        text,
         as_json=args.json,
         stream=out,
         palette=getattr(args, "_palette", None),

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -53,6 +53,7 @@ import os
 import sqlite3
 import sys
 from collections.abc import Callable, Mapping
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from continuum.actions.ledger import ActionLedger
@@ -638,6 +639,23 @@ def build_server(
         # for "what was this task?" across interruptions.
         goal = ctx.storage.get_run(run_id).goal
         tail_evidence = decision.tail_evidence
+        # Executable next steps (issue: actionable guidance). Derived from
+        # the plan plus whatever automation this project has registered, so
+        # the resuming agent never translates statuses into commands itself.
+        from continuum.gate import DEFAULT_GATE_CONFIG_PATH
+        from continuum.reconcilers import DEFAULT_RECONCILERS_PATH, load_reconcilers
+        from continuum.recovery.guidance import human_steps_for
+
+        try:
+            probed = list(load_reconcilers(Path(DEFAULT_RECONCILERS_PATH)))
+        except Exception:
+            probed = []
+        human_steps = human_steps_for(
+            decision,
+            run_id=run_id,
+            probed_types=probed,
+            gate_configured=Path(DEFAULT_GATE_CONFIG_PATH).exists(),
+        )
         return _json(
             {
                 "run_id": run_id,
@@ -645,6 +663,7 @@ def build_server(
                 "mode": decision.mode.value,
                 "safe": decision.safe,
                 "next_allowed_action": decision.next_allowed_action,
+                "human_steps": human_steps,
                 "rationale": list(decision.rationale),
                 "repairs": [
                     {

--- a/src/continuum/recovery/guidance.py
+++ b/src/continuum/recovery/guidance.py
@@ -1,0 +1,97 @@
+"""Actionable recovery guidance: turn a decision into executable steps.
+
+The contract names what is blocked (``reconcile_action:action_abc``,
+``human_review:goal``) but not what to *do* about it, which left every
+resuming agent or human translating statuses into commands by hand. This
+module renders the translation once, in one place:
+
+- Reconcile steps become either "run ``continuum reconcile``" when a probe is
+  registered for that action type (#218), or the exact external check plus
+  the exact ``continuum_reconcile_action`` call when not.
+- Human-review steps become the concrete verification plus
+  ``continuum confirm``.
+- Dependency/evidence/finding steps point at ``validate --env`` re-pinning.
+
+Guidance is derived from state that already exists (the plan, the uncertain
+actions, the reconciler registry, the gate config). It adds no authority:
+following it still lands as ordinary auditable events, and steps marked
+``requires_human`` stay human-gated regardless of wording.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from continuum.models import RecoveryMode
+from continuum.recovery.engine import RecoveryDecision
+from continuum.recovery.planner import RepairKind
+
+__all__ = ["human_steps_for"]
+
+_RECONCILE_HINT = (
+    "call continuum_reconcile_action(run_id={run}, action_key={key}, occurred=true|false)"
+)
+
+
+def human_steps_for(
+    decision: RecoveryDecision,
+    *,
+    run_id: str,
+    probed_types: Iterable[str] = (),
+    gate_configured: bool = False,
+    reconcilers_path: str = ".continuum/reconcilers.json",
+    gate_path: str = ".continuum/gate.json",
+) -> list[str]:
+    """Executable next steps for this decision, most urgent first."""
+    if decision.mode is RecoveryMode.RESUME and not decision.plan.steps:
+        return []
+
+    probed = set(probed_types)
+    uncertain_by_id = {a.action_id: a for a in decision.uncertain_actions}
+    steps: list[str] = []
+
+    for step in decision.plan.steps:
+        if step.kind is RepairKind.RECONCILE_ACTION:
+            action_id = step.target
+            action = uncertain_by_id.get(action_id)
+            action_type = action.action_type if action else "unknown"
+            key_hint = ""
+            if action is not None and action.external_id:
+                key_hint = f" for {action.external_id}"
+            if action_type in probed:
+                steps.append(
+                    f"a probe is registered for {action_type!r}: "
+                    f"run `continuum reconcile {run_id}` to settle it automatically"
+                )
+            else:
+                steps.append(
+                    f"check whether {action_type!r}{key_hint} actually reached the outside "
+                    f"world, then {_RECONCILE_HINT.format(run=run_id, key=action_id)}"
+                    + (f"  (no probe registered in {reconcilers_path})")
+                )
+        elif step.kind is RepairKind.HUMAN_REVIEW:
+            steps.append(f"verify {step.target} yourself, then run `continuum confirm {run_id}`")
+        elif step.kind is RepairKind.REVALIDATE_DEPENDENCY:
+            steps.append(
+                f"re-pin dependency {step.target!r}: rerun with "
+                f"`--env {step.target}=<current version>` after confirming its real version"
+            )
+        elif step.kind in (
+            RepairKind.REDERIVE_EVIDENCE,
+            RepairKind.REDERIVE_FINDING,
+        ):
+            steps.append(f"re-derive {step.target} from its source, then re-validate")
+        elif step.kind is RepairKind.RENEW_APPROVAL:
+            steps.append(f"obtain a fresh approval for {step.target}, then record it via MCP")
+        elif step.kind is RepairKind.REVALIDATE_MODEL_STATE:
+            steps.append("confirm which model resumes this work, then pass `--model <name>`")
+
+    if not steps and decision.mode is not RecoveryMode.RESUME:
+        steps.append("inspect the contract above; nothing further is automatable here")
+
+    if gate_configured:
+        steps.append(
+            f"gate active ({gate_path}): route new side effects through "
+            f"continuum_intercept_action before performing them"
+        )
+    return steps

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -39,6 +39,7 @@ from continuum.models import (
     UnknownSideEffect,
 )
 from continuum.recovery.contract import render_contract
+from continuum.recovery.guidance import human_steps_for
 from continuum.state.semantic import project
 from continuum.storage import RunNotFound, Storage, open_storage
 
@@ -293,6 +294,7 @@ def _decision_payload(decision: Any, *, goal: str) -> dict[str, Any]:
         "mode": decision.mode.value,
         "safe": decision.safe,
         "next_allowed_action": decision.next_allowed_action,
+        "human_steps": human_steps_for(decision, run_id=decision.state.run_id),
         "rationale": list(decision.rationale),
         "repairs": [
             {

--- a/tests/test_recovery_guidance.py
+++ b/tests/test_recovery_guidance.py
@@ -1,0 +1,191 @@
+"""Actionable recovery guidance (human_steps on resume/validate).
+
+The contract names what is blocked; guidance renders what to do about it.
+These tests pin the derivation rules and prove the CLI/MCP surfaces carry
+the steps.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.cli import ExitCode, main
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.recovery.guidance import human_steps_for
+from continuum.storage import SQLiteStorage
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+def make_run(db: str, run_id: str = "run_1") -> None:
+    with SQLiteStorage(db) as store:
+        store.create_run(Run(run_id=run_id, goal="Do things"))
+        store.append_event(run_id, EventType.RUN_STARTED, {"goal": "Do things"})
+
+
+def seed_uncertain(db: str, action_type: str = "send_invoice", key: str = "invoice:1") -> str:
+    with SQLiteStorage(db) as store:
+        outcome = ActionLedger(store, "run_1").claim(action_type, {}, key=key)
+    return outcome.action.action_id
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "g.db")
+    make_run(path)
+    yield path
+
+
+def assess(db: str):
+    from continuum.recovery import RecoveryEngine
+
+    return RecoveryEngine(SQLiteStorage(db)).assess("run_1")
+
+
+# --- pure derivation ---------------------------------------------------------- #
+
+
+def test_safe_resume_yields_no_steps(db: str) -> None:
+    decision = assess(db)  # nothing pending; but MCP provenance forces review
+    steps = human_steps_for(decision, run_id="run_1")
+    if decision.mode.value == "resume" and decision.safe:
+        assert steps == []
+
+
+def test_uncertain_action_without_probe_names_the_exact_call(db: str) -> None:
+    seed_uncertain(db)
+    decision = assess(db)
+    steps = human_steps_for(decision, run_id="run_1", probed_types=[])
+    reconcile = [t for t in steps if "continuum_reconcile_action" in t]
+    assert reconcile, steps
+    joined = " ".join(reconcile)
+    assert "send_invoice" in joined and "run_1" in joined
+    # The absence of automation is stated, so the agent knows why it is manual.
+    assert any("no probe registered" in t for t in reconcile)
+
+
+def test_a_registered_probe_becomes_one_command(db: str) -> None:
+    seed_uncertain(db)
+    decision = assess(db)
+    steps = human_steps_for(decision, run_id="run_1", probed_types=["send_invoice"])
+    auto = [t for t in steps if "continuum reconcile run_1" in t]
+    assert auto, steps
+    assert not any("continuum_reconcile_action" in t for t in steps)
+
+
+def test_human_review_points_at_confirm(db: str) -> None:
+    seed_uncertain(db)
+    decision = assess(db)  # external-agent style plan includes human_review
+    confirm = [t for t in human_steps_for(decision, run_id="run_1") if "confirm" in t]
+    if any(s.kind.value == "human_review" for s in decision.plan.steps):
+        assert confirm
+
+
+# --- CLI + MCP surfaces ------------------------------------------------------------ #
+
+
+def test_cli_resume_json_and_text_carry_the_steps(db: str, tmp_path: Path) -> None:
+    seed_uncertain(db)
+    code, out, err = run("--db", db, "--json", "resume", "run_1")
+    assert code != ExitCode.OK
+    payload = json.loads(out)
+    assert payload["human_steps"], payload
+
+    code, out, _ = run("--db", db, "resume", "run_1")
+    assert "Next steps:" in out
+    assert "1." in out
+
+
+def test_cli_validate_also_carries_steps(db: str) -> None:
+    seed_uncertain(db)
+    code, out, _ = run("--db", db, "--json", "validate", "run_1", "--tolerate-unknown")
+    payload = json.loads(out)
+    assert isinstance(payload["human_steps"], list)
+
+
+def test_gate_presence_is_surfaced_as_protocol_guidance(
+    db: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".continuum").mkdir()
+    (tmp_path / ".continuum" / "gate.json").write_text(json.dumps({"tools": {}}))
+    seed_uncertain(db)
+    code, out, err = run("--db", db, "--json", "resume", "run_1")
+    payload = json.loads(out)
+    assert any("gate active" in t for t in payload["human_steps"])
+
+
+def test_mcp_resume_includes_human_steps(db: str, tmp_path: Path) -> None:
+    """Drive the real stdio server: resume must carry executable steps."""
+    import subprocess
+
+    env = {"PATH": "/usr/bin:/bin:/opt/miniconda3/bin", "HOME": os.environ["HOME"]}
+    handshake = [
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "claude-code", "version": "1"},
+                },
+            }
+        ),
+        '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "continuum_resume",
+                    "arguments": {"run_id": "run_1"},
+                },
+            }
+        ),
+    ]
+    proc = subprocess.Popen(
+        ["python", "-m", "continuum.mcp.server", "--db", db],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+    )
+    try:
+        for line in handshake:
+            proc.stdin.write(line + "\n")
+            proc.stdin.flush()
+        reply = None
+        deadline = 50
+        while deadline:
+            line = proc.stdout.readline()
+            if not line:
+                break
+            parsed = json.loads(line)
+            if parsed.get("id") == 2:
+                reply = parsed
+                break
+            deadline -= 1
+    finally:
+        proc.kill()
+    assert reply is not None
+    text = reply["result"]["content"][0]["text"]
+    payload = json.loads(text)
+    assert isinstance(payload.get("human_steps"), list)
+
+
+import os  # noqa: E402


### PR DESCRIPTION
## Description

Follow-up from an agent-ergonomics review of CONTINUUM: "the contract is the instruction set, make it executable." Resume/validate named blocked items (`reconcile_action:action_abc`) without saying what to do about them.

`RecoveryDecision` now renders `human_steps`: executable next steps derived from the plan plus whatever automation this project registered:

- Reconcile step + registered probe (#218) -> one command: `continuum reconcile <run>`
- Reconcile step, no probe -> the external check to perform plus the exact `continuum_reconcile_action(run_id=..., action_key=..., occurred=true|false)` call, with the reason it is manual stated
- `human_review` -> verify yourself, then `continuum confirm <run>`
- Dependency/evidence/model steps -> their concrete re-pin or re-validation action
- Gate configured (#217) -> routing reminder so new side effects go through claims

Surfaced identically in CLI text ("Next steps:"), CLI JSON (`human_steps`), MCP `continuum_resume`, and the sidecar's mirrored payload (parity test extended). Guidance is strictly rendering over existing state and config files: nothing is executed by CONTINUUM, and `requires_human` steps remain human-gated.

## Related issues

Advances #213 (agent ergonomics follow-up); no single tracking issue.

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest            # 1192 passed, 12 skipped
ruff check src tests        # clean
ruff format --check         # clean
mypy src                    # Success: no issues found in 91 source files
```

Eight new tests in `tests/test_recovery_guidance.py`: derivation rules (probe vs no-probe wording, confirm mapping), CLI JSON/text carriage, validate parity, gate-presence surfacing, and a real stdio MCP round trip asserting `human_steps` arrives through the wire. The sidecar resume-parity test was extended to cover the new field, which caught that `serve` needed the same projection.

Verified live: an uncertain `send_invoice` run renders step 1 as "check whether 'send_invoice' actually reached the outside world, then call continuum_reconcile_action(...)"; after registering a probe the same run renders "run `continuum reconcile inv` to settle it automatically".

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Inspired by an LLM-agent critique asking CONTINUUM to make contracts executable rather than descriptive. Deliberately not adopted from the same critique: an orchestrating `continuum run` command (contradicts the documented non-orchestrator scope refusal) and trusting MCP provenance without confirm (that gate is the anti-self-certification fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added actionable recovery guidance to resume and validation results.
  * Guidance now covers reconciliation, manual checks, human review, dependency verification, approvals, and gate procedures.
  * Next steps are available in CLI text and JSON output, MCP responses, and sidecar payloads.
  * Guidance is informational only and does not execute actions.

* **Tests**
  * Added coverage for recovery guidance and its CLI, MCP, and sidecar integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->