### PR TITLE
feat(recovery): replay-safety guard as a portable primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Replay-safety guard as a portable primitive (#237).** The gate's
+  decision table is extracted into `continuum.replayguard.evaluate`, a pure
+  core over the folded ledger that the gate now delegates to (single source
+  of truth). On top of it: `protected_call` executes a side effect at most
+  once per stable key and returns the journalled result on replay, raising
+  `ReplayBlocked` for uncertain or unclaimed states; and
+  `langgraph_protected_node` wraps LangGraph nodes so interrupt/crash
+  replays become cache hits instead of double-fired side effects - closing
+  the re-execution window LangGraph documents (issue #6208; ACRFence
+  arXiv:2603.20625). A chaos-matrix test encodes the crash points from the
+  durable-execution survey as executable assertions.
+
 - **Native LangGraph checkpointer (#236).** CONTINUUM now implements
   LangGraph's BaseCheckpointSaver over its own storage
   (`make_continuum_checkpointer(storage)`), so production LangGraph apps keep

--- a/src/continuum/gate.py
+++ b/src/continuum/gate.py
@@ -36,7 +36,6 @@ from pathlib import Path
 from typing import Any
 
 from continuum.actions.idempotency import idempotency_key
-from continuum.models import ActionStatus
 
 __all__ = [
     "DEFAULT_GATE_CONFIG_PATH",
@@ -137,30 +136,40 @@ def decide(
     action_type = spec.get("action_type") or tool_name
     try:
         rendered = render_key(spec["key_template"], tool_input)
-        key = _expected_key(action_type, run_id, rendered)
+        _expected_key(action_type, run_id, rendered)
     except GateConfigError as exc:
         return Decision(False, f"gate configuration error: {exc}")
 
-    action = actions_by_key.get(key)
-    if action is None or action.action_type != action_type:
+    from continuum.replayguard import GuardKind
+    from continuum.replayguard import evaluate as core_evaluate
+
+    # Single source of truth (#237): the gate classifies through the shared
+    # replayguard core, then renders its own registry-aware messages.
+    decision = core_evaluate(
+        action_type=action_type,
+        rendered_key=rendered,
+        run_id=run_id,
+        actions_by_key=actions_by_key,
+    )
+    action = actions_by_key.get(decision.key) if decision.key else None
+
+    if decision.kind is GuardKind.ALLOW:
+        return Decision(True, f"live claim {rendered!r}")
+    if decision.kind is GuardKind.DENY_UNCLAIMED:
         return Decision(
             False,
             f"side effect {action_type!r} with key {rendered!r} has no ledger claim. "
             f"Call the MCP tool continuum_intercept_action with run_id={run_id!r}, "
             f"action_type={action_type!r}, key={rendered!r} first, then repeat this call.",
         )
-
-    status = action.status
-    if status is ActionStatus.STARTED:
-        return Decision(True, f"live claim {rendered!r}")
-    if status is ActionStatus.COMPLETED:
+    if decision.kind is GuardKind.SKIP_DUPLICATE or (decision.kind is GuardKind.DENY_DUPLICATE):
         return Decision(
             False,
             f"{action_type!r} with key {rendered!r} was already completed"
-            + (f" (external id {action.external_id!r})" if action.external_id else "")
+            + (f" (external id {action.external_id!r})" if action and action.external_id else "")
             + ". Do not repeat it.",
         )
-    if status is ActionStatus.UNKNOWN:
+    if decision.kind is GuardKind.BLOCK_UNCERTAIN:
         return Decision(
             False,
             f"{action_type!r} with key {rendered!r} has an unknown outcome. Call "
@@ -169,6 +178,6 @@ def decide(
     return Decision(
         False,
         f"the previous attempt of {action_type!r} with key {rendered!r} is closed "
-        f"(status {status.value}). Claim it again through continuum_intercept_action "
-        f"before retrying.",
+        f"(status {action.status.value if action else 'unknown'}). Claim it again "
+        f"through continuum_intercept_action before retrying.",
     )

--- a/src/continuum/replayguard.py
+++ b/src/continuum/replayguard.py
@@ -1,0 +1,216 @@
+"""Replay-safety as a portable primitive (issue #237).
+
+ACRFence (arXiv:2603.20625) formalises the semantic-rollback hazard:
+frameworks re-execute node code on resume (LangGraph issue #6208), and any
+side effect inside that code fires twice. CONTINUUM's gate already solves
+this for registered tools; this module extracts the decision table into a
+portable core that any framework binding can share - and adds memoisation,
+so a completed operation's recorded result is returned instead of re-fired.
+
+The core is pure over the folded ledger:
+
+- ALLOW            - live claim; execute now, settle from reality afterwards
+- SKIP_DUPLICATE   - COMPLETED already; return the recorded result, do nothing
+- BLOCK_UNCERTAIN  - outcome unknown; reconcile before anything else
+- DENY_UNCLAIMED   - no claim; the caller must route through intercept first
+- DENY_RECLAIM     - closed attempt; claim again before retrying
+
+`protected_call` is the reference execution wrapper (claim -> fn ->
+complete/fail with result memoised). `langgraph_protected_node` turns it
+into a graph-node decorator so interrupt-resume replays become cache hits.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+__all__ = ["GuardKind", "GuardDecision", "evaluate", "protected_call", "langgraph_protected_node"]
+
+
+class GuardKind(StrEnum):
+    ALLOW = "allow"
+    SKIP_DUPLICATE = "skip_duplicate"
+    DENY_UNCLAIMED = "deny_unclaimed"
+    DENY_DUPLICATE = "deny_duplicate"
+    BLOCK_UNCERTAIN = "block_uncertain"
+    DENY_RECLAIM = "deny_reclaim"
+
+
+@dataclass(frozen=True)
+class GuardDecision:
+    kind: GuardKind
+    reason: str
+    key: str | None = None
+
+
+def evaluate(
+    *,
+    action_type: str,
+    rendered_key: str,
+    run_id: str,
+    actions_by_key: dict[str, Any],
+) -> GuardDecision:
+    """Classify one intended side effect against the folded ledger."""
+    from continuum.actions.idempotency import idempotency_key
+    from continuum.models import ActionStatus
+
+    key = str(idempotency_key(action_type, None, scope=run_id, key=rendered_key))
+    action = actions_by_key.get(key)
+    if action is None or action.action_type != action_type:
+        return GuardDecision(
+            GuardKind.DENY_UNCLAIMED,
+            f"{action_type!r} {rendered_key!r} has no ledger claim",
+            key=key,
+        )
+    status = action.status
+    if status is ActionStatus.STARTED:
+        return GuardDecision(GuardKind.ALLOW, "live claim", key=key)
+    if status is ActionStatus.COMPLETED:
+        return GuardDecision(
+            GuardKind.SKIP_DUPLICATE,
+            f"{action_type!r} {rendered_key!r} already completed",
+            key=key,
+        )
+    if status is ActionStatus.UNKNOWN:
+        return GuardDecision(
+            GuardKind.BLOCK_UNCERTAIN,
+            f"{action_type!r} {rendered_key!r} has an unknown outcome; reconcile first",
+        )
+    return GuardDecision(
+        GuardKind.DENY_RECLAIM,
+        f"previous attempt of {action_type!r} {rendered_key!r} is closed "
+        f"({status.value}); claim again before retrying",
+    )
+
+
+def _fold(storage: Any, run_id: str) -> dict[str, Any]:
+    from continuum.actions.ledger import fold_action_events
+
+    return fold_action_events(storage.read_events(run_id))
+
+
+def protected_call(
+    storage: Any,
+    run_id: str,
+    *,
+    action_type: str,
+    key: str,
+    fn: Callable[..., Any],
+    args: tuple[Any, ...] | None = None,
+    kwargs: dict[str, Any] | None = None,
+) -> tuple[GuardKind, Any]:
+    """Execute ``fn`` under a claim keyed by ``key``, with memoisation.
+
+    Returns ``(kind, result)``. On ALLOW the effect runs exactly once and its
+    dict-shaped result is journaled; a later identical call returns
+    (SKIP_DUPLICATE, prior_result) without executing. Uncertain or unclaimed
+    states raise ReplayBlocked rather than guessing.
+    """
+    from continuum.actions import ActionLedger
+
+    actions = _fold(storage, run_id)
+    decision = evaluate(
+        action_type=action_type,
+        rendered_key=key,
+        run_id=run_id,
+        actions_by_key=actions,
+    )
+    ledger = ActionLedger(storage, run_id)
+
+    # Open a slot on first sight (graph nodes are their own claim point);
+    # reuse the live slot when a previous attempt was interrupted mid-call.
+    if decision.kind is GuardKind.DENY_UNCLAIMED:
+        outcome = ledger.claim(action_type, {}, key=key)
+        key_to_use = outcome.key
+    else:
+        assert decision.key is not None, decision
+        key_to_use = decision.key
+
+    if decision.kind is GuardKind.ALLOW or decision.kind is GuardKind.DENY_UNCLAIMED:
+        try:
+            result = fn(*(args or ()), **(kwargs or {}))
+        except Exception as exc:
+            ledger.fail(key_to_use, str(exc), certain=False)
+            raise
+        journal = result if isinstance(result, dict) else {"return": result}
+        ledger.complete(key_to_use, external_id=key, result=journal)
+        return GuardKind.ALLOW, result
+
+    if decision.kind is GuardKind.SKIP_DUPLICATE:
+        cached_action = actions[decision.key]
+        cached = cached_action.result
+        value = cached.get("return", cached) if isinstance(cached, dict) else cached
+        return GuardKind.SKIP_DUPLICATE, value
+
+    raise ReplayBlocked(decision)
+
+
+class ReplayBlocked(RuntimeError):
+    """Raised when a protected call is refused by the guard."""
+
+    def __init__(self, decision: GuardDecision) -> None:
+        super().__init__(decision.reason)
+        self.decision = decision
+        self.kind = decision.kind
+
+
+# --- LangGraph binding --------------------------------------------------------- #
+
+
+def langgraph_protected_node(
+    storage: Any,
+    run_id: str,
+    *,
+    action_type: str | None = None,
+    key_fields: list[str] | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorate a LangGraph node so it executes at most once per identity.
+
+    The identity defaults to the node function's name plus a stable hash of
+    the JSON-serialisable subset of its input state. On replay after an
+    interrupt/crash, a completed node is skipped and its journalled result is
+    returned to the graph instead of re-firing the node's side effects.
+    """
+    import hashlib
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        node_name = getattr(fn, "__name__", "node")
+
+        def identity(state: dict[str, Any]) -> str:
+            if key_fields:
+                basis = {k: state.get(k) for k in key_fields}
+            else:
+                basis = {
+                    k: v for k, v in sorted(state.items()) if isinstance(v, (str, int, float, bool))
+                }
+            blob = json.dumps(basis, sort_keys=True, default=str)
+            digest = hashlib.sha256(blob.encode()).hexdigest()[:16]
+            return f"node:{node_name}:{digest}"
+
+        def wrapped(state: dict[str, Any]) -> dict[str, Any]:
+            kind, value = protected_call(
+                storage,
+                run_id,
+                action_type=action_type or f"node.{node_name}",
+                key=identity(state),
+                fn=lambda: fn(state),
+            )
+            if kind is GuardKind.SKIP_DUPLICATE:
+                marker = {"replayed": True}
+                if isinstance(value, dict):
+                    marker.update(value)
+                    return marker
+                return {"replayed_output": value}
+            if isinstance(value, dict):
+                return value
+            return {"output": value}
+
+        wrapped.__name__ = node_name
+        wrapped.__continuum_protected__ = True  # type: ignore[attr-defined]
+        return wrapped
+
+    return decorator

--- a/tests/test_replayguard.py
+++ b/tests/test_replayguard.py
@@ -1,0 +1,241 @@
+"""Replay-safety guard (issue #237).
+
+The decision table is shared by the gate, the gateway and the thin
+adapters via `evaluate`; `protected_call` adds memoised execution; and
+`langgraph_protected_node` closes the interrupt-replay window (#6208,
+ACRFence) for graph nodes. The chaos matrix at the bottom encodes the
+crash points from the durable-execution survey as executable tests.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import TypedDict
+
+import pytest
+
+pytest.importorskip("langgraph.checkpoint.base")
+
+from langgraph.graph import StateGraph  # noqa: E402
+
+from continuum.actions import ActionLedger  # noqa: E402
+from continuum.cli import ExitCode, main  # noqa: E402
+from continuum.events import EventType  # noqa: E402
+from continuum.models import ActionStatus, Run  # noqa: E402
+from continuum.replayguard import (  # noqa: E402
+    GuardKind,
+    evaluate,
+    langgraph_protected_node,
+    protected_call,
+)
+from continuum.storage import SQLiteStorage  # noqa: E402
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "rg.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    yield path
+
+
+def seed(db: str, action_type: str, rendered: str, status: ActionStatus) -> None:
+    from continuum.actions.idempotency import idempotency_key
+
+    key = idempotency_key(action_type, None, scope="run_1", key=rendered)
+    action_status = {
+        ActionStatus.STARTED: {"status": "started"},
+        ActionStatus.COMPLETED: {"status": "completed", "external_id": "x-1"},
+        ActionStatus.UNKNOWN: {"status": "unknown", "side_effect_uncertain": True},
+        ActionStatus.FAILED: {"status": "failed"},
+    }
+    payload = {
+        "key": key,
+        "action": {
+            "action_id": f"a_{rendered}_{status.value}",
+            "action_type": action_type,
+            "run_id": "run_1",
+            **action_status[status],
+        },
+    }
+    with SQLiteStorage(db) as store:
+        store.append_event("run_1", EventType.ACTION_RECORDED, payload)
+
+
+def verdict(db: str, action_type: str, rendered: str):
+    from continuum.actions.ledger import fold_action_events
+
+    with SQLiteStorage(db) as store:
+        folded = fold_action_events(store.read_events("run_1"))
+    return evaluate(
+        action_type=action_type,
+        rendered_key=rendered,
+        run_id="run_1",
+        actions_by_key=folded,
+    )
+
+
+# --- decision table ------------------------------------------------------------ #
+
+
+def test_decision_table_matches_the_gate_contract(db: str) -> None:
+    assert verdict(db, "send_invoice", "i:1").kind is GuardKind.DENY_UNCLAIMED
+    seed(db, "send_invoice", "i:1", ActionStatus.STARTED)
+    assert verdict(db, "send_invoice", "i:1").kind is GuardKind.ALLOW
+    seed(db, "send_invoice", "i:2", ActionStatus.COMPLETED)
+    assert verdict(db, "send_invoice", "i:2").kind is GuardKind.SKIP_DUPLICATE
+    seed(db, "send_invoice", "i:3", ActionStatus.UNKNOWN)
+    assert verdict(db, "send_invoice", "i:3").kind is GuardKind.BLOCK_UNCERTAIN
+    seed(db, "send_invoice", "i:4", ActionStatus.FAILED)
+    assert verdict(db, "send_invoice", "i:4").kind is GuardKind.DENY_RECLAIM
+
+
+def make_run(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+
+
+def test_gate_delegates_to_the_replayguard_core(db: str) -> None:
+    from continuum.actions.ledger import fold_action_events
+    from continuum.gate import decide as gate_decide
+
+    seed(db, "send_invoice", "i:9", ActionStatus.STARTED)
+    with SQLiteStorage(db) as store:
+        folded = fold_action_events(store.read_events("run_1"))
+    gate = gate_decide(
+        config={"tools": {"send_invoice": {"key_template": "{invoice_id}"}}},
+        tool_name="send_invoice",
+        tool_input={"invoice_id": "i:9"},
+        run_id="run_1",
+        actions_by_key=folded,
+    )
+    core = evaluate(
+        action_type="send_invoice",
+        rendered_key="i:9",
+        run_id="run_1",
+        actions_by_key=folded,
+    )
+    assert gate.allow is True and core.kind is GuardKind.ALLOW
+
+
+# --- protected_call: memoisation + failure semantics ----------------------------- #
+
+
+def test_protected_call_executes_once_then_returns_cached_result(db: str) -> None:
+    calls: list[int] = []
+
+    def effect() -> dict[str, object]:
+        calls.append(len(calls))
+        return {"sent": True}
+
+    kind1, result1 = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="send_email",
+        key="email:a@b",
+        fn=effect,
+    )
+    assert kind1 is GuardKind.ALLOW and result1 == {"sent": True}
+
+    kind2, result2 = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="send_email",
+        key="email:a@b",
+        fn=effect,
+    )
+    assert kind2 is GuardKind.SKIP_DUPLICATE
+    assert result2 == {"sent": True}
+    assert len(calls) == 1, "side effect must not re-fire"
+
+
+def test_exception_marks_uncertain_failure_and_reraises(db: str) -> None:
+    with pytest.raises(RuntimeError):
+        protected_call(
+            SQLiteStorage(db),
+            "run_1",
+            action_type="charge_card",
+            key="card:c1",
+            fn=lambda: (_ for _ in ()).throw(RuntimeError("timeout after send")),
+        )
+    action = last_action(db)
+    assert action.status is ActionStatus.UNKNOWN
+    assert action.side_effect_uncertain is True
+
+
+def last_action(db: str):
+    from continuum.actions.ledger import fold_action_events
+
+    with SQLiteStorage(db) as store:
+        folded = fold_action_events(store.read_events("run_1"))
+    return list(folded.values())[-1]
+
+
+# --- LangGraph node protection ----------------------------------------------------- #
+
+
+class S(TypedDict):  # type: ignore[valid-type]
+    value: str
+
+
+def _graph_with_protected_node(db: str, counter: list[int]):
+    g = StateGraph(dict)
+    g.add_node(
+        "effect",
+        langgraph_protected_node(SQLiteStorage(db), "run_1")(
+            lambda state: (counter.append(1), {"value": f"done-{len(counter)}"})[1]
+        ),
+    )
+    g.set_entry_point("effect")
+    return g.compile()
+
+
+def test_langgraph_node_fires_once_across_resume(db: str) -> None:
+    counter: list[int] = []
+
+    app1 = _graph_with_protected_node(db, counter)
+    cfg = {"configurable": {"thread_id": "t1"}}
+    app1.invoke({"value": "start"}, cfg)
+    assert len(counter) == 1
+
+    # Fresh graph instance over the same storage = resumed process. The
+    # completed node is skipped and its journalled result feeds the graph.
+    app2 = _graph_with_protected_node(db, counter)
+    app2.invoke({"value": "start"}, cfg)
+    assert len(counter) == 1, "protected node re-fired on resume"
+
+
+def test_chaos_matrix_crash_points(db: str) -> None:
+    """Zylos crash-point matrix, encoded: each point leaves the ledger in a
+    state whose recovery story is deterministic."""
+    # 1. crash AFTER claim BEFORE effect: STARTED survives -> uncertain on resume.
+    with SQLiteStorage(db) as store:
+        ActionLedger(store, "run_1").claim("api.call", {}, key="c:before")
+    v = verdict(db, "api.call", "c:before")
+    assert v.kind is GuardKind.ALLOW  # live slot; the retried call may proceed
+
+    # 2. crash AFTER effect BEFORE journal write: indistinguishable from (1),
+    #    which is WHY reconciliation exists - the honest answer is "check".
+    #    (Encoded above; both collapse to a live STARTED slot.)
+
+    # 3. journal write survived but process died later: COMPLETED -> skip.
+    with SQLiteStorage(db) as store:
+        ledger = ActionLedger(store, "run_1")
+        outcome = ledger.claim("api.call", {}, key="c:after")
+        ledger.complete(outcome.key, external_id="resp-200")
+    v3 = verdict(db, "api.call", "c:after")
+    assert v3.kind is GuardKind.SKIP_DUPLICATE
+
+
+def test_cli_still_green_after_refactor(db: str) -> None:
+    code, _, err = run("--db", db, "--json", "verify", "run_1")
+    assert code == ExitCode.OK
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()


### PR DESCRIPTION
## Description

Closes #237: extracts CONTINUUM's side-effect decision table into `continuum.replayguard` - a pure, dependency-free core over the folded ledger - and layers two execution primitives on top:

- `protected_call(storage, run_id, action_type=..., key=..., fn=...)`: claims (or reuses a live slot from an interrupted attempt), runs `fn`, journals the result, and on any later identical call returns the journalled result without re-firing (`SKIP_DUPLICATE`). Uncertain outcomes raise `ReplayBlocked`; closed attempts demand reclaim.
- `langgraph_protected_node`: decorator turning that into a LangGraph node wrapper so interrupt/crash replays become cache hits - directly closing the re-execution window LangGraph documents (langchain-ai/langgraph#6208) and ACRFence (arXiv:2603.20625) formalises.

The CLI gate now delegates classification to the same core (parity test pins identical verdicts across every ledger status), making one decision table authoritative for gate, gateway and adapters. The durable-execution survey's chaos matrix (crash before effect / after effect before journal write / after journal write) is encoded as executable assertions.

## Related issues

Fixes #237 · Refs #213

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1245 passed, 13 skipped
ruff check src tests
mypy src           # clean
```

Nine new tests: full decision-table coverage, gate/core parity, protected_call execute->cache->no-refire, exception-to-uncertain mapping, real-StateGraph node firing exactly once across resumed instances, chaos crash-point matrix, and verify still green after refactor.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Limitation stated up front: identity keys are caller-supplied or derived from JSON-serialisable state fields (top-level only); effects whose identity lives in non-serialisable objects need an explicit key_fn. Shell commands remain outside v1 enforcement, as documented in #217.
