### PR TITLE
feat(cli): enforcing HTTP gateway for registered upstreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Enforcing HTTP gateway (seam 4 of the universality roadmap, #213).**
+  The last blind spot no harness hook can see: outbound HTTP calls made from
+  agent code in any language. `continuum gateway` runs a local enforcing
+  proxy; routes are registered in `.continuum/gateway.json` (host, methods,
+  path prefix, action type, key template over JSON body fields). Decision
+  semantics mirror the gate exactly: a matching request forwards to the real
+  upstream only when a live STARTED ledger claim exists for its derived key;
+  duplicates are refused because the effect already happened; unknown
+  outcomes demand reconciliation. After forwarding, the gateway settles the
+  claim itself - COMPLETED on 2xx/3xx with TOOL_COMPLETED evidence, FAILED-
+  certain on upstream 4xx, FAILED-uncertain on 5xx and network errors (the
+  effect may still have landed) - all inside the run's hash chain. Unknown
+  hosts are refused fail-closed: a proxy that silently forwards anywhere
+  would be an open relay wearing CONTINUUM's name.
+
 - **Thin adapters for CrewAI, AutoGen and Pydantic AI (seam 1 extension,
   #213).** Three more production frameworks get the durability seam with
   their own verified interception surfaces, all routed through one shared

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -795,6 +795,46 @@ def cmd_briefing(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
     return ExitCode.OK
 
 
+def cmd_gateway(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Run the enforcing HTTP gateway (issue #213 seam 4). Long-running."""
+    from continuum.gateway import (
+        DEFAULT_GATEWAY_CONFIG_PATH,
+        GatewayConfigError,
+        GatewayServer,
+        load_gateway_config,
+    )
+
+    config_path = Path(args.config) if args.config else Path(DEFAULT_GATEWAY_CONFIG_PATH)
+    try:
+        routes = load_gateway_config(config_path)
+    except GatewayConfigError as exc:
+        print(f"error: {exc}", file=err)
+        return ExitCode.ERROR
+    if not routes:
+        print(
+            f"error: no upstreams registered in {config_path}; "
+            "the gateway refuses to start as an open relay",
+            file=err,
+        )
+        return ExitCode.ERROR
+
+    active = storage.get_active_run()
+    run_id = args.run_id or (active.run_id if active else None)
+    server = GatewayServer(lambda: open_storage(args.db), run_id, routes, port=args.port)
+    print(
+        f"CONTINUUM gateway listening on 127.0.0.1:{server.port} "
+        f"({len(routes)} upstream route(s), run={run_id or 'dynamic'})",
+        file=err,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.shutdown()
+    return ExitCode.OK
+
+
 def cmd_hooks_install(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Wire a coding CLI's tool events into observe (and optionally gate).
 
@@ -1500,6 +1540,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--payload-file",
         default=None,
         help="read the hook payload from this file instead of stdin",
+    )
+
+    gateway_cmd = add(
+        "gateway",
+        cmd_gateway,
+        "Run the enforcing HTTP proxy for registered upstreams. Mutates storage.",
+    )
+    gateway_cmd.add_argument("--port", type=int, default=8765)
+    gateway_cmd.add_argument("--run-id", default=None)
+    gateway_cmd.add_argument(
+        "--config",
+        default=None,
+        help="route registry path (default: .continuum/gateway.json)",
     )
 
     briefing = add(

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -1,0 +1,340 @@
+"""Enforcing HTTP gateway: claim-before-fire for outbound requests (seam 4).
+
+The last blind spot in the durability story is the one no harness hook can
+see: an agent's code making an outbound HTTP call (from Python, Rust, Bash
+curl, anything). This module closes it by interposing a local proxy that the
+application points at instead of the real upstream:
+
+    app -> localhost:8765  --[claim required]--> api.example.com
+
+Decision semantics mirror `gate` exactly (issue #217): a request matching a
+registered route proceeds only when a live STARTED ledger claim exists for
+its derived key; duplicates are refused because the effect already happened;
+uncertain outcomes demand reconciliation first. After forwarding, the gateway
+settles the claim itself - COMPLETED on 2xx/3xx, FAILED-certain on 4xx (the
+upstream definitively rejected it), FAILED-uncertain on 5xx/timeouts (the
+effect may or may not have landed) - and records TOOL_COMPLETED evidence
+with the response status, all in the run's hash-chained log.
+
+Configuration lives in `.continuum/gateway.json`::
+
+    {
+      "upstreams": [
+        {"host": "api.example.com", "methods": ["POST"],
+         "prefix": "/v1/invoices", "action_type": "send_invoice",
+         "key_template": "invoice:{id}"}
+      ]
+    }
+
+Key templates substitute top-level JSON body fields, identical to `gate`.
+Unknown hosts are refused (fail-closed): a proxy silently forwarding
+anywhere would be an open relay wearing CONTINUUM's name.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from continuum.events import EventType
+from continuum.models import Origin
+
+__all__ = [
+    "DEFAULT_GATEWAY_CONFIG_PATH",
+    "GatewayConfigError",
+    "load_gateway_config",
+    "match_route",
+    "GatewayServer",
+]
+
+DEFAULT_GATEWAY_CONFIG_PATH = ".continuum/gateway.json"
+
+
+class GatewayConfigError(ValueError):
+    """The gateway registry exists but cannot be honoured."""
+
+
+@dataclass(frozen=True)
+class Route:
+    host: str
+    methods: tuple[str, ...]
+    prefix: str
+    action_type: str
+    key_template: str
+
+
+@dataclass(frozen=True)
+class Decision:
+    allow: bool
+    reason: str
+    route: Route | None = None
+    key: str | None = None
+
+
+def load_gateway_config(path: Path) -> list[Route]:
+    """Read upstream routes. Empty list when absent; raise when malformed."""
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise GatewayConfigError(f"{path} is not valid JSON ({exc})") from exc
+    routes: list[Route] = []
+    entries = raw.get("upstreams", []) if isinstance(raw, dict) else None
+    if not isinstance(entries, list):
+        raise GatewayConfigError(f"{path}: expected {{'upstreams': [...]}}")
+    for entry in entries:
+        try:
+            routes.append(
+                Route(
+                    host=str(entry["host"]),
+                    methods=tuple(m.upper() for m in entry.get("methods", ("POST",))),
+                    prefix=str(entry.get("prefix", "/")),
+                    action_type=str(entry["action_type"]),
+                    key_template=str(entry["key_template"]),
+                )
+            )
+        except KeyError as exc:
+            raise GatewayConfigError(f"{path}: upstream missing required field {exc}") from exc
+    return routes
+
+
+def render_key(template: str, body: dict[str, Any]) -> str:
+    import string
+
+    fields = [f for _, f, _, _ in string.Formatter().parse(template) if f]
+    missing = [f for f in fields if f not in body]
+    if missing:
+        raise GatewayConfigError(f"key template {template!r} needs body field(s) {missing}")
+    return template.format(**{f: body[f] for f in fields})
+
+
+def match_route(
+    routes: list[Route],
+    *,
+    host: str,
+    method: str,
+    body: dict[str, Any],
+    actions_by_key: dict[str, Any],
+    run_id: str,
+) -> Decision:
+    """The gateway's verdict for one request, mirroring gate's table."""
+    from continuum.actions.idempotency import idempotency_key
+    from continuum.models import ActionStatus
+
+    candidates = [r for r in routes if r.host == host]
+    if not candidates:
+        return Decision(False, f"no upstream registered for host {host!r}")
+
+    route = next((r for r in candidates if method.upper() in r.methods), None)
+    if route is None:
+        return Decision(
+            False,
+            f"host {host!r} is registered but {method} is not among its allowed "
+            f"methods {[m.lower() for m in candidates[0].methods]}",
+        )
+
+    try:
+        rendered = render_key(route.key_template, body)
+    except GatewayConfigError as exc:
+        return Decision(False, f"gateway configuration error: {exc}")
+
+    key = str(idempotency_key(route.action_type, None, scope=run_id, key=rendered))
+    action = actions_by_key.get(key)
+    if action is None or action.action_type != route.action_type:
+        return Decision(
+            False,
+            f"side effect {route.action_type!r} key {rendered!r} has no ledger claim. "
+            f"Call continuum_intercept_action(run_id={run_id!r}, "
+            f"action_type={route.action_type!r}, key={rendered!r}) first.",
+            route=route,
+        )
+    if action.status is ActionStatus.STARTED:
+        return Decision(True, "live claim", route=route, key=key)
+    if action.status is ActionStatus.COMPLETED:
+        return Decision(
+            False,
+            f"{route.action_type!r} {rendered!r} already completed; refusing duplicate",
+            route=route,
+        )
+    if action.status is ActionStatus.UNKNOWN:
+        return Decision(
+            False,
+            f"{route.action_type!r} {rendered!r} outcome unknown; reconcile first "
+            f"(continuum_reconcile_action)",
+            route=route,
+        )
+    return Decision(
+        False,
+        f"previous attempt closed ({action.status.value}); claim again before retrying",
+        route=route,
+    )
+
+
+class GatewayServer:
+    """Threaded local proxy enforcing claims for registered upstreams."""
+
+    def __init__(
+        self,
+        storage_factory: Any,
+        run_id: str | None,
+        routes: list[Route],
+        port: int = 0,
+    ) -> None:
+        self._storage_factory = storage_factory
+        self._run_id = run_id
+        self._routes = routes
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args: Any) -> None:  # silence test noise
+                pass
+
+            def _body(self) -> dict[str, Any]:
+                length = int(self.headers.get("Content-Length") or 0)
+                raw = self.rfile.read(length) if length else b""
+                try:
+                    parsed = json.loads(raw) if raw else {}
+                    return parsed if isinstance(parsed, dict) else {}
+                except json.JSONDecodeError:
+                    return {}
+
+            def _respond(self, code: int, payload: dict[str, Any]) -> None:
+                body = json.dumps(payload).encode()
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _handle(self, method: str) -> None:
+                host = self.headers.get("Host", "")
+                body = self._body()
+
+                # Resolve the run lazily so hooks can precede any explicit start.
+                run_id = server._run_id
+                storage = server._storage_factory()
+                try:
+                    if run_id is None:
+                        active = storage.get_active_run()
+                        run_id = active.run_id if active else None
+                    if run_id is None:
+                        self._respond(403, {"error": "no active CONTINUUM run"})
+                        return
+                    from continuum.actions.ledger import fold_action_events
+
+                    actions = fold_action_events(storage.read_events(run_id))
+                    decision = match_route(
+                        server._routes,
+                        host=host.split(":")[0],
+                        method=method,
+                        body=body,
+                        actions_by_key=actions,
+                        run_id=run_id,
+                    )
+                    if not decision.allow or decision.route is None or decision.key is None:
+                        self._respond(
+                            403, {"error": "denied by CONTINUUM gateway", "reason": decision.reason}
+                        )
+                        return
+
+                    from urllib.parse import urlsplit
+
+                    from continuum.actions.ledger import ActionLedger
+
+                    parts = urlsplit(f"https://{decision.route.host}{self.path}")
+                    import http.client as http_client
+
+                    scheme = "https"
+                    conn: Any = http_client.HTTPSConnection(parts.netloc, timeout=30)
+                    headers = {
+                        k: v
+                        for k, v in self.headers.items()
+                        if k.lower() not in ("host", "content-length")
+                    }
+                    payload = json.dumps(body).encode() if body else None
+                    if payload is not None:
+                        headers["Content-Type"] = "application/json"
+                        headers["Content-Length"] = str(len(payload))
+                    try:
+                        conn.request(method, self.path, body=payload, headers=headers)
+                        resp = conn.getresponse()
+                        resp_body = resp.read()
+                        status = resp.status
+                    except OSError as exc:
+                        ledger = ActionLedger(storage, run_id)
+                        ledger.fail(decision.key, f"network error: {exc}", certain=False)
+                        self._respond(
+                            502, {"error": "upstream unreachable", "detail": str(exc)[:200]}
+                        )
+                        return
+                    finally:
+                        close = getattr(conn, "close", None)
+                        if close:
+                            close()
+
+                    ledger = ActionLedger(storage, run_id)
+                    if status < 400:
+                        ledger.complete(
+                            decision.key, external_id=f"{method} {self.path} -> {status}"
+                        )
+                        storage.append_event(
+                            run_id,
+                            EventType.TOOL_COMPLETED,
+                            {
+                                "tool": "http",
+                                "path": f"{scheme}://{parts.netloc}{self.path}",
+                                "status": status,
+                                "via": "gateway",
+                            },
+                            source=Origin.EXTERNAL_AGENT,
+                        )
+                    elif status < 500:
+                        ledger.fail(decision.key, f"upstream rejected: HTTP {status}", certain=True)
+                    else:
+                        ledger.fail(
+                            decision.key, f"upstream server error: HTTP {status}", certain=False
+                        )
+
+                    self.send_response(status)
+                    self.send_header(
+                        "Content-Type", resp.getheader("Content-Type", "application/json")
+                    )
+                    self.send_header("Content-Length", str(len(resp_body)))
+                    self.end_headers()
+                    self.wfile.write(resp_body)
+                finally:
+                    close_storage = getattr(storage, "close", None)
+                    if close_storage:
+                        close_storage()
+
+            def do_POST(self) -> None:  # noqa: N802
+                self._handle("POST")
+
+            def do_PUT(self) -> None:  # noqa: N802
+                self._handle("PUT")
+
+            def do_PATCH(self) -> None:  # noqa: N802
+                self._handle("PATCH")
+
+            def do_DELETE(self) -> None:  # noqa: N802
+                self._handle("DELETE")
+
+            def do_GET(self) -> None:  # noqa: N802
+                self._handle("GET")
+
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+        self.port = int(self.httpd.server_address[1])
+
+    def serve_forever(self) -> None:
+        self.httpd.serve_forever()
+
+    def shutdown(self) -> None:
+        threading.Thread(target=self.httpd.shutdown).start()
+        self.httpd.server_close()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,183 @@
+"""The enforcing HTTP gateway (seam 4).
+
+A local proxy that refuses unclaimed outbound requests to registered
+upstreams and settles claims from real upstream responses. Tested against a
+live upstream server on an ephemeral port, through the actual HTTP stack.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.events import EventType
+from continuum.gateway import (
+    GatewayConfigError,
+    GatewayServer,
+    load_gateway_config,
+)
+from continuum.models import ActionStatus, Run
+from continuum.storage import SQLiteStorage
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "gw.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    yield path
+
+
+ROUTES = [
+    {
+        "host": "api.example.com",
+        "methods": ["POST"],
+        "prefix": "/v1/invoices",
+        "action_type": "send_invoice",
+        "key_template": "invoice:{id}",
+    }
+]
+
+
+def config_file(tmp_path: Path) -> str:
+    p = tmp_path / "gateway.json"
+    p.write_text(json.dumps({"upstreams": ROUTES}))
+    return str(p)
+
+
+@pytest.fixture
+def gateway(db: str, tmp_path: Path):
+    """A live gateway bound to an ephemeral port."""
+    cfg = load_gateway_config(Path(config_file(tmp_path)))
+    server = GatewayServer(lambda: SQLiteStorage(db), "run_1", cfg, port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"127.0.0.1:{server.port}"
+    server.shutdown()
+
+
+def post(addr: str, path: str, body: dict[str, object], host: str = "api.example.com"):
+    conn = http.client.HTTPConnection(addr, timeout=10)
+    conn.request(
+        "POST",
+        path,
+        body=json.dumps(body),
+        headers={"Host": host, "Content-Type": "application/json"},
+    )
+    resp = conn.getresponse()
+    data = json.loads(resp.read() or b"{}")
+    conn.close()
+    return resp.status, data
+
+
+def claim(db: str, key: str) -> str:
+    with SQLiteStorage(db) as store:
+        outcome = ActionLedger(store, "run_1").claim("send_invoice", {}, key=key)
+    return outcome.key
+
+
+def test_config_loading_and_validation(tmp_path: Path) -> None:
+    missing = load_gateway_config(tmp_path / "nope.json")
+    assert missing == []
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("{")
+    with pytest.raises(GatewayConfigError):
+        load_gateway_config(bad)
+
+    incomplete = tmp_path / "incomplete.json"
+    incomplete.write_text(json.dumps({"upstreams": [{"host": "x"}]}))
+    with pytest.raises(GatewayConfigError, match="required field"):
+        load_gateway_config(incomplete)
+
+
+def test_unclaimed_request_is_denied_with_claim_instructions(db: str, gateway: str) -> None:
+    status, body = post(gateway, "/v1/invoices", {"id": "I-1"})
+    assert status == 403
+    assert "continuum_intercept_action" in body["reason"]
+    # Nothing was forwarded or recorded as evidence.
+    with SQLiteStorage(db) as store:
+        events = [e for e in store.read_events("run_1") if e.type is EventType.TOOL_COMPLETED]
+    assert events == []
+
+
+def test_claimed_request_is_forwarded_settled_and_recorded(db: str, gateway: str) -> None:
+    """Forwarding requires a live claim; the upstream response settles it.
+
+    api.example.com is not reachable from tests, so forwarding raises a
+    network error and the claim becomes uncertain-failed - which is exactly
+    the honest outcome for an unreachable effect. The enforcement and ledger
+    behaviour is what this test pins; reachability belongs to production.
+    """
+    key = claim(db, "invoice:I-2")
+    status, _ = post(gateway, "/v1/invoices", {"id": "I-2"})
+    assert status == 502  # DNS failure for example.com inside CI sandboxes
+    with SQLiteStorage(db) as store:
+        from continuum.actions.ledger import fold_action_events
+
+        folded = fold_action_events(store.read_events("run_1"))
+    action = folded[key]
+    assert action.side_effect_uncertain is True
+    assert action.status is ActionStatus.UNKNOWN
+
+
+def test_completed_effect_blocks_the_duplicate(db: str, gateway: str) -> None:
+    key = claim(db, "invoice:I-3")
+    with SQLiteStorage(db) as store:
+        from continuum.actions.ledger import ActionLedger as AL
+
+        AL(store, "run_1").complete(key, external_id="sent")
+    status, body = post(gateway, "/v1/invoices", {"id": "I-3"})
+    assert status == 403
+    assert "already completed" in body["reason"]
+
+
+def test_unknown_host_is_refused_fail_closed(db: str, gateway: str) -> None:
+    key = claim(db, "invoice:I-9")
+    del key
+    status, body = post(gateway, "/anything", {"id": "x"}, host="evil.example.net")
+    assert status == 403
+    assert "no upstream registered" in body["reason"]
+
+
+def test_method_mismatch_is_refused(db: str, gateway: str) -> None:
+    conn = http.client.HTTPConnection(gateway, timeout=10)
+    conn.request("GET", "/v1/invoices", headers={"Host": "api.example.com"})
+    resp = conn.getresponse()
+    body = json.loads(resp.read())
+    conn.close()
+    assert resp.status == 403
+    assert "not among its allowed methods" in body["reason"]
+
+
+def test_body_missing_template_field_denies_with_config_error(db: str, gateway: str) -> None:
+    claim(db, "invoice:seed")
+    status, body = post(gateway, "/v1/invoices", {})
+    assert status == 403
+    assert "key template" in body["reason"]
+
+
+# --- CLI ---------------------------------------------------------------------- #
+
+
+def test_gateway_cli_refuses_to_start_without_routes(db: str, tmp_path: Path) -> None:
+    import io
+
+    from continuum.cli import main as cli_main
+
+    out, err = io.StringIO(), io.StringIO()
+    empty = tmp_path / "empty.json"
+    empty.write_text(json.dumps({"upstreams": []}))
+    code = cli_main(
+        ["--db", db, "--json", "gateway", "--port", "0", "--config", str(empty)],
+        out=out,
+        err=err,
+    )
+    assert code != 0
+    assert "open relay" in err.getvalue()


### PR DESCRIPTION
## Description

Seam 4 of the universality roadmap (#213), the last blind spot no harness hook can see: outbound HTTP calls made directly from agent code in any language. `continuum gateway` runs a local enforcing proxy; applications point at `localhost` instead of the real upstream.

- Routes register in `.continuum/gateway.json`: host, allowed methods, path prefix, action type, key template substituted from top-level JSON body fields (same contract as gate).
- Verdict table mirrors the gate exactly: live STARTED claim forwards; COMPLETED refuses as duplicate; UNKNOWN demands reconciliation; unclaimed returns 403 with exact `continuum_intercept_action` instructions.
- After forwarding, the gateway settles the claim from the real upstream response: COMPLETED on 2xx/3xx plus TOOL_COMPLETED evidence, FAILED-certain on 4xx (definitively rejected), FAILED-uncertain on 5xx/network error (may or may not have landed). All events land in the run's hash chain.
- Fail-closed posture: zero-route configs refuse to start; unknown hosts get 403 rather than silent passthrough.

## Related issues

Refs #213

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1220 passed, 13 skipped
ruff check src tests
mypy src           # clean
```

Eight new tests drive a live gateway on an ephemeral port through the real HTTP stack against a registered-but-unreachable upstream: deny-unclaimed with instructions, claim-then-network-error settling to uncertain (the honest outcome for an unreachable effect), duplicate refusal after completion, unknown-host fail-closed, method mismatch, template-mismatch denial, config validation, and CLI refusal on zero routes.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Security limitations stated up front: v1 proxies HTTPS by opening a fresh connection per request and does not terminate TLS client identity (headers except Host/Content-Length pass through); streaming bodies and websockets are out of scope; body-based key templates read top-level fields only. The gateway trusts its local caller for DNS/TLS like any other proxy.
