### PR TITLE
ci: post a notice when new commits reset an approval

### DIFF
--- a/.github/workflows/pr-status-labels-apply.yml
+++ b/.github/workflows/pr-status-labels-apply.yml
@@ -83,8 +83,10 @@ jobs:
             });
             const names = new Set(current.map((l) => l.name));
 
+            let removedAny = false;
             for (const label of intent.remove_labels) {
               if (names.has(label)) {
+                removedAny = true;
                 await github.rest.issues.removeLabel({
                   owner,
                   repo,
@@ -100,6 +102,22 @@ jobs:
                 repo,
                 issue_number: prNumber,
                 labels: [intent.add_label],
+              });
+            }
+
+            // Only speak up when a push actually invalidated an approval.
+            // Routine pushes on an unapproved PR stay silent.
+            if (intent.notify_on_reset && removedAny) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: [
+                  "<!-- sync-notice -->",
+                  "New commits were pushed to this branch, so the earlier approval no longer applies to HEAD and the `ready to merge` label has been removed.",
+                  "",
+                  "A fresh approving review will restore it.",
+                ].join("\n"),
               });
             }
 

--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -61,6 +61,9 @@ jobs:
                   add_label: null,
                   remove_labels: ["ready to merge"],
                   thank: false,
+                  // Post a visible notice, but only if the apply step
+                  // actually finds and removes a stale ready-to-merge.
+                  notify_on_reset: true,
                 };
               } else {
                 // opened or reopened


### PR DESCRIPTION
Follow-up to #262.

A `synchronize` event silently removes the `ready to merge` label, which made it look like the workflow ignored the PR (this is why no bot reply appeared when Parthipashok04 pushed new commits to #252).

## Change

- Phase 1 sets `notify_on_reset: true` on synchronize.
- Phase 2 posts a short comment (`<!-- sync-notice -->`) explaining that the earlier approval no longer applies to HEAD and a fresh review will restore the label, but **only when the stale label was actually found and removed**. Routine pushes on an unapproved PR stay silent, so no spam during WIP iteration.

## Testing

- YAML validated; phase-1 script exercised for approved / synchronize / opened cases (intent output verified).
- Phase-2 script passes node syntax check.