### PR TITLE
feat(mcp): record and brief reasoning summaries across interruptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Reasoning-context rehydration (#235).** Task-state recovery without
+  cognitive-state recovery produces sessions that are safe yet amnesiac.
+  New mutating MCP tool `continuum_record_summary` stores a bounded,
+  self-authored summary of where the agent's reasoning stands - plan stack,
+  decisions with rationale, open questions, working set - hard-capped at
+  4096 serialized characters so it can never become a transcript dump.
+  Summaries land as REASONING_SUMMARY events with EXTERNAL_AGENT provenance
+  and are strictly informational: they never move mode or safety. The
+  SessionStart briefing serves the newest summary verbatim ("where the last
+  session left off"), so a fresh session inherits the dead session's plan
+  instead of guessing from a progress bar.
+
 - **README refresh.** The README predated this week's work in every
   direction users touch first: the Quick Start now leads with the two-minute
   harness-wiring path (start a run, `hooks install`, no CLAUDE.md); the

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -632,7 +632,6 @@ def cmd_confirm(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
     return exit_code_for(decision.mode)
 
 
-
 def cmd_complete(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Close a run as done, from the keyboard (the maintainer's escape hatch).
 
@@ -806,6 +805,24 @@ def cmd_briefing(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
         + (f", {state.progress.failed} failed" if state.progress.failed else ""),
         f"recovery: {decision.mode.value} (safe={decision.safe})",
     ]
+    # Newest reasoning summary (#235): the resumed agent inherits the dead
+    # session's plan state, not just its progress counters.
+    summaries = [e for e in storage.read_events(run_id) if e.type is EventType.REASONING_SUMMARY]
+    if summaries:
+        summary = summaries[-1].payload.get("summary", {})
+        lines.append("where the last session left off (self-authored):")
+        for item in summary.get("plan_stack", [])[:3]:
+            lines.append(f"  plan: {item}")
+        for d in summary.get("decisions", [])[-3:]:
+            what = d.get("what", "")
+            why = d.get("why", "")
+            lines.append(f"  decision: {what}" + (f" ({why})" if why else ""))
+        for q in summary.get("open_questions", [])[:3]:
+            lines.append(f"  open: {q}")
+        ws = summary.get("working_set", [])
+        if ws:
+            lines.append(f"  working set: {', '.join(map(str, ws[:5]))}")
+
     obs = contract.post_checkpoint_observations[:5]
     if obs:
         lines.append("files since checkpoint:")
@@ -1569,9 +1586,7 @@ def build_parser() -> argparse.ArgumentParser:
     confirm.add_argument("--model", help="model that will run the resumed agent")
     confirm.add_argument("--tolerate-unknown", action="store_true")
 
-    complete = with_run(
-        add("complete", cmd_complete, "Close a run as done. Mutates storage.")
-    )
+    complete = with_run(add("complete", cmd_complete, "Close a run as done. Mutates storage."))
     complete.add_argument("--summary", default=None, help="one-line closing note")
 
     checkpoint = with_env(with_run(add("checkpoint", cmd_checkpoint, "Force a checkpoint.")))

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -90,6 +90,9 @@ class EventType(StrEnum):
     RECOVERY_BLOCKED = "RECOVERY_BLOCKED"
     REVIEW_CONFIRMED = "REVIEW_CONFIRMED"
 
+    # agent cognition (issue #235): compact self-authored plan state
+    REASONING_SUMMARY = "REASONING_SUMMARY"
+
     # perception and planning (security extension)
     PERCEPTION_OBSERVED = "PERCEPTION_OBSERVED"
     BRANCH_RESOLVED = "BRANCH_RESOLVED"

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -550,6 +550,61 @@ def build_server(
             }
         )
 
+    # -- reasoning summaries ---------------------------------------------- #
+
+    @server.tool(
+        name="continuum_record_summary",
+        description=(
+            "Record a compact summary of WHERE your reasoning is, so a fresh "
+            "session after any interruption inherits your plan instead of "
+            "guessing. Call at natural checkpoints and before ending a turn. "
+            "Schema: {plan_stack: [current step first], decisions: [{what, why}], "
+            "open_questions: [...], working_set: [files/ids in play]}. Hard cap "
+            "4096 characters serialized - summarise, never dump transcripts."
+        ),
+        annotations=mutating,
+    )
+    @guard
+    def continuum_record_summary(
+        run_id: str,
+        plan_stack: list[str] | None = None,
+        decisions: list[dict[str, str]] | None = None,
+        open_questions: list[str] | None = None,
+        working_set: list[str] | None = None,
+        note: str = "",
+    ) -> str:
+        """Store one bounded reasoning summary (issue #235)."""
+        summary = {
+            "plan_stack": plan_stack or [],
+            "decisions": decisions or [],
+            "open_questions": open_questions or [],
+            "working_set": working_set or [],
+            "note": note,
+        }
+        serialized = json.dumps(summary, ensure_ascii=False)
+        if len(serialized) > 4096:
+            from mcp.server.mcpserver.exceptions import ToolError
+
+            raise ToolError(
+                f"reasoning summary is {len(serialized)} chars; cap is 4096. "
+                "Summarise harder: fewer, shorter entries."
+            )
+        ctx.ensure_run(run_id)
+        event = ctx.storage.append_event(
+            run_id,
+            EventType.REASONING_SUMMARY,
+            {"summary": summary},
+            source=Origin.EXTERNAL_AGENT,
+        )
+        return _json(
+            {
+                "run_id": run_id,
+                "sequence": event.sequence,
+                "recorded": True,
+                "bytes": len(serialized),
+            }
+        )
+
     # -- validation ------------------------------------------------------- #
 
     @server.tool(

--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -66,6 +66,10 @@ MUTATING_CALLS: dict[str, dict[str, Any]] = {
         "occurred": True,
     },
     "continuum_confirm": {"run_id": "run_1"},
+    "continuum_record_summary": {
+        "run_id": "run_1",
+        "plan_stack": ["step"],
+    },
 }
 MUTATING = list(MUTATING_CALLS)
 READ_ONLY = ["continuum_validate", "continuum_resume", "continuum_list_actions"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -123,6 +123,7 @@ async def test_every_tool_is_registered(server_ctx: tuple[Any, Any]) -> None:
         "continuum_reconcile_action",
         "continuum_list_actions",
         "continuum_confirm",
+        "continuum_record_summary",
     }
 
 

--- a/tests/test_mcp_slim.py
+++ b/tests/test_mcp_slim.py
@@ -17,4 +17,4 @@ def test_full_mode_exposes_all_tools(monkeypatch) -> None:
     names = {tool.name for tool in server._tool_manager._tools.values()}
     assert "continuum_record_progress" in names
     assert "continuum_checkpoint" in names
-    assert len(names) == 10
+    assert len(names) == 11

--- a/tests/test_reasoning_summary.py
+++ b/tests/test_reasoning_summary.py
@@ -1,0 +1,192 @@
+"""Reasoning-context rehydration (issue #235).
+
+Task-state recovery without cognitive-state recovery produces sessions that
+are safe yet amnesiac: they know 47/100 is done, not what the agent was
+thinking. `continuum_record_summary` stores a bounded, self-authored plan
+summary; `continuum briefing` serves the newest one back at session start.
+Summaries are EXTERNAL_AGENT evidence - informational on resume, never gating.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from continuum.cli import ExitCode, main
+from continuum.events import EventType
+from continuum.models import Origin, Run
+from continuum.storage import SQLiteStorage
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "rs.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="Long task"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "Long task"})
+    yield path
+
+
+def test_cli_briefing_serves_the_newest_summary(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        store.append_event(
+            "run_1",
+            EventType.REASONING_SUMMARY,
+            {
+                "summary": {
+                    "plan_stack": ["compare INV-004 to vendor list"],
+                    "decisions": [{"what": "flag mismatch", "why": "price drift"}],
+                    "open_questions": ["who approved discount?"],
+                    "working_set": ["INV-004", "vendors.csv"],
+                }
+            },
+            source=Origin.EXTERNAL_AGENT,
+        )
+    code, out, err = run("--db", db, "briefing")
+    assert code == ExitCode.OK, err
+    for needle in (
+        "where the last session left off",
+        "compare INV-004 to vendor list",
+        "flag mismatch",
+        "who approved discount?",
+        "INV-004",
+    ):
+        assert needle in out, needle
+
+
+def test_only_the_newest_summary_is_served(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        for stack in (["old plan"], ["new plan"]):
+            store.append_event(
+                "run_1",
+                EventType.REASONING_SUMMARY,
+                {"summary": {"plan_stack": stack}},
+                source=Origin.EXTERNAL_AGENT,
+            )
+    _, out, _ = run("--db", db, "briefing")
+    assert "new plan" in out and "old plan" not in out
+
+
+def test_no_summary_leaves_the_briefing_unchanged(db: str) -> None:
+    code, out, _ = run("--db", db, "briefing")
+    assert code == ExitCode.OK
+    assert "where the last session left off" not in out
+
+
+def test_summaries_are_non_gating_evidence(db: str) -> None:
+    """A summary must never change mode or safety: it is orientation, not
+    certification."""
+    decision_before = _assess(db)
+    with SQLiteStorage(db) as store:
+        store.append_event(
+            "run_1",
+            EventType.REASONING_SUMMARY,
+            {"summary": {"plan_stack": ["anything"]}},
+            source=Origin.EXTERNAL_AGENT,
+        )
+    decision_after = _assess(db)
+    assert decision_before.mode is decision_after.mode
+    assert decision_before.safe == decision_after.safe
+
+
+def _assess(db: str):
+    from continuum.recovery import RecoveryEngine
+
+    return RecoveryEngine(SQLiteStorage(db)).assess("run_1")
+
+
+# --- MCP surface --------------------------------------------------------------- #
+
+
+def test_summary_event_shape_is_bounded_json(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        store.append_event(
+            "run_1",
+            EventType.REASONING_SUMMARY,
+            {"summary": {"plan_stack": ["s"], "note": "n"}},
+            source=Origin.EXTERNAL_AGENT,
+        )
+        events = [e for e in store.read_events("run_1") if e.type is EventType.REASONING_SUMMARY]
+    assert events[-1].payload["summary"]["plan_stack"] == ["s"]
+
+
+def test_mcp_resume_flow_carries_summary_through_briefing_command(db: str, tmp_path: Path) -> None:
+    """End-to-end through real processes: record over MCP stdio, brief via CLI."""
+    import subprocess
+
+    env = dict(os.environ)
+    env["CONTINUUM_MCP_MUTATING_CLIENTS"] = "claude-code"
+    handshake = [
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "claude-code", "version": "1"},
+                },
+            }
+        ),
+        '{"jsonrpc":"2.0","method":"notifications/initialized"}',
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "continuum_record_summary",
+                    "arguments": {
+                        "run_id": "run_1",
+                        "plan_stack": ["reconciling INV-77"],
+                        "open_questions": ["vendor replied?"],
+                    },
+                },
+            }
+        ),
+    ]
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "continuum.mcp.server", "--db", db],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        env=env,
+    )
+    try:
+        for line in handshake:
+            proc.stdin.write(line + "\n")
+            proc.stdin.flush()
+        deadline = 60
+        reply = None
+        while deadline:
+            line = proc.stdout.readline()
+            if not line:
+                break
+            parsed = json.loads(line)
+            if parsed.get("id") == 2:
+                reply = parsed
+                break
+    finally:
+        proc.kill()
+    assert reply is not None and "result" in reply, reply
+    inner = json.loads(reply["result"]["content"][0]["text"])
+    assert inner.get("recorded") is True, inner
+
+    code, out, _ = run("--db", db, "--json", "briefing")
+    assert code == ExitCode.OK
+    context = json.loads(out)["context"]
+    assert "reconciling INV-77" in context
+    assert "vendor replied?" in context


### PR DESCRIPTION
## Description

Closes #235, the first open problem in #244. Adds `continuum_record_summary`, an MCP tool storing a bounded self-authored reasoning summary (plan stack, decisions with rationale, open questions, working set) as REASONING_SUMMARY events; `continuum briefing` serves the newest one at session start. Hard 4096-char cap enforced server-side with an instructive error. Non-projecting by design: summaries orient the next session and never affect mode/safety (pinned by test).

## Related issues

Fixes #235

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1231 passed, 13 skipped
ruff check src tests
mypy src           # clean
```

Seven new tests incl. a real stdio round trip (record over MCP -> briefing contains the plan), newest-wins ordering, absence tolerance, non-gating invariant, and event-shape bounds. Registry/authz/slim-mode suites updated for the eleventh tool.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Limitation: summaries are caller-asserted EXTERNAL_AGENT claims about intent - they orient but never certify, matching house provenance rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a way to save concise reasoning context, including plans, decisions, open questions, working files, and notes.
  - Session briefings now restore the latest saved reasoning summary to help continue work with relevant context.
  - Added a completion command to confirm progress, mark a run complete, and optionally provide a summary.
  - Reasoning summaries are limited in size to keep briefings focused and manageable.

- **Bug Fixes**
  - Improved session context restoration without changing recovery-safety decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->