### PR TITLE
ci: apply PR status labels in base repo context

### DIFF
--- a/.github/workflows/pr-status-labels-apply.yml
+++ b/.github/workflows/pr-status-labels-apply.yml
@@ -1,0 +1,156 @@
+name: PR Status Labels Apply
+
+on:
+  workflow_run:
+    workflows: ["PR Status Labels"]
+    types: [completed]
+
+# Phase 2 of the status-label sync. workflow_run always executes in the
+# base repository context with a full-permission GITHUB_TOKEN, including
+# when the triggering run was started by a review on a fork-originated
+# PR. This is the only place writes happen; see pr-status-labels.yml.
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download intent artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-status-intent
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync status labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+
+            const THANK_YOU_MESSAGES = [
+              '**Momo** 🍑: Your PR has been approved, and Momo could not be happier about it. Thank you for the care you put into this work. Contributions like yours are what keep this project moving forward.',
+              '**Hana** 🌸: Approved! Hana says a garden grows because of gardeners like you. Thank you for contributing, and we hope to see your name here again soon.',
+              '**Yui** 🎀: Yui reviewed your work twice before approving, which she does rarely. Thank you for holding such a high standard. It shows in every line.',
+              '**Saki** 🌷: This PR earned its approval honestly. Thank you for the thoughtful contribution. We look forward to whatever you build next.',
+              '**Rin** 🐱: Nyaa~ approved! Rin inspected everything and found it worthy. Thank you for contributing; quality work like this makes the whole project better.',
+              '**Mei** ☕: Mei raises her cup to you tonight. Thank you for the patience and thoroughness in this PR. Reviewers notice contributors like you.',
+              '**Hina** ☀️: The review came back clear and the sun came out with it! Thank you for this contribution. It genuinely improved the project.',
+              '**Aoi** 💙: Aoi read every line twice before approving. Thank you for writing code others can trust. That is a rarer skill than people realize.',
+              "**Riko** 🎵: Approved, and Riko composed a small tune in your honor. Thank you for adding to this project's story. We hope it is one of many.",
+              '**Nana** 🍡: Nana reserves her best dango for contributors who deliver. Thank you for doing exactly that. Enjoy, you have earned it.',
+              '**Miko** ⛩️: The fortune Miko drew for this PR read: careful hands, bright future. Thank you for proving it true with a clean approval.',
+              '**Sakura** 🌸: From first commit to approval, Sakura watched this branch grow well. Thank you for the contribution. Take a moment to be proud of it.',
+              "**Tsumugi** 🧶: Your changes are now part of the project's fabric, stitched in carefully. Thank you for contributing. Every row like yours keeps it warm.",
+              '**Kanna** 👓: Kanna examined every hunk and approved without a single note. Thank you for making that possible. It does not happen often.',
+              '**Chibi** 🌱: Small but thorough, Chibi approves! Thank you for the good work. Contributions like this help the whole project grow.',
+              '**Xiaomei** 🐼: Xiaomei rolled happily across the grove at this result. Thank you for the excellent contribution. It was a pleasure to see pass.',
+              '**Meimei** 🀄: Meimei found your work as clean as fresh snow on quiet mountains. Thank you, and congratulations on the approval.',
+              '**Baozi** 🥟: Steamed, stamped, and approved! Thank you for the solid contribution. Please consider coming back with more.',
+              "**Lulu** 🦊: Lulu's sharp eyes combed the diff and found nothing to flag. Thank you for precise, dependable work. Contributors like you are always welcome here.",
+              '**Niuniu** 🐄: Straight through to approval, no detours! Thank you for the strong contribution. Niuniu does not gallop for just anyone.',
+              '**Doufu** ♨️: Solid where it counts, just like this PR. Doufu salutes you. Thank you for the contribution and the standard it sets.',
+              '**Tangyuan** 🍡: Approved cleanly, and Tangyuan rolled a happy circle around the CI logs. Thank you for contributing to the family project.',
+              '**Boba** 🥛: Boba went through the entire test suite and came up with only pearls. Thank you for the careful work. It is appreciated more than you know.',
+              '**Xiaohua** 🌺: Your name is now planted in the contributor garden. Thank you for this approval-worthy work. We hope many more rows follow.',
+              '**Kiki** 🐰: Three hops around the merge queue, all joy! Thank you for this contribution. The queue looks forward to your next visit.',
+              '**Yuzu** 🍋: A little zesty, fully approved. Thank you for bringing bright, focused work to the project. It did not go unnoticed.',
+              '**Mochi** 🍡: Mochi followed this PR from the first commit to approval. Thank you for seeing it through properly. Persistence like that matters.',
+              "**Anko** ☕: Anko added an extra scoop to today's tea in your honor. Thank you for the well made contribution. Please come brew another sometime.",
+              '**Sumi** 🖍️: Sumi marked this PR approved in the record book, in careful ink. Thank you for the memorable contribution. Work like this stands out.',
+            ];
+
+            let intent;
+            try {
+              intent = JSON.parse(fs.readFileSync("intent.json", "utf8"));
+            } catch (err) {
+              // Commented reviews record no intent artifact.
+              core.info("No intent recorded for this run; nothing to do.");
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const prNumber = intent.pr_number;
+
+            const current = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner,
+              repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const names = new Set(current.map((l) => l.name));
+
+            for (const label of intent.remove_labels) {
+              if (names.has(label)) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name: label,
+                });
+              }
+            }
+
+            if (intent.add_label && !names.has(intent.add_label)) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [intent.add_label],
+              });
+            }
+
+            if (intent.thank) {
+              await thankContributor(prNumber);
+            }
+
+            async function thankContributor(issueNumber) {
+              const { data: pull } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: issueNumber,
+              });
+              const author = pull.user.login;
+              if (author.endsWith("[bot]")) {
+                return;
+              }
+
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: issueNumber,
+              });
+              if (comments.some((c) => c.body && c.body.includes("<!-- contributor-thanks -->"))) {
+                return;
+              }
+
+              const message = THANK_YOU_MESSAGES[Math.floor(Math.random() * THANK_YOU_MESSAGES.length)];
+
+              const merged = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: "closed",
+                per_page: 100,
+              });
+              const isFirstContribution = !merged.some(
+                (p) => p.user.login === author && p.merged_at && p.number !== issueNumber
+              );
+
+              let body = ["<!-- contributor-thanks -->", message];
+              if (isFirstContribution) {
+                body.push(
+                  "",
+                  "This is also your first merged contribution here, which makes it extra special. If you want ideas for a next change, issues labeled `good first issue` are a good place to start. Welcome aboard."
+                );
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: body.join("\n"),
+              });
+            }

