### PR TITLE
feat(cli): continuum complete + README harness-wiring refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **`continuum complete <run>`: close a run from the keyboard.** Found
+  missing during live testing: MCP-driven runs close via adapter events, but
+  there was no CLI way to finish a run, so finished work kept surfacing as
+  the active run and hijacked every fresh session's resume. The command
+  appends `REVIEW_CONFIRMED` plus `RUN_COMPLETED` (both human-sourced, so
+  self-certification gates clear) and flips the run row to COMPLETED, with
+  an optional `--summary` note. Terminal runs can never be offered for
+  resume again; double-clicking is harmless; unknown runs exit NOT_FOUND.
+
 - **Enforcing HTTP gateway (seam 4 of the universality roadmap, #213).**
   The last blind spot no harness hook can see: outbound HTTP calls made from
   agent code in any language. `continuum gateway` runs a local enforcing

--- a/README.md
+++ b/README.md
@@ -298,11 +298,39 @@ Python surface (`EventType`, `Run`, `SQLiteStorage`, `diff_states`, `project`) a
 continuum runs                                   # list runs
 continuum inspect <run_id>                       # semantic state
 continuum validate <run_id> --env dataset=v4     # validate, read-only
-continuum resume <run_id> --env dataset=v4       # recovery decision + contract
+continuum resume <run_id> --env dataset=v4       # recovery decision + contract + next steps
 continuum checkpoint <run_id>                    # force a checkpoint, mutates
 continuum actions <run_id>                       # external side effects
-continuum show-contract <run_id>                 # the machine-readable contract
+continuum reconcile <run_id>                     # settle uncertain effects with probes
+continuum complete <run_id>                      # close a run as done, from the keyboard
+continuum verify <run_id>                        # re-audit the event hash chain
 ```
+
+### Wiring into harnesses
+
+CONTINUUM meets agents where they already run. All wiring is host-side; the model's cooperation is optional.
+
+```bash
+# Coding CLIs with lifecycle hooks: evidence capture, session briefing,
+# and claim enforcement, installed in one command.
+continuum hooks install claude-code --with-gate   # also: gemini, codex
+
+# Frameworks without hooks: the enforcing HTTP proxy. Point outbound calls
+# at localhost; unclaimed requests are refused, claims are settled from the
+# real upstream response.
+continuum gateway --port 8765                     # routes: .continuum/gateway.json
+
+# Production stacks emitting OpenTelemetry: spans become evidence.
+provider.add_span_processor(continuum.otel.make_span_processor(storage))
+
+# Anything MCP-capable: the original ten-tool server.
+continuum-mcp                                     # via .mcp.json
+```
+
+Optional registries live beside your code and are data, not code:
+`.continuum/gate.json` (side-effect tools + stable-key templates),
+`.continuum/reconcilers.json` (probes that check external systems),
+`.continuum/gateway.json` (upstream routes).
 
 Every command accepts `--json`, and the read-only commands never write, so they are safe against a live database while an agent is mid-run. Exit codes are a safety contract (only a verified-safe run exits 0). The full command list, exit-code table, and state-diff output are in [references/cli.md](references/cli.md).
 

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -57,6 +57,7 @@ from continuum.models import (
     Origin,
     RecoveryMode,
     Run,
+    RunStatus,
 )
 from continuum.observability import render_dashboard
 from continuum.provenance_map import summarize
@@ -629,6 +630,51 @@ def cmd_confirm(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
     )
     print("\nRun `continuum resume` to continue.", file=err)
     return exit_code_for(decision.mode)
+
+
+
+def cmd_complete(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Close a run as done, from the keyboard (the maintainer's escape hatch).
+
+    Found missing during live testing: MCP-driven runs close via
+    RUN_COMPLETED events from adapters, but there was no way to finish a run
+    from the CLI, so finished work kept surfacing as the active run and
+    hijacked every fresh session's resume. This appends REVIEW_CONFIRMED
+    plus RUN_COMPLETED (both Origin.HUMAN, so they clear self-certification
+    gates) and flips the run row to COMPLETED.
+    """
+    run = storage.get_run(args.run_id)  # raises RunNotFound -> NOT_FOUND
+    if args.summary:
+        note = {"summary": args.summary}
+    else:
+        note = {}
+    storage.append_event(
+        args.run_id,
+        EventType.REVIEW_CONFIRMED,
+        {"components": ["goal", "progress"]},
+        source=Origin.HUMAN,
+    )
+    storage.append_event(
+        args.run_id,
+        EventType.RUN_COMPLETED,
+        {"closed_by": "cli", **note},
+        source=Origin.HUMAN,
+    )
+    updated = run.touch(status=RunStatus.COMPLETED)
+    storage.update_run(updated)
+    payload = {
+        "run_id": args.run_id,
+        "status": updated.status.value,
+        "summary": args.summary or "",
+    }
+    _emit(
+        payload,
+        f"Run {args.run_id} completed.",
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
 
 
 def cmd_checkpoint(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
@@ -1525,6 +1571,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     confirm.add_argument("--model", help="model that will run the resumed agent")
     confirm.add_argument("--tolerate-unknown", action="store_true")
+
+    complete = with_run(
+        add("complete", cmd_complete, "Close a run as done. Mutates storage.")
+    )
+    complete.add_argument("--summary", default=None, help="one-line closing note")
 
     checkpoint = with_env(with_run(add("checkpoint", cmd_checkpoint, "Force a checkpoint.")))
     checkpoint.add_argument("--trigger", default="manual")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -837,3 +837,45 @@ def test_validate_json_carries_mode(db: str) -> None:
     data = json.loads(out)
     assert data["mode"] == "resume"
     assert data["safe"] is True
+
+
+# --- closing a run from the keyboard ------------------------------------------ #
+
+
+def test_complete_closes_a_run_and_clears_it_from_active_resolution(
+    tmp_path: Path,
+) -> None:
+    """Found missing during live testing: finished runs kept surfacing as the
+    active run and hijacked every fresh session's resume."""
+    path = str(tmp_path / "c.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="old", goal="finished work"))
+    code, out, _ = run("--db", path, "--json", "complete", "old", "--summary", "shipped")
+    assert code == ExitCode.OK, out
+    payload = json.loads(out)
+    assert payload["status"] == "completed"
+
+    with SQLiteStorage(path) as store:
+        assert store.get_run("old").status.value == "completed"
+        events = [e.type.value for e in store.read_events("old")]
+        assert "REVIEW_CONFIRMED" in events and "RUN_COMPLETED" in events
+        # A completed run is terminal: it can never be offered for resume.
+        assert store.get_active_run() is None
+
+
+def test_complete_is_idempotent_enough_for_double_clicks(tmp_path: Path) -> None:
+    path = str(tmp_path / "d.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="r", goal="g"))
+    code, _, err = run("--db", path, "complete", "r")
+    assert code == ExitCode.OK
+    code, _, err = run("--db", path, "complete", "r")
+    assert code == ExitCode.OK, err
+
+
+def test_complete_unknown_run_is_not_found(tmp_path: Path) -> None:
+    path = str(tmp_path / "e.db")
+    with SQLiteStorage(path):
+        pass
+    code, _, err = run("--db", path, "complete", "ghost")
+    assert code == ExitCode.NOT_FOUND


### PR DESCRIPTION
## Description

Two gaps found in the post-roadmap audit:

1. **`continuum complete <run_id> [--summary]`** - closes a run from the keyboard: appends REVIEW_CONFIRMED + RUN_COMPLETED (both Origin.HUMAN, clearing self-certification gates), flips the run row to COMPLETED. Found missing during live testing when finished MCP-less work kept hijacking fresh sessions' resume.
2. **README refresh** - the command reference predated all of this week's work; now covers observe/gate/briefing/hooks/gateway/reconcile/complete plus a wiring-into-harnesses section describing the four integration seams and the three optional registries.

## Related issues

Refs #213 (ergonomics follow-ups)

## Types of changes

- Type: `feature` | `docs`

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1223 passed, 13 skipped
ruff check src tests
mypy src           # clean
```

Three new tests: completion flips status/events and removes the run from active-resolution; double-click idempotence; unknown-run NOT_FOUND.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.
