### PR TITLE
feat(cli): session briefing injects durable state without CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Session briefing: state without CLAUDE.md (#213 ergonomics follow-up).**
+  The last two voluntary behaviours depending on per-repo prose were
+  resume-on-start and knowing the active run at all. New read-only command
+  `continuum briefing` prints exactly what a returning agent needs - active
+  run, goal, progress, recovery verdict, executable next steps and recent
+  disk-checked observations - as SessionStart-compatible context JSON.
+  `hooks install` now wires it alongside observe on every supported client's
+  session-start event (Claude Code, Gemini CLI, Codex), so a fresh session
+  learns its durable state from deterministic injection instead of a prompt
+  file. With no active run it says how to create one.
+
 - **Actionable recovery guidance (`human_steps`).** The contract named what
   was blocked but not what to do about it, leaving every resuming agent to
   translate `reconcile_action:abc` into commands by hand. Resume and

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -721,6 +721,80 @@ def cmd_observe(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
     return ExitCode.OK
 
 
+def cmd_briefing(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Session-start context injection (no CLAUDE.md required).
+
+    Wired as a SessionStart hook by `hooks install`. Prints, as
+    hook-consumable JSON plus human-readable text, everything a returning
+    agent needs: the active run's goal, progress, recovery verdict,
+    executable next steps, and disk-checked file observations. Read-only;
+    with no active run it says exactly how to create one.
+    """
+    run_id = args.run_id
+    if not run_id:
+        active = storage.get_active_run()
+        run_id = active.run_id if active else None
+
+    if not run_id:
+        text = (
+            "CONTINUUM: no active run. Create one before working durably: "
+            "`continuum start <run_id> --goal '...'`, or call "
+            "continuum_record_progress(run_id, completed, total, goal=...) via MCP."
+        )
+        context = "[CONTINUUM] " + text
+        _emit(
+            {"active_run": None, "context": context},
+            text,
+            as_json=args.json,
+            stream=out,
+            palette=getattr(args, "_palette", None),
+        )
+        return ExitCode.OK
+
+    decision = RecoveryEngine(storage).assess(run_id)
+    steps = _human_steps(decision, run_id)
+    contract = decision.contract
+    state = decision.state
+
+    lines = [
+        f"CONTINUUM active run: {run_id}",
+        f"goal: {state.goal.description}",
+        f"progress: {state.progress.completed}/{state.progress.total or '?'} completed"
+        + (f", {state.progress.failed} failed" if state.progress.failed else ""),
+        f"recovery: {decision.mode.value} (safe={decision.safe})",
+    ]
+    obs = contract.post_checkpoint_observations[:5]
+    if obs:
+        lines.append("files since checkpoint:")
+        lines += [
+            f"  [{o.get('status', '?')}] {o.get('path', '')}" for o in obs if not o.get("truncated")
+        ]
+    if steps:
+        lines.append("next steps:")
+        lines += [f"  {i}. {t}" for i, t in enumerate(steps, 1)]
+
+    text = "\n".join(lines)
+    context = text
+    _emit(
+        {
+            "active_run": run_id,
+            "mode": decision.mode.value,
+            "safe": decision.safe,
+            "context": context,
+            "human_steps": steps,
+            "hookSpecificOutput": {
+                "hookEventName": args.hook_event_name,
+                "additionalContext": context,
+            },
+        },
+        text,
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
+
+
 def cmd_hooks_install(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Wire a coding CLI's tool events into observe (and optionally gate).
 
@@ -735,6 +809,7 @@ def cmd_hooks_install(args: argparse.Namespace, storage: Storage, out: Any, err:
     command = observe_command(db=args.db)
     gate_command = command[: -len("observe")] + "gate"
 
+    briefing_command = command[: -len("observe")] + "briefing"
     statuses = [
         (
             install_client_hook(
@@ -747,7 +822,19 @@ def cmd_hooks_install(args: argparse.Namespace, storage: Storage, out: Any, err:
             "observe",
             profile["post_event"],
             command,
-        )
+        ),
+        (
+            install_client_hook(
+                settings_path,
+                briefing_command,
+                event_name=profile["start_event"],
+                matcher="",
+            ),
+            "",
+            "briefing",
+            profile["start_event"],
+            briefing_command,
+        ),
     ]
     if getattr(args, "with_gate", False):
         statuses.append(
@@ -1413,6 +1500,23 @@ def build_parser() -> argparse.ArgumentParser:
         "--payload-file",
         default=None,
         help="read the hook payload from this file instead of stdin",
+    )
+
+    briefing = add(
+        "briefing",
+        cmd_briefing,
+        "Session-start context: active run, progress, next steps. Read-only.",
+    )
+    briefing.add_argument(
+        "--run-id",
+        default=None,
+        help="run to brief on (default: the most recently active non-terminal run)",
+    )
+    briefing.add_argument(
+        "--hook-event-name",
+        dest="hook_event_name",
+        default="SessionStart",
+        help=argparse.SUPPRESS,
     )
 
     gate = add(

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -66,6 +66,7 @@ _PATH_KEYS = ("file_path", "notebook_path")
 CLIENT_PROFILES: dict[str, dict[str, str]] = {
     "claude-code": {
         "settings": ".claude/settings.json",
+        "start_event": "SessionStart",
         "post_event": "PostToolUse",
         "pre_event": "PreToolUse",
         "write_matcher": "Write|Edit|MultiEdit|NotebookEdit",
@@ -73,6 +74,7 @@ CLIENT_PROFILES: dict[str, dict[str, str]] = {
     },
     "gemini": {
         "settings": ".gemini/settings.json",
+        "start_event": "SessionStart",
         "post_event": "AfterTool",
         "pre_event": "BeforeTool",
         "write_matcher": "write_file|replace",
@@ -80,6 +82,7 @@ CLIENT_PROFILES: dict[str, dict[str, str]] = {
     },
     "codex": {
         "settings": ".codex/hooks.json",
+        "start_event": "SessionStart",
         "post_event": "PostToolUse",
         "pre_event": "PreToolUse",
         # Documented surface as of mid-2026: Codex hooks fire for shell/Bash
@@ -333,7 +336,7 @@ def remove_claude_code_hook(settings_path: Path) -> bool:
                 for h in group["hooks"]
                 if not (
                     isinstance(h, dict)
-                    and (_is_continuum_hook(h, "observe") or _is_continuum_hook(h, "gate"))
+                    and any(_is_continuum_hook(h, k) for k in ("observe", "gate", "briefing"))
                 )
             ]
             if len(kept_hooks) != len(group["hooks"]):

--- a/tests/test_client_installers.py
+++ b/tests/test_client_installers.py
@@ -156,3 +156,22 @@ def test_default_settings_path_comes_from_the_profile(
     assert code == ExitCode.OK, err
     expected = CLIENT_PROFILES[client]["settings"]
     assert (tmp_path / expected).exists(), expected
+
+
+@pytest.mark.parametrize("client", ("claude-code", "gemini", "codex"))
+def test_briefing_is_wired_on_session_start(tmp_path: Path, client: str) -> None:
+    """No CLAUDE.md required: the briefing rides the client's own
+    SessionStart event so state reaches the model deterministically."""
+    profile = CLIENT_PROFILES[client]
+    settings = tmp_path / "settings.json"
+    code, _, err = run("--json", "hooks", "install", client, "--settings", str(settings))
+    assert code == ExitCode.OK, err
+    data = json.loads(settings.read_text())
+    starts = data["hooks"][profile["start_event"]]
+    ours = [
+        g
+        for g in starts
+        if isinstance(g.get("hooks"), list)
+        and any(h.get("command", "").split()[-1] == "briefing" for h in g["hooks"])
+    ]
+    assert len(ours) == 1


### PR DESCRIPTION
## Description

Removes the last CLAUDE.md dependency from CONTINUUM's agent integration. `continuum briefing` (read-only) renders the active run's goal, progress, recovery verdict, human_steps and recent disk-checked observations as SessionStart-compatible context JSON; `hooks install` wires it on every supported client's session-start event. A fresh session learns its durable state by deterministic injection rather than prompt-file prose, and with no active run it is told exactly how to create one.

## Related issues

Refs #213

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has been tested?

pytest 1195 passed / 12 skipped; ruff clean; strict mypy clean. New parametrised test pins SessionStart wiring for all three clients. Live acceptance test follows in-session (scratch dir without any CLAUDE.md).

## Checklist

Tests added or updated for the changed behaviour. CI expected green.