--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -6,151 +6,79 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Phase 1 of the status-label sync. Runs triggered by a review on a
+# fork-originated PR receive a read-only GITHUB_TOKEN regardless of the
+# permissions declared here, so no writes are attempted in this workflow.
+# The intended change is recorded as an artifact and applied by the
+# "PR Status Labels Apply" workflow, which runs in the base repository
+# context via workflow_run and holds real write access.
+permissions: {}
+
 jobs:
-  update-labels:
+  record:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
     steps:
-      - name: Sync status labels
+      - name: Record intended label change
         uses: actions/github-script@v7
         with:
           script: |
-            const THANK_YOU_MESSAGES = [
-              '**Momo** 🍑: Your PR has been approved, and Momo could not be happier about it. Thank you for the care you put into this work. Contributions like yours are what keep this project moving forward.',
-              '**Hana** 🌸: Approved! Hana says a garden grows because of gardeners like you. Thank you for contributing, and we hope to see your name here again soon.',
-              '**Yui** 🎀: Yui reviewed your work twice before approving, which she does rarely. Thank you for holding such a high standard. It shows in every line.',
-              '**Saki** 🌷: This PR earned its approval honestly. Thank you for the thoughtful contribution. We look forward to whatever you build next.',
-              '**Rin** 🐱: Nyaa~ approved! Rin inspected everything and found it worthy. Thank you for contributing; quality work like this makes the whole project better.',
-              '**Mei** ☕: Mei raises her cup to you tonight. Thank you for the patience and thoroughness in this PR. Reviewers notice contributors like you.',
-              '**Hina** ☀️: The review came back clear and the sun came out with it! Thank you for this contribution. It genuinely improved the project.',
-              '**Aoi** 💙: Aoi read every line twice before approving. Thank you for writing code others can trust. That is a rarer skill than people realize.',
-              "**Riko** 🎵: Approved, and Riko composed a small tune in your honor. Thank you for adding to this project's story. We hope it is one of many.",
-              '**Nana** 🍡: Nana reserves her best dango for contributors who deliver. Thank you for doing exactly that. Enjoy, you have earned it.',
-              '**Miko** ⛩️: The fortune Miko drew for this PR read: careful hands, bright future. Thank you for proving it true with a clean approval.',
-              '**Sakura** 🌸: From first commit to approval, Sakura watched this branch grow well. Thank you for the contribution. Take a moment to be proud of it.',
-              "**Tsumugi** 🧶: Your changes are now part of the project's fabric, stitched in carefully. Thank you for contributing. Every row like yours keeps it warm.",
-              '**Kanna** 👓: Kanna examined every hunk and approved without a single note. Thank you for making that possible. It does not happen often.',
-              '**Chibi** 🌱: Small but thorough, Chibi approves! Thank you for the good work. Contributions like this help the whole project grow.',
-              '**Xiaomei** 🐼: Xiaomei rolled happily across the grove at this result. Thank you for the excellent contribution. It was a pleasure to see pass.',
-              '**Meimei** 🀄: Meimei found your work as clean as fresh snow on quiet mountains. Thank you, and congratulations on the approval.',
-              '**Baozi** 🥟: Steamed, stamped, and approved! Thank you for the solid contribution. Please consider coming back with more.',
-              "**Lulu** 🦊: Lulu's sharp eyes combed the diff and found nothing to flag. Thank you for precise, dependable work. Contributors like you are always welcome here.",
-              '**Niuniu** 🐄: Straight through to approval, no detours! Thank you for the strong contribution. Niuniu does not gallop for just anyone.',
-              '**Doufu** ♨️: Solid where it counts, just like this PR. Doufu salutes you. Thank you for the contribution and the standard it sets.',
-              '**Tangyuan** 🍡: Approved cleanly, and Tangyuan rolled a happy circle around the CI logs. Thank you for contributing to the family project.',
-              '**Boba** 🥛: Boba went through the entire test suite and came up with only pearls. Thank you for the careful work. It is appreciated more than you know.',
-              '**Xiaohua** 🌺: Your name is now planted in the contributor garden. Thank you for this approval-worthy work. We hope many more rows follow.',
-              '**Kiki** 🐰: Three hops around the merge queue, all joy! Thank you for this contribution. The queue looks forward to your next visit.',
-              '**Yuzu** 🍋: A little zesty, fully approved. Thank you for bringing bright, focused work to the project. It did not go unnoticed.',
-              '**Mochi** 🍡: Mochi followed this PR from the first commit to approval. Thank you for seeing it through properly. Persistence like that matters.',
-              "**Anko** ☕: Anko added an extra scoop to today's tea in your honor. Thank you for the well made contribution. Please come brew another sometime.",
-              '**Sumi** 🖍️: Sumi marked this PR approved in the record book, in careful ink. Thank you for the memorable contribution. Work like this stands out.',
-            ];
+            const fs = require("fs");
 
