### PR TITLE
docs: refresh README for enforced durability and new integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **README refresh.** The README predated this week's work in every
+  direction users touch first: the Quick Start now leads with the two-minute
+  harness-wiring path (start a run, `hooks install`, no CLAUDE.md); the
+  Features table gains nine rows (gate, briefing, observations, reconciler
+  probes, executable guidance, gateway, OTel bridge, action index);
+  Framework Integration documents the CrewAI/AutoGen/Pydantic-AI thin hooks
+  and the gateway/OTel fallback seams; the Roadmap marks the dashboard and
+  the enforced-durability work complete; test counts are current (1224).
+
 - **Gateway hardening and docs refresh.** The enforcing proxy now refuses
   request bodies above 10 MB with 413, draining (without buffering) up to a
   256 MB sanity bound so clients finish sending and read the refusal instead

--- a/README.md
+++ b/README.md
@@ -53,7 +53,21 @@ uv pip install -e ".[mcp]"    # adds the MCP server (optional)
 
 Two entrypoints are installed: `continuum` (CLI) and `continuum-mcp` (MCP server). The core library and CLI use only the standard library; the `mcp` extra is required solely for the server.
 
-Minimal example, record and recover:
+### Wiring a coding agent (the two-minute path)
+
+For Claude Code, Gemini CLI, or Codex, you do not write Python and do not need a prompt file:
+
+```bash
+continuum start my-task --goal "What the agent should do"
+continuum hooks install claude-code --with-gate   # also: gemini, codex
+```
+
+From then on every file the agent writes is captured as hash-chained evidence,
+its session starts with an automatic status briefing, unclaimed side effects
+registered in `.continuum/gate.json` are refused before they fire, and a fresh
+session after any crash resumes with executable next steps. No CLAUDE.md required.
+
+Minimal library example, record and recover:
 
 ```python
 from continuum import EventType, Run, SQLiteStorage, project
@@ -105,6 +119,14 @@ The detailed explanation, the projection model, and the recovery context are in 
 | Secure planning loop | Two-signal observation verification escalates high-risk branches to REQUIRES_REVIEW |
 | Periodic revalidation | Environment re-checked on a schedule, catching mid-run drift within one cycle |
 | Tamper-evident log | Hash-chained event log (32 event types) with integrity verification |
+| Enforcing gate | Unclaimed side-effect calls are refused before they fire; deny messages teach the claim protocol |
+| Observation hooks | Every file a coding CLI writes becomes digest-verified evidence, outside model control |
+| Session briefing | Fresh sessions learn run state deterministically at start - no prompt file |
+| Reconciler probes | Registered commands settle uncertain side effects automatically; humans see only the rest |
+| Executable guidance | Resume/validate render next steps as runnable commands, not statuses |
+| Enforcing HTTP gateway | Outbound calls in any language require claims; responses settle them from reality |
+| OpenTelemetry bridge | Tool-call spans from production tracing become evidence with zero code changes |
+| Action index | Cross-run idempotency lookups are indexed reads, not full-log scans |
 
 ## Security Extension
 
@@ -149,7 +171,7 @@ CONTINUUM is verified not just with mock unit tests, but against real LLM agents
 
 ### Automated Test Suite and Benchmarks
 
-- **1038 tests passing, 9 skipped** on Python 3.11, 3.12, and 3.13 (including unit, `hypothesis` property-based, concurrency, and adversarial tests).
+- **1224 tests passing, 13 skipped** on Python 3.11, 3.12, and 3.13 (including unit, `hypothesis` property-based, concurrency, and adversarial tests).
 - **CONTINUUM-Bench**: `continuum benchmark` executes in-process recovery benchmarks across five scenarios (`process_crash`, `dataset_change`, `unknown_side_effect`, `partial_completion`, `early_crash`), proving 0 duplicate work, 0 duplicate side effects, and automatic detection of stale environment dependencies.
 
 ### Adversarial Audit of the MCP Surface
@@ -203,6 +225,21 @@ through the LangGraph adapter, showing exactly-once survives the model's argumen
 drift. Treat them as experimental until their adapter-specific tests cover the full
 crash and resume matrix. Full usage, with runnable examples for every adapter, is in
 [references/adapters.md](references/adapters.md).
+
+Three further production frameworks are covered by thin, SDK-free hook
+surfaces in [`adapters/thin.py`](src/continuum/adapters/thin.py), each routing
+through the same claim/complete ledger with stable keys:
+
+| Framework | Interception surface | Entry point |
+|:--|:--|:--|
+| CrewAI | global before/after tool-call hooks | `install_crewai_hooks(storage, run_id)` |
+| AutoGen core | `FunctionTool.run_json` wrapped in place | `wrap_autogen_tool(tool, storage, run_id)` |
+| Pydantic AI | async Hooks capability | `Agent(capabilities=[wrap_pydantic_ai_hooks(storage, run_id)])` |
+
+For stacks none of these reach, two transport-level seams close the gap:
+`continuum gateway` enforces claims on outbound HTTP from any language, and
+`continuum.otel.make_span_processor(storage)` turns existing OpenTelemetry
+tool spans into evidence (`pip install continuum-agent[otel]`).
 
 ### Live LLM validation (real model via OpenRouter)
 
@@ -341,7 +378,8 @@ Every command accepts `--json`, and the read-only commands never write, so they 
 | 1-11 | Data models, semantic state, persistence, checkpointing, validation, action ledger, recovery engine, CLI, crash-recovery examples, environment snapshots/diffs, framework adapters | Complete |
 | 12 | Benchmark suite (CONTINUUM-Bench) | Complete (minimal harness) |
 | 13 | Cloud API (FastAPI + PostgreSQL) | Planned |
-| 14 | Dashboard | Planned |
+| 14 | Dashboard | Complete (`continuum dashboard`) |
+| 15+ | Enforced durability: observation hooks, gate, session briefing, reconciler probes, enforcing gateway, OTel bridge, action index, executable guidance, multi-client installers | Complete (see issue #213) |
 
 Beyond the original plan: the MCP server, MCP authorization layer, provenance and anti-self-certification, community files, schema versioning, and a bounded recovery context are shipped. The design for CONTINUUM-Bench is in [references/bench.md](references/bench.md). See [STATUS.md](STATUS.md) for the verified-vs-believed breakdown and open correctness bugs.
 
@@ -398,7 +436,7 @@ All arXiv links above were resolved against the arXiv API on 2026-08-22.
 - **Not on PyPI.** Install from a clone (see Quick Start).
 - **MCP caller authentication is optional.** When `CONTINUUM_MCP_TOKEN` is set, the server refuses every mutating tool unless the caller presents that shared secret in the `initialize` handshake's `_meta.authToken`. Without it, authorization is by declared identity only (the historical default, preserved for local single-user use). Tracked as [#1](https://github.com/Cyrax321/CONTINUUM/issues/1).
 - **Confirming self-reported state over MCP needs its own secret.** `continuum_confirm` refuses every caller until the operator sets `CONTINUUM_MCP_CONFIRM_TOKEN`, because an agent allowed to record progress must not also be able to confirm it (issue [#201](https://github.com/Cyrax321/CONTINUUM/issues/201)). The default path stays human-driven: run `continuum confirm <run_id>` on the host.
-- **Unbuilt components**: Cloud API (Phase 13) and Dashboard (Phase 14).
+- **Unbuilt components**: Cloud API (Phase 13).
 - **Framework adapters are experimental.** The OpenAI Agents SDK and LangGraph adapters are newer than the generic facade and do not yet carry the same crash-and-resume verification coverage. Prefer `GenericAgentAdapter` for production recovery until their adapter-specific tests cover the full recovery matrix.
 - **Agent/MCP runs need an explicit confirm before auto-resume.** Because externally-reported state is `REQUIRES_REVIEW`, `continuum resume` returns `request_human` until a human runs `continuum confirm <run_id>` (or the MCP `continuum_confirm` tool). This is by design, not a bug; see [Framework Integration](#framework-integration).
 - **e2e autonomy test series** (issue [#6](https://github.com/Cyrax321/CONTINUUM/issues/6)): Three full Claude Code runs scored 7/7 mechanics with unprompted recovery behavior observed. Defensive token-based fallback and path normalization bridge argument drift. Further test iterations across diverse prompt styles remain open.


### PR DESCRIPTION
## Description

README refresh across five stale zones: Quick Start gains the two-minute harness-wiring path (hooks install + start a run, no CLAUDE.md); Features table gains nine rows for everything shipped this week; Framework Integration documents the CrewAI/AutoGen/Pydantic-AI thin hooks plus the gateway/OTel fallback seams; Roadmap marks dashboard + enforced durability complete; test counts current (1224 passed / 13 skipped).

## Related issues

Refs #213

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1224 passed, 13 skipped
ruff check src tests
```

Markdown structure sanity-checked (table rows intact, no merge markers).

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed the Quick Start with guidance for connecting Claude Code, Gemini CLI, and Codex.
  * Documented hooks, evidence capture, session briefings, gate enforcement, recovery guidance, HTTP gateway, and OpenTelemetry integrations.
  * Added framework integration guidance for CrewAI, AutoGen, and Pydantic AI.
  * Updated the feature table, roadmap status, remaining components, and test count.
  * Added a changelog entry summarizing the documentation refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->