### PR TITLE
fix(gateway): body-size cap; refresh CLI reference for new surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Gateway hardening and docs refresh.** The enforcing proxy now refuses
+  request bodies above 10 MB with 413, draining (without buffering) up to a
+  256 MB sanity bound so clients finish sending and read the refusal instead
+  of dying on a broken pipe - a proxy that reads unbounded bodies into memory
+  is a denial-of-service surface against the agent it protects. The CLI
+  reference gains this week's commands plus an "executable configuration"
+  warning: the `.continuum` registries reference commands that run with your
+  user privileges and deserve the same scrutiny as cloned test scripts.
+
 - **`continuum complete <run>`: close a run from the keyboard.** Found
   missing during live testing: MCP-driven runs close via adapter events, but
   there was no CLI way to finish a run, so finished work kept surfacing as

--- a/references/cli.md
+++ b/references/cli.md
@@ -16,11 +16,27 @@ continuum verify <run_id>                        # re-audit the event hash chain
 continuum actions <run_id>                       # external side effects
 continuum show-contract <run_id>                 # the machine-readable contract
 continuum replay <run_id> [--upto N]             # re-derive state from events
+continuum reconcile <run_id> [--dry-run]         # settle uncertain effects with probes
+continuum confirm <run_id>                       # human blessing for self-reported state
+continuum complete <run_id> [--summary "..."]    # close a run as done. mutates
+continuum observe                                # record one tool completion (hook)
+continuum gate                                   # pre-tool-use verdict: allow or deny
+continuum briefing                               # session-start context injection
+continuum gateway --port 8765                    # enforcing proxy for registered upstreams
+continuum hooks install <client> [--with-gate]   # wire a coding CLI (claude-code, gemini, codex)
 ```
 
 Every command accepts `--json`. `inspect`, `history`, `events`, `diff`, `validate`, `resume`,
-`verify`, `actions`, `show-contract` and `replay` never write, so they are safe against a live
-database while an agent is mid-run.
+`verify`, `actions`, `show-contract`, `replay`, `gate` and `briefing` never write, so they are safe
+against a live database while an agent is mid-run. The mutating commands (`start`, `checkpoint`,
+`confirm`, `complete`, `observe`, `reconcile`, `gateway`) say so in their help.
+
+#### Registries are executable configuration
+
+`.continuum/gate.json`, `.continuum/reconcilers.json` and `.continuum/gateway.json` reference
+commands that run with your user privileges, exactly like CI pipelines or Makefiles. Treat a
+cloned repository's registries the way you treat its test scripts: read them before you let an
+agent loose.
 
 #### Exit codes are a safety contract
 

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -644,10 +644,7 @@ def cmd_complete(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
     gates) and flips the run row to COMPLETED.
     """
     run = storage.get_run(args.run_id)  # raises RunNotFound -> NOT_FOUND
-    if args.summary:
-        note = {"summary": args.summary}
-    else:
-        note = {}
+    note = {"summary": args.summary} if args.summary else {}
     storage.append_event(
         args.run_id,
         EventType.REVIEW_CONFIRMED,

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -54,6 +54,19 @@ __all__ = [
 DEFAULT_GATEWAY_CONFIG_PATH = ".continuum/gateway.json"
 
 
+class _BodyTooLarge(Exception):
+    """Internal signal: the request body exceeded the configured cap."""
+
+
+#: Requests larger than this are refused with 413 before the body is read.
+#: A proxy that reads unbounded bodies into memory is a denial-of-service
+#: surface against the very agent it protects.
+MAX_BODY_BYTES = 10 * 1024 * 1024
+
+#: Upper bound on how much we will drain-and-discard before giving up.
+DRAIN_LIMIT_BYTES = 256 * 1024 * 1024
+
+
 class GatewayConfigError(ValueError):
     """The gateway registry exists but cannot be honoured."""
 
@@ -196,8 +209,30 @@ class GatewayServer:
             def log_message(self, *args: Any) -> None:  # silence test noise
                 pass
 
-            def _body(self) -> dict[str, Any]:
+            def _body(self, max_bytes: int = MAX_BODY_BYTES) -> dict[str, Any]:
                 length = int(self.headers.get("Content-Length") or 0)
+                if length > max_bytes:
+                    # Drain (without buffering) so the client can finish
+                    # writing and read our 413, instead of dying on a broken
+                    # pipe mid-send. Refuse to drain beyond a sanity bound.
+                    drained = 0
+                    while drained < length:
+                        chunk = self.rfile.read(min(1024 * 1024, length - drained))
+                        if not chunk:
+                            break
+                        drained += len(chunk)
+                        if drained > DRAIN_LIMIT_BYTES:
+                            self.close_connection = True
+                            self._respond(
+                                413,
+                                {"error": "request body too large to drain"},
+                            )
+                            raise _BodyTooLarge
+                    self._respond(
+                        413,
+                        {"error": f"request body exceeds {max_bytes} bytes"},
+                    )
+                    raise _BodyTooLarge
                 raw = self.rfile.read(length) if length else b""
                 try:
                     parsed = json.loads(raw) if raw else {}
@@ -208,6 +243,8 @@ class GatewayServer:
             def _respond(self, code: int, payload: dict[str, Any]) -> None:
                 body = json.dumps(payload).encode()
                 self.send_response(code)
+                if getattr(self, "close_connection", False):
+                    self.send_header("Connection", "close")
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
@@ -215,7 +252,10 @@ class GatewayServer:
 
             def _handle(self, method: str) -> None:
                 host = self.headers.get("Host", "")
-                body = self._body()
+                try:
+                    body = self._body()
+                except _BodyTooLarge:
+                    return
 
                 # Resolve the run lazily so hooks can precede any explicit start.
                 run_id = server._run_id

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -181,3 +181,20 @@ def test_gateway_cli_refuses_to_start_without_routes(db: str, tmp_path: Path) ->
     )
     assert code != 0
     assert "open relay" in err.getvalue()
+
+
+def test_oversized_body_is_refused_with_413(db: str, gateway: str) -> None:
+    """A proxy reading unbounded bodies is a DoS surface against the agent."""
+    conn = http.client.HTTPConnection(gateway, timeout=10)
+    huge = json.dumps({"id": "x", "blob": "y" * (10 * 1024 * 1024 + 1)})
+    conn.request(
+        "POST",
+        "/v1/invoices",
+        body=huge,
+        headers={"Host": "api.example.com", "Content-Type": "application/json"},
+    )
+    resp = conn.getresponse()
+    body = json.loads(resp.read())
+    conn.close()
+    assert resp.status == 413
+    assert "exceeds" in body["error"]


### PR DESCRIPTION
## Description

Production hardening of this week's surfaces:

- Gateway refuses request bodies above 10 MB with 413, draining without buffering up to a 256 MB sanity bound so clients finish sending and receive the refusal instead of dying on a broken pipe mid-send. An unbounded body read is a DoS surface against the agent being protected.
- references/cli.md gains all of this week's commands plus an explicit warning that .continuum registries are executable configuration deserving clone-time scrutiny.

## Related issues

Refs #213

## Types of changes

- Type: bugfix | docs

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1224 passed, 13 skipped
ruff check src tests
mypy src           # clean
```

New test drives a 10MB+1 request through the live proxy and asserts a clean 413.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.