### PR TITLE
feat(adapters): thin adapters for CrewAI, AutoGen and Pydantic AI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Thin adapters for CrewAI, AutoGen and Pydantic AI (seam 1 extension,
+  #213).** Three more production frameworks get the durability seam with
+  their own verified interception surfaces, all routed through one shared
+  `ContinuumToolGuard` over `ActionLedger`: CrewAI's global before/after
+  tool-call hook registry (with an action-type filter and a working
+  uninstaller), AutoGen's `FunctionTool.run_json` wrapped in place (agent
+  construction code unchanged; failures recorded then re-raised), and Pydantic
+  AI's async Hooks capability (`before_tool_call`/`after_tool_call` matching
+  the documented protocol) registered via `capabilities=[...]`. Keys follow
+  the MCP contract - resource identity via `key_fn`, argument-hash default -
+  so exactly-once survives model drift. Framework imports stay lazy; every
+  surface is tested against duck-typed stand-ins, no SDK required.
+
 - **OpenTelemetry bridge (seam 5 of the universality roadmap, #213).**
   Production stacks already emit OTel; now those spans become CONTINUUM
   evidence with zero framework cooperation. `make_span_processor(storage)`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,5 +139,5 @@ branch = true
 show_missing = true
 skip_covered = false
 [[tool.mypy.overrides]]
-module = "opentelemetry.*"
+module = ["opentelemetry.*", "crewai", "crewai.*", "crewai.hooks"]
 ignore_missing_imports = true

--- a/src/continuum/adapters/thin.py
+++ b/src/continuum/adapters/thin.py
@@ -1,0 +1,243 @@
+"""Thin adapters for CrewAI, AutoGen and Pydantic AI (seam 1, #213 follow-up).
+
+Each framework exposes a different interception surface, verified against
+its real API:
+
+- CrewAI: global ``before_tool_call`` / ``after_tool_call`` hook registry in
+  ``crewai.hooks``; the before hook returns False to block.
+- AutoGen (core): tools expose ``run_json(arguments, cancellation_token)``;
+  wrapping that method intercepts every execution of an existing tool.
+- Pydantic AI: a Hooks capability object with async ``before_tool_call(ctx,
+  tool_name, args)`` / ``after_tool_call(ctx, tool_name, args, result,
+  error=None)`` registered via ``Agent(capabilities=[...])``.
+
+All three route through one shared engine: claim before, evidence after,
+exactly-once under argument drift via optional stable keys. Provenance is
+EXTERNAL_AGENT because the framework asserts the facts.
+
+Framework imports stay lazy: importing this module costs nothing when a
+framework is absent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+__all__ = [
+    "crewai_available",
+    "pydantic_ai_available",
+    "autogen_available",
+    "ContinuumToolGuard",
+    "install_crewai_hooks",
+    "wrap_autogen_tool",
+    "wrap_pydantic_ai_hooks",
+]
+
+
+def _flag(module: str) -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec(module) is not None
+
+
+def crewai_available() -> bool:
+    return _flag("crewai")
+
+
+def pydantic_ai_available() -> bool:
+    return _flag("pydantic_ai")
+
+
+def autogen_available() -> bool:
+    return _flag("autogen_core.tools")
+
+
+class ContinuumToolGuard:
+    """Shared claim/complete plumbing behind the thin adapters.
+
+    Constructed per run over a Storage. ``claim`` opens a ledger slot before a
+    side-effecting tool executes; ``complete``/``fail`` settle it. Keys default
+    to the MCP-style derivation (tool type + argument hash + run scope); pass
+    ``key_fn(tool_name, args) -> str`` for resource-identity keys.
+    """
+
+    def __init__(
+        self,
+        storage: Any,
+        run_id: str,
+        *,
+        key_fn: Callable[[str, dict[str, Any]], str] | None = None,
+        external_id_fn: Callable[[Any], str | None] | None = None,
+    ) -> None:
+        self._storage = storage
+        self._run_id = run_id
+        self._key_fn = key_fn
+        self._external_id_fn = external_id_fn
+        self._ledger: Any | None = None
+        self._seq = 0
+        self._inflight: dict[int, str] = {}
+
+    @property
+    def ledger(self) -> Any:
+        if self._ledger is None:
+            from continuum.actions import ActionLedger
+
+            self._ledger = ActionLedger(self._storage, self._run_id)
+        return self._ledger
+
+    def _args_dict(self, args: Any) -> dict[str, Any]:
+        if isinstance(args, dict):
+            return args
+        if hasattr(args, "model_dump"):
+            return dict(args.model_dump())
+        if isinstance(args, str):
+            return {"input": args}
+        return {"value": args}
+
+    def claim(self, tool_name: str, args: Any) -> int:
+        args_dict = self._args_dict(args)
+        key = str(self._key_fn(tool_name, args_dict)) if self._key_fn is not None else None
+        outcome = self.ledger.claim(tool_name, args_dict, key=key)
+        self._seq += 1
+        token = self._seq
+        self._inflight[token] = outcome.key
+        return token
+
+    def complete(self, token: int, result: Any = None) -> None:
+        key = self._inflight.pop(token, None)
+        if key is None:
+            return
+        external_id = self._external_id_fn(result) if self._external_id_fn else None
+        self.ledger.complete(key, external_id=external_id)
+
+    def fail(self, token: int, error: str, *, certain: bool = True) -> None:
+        key = self._inflight.pop(token, None)
+        if key is None:
+            return
+        self.ledger.fail(key, error, certain=certain)
+
+
+def install_crewai_hooks(
+    storage: Any,
+    run_id: str,
+    *,
+    key_fn: Callable[[str, dict[str, Any]], str] | None = None,
+    action_types: set[str] | None = None,
+) -> Callable[[], None]:
+    """Register global CrewAI before/after tool-call hooks. Returns uninstaller.
+
+    Every registered tool call is claimed then completed through CONTINUUM.
+    Calls whose tool name is not in ``action_types`` pass through untouched
+    (pass ``None`` to track everything). Requires the ``crewai`` package;
+    raises ImportError otherwise.
+    """
+    if not crewai_available():
+        raise ImportError(
+            "crewai is required for install_crewai_hooks. Install it (and "
+            "CONTINUUM stays dependency-free)."
+        )
+    from crewai import hooks as crewai_hooks
+
+    guard = ContinuumToolGuard(storage, run_id, key_fn=key_fn)
+    tokens: dict[int, int] = {}
+
+    def before(context: Any) -> bool | None:
+        tool_name = getattr(context, "tool_name", "") or ""
+        if action_types is not None and tool_name not in action_types:
+            return None
+        raw_args = getattr(context, "tool_input", {}) or {}
+        token = guard.claim(tool_name, raw_args)
+        tokens[id(context)] = token
+        return None  # allow
+
+    def after(context: Any) -> str | None:
+        token = tokens.pop(id(context), None)
+        if token is None:
+            return None
+        error = getattr(context, "error", None)
+        result = getattr(context, "result", None)
+        if error:
+            guard.fail(token, str(error))
+        else:
+            guard.complete(token, result)
+        return None  # keep original result
+
+    crewai_hooks.register_before_tool_call_hook(before)
+    crewai_hooks.register_after_tool_call_hook(after)
+
+    def uninstall() -> None:
+        try:
+            crewai_hooks.unregister_before_tool_call_hook(before)
+            crewai_hooks.unregister_after_tool_call_hook(after)
+        except AttributeError:
+            # Older crews: registry exposes clear-all only.
+            crewai_hooks.clear_all_tool_call_hooks()
+
+    return uninstall
+
+
+def wrap_autogen_tool(
+    tool: Any,
+    storage: Any,
+    run_id: str,
+    *,
+    key_fn: Callable[[str, dict[str, Any]], str] | None = None,
+) -> Any:
+    """Wrap an AutoGen FunctionTool's ``run_json`` with claim/complete.
+
+    The returned object is the same tool instance: its execution entry point
+    is replaced in place, so agent construction code does not change.
+    """
+    guard = ContinuumToolGuard(storage, run_id, key_fn=key_fn)
+    original = tool.run_json
+
+    def run_json_wrapped(args: Any, *rest: Any, **kwargs: Any) -> Any:
+        args_dict = args if isinstance(args, dict) else {"value": args}
+        token = guard.claim(getattr(tool, "name", "autogen_tool"), args_dict)
+        try:
+            result = original(args, *rest, **kwargs)
+        except Exception as exc:
+            guard.fail(token, str(exc))
+            raise
+        guard.complete(token, result)
+        return result
+
+    tool.run_json = run_json_wrapped
+    return tool
+
+
+def wrap_pydantic_ai_hooks(
+    storage: Any,
+    run_id: str,
+    *,
+    key_fn: Callable[[str, dict[str, Any]], str] | None = None,
+) -> Any:
+    """Return a Hooks-capability-shaped object for pydantic-ai Agents.
+
+    Register it via ``Agent(model, capabilities=[wrap_pydantic_ai_hooks(ad)])``
+    (or the hooks constructor argument of your installed version). The async
+    signatures match the documented capability protocol.
+    """
+    guard = ContinuumToolGuard(storage, run_id, key_fn=key_fn)
+    tokens: dict[int, int] = {}
+
+    class ContinuumPydanticHooks:
+        async def before_tool_call(self, ctx: Any, tool_name: str, args: Any) -> Any:
+            token = guard.claim(tool_name, args)
+            tokens[id(ctx)] = token
+            return args
+
+        async def after_tool_call(
+            self, ctx: Any, tool_name: str, args: Any, result: Any, error: Any = None
+        ) -> Any:
+            token = tokens.pop(id(ctx), None)
+            if token is None:
+                return result
+            if error:
+                guard.fail(token, str(error))
+            else:
+                guard.complete(token, result)
+            return result
+
+    return ContinuumPydanticHooks()

--- a/tests/test_adapters_thin.py
+++ b/tests/test_adapters_thin.py
@@ -1,0 +1,221 @@
+"""Tests for the thin CrewAI / AutoGen / Pydantic AI adapters.
+
+No framework SDK is required: each interception surface is exercised with
+duck-typed stand-ins (a fake crewai.hooks registry, a fake AutoGen tool, a
+fake pydantic-ai context), because what CONTINUUM depends on is the shape of
+the seam, not the framework package.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from continuum.adapters.thin import (
+    ContinuumToolGuard,
+    install_crewai_hooks,
+    wrap_autogen_tool,
+    wrap_pydantic_ai_hooks,
+)
+from continuum.events import EventType
+from continuum.models import ActionStatus, Run
+from continuum.storage import SQLiteStorage
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "thin.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    yield path
+
+
+def last_action(db: str):
+    with SQLiteStorage(db) as store:
+        from continuum.actions.ledger import fold_action_events
+
+        return list(fold_action_events(store.read_events("run_1")).values())[-1]
+
+
+def statuses(db: str) -> list[str]:
+    from continuum.actions.ledger import fold_action_events
+
+    with SQLiteStorage(db) as store:
+        folded = fold_action_events(store.read_events("run_1"))
+    return [a.status.value for a in folded.values()]
+
+
+# --- shared guard ------------------------------------------------------------- #
+
+
+def test_guard_claims_and_completes_through_the_real_ledger(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        guard = ContinuumToolGuard(store, "run_1")
+        token = guard.claim("send_invoice", {"id": "I-9"})
+        assert statuses(db)[-1] == "started"
+        guard.complete(token, result="sent")
+    action = last_action(db)
+    assert action.status is ActionStatus.COMPLETED
+
+
+def test_key_fn_overrides_the_default_derivation(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        guard = ContinuumToolGuard(store, "run_1", key_fn=lambda t, a: f"inv:{a['id']}")
+        token = guard.claim("send_invoice", {"id": "I-1"})
+        guard.complete(token)
+    action = last_action(db)
+    assert action.action_type == "send_invoice"
+
+
+def test_fail_marks_not_occurred_when_certain(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        guard = ContinuumToolGuard(store, "run_1")
+        token = guard.claim("deploy", {"env": "prod"})
+        guard.fail(token, "connection refused before request sent", certain=True)
+    assert last_action(db).status is ActionStatus.FAILED
+
+
+# --- CrewAI --------------------------------------------------------------------- #
+
+
+class FakeCrewAIHooks(types.ModuleType):
+    """A stand-in for crewai.hooks capturing registrations."""
+
+    def __init__(self) -> None:
+        super().__init__("crewai.hooks")
+        self.before: list[Any] = []
+        self.after: list[Any] = []
+        self.register_before_tool_call_hook = self.before.append
+        self.register_after_tool_call_hook = self.after.append
+        self.unregister_before_tool_call_hook = self.before.remove
+        self.unregister_after_tool_call_hook = self.after.remove
+
+
+class Context:
+    def __init__(self, tool_name: str, tool_input: dict[str, object], result: object = None):
+        self.tool_name = tool_name
+        self.tool_input = tool_input
+        self.result = result
+        self.error = None
+
+
+def test_crewai_hooks_route_claims_and_completions(
+    db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = FakeCrewAIHooks()
+    crewai_pkg = types.ModuleType("crewai")
+    monkeypatch.setitem(sys.modules, "crewai", crewai_pkg)
+    monkeypatch.setitem(sys.modules, "crewai.hooks", fake)
+    monkeypatch.setattr("continuum.adapters.thin.crewai_available", lambda: True)
+
+    uninstall = install_crewai_hooks(SQLiteStorage(db), "run_1")
+    assert len(fake.before) == 1 and len(fake.after) == 1
+
+    ctx = Context("send_invoice", {"id": "X"})
+    assert fake.before[0](ctx) is None  # allowed
+    ctx.result = "queued"
+    assert fake.after[0](ctx) is None
+    assert last_action(db).status is ActionStatus.COMPLETED
+
+    uninstall()
+    # After uninstall the registry is empty: the framework would call nothing.
+    assert fake.before == [] and fake.after == []
+    assert len(statuses(db)) == 1
+
+
+def test_crewai_action_type_filter_passes_untracked_tools(
+    db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = FakeCrewAIHooks()
+    monkeypatch.setitem(sys.modules, "crewai", types.ModuleType("crewai"))
+    monkeypatch.setitem(sys.modules, "crewai.hooks", fake)
+    monkeypatch.setattr("continuum.adapters.thin.crewai_available", lambda: True)
+
+    install_crewai_hooks(SQLiteStorage(db), "run_1", action_types={"send_email"})
+    fake.before[0](Context("read_file", {}))
+    fake.after[0](Context("read_file", {}, result="ok"))
+    assert not statuses(db)
+
+
+def test_crewai_install_requires_the_package() -> None:
+    from continuum.adapters import thin
+
+    saved = thin.crewai_available
+    try:
+        thin.crewai_available = lambda: False
+        with pytest.raises(ImportError, match="crewai"):
+            install_crewai_hooks(None, "run_1")
+    finally:
+        thin.crewai_available = saved
+
+
+# --- AutoGen ---------------------------------------------------------------------- #
+
+
+class FakeAutoGenTool:
+    name = "create_ticket"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run_json(self, args: dict[str, object], cancellation_token: object = None) -> str:
+        self.calls += 1
+        if args.get("boom"):
+            raise RuntimeError("upstream exploded")
+        return f"ticket:{args.get('title')}"
+
+
+def test_autogen_wrapper_claims_and_completes(db: str) -> None:
+    tool = FakeAutoGenTool()
+    wrapped = wrap_autogen_tool(
+        tool, SQLiteStorage(db), "run_1", key_fn=lambda t, a: f"ticket:{a['title']}"
+    )
+    out = wrapped.run_json({"title": "Fix login"}, cancellation_token=None)
+    assert out == "ticket:Fix login"
+    assert tool.calls == 1
+    action = last_action(db)
+    assert action.status is ActionStatus.COMPLETED
+
+
+def test_autogen_failure_is_recorded_then_reraised(db: str) -> None:
+    tool = FakeAutoGenTool()
+    wrapped = wrap_autogen_tool(tool, SQLiteStorage(db), "run_1")
+    with pytest.raises(RuntimeError):
+        wrapped.run_json({"boom": True})
+    assert last_action(db).status is ActionStatus.FAILED
+
+
+# --- Pydantic AI ------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pydantic_capability_routes_async_hooks(db: str) -> None:
+    hooks = wrap_pydantic_ai_hooks(SQLiteStorage(db), "run_1")
+
+    class Ctx:
+        pass
+
+    ctx = Ctx()
+    await hooks.before_tool_call(ctx, "charge_card", {"customer": "c1"})
+    await hooks.after_tool_call(ctx, "charge_card", {"customer": "c1"}, result="charged")
+    assert last_action(db).status is ActionStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_pydantic_error_path_fails_the_action(db: str) -> None:
+    hooks = wrap_pydantic_ai_hooks(SQLiteStorage(db), "run_1")
+
+    class Ctx:
+        pass
+
+    ctx = Ctx()
+    await hooks.before_tool_call(ctx, "charge_card", {"customer": "c2"})
+    await hooks.after_tool_call(
+        ctx, "charge_card", {"customer": "c2"}, result=None, error="card declined"
+    )
+    assert last_action(db).status is ActionStatus.FAILED


### PR DESCRIPTION
## Description

Seam 1 extension (#213): three more production frameworks get CONTINUUM's durability seam through one shared `ContinuumToolGuard` over `ActionLedger`.

| Framework | Interception surface (verified) | Entry point |
|---|---|---|
| CrewAI | global `before_tool_call`/`after_tool_call` hook registry; before returns False to block | `install_crewai_hooks(storage, run_id)` |
| AutoGen core | `FunctionTool.run_json(args, cancellation_token)` wrapped in place | `wrap_autogen_tool(tool, storage, run_id)` |
| Pydantic AI | Hooks capability: async `before_tool_call(ctx, tool_name, args)` / `after_tool_call(..., result, error)` | `Agent(capabilities=[wrap_pydantic_ai_hooks(storage, run_id)])` |

Keys follow the MCP stable-key contract (`key_fn(tool_name, args)` for resource identity, argument-hash + run scope by default). Failures record as FAILED when certain; provenance stays EXTERNAL_AGENT.

## Related issues

Refs #213

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1212 passed, 13 skipped
ruff check src tests
mypy src           # clean
```

Ten new tests exercise every surface with duck-typed stand-ins (fake crewai.hooks module capturing registrations, fake AutoGen tool, fake pydantic context) plus the real ledger underneath: claim->complete flows, key_fn override, certain-failure mapping, action-type filtering, uninstaller behaviour, failure-then-reraise, and both async pydantic paths.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Known limitations stated up front: CrewAI's after-hook can only observe results (its contract replaces output strings, which we do not do); AutoGen coverage applies to tools wrapped before agent construction; Pydantic AI capability shape follows their March 2026 protocol and may need a shim if the Hooks protocol renames.
