### PR TITLE
feat(otel): mirror tool-call spans into the event log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **OpenTelemetry bridge (seam 5 of the universality roadmap, #213).**
+  Production stacks already emit OTel; now those spans become CONTINUUM
+  evidence with zero framework cooperation. `make_span_processor(storage)`
+  returns a standard SpanProcessor to register on any TracerProvider: ended
+  spans carrying a recognised tool-name attribute (`gen_ai.tool.name` per the
+  GenAI semantic conventions plus common vendor spellings) are mirrored into
+  the active run's hash-chained log as `TOOL_COMPLETED`/`TOOL_FAILED`,
+  EXTERNAL_AGENT provenance, identical in shape to hook observations. The
+  pure core (`observation_from_span`, `record_span`) is duck-typed and
+  dependency-free; the SDK import is lazy with an actionable install hint,
+  and the bridge ships behind the new `otel` extra. This covers frameworks
+  CONTINUUM cannot wrap or hook - Rust/Go/TS agents, internal platforms -
+  wherever they emit traces.
+
 - **Session briefing: state without CLAUDE.md (#213 ergonomics follow-up).**
   The last two voluntary behaviours depending on per-repo prose were
   resume-on-start and knowing the active run at all. New read-only command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ dev = [
 # The MCP server is optional: the core library and CLI never import it, so
 # installing CONTINUUM does not pull in a server stack you may not want.
 mcp = ["mcp>=2.0"]
+# The OpenTelemetry bridge is optional: the core library never imports it.
+otel = ["opentelemetry-api>=1.20"]
 # The LangGraph adapter is optional: it wraps langgraph's StateGraph and tool
 # decorators with CONTINUUM's durability layer.
 langgraph = ["langgraph>=0.2"]
@@ -136,3 +138,6 @@ branch = true
 [tool.coverage.report]
 show_missing = true
 skip_covered = false
+[[tool.mypy.overrides]]
+module = "opentelemetry.*"
+ignore_missing_imports = true

--- a/src/continuum/otel.py
+++ b/src/continuum/otel.py
@@ -1,0 +1,165 @@
+"""OpenTelemetry bridge: mirror tool-call spans into the event log (seam 5).
+
+Production agent stacks overwhelmingly emit OpenTelemetry. This module turns
+that existing telemetry into CONTINUUM evidence with zero framework
+cooperation and zero code changes in the traced application: register one
+span processor, and every span that looks like a tool call lands in the
+active run's hash-chained log exactly as `continuum observe` records them.
+
+Design notes:
+
+- The pure core (:func:`observation_from_span`, :func:`record_span`) depends
+  on nothing: spans are duck-typed objects with ``name`` / ``attributes`` /
+  ``status``, so tests run without the OTel SDK installed.
+- The SDK-facing glue (:func:`make_span_processor`) imports OpenTelemetry
+  lazily and raises an actionable hint when it is absent, mirroring how the
+  adapters treat their optional frameworks.
+- Recognition is deliberately heuristic and documented: production pipelines
+  use several attribute conventions (``gen_ai.tool.name`` per the GenAI
+  semantic conventions, plus popular vendor spellings), so anything that
+  names a tool is treated as a tool span. Non-tool spans are ignored; a
+  failed span records TOOL_FAILED instead of TOOL_COMPLETED.
+
+Provenance follows house rules: observations are EXTERNAL_AGENT evidence,
+never trusted state.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from continuum.events import EventType
+from continuum.models import Origin
+from continuum.storage.base import Storage
+
+__all__ = ["observation_from_span", "record_span", "make_span_processor"]
+
+#: Span-attribute keys recognised as "this span called a tool", by convention
+#: family. First match wins.
+_TOOL_NAME_KEYS = (
+    "gen_ai.tool.name",
+    "tool.name",
+    "openinference.tool.name",
+    "mcp.tool.name",
+    "function.name",
+)
+
+#: Attribute keys recognised as a primary file path, matching observe's
+#: extraction order so OTel and hook observations look identical downstream.
+_PATH_KEYS = ("file_path", "notebook_path", "path", "filepath", "target")
+
+
+def _attr(attributes: Any, key: str) -> Any:
+    try:
+        return attributes.get(key)
+    except AttributeError:
+        if isinstance(attributes, dict):
+            return attributes.get(key)
+        return None
+
+
+def observation_from_span(name: str, attributes: Any, *, ok: bool = True) -> dict[str, Any] | None:
+    """Extract an observation payload from one span, or None to ignore it.
+
+    A span qualifies when any known attribute names a tool. The payload shape
+    matches `continuum observe`'s: {"tool": ..., "path": ..., optional size
+    and digest keys are never invented here because a span does not carry the
+    file's bytes}.
+    """
+    tool: str | None = None
+    for key in _TOOL_NAME_KEYS:
+        value = _attr(attributes, key)
+        if isinstance(value, str) and value:
+            tool = value
+            break
+    if tool is None:
+        return None
+
+    payload: dict[str, Any] = {"tool": tool}
+    for key in _PATH_KEYS:
+        value = _attr(attributes, key)
+        if isinstance(value, str) and value:
+            payload["path"] = value
+            break
+    payload["via"] = "otel"
+    payload["ok"] = bool(ok)
+    return payload
+
+
+def record_span(
+    storage: Storage,
+    name: str,
+    attributes: Any,
+    *,
+    ok: bool = True,
+    run_id: str | None = None,
+) -> str | None:
+    """Record one span into the active (or explicit) run. Returns run_id."""
+    payload = observation_from_span(name, attributes, ok=ok)
+    if payload is None:
+        return None
+    target = run_id
+    if target is None:
+        active = storage.get_active_run()
+        target = active.run_id if active else None
+    if target is None:
+        # Same tolerance as observe: telemetry without a run is dropped, not
+        # an error, because tracing exists across every session in the repo.
+        return None
+    event_type = EventType.TOOL_COMPLETED if ok else EventType.TOOL_FAILED
+    storage.append_event(target, event_type, payload, source=Origin.EXTERNAL_AGENT)
+    return target
+
+
+def make_span_processor(
+    storage: Storage,
+    *,
+    run_id: str | None = None,
+) -> Any:
+    """Return an OpenTelemetry SpanProcessor that mirrors tool spans.
+
+    Raises RuntimeError with an install hint when the OpenTelemetry API is
+    not importable; add ``opentelemetry-api`` (and your existing exporter of
+    choice stays untouched - this processor only observes).
+    """
+    try:
+        from opentelemetry.sdk.trace import SpanProcessor
+    except Exception as exc:  # pragma: no cover - exercised only without SDK
+        raise RuntimeError(
+            "OpenTelemetry is not installed. Install 'opentelemetry-api' "
+            "(and 'opentelemetry-sdk' if you create the provider here) to use "
+            "the CONTINUUM span processor."
+        ) from exc
+
+    from opentelemetry.sdk.trace import ReadableSpan
+
+    base: type = SpanProcessor  # Any when the SDK is absent for mypy
+
+    class ContinuumSpanProcessor(base):  # type: ignore[misc]
+        """Mirror ended tool spans into the CONTINUUM event log."""
+
+        def __init__(self, target_run_id: str | None = None) -> None:
+            self._run_id = target_run_id
+
+        def on_end(self, span: ReadableSpan) -> None:
+            attributes = getattr(span, "attributes", {}) or {}
+            status = getattr(span, "status", None)
+            ok = getattr(status, "is_ok", True) if status is not None else True
+            record_span(
+                storage,
+                span.name,
+                attributes,
+                ok=bool(ok),
+                run_id=self._run_id,
+            )
+
+        def on_start(self, span: Any, parent_context: Any = None) -> None:
+            return None
+
+        def shutdown(self) -> bool:
+            return True
+
+        def force_flush(self, timeout_millis: int = 30000) -> bool:
+            return True
+
+    return ContinuumSpanProcessor(run_id)

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,0 +1,124 @@
+"""OpenTelemetry bridge (seam 5).
+
+Tool-call spans arriving through standard OTel pipelines become ordinary
+CONTINUUM evidence. The pure core is tested without the OTel SDK installed;
+spans are duck-typed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from continuum.events import EventType
+from continuum.models import Origin, Run
+from continuum.otel import observation_from_span, record_span
+from continuum.storage import SQLiteStorage
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "otel.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    yield path
+
+
+class FakeSpan:
+    """Duck-typed stand-in for a ReadableSpan."""
+
+    def __init__(self, name: str, attributes: dict[str, object], ok: bool = True) -> None:
+        self.name = name
+        self.attributes = attributes
+
+        class _Status:
+            def __init__(self, ok: bool) -> None:
+                self.is_ok = ok
+
+        self.status = _Status(ok)
+
+
+def test_gen_ai_tool_spans_are_recognised() -> None:
+    payload = observation_from_span(
+        "execute_tool",
+        {"gen_ai.tool.name": "write_file", "file_path": "/tmp/a.txt"},
+    )
+    assert payload is not None
+    assert payload["tool"] == "write_file"
+    assert payload["path"] == "/tmp/a.txt"
+    assert payload["via"] == "otel"
+
+
+def test_vendor_attribute_families_are_recognised() -> None:
+    for key in ("tool.name", "openinference.tool.name", "mcp.tool.name", "function.name"):
+        payload = observation_from_span("span", {key: "search_web"})
+        assert payload is not None and payload["tool"] == "search_web", key
+
+
+def test_non_tool_spans_are_ignored() -> None:
+    assert observation_from_span("llm_call", {"gen_ai.request.model": "gpt"}) is None
+    assert observation_from_span("http get", {"url": "https://x"}) is None
+
+
+def test_failed_tool_spans_record_as_failures(db: str) -> None:
+    span = FakeSpan("execute_tool", {"tool.name": "send_invoice"}, ok=False)
+    run = record_span(SQLiteStorage(db), span.name, span.attributes, ok=False)
+    assert run == "run_1"
+    with SQLiteStorage(db) as store:
+        events = store.read_events("run_1")
+    assert events[-1].type is EventType.TOOL_FAILED
+    assert events[-1].source is Origin.EXTERNAL_AGENT
+
+
+def test_successful_span_records_with_active_run_fallback(db: str) -> None:
+    span = FakeSpan("execute_tool", {"gen_ai.tool.name": "write_file", "file_path": "/tmp/x.txt"})
+    got = record_span(SQLiteStorage(db), span.name, span.attributes)
+    assert got == "run_1"
+    with SQLiteStorage(db) as store:
+        events = store.read_events("run_1")
+    assert events[-1].type is EventType.TOOL_COMPLETED
+    assert events[-1].payload["path"] == "/tmp/x.txt"
+
+
+def test_telemetry_without_a_run_is_dropped_silently(tmp_path: Path) -> None:
+    path = str(tmp_path / "empty.db")
+    with SQLiteStorage(path):
+        pass
+    span = FakeSpan("execute_tool", {"tool.name": "x"})
+    assert record_span(SQLiteStorage(path), span.name, span.attributes) is None
+
+
+def test_processor_end_to_end_when_sdk_present(db: str) -> None:
+    otel = pytest.importorskip("opentelemetry.sdk.trace")
+    from continuum.otel import make_span_processor
+
+    processor = make_span_processor(SQLiteStorage(db))
+    span = FakeSpan("execute_tool", {"tool.name": "write_file", "file_path": "/tmp/y.txt"})
+    readable = span  # duck-typed; the processor only reads name/attributes/status
+    processor.on_end(readable)  # type: ignore[arg-type]
+    with SQLiteStorage(db) as store:
+        events = store.read_events("run_1")
+    assert events[-1].type is EventType.TOOL_COMPLETED
+    assert events[-1].payload["tool"] == "write_file"
+    assert otel is not None
+
+
+def test_processor_factory_gives_install_hint_without_sdk(
+    monkeypatch: pytest.MonkeyPatch, db: str
+) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocked(name: str, *args: object, **kwargs: object) -> object:
+        if name.startswith("opentelemetry"):
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", blocked)
+    from continuum.otel import make_span_processor
+
+    with pytest.raises(RuntimeError, match="opentelemetry-api"):
+        make_span_processor(SQLiteStorage(db))


### PR DESCRIPTION
## Description

Seam 5 of the universality roadmap (#213): production stacks already emit OpenTelemetry, so their tool-call spans become CONTINUUM evidence with zero framework cooperation. `make_span_processor(storage)` returns a standard OTel SpanProcessor to register on any TracerProvider; ended spans carrying a recognised tool-name attribute (`gen_ai.tool.name` per GenAI semantic conventions, plus `tool.name` / `openinference.tool.name` / `mcp.tool.name` / `function.name`) are mirrored into the active run's log as TOOL_COMPLETED/TOOL_FAILED with EXTERNAL_AGENT provenance, shaped identically to hook observations so downstream consumers cannot tell them apart.

Pure core is duck-typed and dependency-free; SDK glue imports lazily with an actionable install hint. Ships behind a new `otel` extra.

## Related issues

Refs #213

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1202 passed, 13 skipped (SDK-absent path exercised)
ruff check src tests
mypy src           # clean
```

Eight new tests: attribute-family recognition across conventions, non-tool span rejection, failure mapping to TOOL_FAILED, active-run fallback, drop-without-run tolerance, end-to-end processor test (skip-guarded on the SDK), install-hint when the SDK is missing.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Known limitation: recognition is heuristic by design; spans that encode tool calls in entirely custom attributes need a one-line addition to _TOOL_NAME_KEYS. Path extraction only records what the span itself carries - no file reads happen in this bridge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry integration to capture recognized tool-call spans as completed or failed activity records.
  * Supports common tool-name conventions across external frameworks and agents.
  * Added an optional `otel` installation extra for OpenTelemetry support.
  * Telemetry is safely ignored when no active run is available.
* **Documentation**
  * Documented the new OpenTelemetry bridge in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->