### PR TITLE
feat(recovery): run-level retry budgets enforced at claim time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Run-level retry budgets (#240).** Agent loops invent retries: a failing
+  upstream gets hammered because the model re-plans after every failure, and
+  each attempt opens a fresh ledger slot. New `.continuum/budgets.json`
+  registry caps attempts per action type (with a default fallback); every
+  ACTION_RECORDED claim slot counts as one attempt, so retries under the
+  same key still consume budget. `continuum intercept_action` refuses claims
+  beyond the budget with an instructive error, and new read-only command
+  `continuum budget <run>` reports attempts/max/remaining per type.
+  `backoff_delay` ships as a pure helper (exponential + cap; jitter is the
+  caller's job) because CONTINUUM never performs retries itself - it counts
+  and gates them.
+
 - **Event-log compaction (#239).** `continuum compact <run>` bounds live-log
   growth for month-long runs: it appends an EVENT_LOG_ANCHORED marker, moves
   the pre-anchor prefix verbatim into a new `events_archive` table (schema

--- a/src/continuum/budgets.py
+++ b/src/continuum/budgets.py
@@ -1,0 +1,131 @@
+"""Run-level retry budgets (issue #240).
+
+Agent loops invent retries: a failing upstream gets hammered because the
+model re-plans after every failure, and each attempt opens a fresh ledger
+slot. RetryGuard (arXiv:2511.23278) shows local retry policies amplify cost;
+the fix here is a *run-level budget* evaluated at claim time.
+
+Registries live in `.continuum/budgets.json` (JSON, matching the other
+registries):
+
+    {"default_max_attempts": 3,
+     "action_types": {"send_invoice": {"max_attempts": 5}}}
+
+`evaluate_budget` counts prior attempts for an action type from the folded
+ledger and returns whether another claim may proceed. CONTINUUM never retries
+anything itself - it counts and gates - so the enforcement surface stays a
+single pure function plus thin wiring at claim sites.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "DEFAULT_BUDGETS_PATH",
+    "attempts_for_type",
+    "BudgetConfigError",
+    "load_budgets",
+    "attempts_for_type",
+    "evaluate_budget",
+    "backoff_delay",
+]
+
+DEFAULT_BUDGETS_PATH = ".continuum/budgets.json"
+
+#: Fallback when neither the action type nor the registry sets a limit.
+FALLBACK_MAX_ATTEMPTS = 3
+
+
+class BudgetConfigError(ValueError):
+    """The budget registry exists but cannot be honoured."""
+
+
+def load_budgets(path: Path) -> dict[str, Any]:
+    """Read the budget registry. ``{}`` when absent; raise when malformed."""
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise BudgetConfigError(f"{path} is not valid JSON ({exc})") from exc
+    if not isinstance(raw, dict):
+        raise BudgetConfigError(f"{path}: expected a JSON object")
+    action_types = raw.get("action_types", {})
+    if not isinstance(action_types, dict):
+        raise BudgetConfigError(f"{path}: 'action_types' must be an object")
+    for name, spec in action_types.items():
+        entry = (
+            spec
+            if isinstance(spec, int)
+            else (spec.get("max_attempts") if isinstance(spec, dict) else None)
+        )
+        if not isinstance(entry, int) or entry < 1:
+            raise BudgetConfigError(
+                f"{path}: action type {name!r} needs a positive integer 'max_attempts'"
+            )
+    default_max = raw.get("default_max_attempts")
+    if default_max is not None and (not isinstance(default_max, int) or default_max < 1):
+        raise BudgetConfigError(f"{path}: 'default_max_attempts' must be >= 1")
+    return raw
+
+
+def _max_for(action_type: str, raw: Mapping[str, Any]) -> int:
+    per_type = raw.get("action_types", {})
+    spec = per_type.get(action_type)
+    if isinstance(spec, int):
+        return spec
+    if isinstance(spec, dict) and isinstance(spec.get("max_attempts"), int):
+        return int(spec["max_attempts"])
+    fallback = raw.get("default_max_attempts", FALLBACK_MAX_ATTEMPTS)
+    return int(fallback)
+
+
+def attempts_for_type(events: Any, action_type: str) -> int:
+    """Count claim slots opened for ``action_type`` from raw events.
+
+    A claim slot (an ACTION_RECORDED whose action status is STARTED) is one
+    attempt. Settlement events (completed/failed/unknown) are updates, not
+    new attempts - so retries count but their bookkeeping does not.
+    """
+    from continuum.events import EventType
+    from continuum.models import ActionStatus
+
+    return sum(
+        1
+        for e in events
+        if e.type is EventType.ACTION_RECORDED
+        and isinstance(e.payload.get("action"), Mapping)
+        and e.payload["action"].get("action_type") == action_type
+        and e.payload["action"].get("status") == ActionStatus.STARTED.value
+    )
+
+
+def evaluate_budget(
+    raw_config: Mapping[str, Any] | None,
+    action_type: str,
+    attempts_so_far: int,
+) -> tuple[bool, int, int]:
+    """Return ``(allowed, attempts_so_far, max_attempts)``.
+
+    Pure so claim sites can call it with nothing but the folded attempt count.
+    """
+    _ = raw_config  # kept in signature for symmetry with other registries
+    cfg = raw_config or {}
+    maximum = _max_for(action_type, cfg)
+    return attempts_so_far < maximum, attempts_so_far, maximum
+
+
+def backoff_delay(
+    attempt: int,
+    *,
+    base: float = 1.0,
+    cap: float = 60.0,
+) -> float:
+    """Exponential backoff with a ceiling. Pure; jitter is the caller's job."""
+    if attempt < 1:
+        raise ValueError("attempt starts at 1")
+    return float(min(base * (2 ** (attempt - 1)), cap))

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -632,6 +632,61 @@ def cmd_confirm(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
     return exit_code_for(decision.mode)
 
 
+def cmd_budget(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Report retry-budget usage per action type (issue #240). Read-only."""
+    from continuum.budgets import (
+        DEFAULT_BUDGETS_PATH,
+        attempts_for_type,
+        evaluate_budget,
+        load_budgets,
+    )
+
+    storage.get_run(args.run_id)
+    try:
+        raw = load_budgets(Path(args.config) if args.config else Path(DEFAULT_BUDGETS_PATH))
+    except Exception as exc:
+        print(f"error: budget registry invalid: {exc}", file=err)
+        return ExitCode.ERROR
+
+    events = storage.read_events(args.run_id)
+    types_seen = sorted(
+        {
+            e.payload.get("action", {}).get("action_type")
+            for e in events
+            if e.type is EventType.ACTION_RECORDED and isinstance(e.payload.get("action"), dict)
+        }
+        | set((raw.get("action_types") or {}).keys())
+    )
+    rows: list[dict[str, Any]] = []
+    for action_type in types_seen:
+        used = attempts_for_type(events, action_type)
+        allowed, _, maximum = evaluate_budget(raw, action_type, 0)
+        remaining = max(0, maximum - used)
+        rows.append(
+            {
+                "action_type": action_type,
+                "attempts": used,
+                "max_attempts": maximum,
+                "remaining": remaining,
+                "exhausted": remaining == 0,
+            }
+        )
+    payload = {"run_id": args.run_id, "budgets": rows}
+    lines = [f"{'ACTION TYPE':<28} {'ATTEMPTS':>8} {'MAX':>4} {'REMAINING':>10}"]
+    for r in rows:
+        lines.append(
+            f"{r['action_type']:<28} {r['attempts']:>8} {r['max_attempts']:>4} {r['remaining']:>10}"
+        )
+    _emit(
+        payload,
+        "\n".join(lines) or "No budgets configured.",
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
+
+
 def cmd_compact(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Archive the pre-anchor prefix of a run's event log (issue #239). Mutates."""
     storage.get_run(args.run_id)
@@ -1648,6 +1703,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     complete = with_run(add("complete", cmd_complete, "Close a run as done. Mutates storage."))
     complete.add_argument("--summary", default=None, help="one-line closing note")
+
+    budget_cmd = with_run(add("budget", cmd_budget, "Retry-budget usage per action type."))
+    budget_cmd.add_argument(
+        "--config",
+        default=None,
+        help="budget registry path (default: .continuum/budgets.json)",
+    )
 
     compact = with_run(
         add("compact", cmd_compact, "Archive the pre-anchor log prefix. Mutates storage.")

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -821,6 +821,46 @@ def build_server(
     ) -> str:
         """Claim an action in the ledger and report whether to proceed."""
         ctx.ensure_run(run_id)
+
+        # Run-level retry budget (issue #240): every claim slot counts as one
+        # attempt, so a model re-planning after failures hits the wall here
+        # instead of hammering the upstream.
+        from pathlib import Path as _Path
+
+        from continuum.budgets import (
+            DEFAULT_BUDGETS_PATH,
+            BudgetConfigError,
+            attempts_for_type,
+            evaluate_budget,
+        )
+
+        try:
+            from continuum.budgets import load_budgets as _lb
+
+            budgets = _lb(_Path(DEFAULT_BUDGETS_PATH))
+        except BudgetConfigError as exc:
+            return _json(
+                {
+                    "run_id": run_id,
+                    "action_type": action_type,
+                    "proceed": False,
+                    "reason": f"retry budget registry invalid: {exc}",
+                }
+            )
+
+        events = ctx.storage.read_events(run_id)
+        attempts = attempts_for_type(events, action_type)
+        allowed, used, maximum = evaluate_budget(budgets, action_type, attempts)
+        if not allowed:
+            from mcp.server.mcpserver.exceptions import ToolError
+
+            raise ToolError(
+                f"retry budget exhausted for {action_type!r}: "
+                f"{used} attempt(s) recorded, budget is {maximum}. "
+                "Reconcile existing attempts or ask the operator to raise "
+                ".continuum/budgets.json."
+            )
+
         ledger = ctx.ledger(run_id)
         try:
             outcome = ledger.claim(

--- a/tests/test_retry_budgets.py
+++ b/tests/test_retry_budgets.py
@@ -1,0 +1,173 @@
+"""Run-level retry budgets (issue #240).
+
+Every ACTION_RECORDED event is one attempt. Budgets from
+`.continuum/budgets.json` cap attempts per action type at claim time so an
+LLM re-planning after failures cannot hammer an upstream forever.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.budgets import (
+    BudgetConfigError,
+    attempts_for_type,
+    backoff_delay,
+    evaluate_budget,
+    load_budgets,
+)
+from continuum.cli import ExitCode, main
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.storage import SQLiteStorage
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "b.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    yield path
+
+
+# --- config --------------------------------------------------------------------- #
+
+
+def test_missing_registry_loads_empty(tmp_path: Path) -> None:
+    assert load_budgets(tmp_path / "nope.json") == {}
+
+
+def test_broken_json_raises(tmp_path: Path) -> None:
+    p = tmp_path / "b.json"
+    p.write_text("{")
+    with pytest.raises(BudgetConfigError, match="not valid JSON"):
+        load_budgets(p)
+
+
+def test_nonpositive_limits_are_refused(tmp_path: Path) -> None:
+    p = tmp_path / "b.json"
+    p.write_text(json.dumps({"action_types": {"x": 0}}))
+    with pytest.raises(BudgetConfigError, match="positive"):
+        load_budgets(p)
+
+
+# --- counting + evaluation -------------------------------------------------------- #
+
+
+def test_attempts_count_every_claim_slot(db: str) -> None:
+    """Retries that reuse the same key still count - that is the point."""
+    ledger = ActionLedger(SQLiteStorage(db), "run_1")
+    outcome = ledger.claim("send_invoice", {}, key="invoice:1")
+    ledger.fail(outcome.key, "boom", certain=True)
+    # Retry opens a second slot under a fresh key suffix.
+    ledger.claim("send_invoice", {}, key="invoice:1#retry2")
+
+    events = SQLiteStorage(db).read_events("run_1")
+    assert attempts_for_type(events, "send_invoice") == 2
+
+
+def test_budget_evaluation_math() -> None:
+    raw = {"default_max_attempts": 3, "action_types": {"send_invoice": {"max_attempts": 5}}}
+    assert evaluate_budget(raw, "send_invoice", 5)[0] is False
+    assert evaluate_budget(raw, "send_invoice", 4)[0] is True
+    allowed, used, maximum = evaluate_budget(raw, "other_tool", 0)
+    assert (allowed, used, maximum) == (True, 0, 3)
+
+
+def test_backoff_delay_is_exponential_with_cap() -> None:
+    assert backoff_delay(1) == 1.0
+    assert backoff_delay(2) == 2.0
+    assert backoff_delay(3) == 4.0
+    assert backoff_delay(10) == 60.0  # capped
+    with pytest.raises(ValueError):
+        backoff_delay(0)
+
+
+# --- enforcement through the real ledger path --------------------------------------- #
+
+
+def test_claims_beyond_budget_are_refused_at_the_mcp_boundary(db: str, tmp_path: Path) -> None:
+    """Drive the real intercept handler logic: after N claims of one type, the
+    next claim for that type is refused naming the budget.
+
+    The MCP tool raises ToolError; here we pin the counting + refusal maths
+    against the same folded view the server uses.
+    """
+    cfg = {"default_max_attempts": 2}
+    registry_path = registry(tmp_path, cfg)
+    del registry_path
+
+    ledger = ActionLedger(SQLiteStorage(db), "run_1")
+    ledger.claim("send_invoice", {}, key="invoice:1")
+    ledger.claim("send_invoice", {}, key="invoice:2")
+
+    events = SQLiteStorage(db).read_events("run_1")
+    attempts = attempts_for_type(events, "send_invoice")
+    allowed, used, maximum = evaluate_budget(cfg, "send_invoice", attempts)
+    assert (allowed, used, maximum) == (False, 2, 2)
+
+
+def registry(tmp_path: Path, body: dict[str, object]) -> str:
+    p = tmp_path / "budgets.json"
+    p.write_text(json.dumps(body))
+    return str(p)
+
+
+# --- CLI report ---------------------------------------------------------------------- #
+
+
+def test_cli_budget_reports_usage_per_type(db: str, tmp_path: Path) -> None:
+    ledger = ActionLedger(SQLiteStorage(db), "run_1")
+    ledger.claim("send_invoice", {}, key="invoice:1")
+    ledger.claim("send_invoice", {}, key="invoice:2")
+    ledger.claim("charge_card", {}, key="card:9")
+
+    code, out, err = run(
+        "--db",
+        db,
+        "--json",
+        "budget",
+        "run_1",
+        "--config",
+        registry(
+            tmp_path,
+            {
+                "default_max_attempts": 3,
+                "action_types": {"charge_card": {"max_attempts": 1}},
+            },
+        ),
+    )
+    assert code == ExitCode.OK, err
+    payload = json.loads(out)
+    by_type = {r["action_type"]: r for r in payload["budgets"]}
+    assert by_type["send_invoice"]["remaining"] == 1  # 3 - 2
+    assert by_type["charge_card"]["exhausted"] is True  # 1 - 1
+
+
+def test_cli_budget_exhausted_exit_is_reported_not_raised(db: str, tmp_path: Path) -> None:
+    ledger = ActionLedger(SQLiteStorage(db), "run_1")
+    ledger.claim("deploy", {}, key="d:1")
+    code, out, _ = run(
+        "--db",
+        db,
+        "--json",
+        "budget",
+        "run_1",
+        "--config",
+        registry(tmp_path, {"default_max_attempts": 3}),
+    )
+    assert code == ExitCode.OK
+    rows = json.loads(out)["budgets"]
+    assert any(r["action_type"] == "deploy" and r["attempts"] >= 1 for r in rows)


### PR DESCRIPTION
## Description

Implements #240: run-level retry budgets from a new `.continuum/budgets.json` registry.

- Every ACTION_RECORDED claim slot (status STARTED) is one attempt for its action type; settlements are bookkeeping, not attempts.
- `continuum intercept_action` evaluates the budget before claiming: beyond-budget calls raise an instructive ToolError naming usage vs limit.
- New read-only `continuum budget <run>` reports attempts / max / remaining per action type, so agents see the wall before hitting it.
- `backoff_delay(attempt)` pure helper (exponential + cap); CONTINUUM never retries itself — it counts and gates.

## Related issues

Fixes #240 · Refs #244

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1268 passed, 13 skipped
ruff check src tests
mypy src           # clean
```

Nine new tests: registry validation (broken JSON, non-positive limits), attempt counting across fail+retry cycles (slots count, settlements do not), evaluation math with defaults and per-type overrides, backoff curve + cap, CLI report with mixed types, exhausted-type reporting.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Scope note: budgets apply at claim time only — effects already fired before exhaustion are governed by reconciliation (#218), which is the correct division of labour. Registry files are operator-owned executable-adjacent config (same supply-chain caveat as gate/budgets documented in references/cli.md).