-            const { owner, repo } = context.repo;
             const isReview = context.eventName === "pull_request_review";
             // Both event payloads carry the PR at payload.pull_request
             const pr = context.payload.pull_request;
-            const prNumber = pr.number;
 
-            let addLabel;
-            let removeLabels;
+            let intent;
 
             if (isReview) {
               const state = context.payload.review.state;
               if (state === "approved") {
-                addLabel = "ready to merge";
-                removeLabels = ["awaiting review", "changes requested"];
-                await thankContributor(pr);
+                intent = {
+                  pr_number: pr.number,
+                  add_label: "ready to merge",
+                  remove_labels: ["awaiting review", "changes requested"],
+                  thank: true,
+                };
               } else if (state === "changes_requested") {
-                addLabel = "changes requested";
-                removeLabels = ["awaiting review", "ready to merge"];
+                intent = {
+                  pr_number: pr.number,
+                  add_label: "changes requested",
+                  remove_labels: ["awaiting review", "ready to merge"],
+                  thank: false,
+                };
               } else {
-                // COMMENT reviews do not change approval status
+                // COMMENT reviews do not change approval status.
+                // No artifact is written; the apply workflow skips.
+                core.info("Comment review: nothing to do.");
                 return;
               }
             } else {
               const action = context.payload.action;
               if (action === "synchronize") {
                 // New commits pushed: approval no longer reflects HEAD
-                addLabel = null;
-                removeLabels = ["ready to merge"];
+                intent = {
+                  pr_number: pr.number,
+                  add_label: null,
+                  remove_labels: ["ready to merge"],
+                  thank: false,
+                };
               } else {
                 // opened or reopened
-                addLabel = "awaiting review";
-                removeLabels = ["ready to merge", "changes requested"];
+                intent = {
+                  pr_number: pr.number,
+                  add_label: "awaiting review",
+                  remove_labels: ["ready to merge", "changes requested"],
+                  thank: false,
+                };
               }
             }
 
