### PR TITLE
feat(dashboard): human-in-the-loop surface for request_human runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Human-in-the-loop surface on the dashboard (#242).** request_human
+  walls finally have a door with an audit row: the run page renders buttons
+  for confirm (REVIEW_CONFIRMED, Origin.HUMAN), reconcile
+  occurred=true/false through ActionLedger.reconcile, and complete (run row
+  flipped to COMPLETED) whenever a run is blocked or has uncertain actions.
+  Mutating POST endpoints are fail-closed - refused until
+  CONTINUUM_DASHBOARD_TOKEN is set - and every action maps 1:1 onto the
+  human CLI verb, landing identical event types and provenance. Reads stay
+  open; unknown routes 404.
+
 - **Version pinning on claims and summaries (#241).** Replay correctness
   needs environment identity: which prompt version, tool schema and model
   produced a decision (prompt-migration hazard, arXiv:2507.05573; Zylos

--- a/src/continuum/dashboard/app.py
+++ b/src/continuum/dashboard/app.py
@@ -66,10 +66,63 @@ def render_run_detail_html(storage: Storage, run_id: str) -> str:
         for e in events[-20:]
     )
     events_html = f'<table border="1" cellpadding="4"><tr><th>Seq</th><th>Type</th><th>Payload</th></tr>{events_rows}</table>'
+
+    # Human-in-the-loop surface (issue #242): buttons only when there is
+    # something a person can actually settle.
+    hitl_html = ""
+    try:
+        from continuum.dashboard.hitl import pending_actions_with_keys
+
+        pending = pending_actions_with_keys(storage, run_id)
+        needs_confirm = decision.mode.value == "request_human"
+        if pending or needs_confirm:
+            rows = []
+            if needs_confirm:
+                rows.append(
+                    '<form method="post" action="/action/confirm">'
+                    f'<input type="hidden" name="run_id" value="{html.escape(run_id)}">'
+                    '<button type="submit">Confirm goal + progress (human review done)</button>'
+                    "</form>"
+                )
+            for key, action in pending:
+                esc_key = html.escape(key)
+                rows.append(
+                    f'<div style="margin:6px 0"><code>{esc_key}</code> '
+                    f"{html.escape(action.action_type)} is "
+                    f"<b>{html.escape(action.status.value)}</b><br>"
+                    '<form method="post" action="/action/reconcile" '
+                    'style="display:inline">'
+                    f'<input type="hidden" name="run_id" value="{html.escape(run_id)}">'
+                    f'<input type="hidden" name="ledger_key" value="{esc_key}">'
+                    '<input type="hidden" name="occurred" value="true">'
+                    '<button type="submit">Settle: it DID happen</button></form> '
+                    '<form method="post" action="/action/reconcile" '
+                    'style="display:inline">'
+                    f'<input type="hidden" name="run_id" value="{html.escape(run_id)}">'
+                    f'<input type="hidden" name="ledger_key" value="{esc_key}">'
+                    '<input type="hidden" name="occurred" value="false">'
+                    '<button type="submit">Settle: it did NOT happen</button></form>'
+                    "</div>"
+                )
+            hitl_html = "<h2>Human-in-the-loop</h2>" + "".join(rows)
+
+        complete_html = ""
+        if run.status.value != "completed":
+            complete_html = (
+                '<form method="post" action="/action/complete">'
+                f'<input type="hidden" name="run_id" value="{html.escape(run_id)}">'
+                '<input name="summary" placeholder="closing summary (optional)">'
+                '<button type="submit">Mark completed</button></form>'
+            )
+            hitl_html += complete_html
+    except Exception as exc:  # presentation must not crash the page
+        hitl_html = f"<p>[hitl unavailable: {html.escape(str(exc))}]</p>"
+
     return f"""<!doctype html>
 <html><head><meta charset=\"utf-8\"><title>Run {html.escape(run_id)}</title></head>
 <body><h1>Run {html.escape(run_id)}</h1>
 <p>Goal: {html.escape(run.goal)} | Status: {html.escape(run.status.value)}</p>
+{hitl_html}
 <h2>Contract</h2>{ledger_html}
 <h2>Validation</h2>{validation_html}
 <h2>Recent events</h2>{events_html}
@@ -77,21 +130,91 @@ def render_run_detail_html(storage: Storage, run_id: str) -> str:
 
 
 def serve_dashboard(storage: Storage, port: int = 8000) -> None:
+    import urllib.parse
+
+    from continuum.dashboard.hitl import (
+        HitlUnauthorized,
+        authorize_hitl,
+        complete_run,
+        confirm_run,
+        reconcile_action,
+    )
+
     class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+            return
+
+        def _html(self, content: str, code: int = 200) -> None:
+            self.send_response(code)
+            self.send_header("Content-type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(content.encode("utf-8"))
+
         def do_GET(self) -> None:  # noqa: N802
             if self.path.startswith("/runs/"):
                 run_id = self.path.split("/runs/")[1].split("?")[0].split("/")[0]
                 content = render_run_detail_html(storage, run_id)
             else:
                 content = render_dashboard_html(storage)
-            self.send_response(200)
-            self.send_header("Content-type", "text/html; charset=utf-8")
-            self.end_headers()
-            self.wfile.write(content.encode("utf-8"))
+            self._html(content)
 
-        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
-            return
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length") or 0)
+            raw = self.rfile.read(length) if length else b""
+            form = dict(urllib.parse.parse_qsl(raw.decode("utf-8")))
+            token = form.get("token") or self.headers.get("X-Dashboard-Token")
 
-    with socketserver.TCPServer(("", port), Handler) as httpd:
+            run_id = form.get("run_id", "")
+
+            def ok(msg: str) -> None:
+                detail = render_run_detail_html(storage, run_id) if run_id else ""
+                self._html(
+                    f"<p>[ok] {html.escape(msg)}</p>{detail}"
+                    '<p><a href="/">Back to dashboard</a></p>',
+                )
+
+            try:
+                authorize_hitl(token)
+            except HitlUnauthorized as exc:
+                self._html(
+                    f"<!doctype html><html><body><h1>403 Forbidden</h1>"
+                    f"<p>{html.escape(str(exc))}</p>"
+                    '<p><a href="/">Back</a></p></body></html>',
+                    code=403,
+                )
+                return
+
+            action = self.path.strip("/").split("?")[0]
+            try:
+                if action == "action/confirm":
+                    confirm_run(storage, run_id)
+                    ok("goal and progress confirmed (REVIEW_CONFIRMED)")
+                elif action == "action/reconcile":
+                    key = form.get("ledger_key", "")
+                    occurred = form.get("occurred") == "true"
+                    reconcile_action(
+                        storage,
+                        run_id,
+                        key,
+                        occurred=occurred,
+                        external_id=form.get("external_id") or None,
+                    )
+                    ok(f"reconciled {key[:16]}... occurred={occurred}")
+                elif action == "action/complete":
+                    complete_run(storage, run_id, summary=form.get("summary", ""))
+                    ok("run completed")
+                else:
+                    self._html("<h1>404 Not Found</h1>", code=404)
+            except Exception as exc:
+                self._html(
+                    f"<!doctype html><html><body><h1>400 Bad Request</h1>"
+                    f"<pre>{html.escape(str(exc))}</pre>"
+                    '<p><a href="/">Back</a></p></body></html>',
+                    code=400,
+                )
+
+    server_class = socketserver.ThreadingTCPServer
+    server_class.allow_reuse_address = True
+    with server_class(("", port), Handler) as httpd:
         print(f"Serving dashboard at http://localhost:{port}")
         httpd.serve_forever()

--- a/src/continuum/dashboard/hitl.py
+++ b/src/continuum/dashboard/hitl.py
@@ -1,0 +1,98 @@
+"""Human-in-the-loop actions over the dashboard (issue #242).
+
+request_human walls are correct but their only door was a CLI. This module
+adds three operator verbs served as authenticated POST endpoints and rendered
+as buttons on the run page:
+
+- confirm      : REVIEW_CONFIRMED (Origin.HUMAN), clearing self-certification gates
+- reconcile    : ACTION_RECONCILED through ActionLedger.reconcile, settling an
+                 uncertain side effect from real evidence
+- complete     : RUN_COMPLETED plus a COMPLETED run row
+
+Audit parity is the invariant: every button maps 1:1 onto the human CLI verb,
+lands the same event types with the same provenance, and nothing here widens
+what agents may certify themselves. Mutating endpoints are refused unless
+``CONTINUUM_DASHBOARD_TOKEN`` is set - fail-closed by default, matching the
+MCP authz posture.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from continuum.actions import ActionLedger
+from continuum.events import EventType
+from continuum.models import ActionStatus, Origin, RunStatus
+from continuum.storage.base import Storage
+
+__all__ = [
+    "DEFAULT_HITL_TOKEN_ENV",
+    "pending_actions_with_keys",
+    "confirm_run",
+    "complete_run",
+    "reconcile_action",
+    "authorize_hitl",
+]
+
+DEFAULT_HITL_TOKEN_ENV = "CONTINUUM_DASHBOARD_TOKEN"
+
+
+class HitlUnauthorized(Exception):
+    """Mutating endpoint called without the operator token."""
+
+
+def authorize_hitl(token_from_request: str | None) -> None:
+    import os
+
+    expected = os.environ.get(DEFAULT_HITL_TOKEN_ENV)
+    if not expected:
+        raise HitlUnauthorized(f"set {DEFAULT_HITL_TOKEN_ENV} to enable dashboard mutations")
+    if not token_from_request or token_from_request != expected:
+        raise HitlUnauthorized("invalid dashboard token")
+
+
+def confirm_run(storage: Storage, run_id: str) -> None:
+    storage.get_run(run_id)
+    storage.append_event(
+        run_id,
+        EventType.REVIEW_CONFIRMED,
+        {"components": ["goal", "progress"], "via": "dashboard"},
+        source=Origin.HUMAN,
+    )
+
+
+def complete_run(storage: Storage, run_id: str, summary: str = "") -> None:
+    run = storage.get_run(run_id)
+    note = {"closed_by": "dashboard"}
+    if summary:
+        note["summary"] = summary
+    storage.append_event(run_id, EventType.RUN_COMPLETED, note, source=Origin.HUMAN)
+    storage.update_run(run.touch(status=RunStatus.COMPLETED))
+
+
+def reconcile_action(
+    storage: Storage,
+    run_id: str,
+    ledger_key: str,
+    *,
+    occurred: bool,
+    external_id: str | None = None,
+) -> None:
+    ActionLedger(storage, run_id).reconcile(
+        ledger_key,
+        occurred=occurred,
+        external_id=external_id,
+        note="settled from the dashboard",
+    )
+
+
+def pending_actions_with_keys(storage: Storage, run_id: str) -> list[tuple[str, Any]]:
+    """Uncertain actions paired with their full ledger key (for buttons)."""
+    from continuum.actions.ledger import fold_action_events
+
+    folded = fold_action_events(storage.read_events(run_id))
+    out: list[tuple[str, Any]] = []
+    for key, action in folded.items():
+        if action.status in (ActionStatus.STARTED, ActionStatus.UNKNOWN):
+            out.append((key, action))
+    return out

--- a/tests/test_dashboard_hitl.py
+++ b/tests/test_dashboard_hitl.py
@@ -1,0 +1,226 @@
+"""Human-in-the-loop dashboard surface (issue #242).
+
+Buttons on the run page map 1:1 onto the human CLI verbs (confirm,
+reconcile occurred=true/false, complete) and land identical events with
+identical provenance. Mutating endpoints are fail-closed:
+CONTINUUM_DASHBOARD_TOKEN must be set or every POST is refused.
+"""
+
+from __future__ import annotations
+
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.dashboard.app import serve_dashboard
+from continuum.events import EventType
+from continuum.models import Origin, Run
+from continuum.storage import SQLiteStorage
+
+
+@pytest.fixture(autouse=True)
+def token(monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("CONTINUUM_DASHBOARD_TOKEN", "op-secret")
+    return "op-secret"
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "hitl.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="Do a thing"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "Do a thing"})
+    yield path
+
+
+@pytest.fixture
+def addr(db: str):
+    server = _ServerThread(db)
+    server.start()
+    yield server.addr
+    server.shutdown()
+
+
+class _ServerThread:
+    """Runs serve_dashboard in a thread on an OS-assigned port."""
+
+    def __init__(self, db: str) -> None:
+        import socket
+
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            self.port = int(sock.getsockname()[1])
+        self.thread = threading.Thread(
+            target=serve_dashboard, args=(SQLiteStorage(db), self.port), daemon=True
+        )
+        self.addr = f"127.0.0.1:{self.port}"
+
+    def start(self) -> None:
+        self.thread.start()
+
+    def shutdown(self) -> None:
+        pass
+
+
+_ports = {"n": 8940}
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def post(addr: str, path: str, form: dict[str, str]) -> tuple[int, str]:
+    data = urllib.parse.urlencode(form).encode()
+    req = urllib.request.Request(f"http://{addr}{path}", data=data)
+    try:
+        resp = urllib.request.urlopen(req, timeout=5)
+        return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode()
+
+
+def seed_uncertain(db: str, key: str = "invoice:I-1") -> str:
+    ledger = ActionLedger(SQLiteStorage(db), "run_1")
+    outcome = ledger.claim("send_invoice", {}, key=key)
+    del outcome
+    from continuum.actions.idempotency import idempotency_key
+
+    return idempotency_key("send_invoice", None, scope="run_1", key=key)
+
+
+def fold_statuses(db: str) -> list[str]:
+    from continuum.actions.ledger import fold_action_events
+
+    with SQLiteStorage(db) as store:
+        folded = fold_action_events(store.read_events("run_1"))
+    return [a.status.value for a in folded.values()]
+
+
+# --- auth ------------------------------------------------------------------------ #
+
+
+def test_mutations_refused_without_token(db: str, addr: str) -> None:
+    status, body = post(addr, "/action/confirm", {"run_id": "run_1"})
+    assert status == 403
+    assert "invalid dashboard token" in body
+
+
+def test_mutations_refused_with_wrong_token(db: str, addr: str) -> None:
+    status, body = post(addr, "/action/confirm", {"run_id": "run_1", "token": "wrong"})
+    assert status == 403
+    assert "invalid dashboard token" in body
+
+
+def test_reads_stay_open_without_token(db: str, addr: str) -> None:
+    status, body = urllib_get(addr, "/")
+    assert status == 200
+    assert "CONTINUUM Dashboard" in body
+
+
+def urllib_get(addr: str, path: str) -> tuple[int, str]:
+    resp = urllib.request.urlopen(f"http://{addr}{path}", timeout=5)
+    return resp.status, resp.read().decode()
+
+
+# --- confirm ------------------------------------------------------------------------ #
+
+
+def test_confirm_button_lands_human_review_confirmed(db: str, addr: str) -> None:
+    status, body = post(addr, "/action/confirm", {"run_id": "run_1", "token": "op-secret"})
+    assert status == 200
+    assert "[ok] goal and progress confirmed" in body
+
+    with SQLiteStorage(db) as store:
+        events = [e for e in store.read_events("run_1") if e.type is EventType.REVIEW_CONFIRMED]
+    assert events and events[-1].source is Origin.HUMAN
+    assert events[-1].payload.get("via") == "dashboard"
+
+
+# --- reconcile ------------------------------------------------------------------------ #
+
+
+def test_reconcile_true_settles_uncertain_action(db: str, addr: str) -> None:
+    key = seed_uncertain(db, key="invoice:H-1")
+    status, body = post(
+        addr,
+        "/action/reconcile",
+        {
+            "run_id": "run_1",
+            "ledger_key": key,
+            "occurred": "true",
+            "token": "op-secret",
+        },
+    )
+    assert status == 200
+    assert "reconciled" in body
+    assert "completed" in fold_statuses(db)
+
+
+def test_reconcile_false_frees_the_action_for_retry(db: str, addr: str) -> None:
+    seed_uncertain(db, key="invoice:H-2")
+    status, _ = post(
+        addr,
+        "/action/reconcile",
+        {
+            "run_id": "run_1",
+            "ledger_key": idem("invoice:H-2"),
+            "occurred": "false",
+            "token": "op-secret",
+        },
+    )
+    assert status == 200
+    assert "failed" in fold_statuses(db)
+
+
+def idem(rendered: str) -> str:
+    from continuum.actions.idempotency import idempotency_key
+
+    return idempotency_key("send_invoice", None, scope="run_1", key=rendered)
+
+
+# --- complete ------------------------------------------------------------------------ #
+
+
+def test_complete_button_flips_the_run_row(db: str, addr: str) -> None:
+    status, body = post(
+        addr,
+        "/action/complete",
+        {
+            "run_id": "run_1",
+            "summary": "shipped",
+            "token": "op-secret",
+        },
+    )
+    assert status == 200
+    assert "run completed" in body
+    with SQLiteStorage(db) as store:
+        assert store.get_run("run_1").status.value == "completed"
+        events = [e for e in store.read_events("run_1") if e.type is EventType.RUN_COMPLETED]
+    assert events and events[-1].payload["summary"] == "shipped"
+
+
+# --- unknown route --------------------------------------------------------------------- #
+
+
+def test_unknown_post_route_maps_to_404(db: str, addr: str) -> None:
+    status, body = post(
+        addr,
+        "/action/teleport",
+        {
+            "run_id": "run_1",
+            "token": "op-secret",
+        },
+    )
+    assert status == 404
+
+
+EOF_MARK = None


### PR DESCRIPTION
## Description

Implements #242: the dashboard run page now renders operator buttons whenever a run is blocked at `request_human` or holds uncertain actions:

- **Confirm** goal + progress → REVIEW_CONFIRMED (Origin.HUMAN), same as `continuum confirm`
- **Settle uncertain actions** → `occurred=true|false` through ActionLedger.reconcile, per folded ledger key
- **Mark completed** → RUN_COMPLETED + COMPLETED row

Mutating POST endpoints are fail-closed: they refuse until `CONTINUUM_DASHBOARD_TOKEN` is set in the server's environment, matching the MCP authz posture. Reads stay open without any token. Unknown routes map to 404; handler errors return 400 with the message instead of killing the process.

Audit parity is the invariant under test: every button lands identical event types and provenance as its CLI twin.

## Related issues

Fixes #242 · Refs #244

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1285 passed, 13 skipped
ruff check src tests
mypy src           # clean
```

Eight new tests in tests/test_dashboard_hitl.py drive a live dashboard thread over real HTTP: token-required refusals (missing + wrong), reads staying open, confirm landing HUMAN-sourced REVIEW_CONFIRMED, both reconcile directions settling through the real ledger, complete flipping the run row with summary persisted, and unknown-route 404.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Security limitations stated up front: the token is a single shared operator secret over plain HTTP — bind behind your own TLS terminator if not on localhost; CSRF is out of scope for v1 (same-origin form posts from the operator's own browser session); the webhook-out half of #242 stays open as future work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard controls to confirm goals, reconcile uncertain actions, and complete runs.
  * Pending actions now display the information needed for reconciliation.
  * Dashboard actions provide clear success and error responses.

* **Security**
  * Changes made through the dashboard require a configured authentication token.
  * Read-only dashboard access remains available without authentication.

* **Bug Fixes**
  * Unknown dashboard routes now return a proper not-found response.

* **Documentation**
  * Added unreleased changelog notes covering dashboard actions and CLI parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->