### PR TITLE
docs(mcp): document the CONNECTION_CLOSED failure mode and the eleventh tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -534,6 +534,32 @@ All notable changes to this project are documented here. The format follows
 
 ### Changed
 
+- **MCP docs: the `CONNECTION_CLOSED` failure mode, and the eleventh tool.**
+  `docs/api/mcp.md` promised that with `.mcp.json` present "Claude Code registers
+  the server automatically". That holds only when the environment CONTINUUM was
+  installed into is on the `PATH` the client inherited. When it is not, the client
+  cannot spawn `continuum-mcp` at all and reports the failed spawn as
+  `CONNECTION_CLOSED` - a message that reads like a server that crashed but
+  describes an executable that was never found. No CONTINUUM code runs in that
+  state, so the server cannot detect, report, or recover from it, and the whole
+  diagnosis has to happen client-side. The registration section now states what a
+  bare command name actually requires, and a new Troubleshooting section carries
+  the diagnosis (`which` / `where.exe`, then `--help` through the full path) and
+  two remedies: launch the client from the activated environment, or pin the
+  absolute path with `claude mcp add --scope local`. The second also documents the
+  conflicting-scopes diagnostic it produces and warns against
+  `claude mcp remove continuum-mcp -s project`, which edits the committed
+  `.mcp.json` and unregisters the server for every other clone. Registration is no
+  longer described as instrumenting anything on its own: state is recorded when
+  the agent calls the tools, or when the `PostToolUse` hook records a write
+  outside the model's control.
+- **MCP tool count corrected to eleven.** `continuum_record_summary` (#235)
+  shipped with a CHANGELOG entry but never reached the reference docs. It is now
+  in the `docs/api/mcp.md` tool table, and the count is corrected from ten to
+  eleven - three read-only, eight mutating - in `README.md`, `docs/api/README.md`,
+  `docs/research/token_floor.md`, `references/mcp.md`,
+  `references/auto-resume-integration.md`, and `references/testing.md`.
+
 
 - **README.** `Contents` laid out as a horizontal wrapping nav; Security
   Extension added to the Features table and table of contents; website link

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ uv pip install -e ".[mcp]"
 CONTINUUM_MCP_MUTATING_CLIENTS=your-client-name continuum-mcp
 ```
 
-Ten tools over stdio. Three are read-only (`continuum_validate`, `continuum_resume`, `continuum_list_actions`); seven mutate. Side effects are two-phase (claim, perform, complete), and mutating tools deny by default behind an allowlist. Agent-reported state is recorded with `Origin.EXTERNAL_AGENT` provenance and marked `REQUIRES_REVIEW`. Verification details, including crash recovery at startup and the end to end Claude Code test, are in [references/mcp.md](references/mcp.md). The authentication limitation is covered in [references/architecture.md](references/architecture.md) (MCP server and Security sections), and the MCP narrative is in [references/quickstart.md](references/quickstart.md).
+Eleven tools over stdio. Three are read-only (`continuum_validate`, `continuum_resume`, `continuum_list_actions`); eight mutate. Side effects are two-phase (claim, perform, complete), and mutating tools deny by default behind an allowlist. Agent-reported state is recorded with `Origin.EXTERNAL_AGENT` provenance and marked `REQUIRES_REVIEW`. Verification details, including crash recovery at startup and the end to end Claude Code test, are in [references/mcp.md](references/mcp.md). The authentication limitation is covered in [references/architecture.md](references/architecture.md) (MCP server and Security sections), and the MCP narrative is in [references/quickstart.md](references/quickstart.md). If a registered server reports `CONNECTION_CLOSED`, the cause is almost always `PATH` resolution rather than the server itself: [docs/api/mcp.md](docs/api/mcp.md#troubleshooting) has the diagnosis and two remedies.
 
 ## Framework Integration
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -31,7 +31,7 @@ may resume. The integration points, in order of most to least common, are:
 - [Checkpoints](checkpoints.md) - CheckpointManager, RestoredRun
 - [Recovery](recovery.md) - RecoveryEngine, RecoveryDecision
 - [Validation](validation.md) - StateValidator, validate_state, ValidationOutcome
-- [MCP server](mcp.md) - continuum-mcp, the ten tools, build_server
+- [MCP server](mcp.md) - continuum-mcp, the eleven tools, build_server
 - [Security](security.md) - attestation and caller authentication
 - [CLI](cli.md) - the `continuum` command reference
 

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -13,9 +13,35 @@ continuum-mcp --transport sse
 continuum-mcp --transport streamable-http
 ```
 
-With the project's `.mcp.json` present, Claude Code registers the server
-automatically and every agent action is checkpointed, validated, and recorded as
-it happens.
+## Registration
+
+Claude Code discovers the server from the project's `.mcp.json`, which declares
+it by bare command name:
+
+```json
+{
+  "mcpServers": {
+    "continuum-mcp": {
+      "command": "continuum-mcp",
+      "args": ["--db", "continuum.db"],
+      "env": { "CONTINUUM_MCP_MUTATING_CLIENTS": "claude-code" }
+    }
+  }
+}
+```
+
+The bare name is deliberate — an absolute path in a committed file would be wrong
+on every machine except the one that wrote it — but it means the client resolves
+`continuum-mcp` against the `PATH` it inherited. Registration therefore succeeds
+only when the environment CONTINUUM was installed into is on that `PATH`. When it
+is not, the client cannot start the server at all; see
+[Troubleshooting](#troubleshooting).
+
+Registration makes the tools below available to the agent. It does not by itself
+instrument anything: state is recorded when the agent calls the tools, and —
+because a voluntary call can always be missed — when the `PostToolUse` hook
+installed by `continuum hooks install claude-code` records a file write outside
+the model's control.
 
 ## Tools
 
@@ -26,6 +52,7 @@ tools are gated by the allowlist (see Security).
 |------|------|---------|
 | `continuum_record_progress` | mutate | Record goal progress (completed/total). |
 | `continuum_checkpoint` | mutate | Force a state checkpoint. |
+| `continuum_record_summary` | mutate | Record where reasoning stands (plan stack, decisions, open questions, working set) so a fresh session inherits the plan instead of guessing. Capped at 4096 serialized characters; informational only — never moves mode or safety. |
 | `continuum_intercept_action` | mutate | Claim a side effect; returns whether to proceed. |
 | `continuum_complete_action` | mutate | Record a side effect succeeded. |
 | `continuum_fail_action` | mutate | Record a side effect did not happen. |
@@ -34,6 +61,8 @@ tools are gated by the allowlist (see Security).
 | `continuum_validate` | read | Check state against the current environment. |
 | `continuum_resume` | read | Assess and describe how the run may resume. Omit `run_id` to target the most recently active (interrupted) run. Returns the run's `goal` so a resumed session knows what to continue. |
 | `continuum_list_actions` | read | List recorded side effects and their outcomes. |
+
+Eleven tools: three read-only, eight mutating.
 
 ## build_server
 
@@ -48,3 +77,96 @@ to serve.
 
 `continuum.mcp.server.main(argv=None)` is the `continuum-mcp` console entry
 point. It parses `--db` and `--transport` and runs the server.
+
+## Troubleshooting
+
+### `CONNECTION_CLOSED`
+
+```
+❯ /mcp
+⎿ Failed to reconnect to continuum-mcp: CONNECTION_CLOSED
+```
+
+`claude mcp list` reports the same condition as `✘ Failed to connect`.
+
+The wording describes a server that started and then died. Usually it is a server
+that never started: the client could not resolve `continuum-mcp` on the `PATH` it
+inherited, and a spawn that fails surfaces as a transport that closed.
+
+No CONTINUUM code runs in this failure. The executable is never located, so the
+server cannot detect the condition, report it, or recover from it — the whole
+diagnosis has to happen on the client side, which is why it is documented here
+rather than handled in code.
+
+This is not a Windows-specific defect, but it shows up there most often. A console
+script installs as `.venv\Scripts\continuum-mcp.exe`, and that directory joins
+`PATH` only inside an activated virtual environment, so a client started from
+anywhere else — a desktop launcher, a fresh terminal, an IDE — inherits a `PATH`
+without it. The same failure occurs on macOS and Linux whenever the client is
+launched outside the environment holding the install; an already-activated shell
+is what usually hides it.
+
+#### Confirm the cause
+
+Ask whether the name resolves in the environment the client was launched from:
+
+```
+which continuum-mcp        # macOS, Linux
+where.exe continuum-mcp    # Windows (PowerShell)
+```
+
+Finding nothing is the diagnosis. Then confirm the server itself is healthy by
+running it through its full path:
+
+```
+/path/to/.venv/bin/continuum-mcp --help                 # macOS, Linux
+& "C:\path\to\.venv\Scripts\continuum-mcp.exe" --help   # Windows (PowerShell)
+```
+
+Usage text and exit 0 mean the server is sound and only resolution failed.
+
+#### Remedy 1 — launch the client from the installed environment
+
+Activate the environment first, so the client inherits a `PATH` that contains the
+install:
+
+```
+source .venv/bin/activate        # macOS, Linux
+.\.venv\Scripts\Activate.ps1     # Windows (PowerShell)
+
+claude                           # then start the client from that shell
+```
+
+Nothing is written to the repository and `.mcp.json` resolves as intended.
+
+#### Remedy 2 — pin the absolute path in the local scope
+
+When the client is not launched from a shell — a desktop app, or an IDE — register
+the resolved path instead:
+
+```
+claude mcp add continuum-mcp --scope local --env CONTINUUM_MCP_MUTATING_CLIENTS=claude-code -- /absolute/path/to/.venv/bin/continuum-mcp --db continuum.db
+```
+
+It is one line on purpose: a backslash continuation would not survive
+PowerShell. Everything after `--` is the command and its arguments, so on
+Windows that tail becomes the `.exe` under `Scripts`:
+
+```
+-- "C:\path\to\.venv\Scripts\continuum-mcp.exe" --db continuum.db
+```
+
+Keep the `--env` flag: mutating tools deny unlisted callers by default, so an
+entry without it connects but exposes only the three read-only tools.
+
+`--scope local` writes to `~/.claude.json` under this project's entry. That file
+is per-user and never committed, so an absolute path there is correct and affects
+nobody else. Local scope takes precedence over project scope, so this entry wins
+over `.mcp.json`.
+
+Claude Code will then report a conflicting-scopes diagnostic naming both
+endpoints. That is expected — both definitions exist, and the local one is the one
+in use. Do not resolve it with `claude mcp remove continuum-mcp -s project`, which
+edits the committed `.mcp.json` and unregisters the server for everyone who clones
+the repository. Leave the diagnostic in place, or drop the local entry with
+`-s local` once the environment is on `PATH`.

--- a/docs/research/token_floor.md
+++ b/docs/research/token_floor.md
@@ -1,10 +1,10 @@
 # Reduce Per Session Token Floor
 
-Every session pays for the system prompt plus the schemas of all ten MCP tools, regardless of how little work is done. For a short resume check this dominates cost.
+Every session pays for the system prompt plus the schemas of all eleven MCP tools, regardless of how little work is done. For a short resume check this dominates cost.
 
 ## Current cost
 
-The MCP server exposes ten tools via `tools/list`. Each schema is sent as part of the model context. The system prompt in `CLAUDE.md` plus ten schemas is the floor before any user message.
+The MCP server exposes eleven tools via `tools/list`. Each schema is sent as part of the model context. The system prompt in `CLAUDE.md` plus eleven schemas is the floor before any user message.
 
 ## Proposal
 

--- a/references/auto-resume-integration.md
+++ b/references/auto-resume-integration.md
@@ -82,10 +82,11 @@ Registered in `.mcp.json` (project root):
 
 - Spawns as a stdio MCP server; it opens `continuum.db` in the current working
   directory.
-- **Ten tools**, split read-only vs mutating:
+- **Eleven tools**, split read-only vs mutating:
   `continuum_record_progress`, `continuum_checkpoint`,
-  `continuum_intercept_action`, `continuum_complete_action`,
-  `continuum_fail_action`, `continuum_reconcile_action`, `continuum_confirm`
+  `continuum_record_summary`, `continuum_intercept_action`,
+  `continuum_complete_action`, `continuum_fail_action`,
+  `continuum_reconcile_action`, `continuum_confirm`
   (mutating), and `continuum_validate`, `continuum_resume`,
   `continuum_list_actions` (read-only).
 - **Authorization** (`authz.py`): mutating tools are gated by an allowlist
@@ -240,7 +241,7 @@ coarser than desired.
 
 ### P7. Per-session token floor
 Every session pays for the system prompt (`CLAUDE.md`) plus the schemas of all
-ten MCP tools, regardless of how little work is done. For many short
+eleven MCP tools, regardless of how little work is done. For many short
 resume checks this fixed cost dominates.
 
 ---

--- a/references/mcp.md
+++ b/references/mcp.md
@@ -28,7 +28,7 @@ help, and the re-raise when there is nothing to clear. Recorded in CHANGELOG.md
 under Fixed.
 
 **The server is verified usable through Claude Code.** Registered as an MCP
-server, it reports `✔ Connected`, exposes all ten tools with the correct
+server, it reports `✔ Connected`, exposes all eleven tools with the correct
 read-only/mutating split, and the full `continuum_record_progress` to
 `continuum_checkpoint` to `continuum_intercept_action` to
 `continuum_complete_action` to `continuum_resume` cycle returns correct,

--- a/references/testing.md
+++ b/references/testing.md
@@ -134,7 +134,7 @@ continuum attest-verify <run_id> --attest <file>
 | 1 | pytest/ruff/format/mypy clean |
 | 2 | benchmark shows 0 duplicates; verify ok; crash examples print resumed state |
 | 3 | fresh session briefs unprompted; observations `[verified]`; gate denials teach then pass |
-| 4 | inspector lists ten tools; mutating calls honour the allowlist |
+| 4 | inspector lists eleven tools; mutating calls honour the allowlist |
 | 5 | exactly-once holds across soft resume and hard crash for every adapter |
 | 6 | tool spans appear in `continuum events` with `via: otel` |
 | 7 | 403 -> claim -> forward -> settled, all visible in the event chain |


### PR DESCRIPTION
## Description

Registering `continuum-mcp` with Claude Code can fail with a message that points away from the actual cause:

```
❯ /mcp
⎿ Failed to reconnect to continuum-mcp: CONNECTION_CLOSED
```

`docs/api/mcp.md` said this about registration:

> With the project's `.mcp.json` present, Claude Code registers the server automatically and every agent action is checkpointed, validated, and recorded as it happens.

Both halves of that sentence overstate what registration does.

**1. Registration depends on `PATH`.** `.mcp.json` declares the server by bare command name (`"command": "continuum-mcp"`). The client resolves that name against the `PATH` it inherited, so registration only succeeds when the environment CONTINUUM was installed into is on that `PATH`. When it is not, the client never starts the server and reports the failed spawn as `CONNECTION_CLOSED` — wording that reads like a server which crashed, but which describes an executable that was never found.

The consequence that matters for this repository: **no CONTINUUM code runs in that state.** The executable is never located, so the server cannot detect the condition, report it, or recover from it. It cannot be fixed in `src/`. The entire diagnosis is client-side, which is why this PR is documentation rather than code.

CONTINUUM already learned this lesson elsewhere. `observe_command()` resolves the executable and bakes the absolute path into the hook it installs, and its docstring says exactly why:

> The absolute path of the `continuum` executable is resolved at install time and baked into the settings: hook processes may not inherit the PATH that found the binary originally.

`.mcp.json` cannot do the same thing — it is committed and shared, and an absolute path there would be wrong on every machine except the one that wrote it. The bare name is the right choice. What was missing was documenting what it requires.

**2. Registration does not instrument anything by itself.** The tools record state when the agent calls them; the `PostToolUse` hook installed by `continuum hooks install claude-code` is what records writes outside the model's control. That distinction is the premise `clienthooks.py` opens with, and the doc had collapsed it into "every agent action is … recorded as it happens".

### What this PR adds

- A **Registration** section in `docs/api/mcp.md` stating what the bare command name actually requires.
- A **Troubleshooting** section with the symptom, the diagnosis (`which` / `where.exe`, then `--help` through the full path), and two remedies — launch the client from the activated environment, or pin the absolute path with `claude mcp add --scope local`. Includes the platform note on why this surfaces on Windows most often without being a Windows-specific defect.
- Remedy 2 documents the conflicting-scopes diagnostic that local-scope registration produces, and warns against the resolution Claude Code itself suggests: `claude mcp remove continuum-mcp -s project` edits the committed `.mcp.json` and unregisters the server for everyone who clones the repository.

### Second defect found: the documented tool count

`continuum_record_summary` (#235) shipped with a CHANGELOG entry but never reached the reference docs. A live `tools/list` returns **11** tools — 3 read-only, 8 mutating — while the docs said ten, three and seven. The tool table gains the missing row and the count is corrected in six files.

## Related issues

No existing issue. I hit this while installing the server on Windows and searched all 60 open and closed issues for a prior report before writing this up.

Adjacent but **not** addressed here: #211 (Windows test helpers replacing the child environment with a POSIX `PATH`) is a different `PATH` problem, inside the test suite rather than at client spawn.

Refs #235 — the tool whose documentation this backfills.

## Types of changes

- Type: `docs`

## Breaking changes

No. Documentation only; no source file is touched.

## How has this been tested?

Every factual claim in the new section was reproduced on this machine before it was written. Environment: Windows 11, Python 3.13 in `.venv`, Claude Code CLI, `pip install -e ".[mcp]"`.

**The failure, and that `PATH` is the cause** (PowerShell):

```powershell
where.exe continuum-mcp
# exit 1 — INFO: Could not find files for the given pattern(s).

.\.venv\Scripts\Activate.ps1
where.exe continuum-mcp
# exit 0 — D:\pROJ OPEN\CONTINUUM\.venv\Scripts\continuum-mcp.exe
```

That is the whole bug in two commands: the name the client is asked to spawn does not resolve until the environment is active. `claude mcp list` reproduced the client-side symptom as `✘ Failed to connect — CONNECTION_CLOSED`.

**That the server itself is not at fault.** A full JSON-RPC `initialize` → `notifications/initialized` → `tools/list` handshake driven against the absolute path returned a valid `result` frame, exit 0, and empty stderr. Repeating it with a stripped environment (`env -i`) also exits 0, which rules out the `.mcp.json` `env` block as a contributor.

**Both documented remedies.**

- Remedy 1 — activate, then launch the client from that shell: verified above; the bare name resolves to the venv executable.
- Remedy 2 — `claude mcp add continuum-mcp --scope local --env CONTINUUM_MCP_MUTATING_CLIENTS=claude-code -- "<abs path>\continuum-mcp.exe" --db continuum.db`. `claude mcp list` then reports `✔ Connected`, and the entry lands in `~/.claude.json` under `projects/<project path>/mcpServers` — per-user and uncommitted, as the doc states. The conflicting-scopes diagnostic appeared exactly as documented, naming both the project and local endpoints, with the local one in use.

**The corrected tool count**, from a live `tools/list` against this branch:

```
11 tools — read: continuum_validate, continuum_resume, continuum_list_actions
           mutate: continuum_record_progress, continuum_checkpoint,
                   continuum_record_summary, continuum_confirm,
                   continuum_intercept_action, continuum_complete_action,
                   continuum_fail_action, continuum_reconcile_action
```

**Gates** (the exact commands from `.github/workflows/ci.yml`):

```
ruff check src/ tests/ examples/           -> All checks passed!
ruff format --check src/ tests/ examples/  -> 198 files already formatted
mypy src/continuum                         -> Success: no issues found in 96 source files
```

Whole-tree `ruff format --check` reports `10 files would be reformatted, 259 files already formatted` both with and without this branch's changes — byte-identical before and after. All ten are pre-existing on `main`, all lie outside the paths CI checks, and `docs/api/mcp.md` is not among them.

No test was added: there is no behaviour change, and nothing under `tests/` asserts on documentation content (verified by grep).

## Checklist

- **Tests added or updated** — n/a. Documentation only, no behaviour change.
- **Documentation updated where the change affects user-facing behaviour** — this PR is that update.
- **CI passes on the latest commit** — the three CI gates were run locally and pass (above). Note that on my previous PR the CI run was held at `action_required` because I am a first-time contributor from a fork, so a maintainer may need to approve the workflow run.
- **Security-relevant changes state known limitations** — nothing security-relevant is changed, and the documented remedy is deliberately the conservative one: the absolute path goes in the per-user, uncommitted `~/.claude.json`, and the doc explicitly warns against editing the committed `.mcp.json`. The documented `claude mcp add` command retains `--env CONTINUUM_MCP_MUTATING_CLIENTS=claude-code`, with a note that omitting it yields a connected server exposing only the three read-only tools — so following these instructions does not weaken the deny-by-default allowlist.

## Additional context

**Alternatives considered and rejected.**

- *Changing `.mcp.json`* to an absolute path, or to `${VAR:-default}` expansion. Rejected: an absolute path is wrong on every other clone, and env-var expansion is not consistently supported across MCP clients. The bare name is correct; it just needed documenting.
- *Adding a `continuum mcp install` (or `doctor`) command* that resolves the executable and writes it into local scope — mirroring what `continuum hooks install` already does for hooks. This is the real ergonomic fix and it would make the failure self-diagnosing from the CLI side. I deliberately did not add it here: it invents new CLI surface, which is a maintainer's decision rather than a drive-by documentation PR's. Happy to open it as a follow-up if that is wanted.

**Left alone on purpose.** `references/testing.md` and `docs/research/token_floor.md` had the stale count too and are corrected, but I checked each occurrence for whether it was a live claim or a record of a past measurement before touching it — `test.md`'s audit records were left untouched, and they contain no tool count.

**Relationship to #252.** That PR fixes five Windows portability bugs in code (POSIX-only hook quoting, `printf` test probes, bare `python` in subprocesses, hardcoded `/tmp`, and stdout encoding under redirection). This PR is independent: branched from `main`, no overlapping files, and neither needs the other to land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documented the newly available `continuum_record_summary` MCP tool.
  - Clarified that the MCP integration exposes eleven tools, including eight mutating tools.

- **Documentation**
  - Added setup and troubleshooting guidance for `CONNECTION_CLOSED` startup failures.
  - Documented PATH requirements, absolute-path registration, scope conflicts, authentication, and hook-based state recording.
  - Updated tool counts and token-cost references across integration, API, research, and testing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->