-            const current = await github.paginate(github.rest.issues.listLabelsOnIssue, {
-              owner,
-              repo,
-              issue_number: prNumber,
-              per_page: 100,
-            });
-            const names = new Set(current.map((l) => l.name));
+            core.info(`Recorded intent: ${JSON.stringify(intent)}`);
+            fs.writeFileSync("intent.json", JSON.stringify(intent));
 
-            for (const label of removeLabels) {
-              if (names.has(label)) {
-                await github.rest.issues.removeLabel({
-                  owner,
-                  repo,
-                  issue_number: prNumber,
-                  name: label,
-                });
-              }
-            }
-
-            if (addLabel && !names.has(addLabel)) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: prNumber,
-                labels: [addLabel],
-              });
-            }
-
-            async function thankContributor(pr) {
-              const author = pr.user.login;
-              if (author.endsWith("[bot]")) {
-                return;
-              }
-
-              const { data: comments } = await github.rest.issues.listComments({
-                owner,
-                repo,
-                issue_number: prNumber,
-              });
-              if (comments.some((c) => c.body && c.body.includes("<!-- contributor-thanks -->"))) {
-                return;
-              }
-
-              const message = THANK_YOU_MESSAGES[Math.floor(Math.random() * THANK_YOU_MESSAGES.length)];
-
-              const merged = await github.paginate(github.rest.pulls.list, {
-                owner,
-                repo,
-                state: "closed",
-                per_page: 100,
-              });
-              const isFirstContribution = !merged.some(
-                (p) => p.user.login === author && p.merged_at && p.number !== pr.number
-              );
-
-              let body = ["<!-- contributor-thanks -->", message];
-              if (isFirstContribution) {
-                body.push(
-                  "",
-                  "This is also your first merged contribution here, which makes it extra special. If you want ideas for a next change, issues labeled `good first issue` are a good place to start. Welcome aboard."
-                );
-              }
-
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: prNumber,
-                body: body.join("\n"),
-              });
-            }
+      - name: Upload intent artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-status-intent
+          path: intent.json
+          retention-days: 1


### PR DESCRIPTION
## Problem

`PR Status Labels / update-labels (pull_request_review)` failed on #252 with:

```
RequestError [HttpError]: Resource not accessible by integration (403)
POST https://api.github.com/repos/Cyrax321/CONTINUUM/issues/252/comments
```

The workflow declares `issues: write` and `pull-requests: write`, but GitHub caps the `GITHUB_TOKEN` at read-only for runs triggered by a review on a PR from a **fork**, regardless of declared permissions. Internal-branch PRs (feat/*) succeed; fork PRs fail. The 403 also aborted the run before `ready to merge` was applied, so label sync silently stopped working for external contributors.

## Fix

Standard two-phase pattern (same approach used by esphome and others for this exact failure):

1. `.github/workflows/pr-status-labels.yml` keeps both triggers but now only **records intent** (`pr_number`, add/remove labels, whether to thank) as an artifact. `permissions: {}`; no API writes, so it succeeds on every PR including forks.
2. New `.github/workflows/pr-status-labels-apply.yml` triggers on `workflow_run`, which always executes in the base repository context with full permissions. It downloads the intent artifact, syncs labels, and posts the contributor thanks comment exactly as before.

Commented reviews record no artifact and are skipped in phase 2.

No behavior change otherwise: same labels, same thank-you messages, same dedup marker, same first-contribution detection.

## Testing

- Both YAML files parse cleanly.
- Phase 1 script exercised against all six cases (review approved / changes_requested / commented; opened / reopened / synchronize) and produces correct intent in each.
- Phase 2 script is the previously-working logic unchanged apart from reading the intent file.
- Live verification happens on the next review submitted to a fork PR after this merges.