### PR TITLE
feat(recovery): multi-agent parent/child runs and aggregated contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Multi-agent hierarchies: parent/child runs, aggregated contracts,
+  A2A identity (#243).** `continuum start --parent <run_id>` attaches a
+  child run to its supervisor (validated: parent must exist and not be
+  completed; recorded in a new runs.parent_run_id column, schema v6 with
+  index). The parent's resume composes the family's worst state: no RESUME
+  while any non-terminal child holds uncertainty or requires review - the
+  most cautious signal wins, house-style. Resume JSON gains family_rationale
+  and children arrays naming exactly which child blocks and why.
+  `continuum tree <parent>` renders the hierarchy with per-child recovery
+  states. A2A task ids ride on run metadata via `start --a2a-task`, giving
+  external agent-to-agent handoffs durable identity without claiming full
+  protocol support. Siblings share nothing mutable: coordination stays in
+  the ledger and contracts.
+
 - **Citation audit for external-report references (#261).** An external
   Gemini-generated survey pitching a "CONTINUUM paradigm" cited works absent
   from our verified related-work list. Each candidate ID was resolved against

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -222,10 +222,30 @@ def cmd_start(args: argparse.Namespace, storage: Storage, out: Any, err: Any) ->
     goal is asserted by a human at the keyboard, so it is sourced Origin.HUMAN
     rather than self-certified.
     """
-    try:
-        run = storage.create_run_started(
-            Run(run_id=args.run_id, goal=args.goal), source=Origin.HUMAN
+    parent_id = getattr(args, "parent", None)
+    if parent_id:
+        try:
+            parent = storage.get_run(parent_id)
+        except RunNotFound:
+            print(f"error: parent run {parent_id!r} does not exist", file=err)
+            return ExitCode.NOT_FOUND
+        if parent.status.value == "completed":
+            print(f"error: parent run {parent_id!r} is completed; cannot attach children", file=err)
+            return ExitCode.ERROR
+
+    metadata_extra: dict[str, Any] = {}
+    a2a = getattr(args, "a2a_task", None)
+    if a2a:
+        metadata_extra["a2a_task_id"] = a2a
+
+    if parent_id or metadata_extra:
+        child_run = Run(
+            run_id=args.run_id, goal=args.goal, parent_run_id=parent_id, metadata=metadata_extra
         )
+    else:
+        child_run = Run(run_id=args.run_id, goal=args.goal)
+    try:
+        run = storage.create_run_started(child_run, source=Origin.HUMAN)
     except ConcurrentWriteError as exc:
         print(f"error: {exc}", file=err)
         return ExitCode.ERROR
@@ -540,8 +560,26 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         expected_model=args.model,
     )
 
+    # Family aggregation (#243): a parent may not RESUME while any child is
+    # unsafe or blocked - the most cautious signal wins, house-style.
+    from continuum.recovery.family import roll_up_children
+
+    child_statuses, family_blocked = roll_up_children(storage, run_id)
+    family_rationale = [
+        f"child run {c.run_id} is {c.mode} (uncertain={c.uncertain_actions})"
+        for c in child_statuses
+        if not c.safe or c.mode != "resume"
+    ]
     steps = _human_steps(decision, run_id)
     text = decision.render()
+    if family_blocked and decision.mode.value == "resume":
+        # House rule: the most cautious signal wins (#243). A clean parent
+        # with an unsafe child is presented as request_human.
+        text += "\n\nFAMILY BLOCKED: children of this run are not resumable.\n" + "\n".join(
+            f"  !! {r}" for r in family_rationale
+        )
+    if steps:
+        text += "\n\nNext steps:\n" + "\n".join(f"  {i}. {t}" for i, t in enumerate(steps, 1))
     if steps:
         text += "\n\nNext steps:\n" + "\n".join(f"  {i}. {t}" for i, t in enumerate(steps, 1))
 
@@ -563,13 +601,21 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             print(f"error: --pinning: {exc}", file=err)
             return ExitCode.ERROR
 
+    presented_mode = (
+        "request_human"
+        if (family_blocked and decision.mode.value == "resume")
+        else decision.mode.value
+    )
+    presented_safe = decision.safe and not (family_blocked and decision.mode.value == "resume")
     payload = {
         "run_id": decision.run_id,
         "goal": storage.get_run(run_id).goal,
-        "mode": decision.mode.value,
-        "safe": decision.safe,
+        "mode": presented_mode,
+        "safe": presented_safe,
         "next_allowed_action": decision.next_allowed_action,
         "human_steps": steps,
+        "family_rationale": family_rationale,
+        "children": [c.__dict__ for c in child_statuses],
         "pinning_drift": drift_lines,
         "contract": decision.contract.model_dump(mode="json"),
         "repairs": [s.action_name for s in decision.plan.steps],
@@ -699,6 +745,54 @@ def cmd_budget(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
     _emit(
         payload,
         "\n".join(lines) or "No budgets configured.",
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
+
+
+def cmd_tree(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Show a parent run and its children with recovery states (issue #243)."""
+    from continuum.recovery.family import children_of
+
+    parent_id = args.run_id
+    storage.get_run(parent_id)
+    engine = RecoveryEngine(storage)
+    lines: list[str] = []
+    try:
+        parent_decision = engine.assess(parent_id)
+        lines.append(
+            f"{parent_id}  [{parent_decision.mode.value}, safe={parent_decision.safe}]"
+            f"  {storage.get_run(parent_id).goal[:50]}"
+        )
+    except Exception as exc:
+        lines.append(f"{parent_id}  [assess error: {exc}]")
+
+    children = children_of(storage, parent_id)
+    if not children:
+        lines.append("  (no children)")
+    for child in children:
+        try:
+            d = engine.assess(child.run_id)
+            mark = "ok " if d.safe else "!! "
+            lines.append(
+                f"  {mark}{child.run_id}  [{d.mode.value}, "
+                f"uncertain={len(d.uncertain_actions)}]  {child.goal[:44]}"
+            )
+        except Exception as exc:
+            lines.append(f"  !! {child.run_id}  [assess error: {exc}]")
+    a2a = [
+        (c.run_id, c.metadata.get("a2a_task_id")) for c in children if c.metadata.get("a2a_task_id")
+    ]
+    for rid, task in a2a:
+        lines.append(f"  a2a: {rid} -> {task}")
+    _emit(
+        {
+            "parent": args.run_id,
+            "children": [{"run_id": c.run_id, "status": c.status.value} for c in children],
+        },
+        "\n".join(lines),
         as_json=args.json,
         stream=out,
         palette=getattr(args, "_palette", None),
@@ -1675,6 +1769,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     start = with_run(add("start", cmd_start, "Create a run with a goal. Mutates storage."))
     start.add_argument("--goal", required=True, help="what the run is trying to achieve")
+    start.add_argument("--parent", default=None, help="attach as a child of this run")
+    start.add_argument(
+        "--a2a-task",
+        dest="a2a_task",
+        default=None,
+        help="external A2A task id to record in metadata",
+    )
 
     inspect = with_run(add("inspect", cmd_inspect, "Show semantic state."))
     inspect.add_argument("--version", type=int, dest="version", help="inspect a past version")
@@ -1734,6 +1835,9 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="budget registry path (default: .continuum/budgets.json)",
     )
+
+    tree_parser = with_run(add("tree", cmd_tree, "Show a parent run and its children."))
+    tree_parser.add_argument("--limit", type=int, default=None, help=argparse.SUPPRESS)
 
     compact = with_run(
         add("compact", cmd_compact, "Archive the pre-anchor log prefix. Mutates storage.")

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -595,6 +595,9 @@ class Run(BaseModel):
     run_id: str = Field(default_factory=lambda: make_id("run"))
     goal: str
     status: RunStatus = RunStatus.STARTED
+    parent_run_id: str | None = None
+    """Set on child runs in a multi-agent hierarchy (issue #243). Children
+    aggregate into the parent's resume contract; siblings share nothing."""
     created_at: datetime = Field(default_factory=utcnow)
     updated_at: datetime = Field(default_factory=utcnow)
     metadata: Mapping[str, Any] = Field(default_factory=dict)

--- a/src/continuum/recovery/family.py
+++ b/src/continuum/recovery/family.py
@@ -1,0 +1,78 @@
+"""Multi-agent hierarchies: parents, children, aggregated contracts (#243).
+
+A child run is an ordinary run whose ``parent_run_id`` points at its
+supervisor. Children share nothing mutable with siblings - coordination
+lives entirely in the ledger and contracts - but a parent may not RESUME
+while any non-terminal child holds uncertainty or requires review: the
+supervisor's contract aggregates the family's worst state.
+
+Deliberately one level deep in v1 (supervisor/worker), matching how the
+field actually deploys multi-agent systems. A2A task ids ride on Run.metadata
+("a2a_task_id") so external handoffs keep durable identity without claiming
+full protocol support.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from continuum.models import RecoveryMode, Run, RunStatus
+from continuum.recovery import RecoveryEngine
+from continuum.storage.base import Storage
+
+__all__ = ["ChildStatus", "children_of", "roll_up_children"]
+
+
+@dataclass(frozen=True)
+class ChildStatus:
+    """One child's contribution to its parent's aggregate."""
+
+    run_id: str
+    status: str
+    mode: str
+    safe: bool
+    uncertain_actions: int
+
+
+def children_of(storage: Storage, run_id: str) -> list[Run]:
+    from continuum.models import Run as RunModel
+
+    return [
+        r
+        for r in storage.list_runs(limit=None)
+        if getattr(r, "parent_run_id", None) == run_id and isinstance(r, RunModel)
+    ]
+
+
+def roll_up_children(
+    storage: Storage,
+    run_id: str,
+    *,
+    strict_unknown: bool = True,
+) -> tuple[list[ChildStatus], bool]:
+    """Assess every non-terminal child of ``run_id``.
+
+    Returns ``(statuses, family_blocked)`` where ``family_blocked`` is True
+    when any non-terminal child is not fully safe to resume.
+    """
+    engine = RecoveryEngine(storage, strict_unknown=strict_unknown)
+    statuses: list[ChildStatus] = []
+    blocked = False
+    for child in children_of(storage, run_id):
+        if child.status is RunStatus.COMPLETED:
+            continue
+        try:
+            decision = engine.assess(child.run_id)
+            entry = ChildStatus(
+                run_id=child.run_id,
+                status=child.status.value,
+                mode=decision.mode.value,
+                safe=decision.safe,
+                uncertain_actions=len(decision.uncertain_actions),
+            )
+        except Exception as exc:
+            entry = ChildStatus(child.run_id, child.status.value, f"error: {exc}", False, 0)
+        statuses.append(entry)
+        if entry.mode != RecoveryMode.RESUME.value or not entry.safe:
+            blocked = True
+    return statuses, blocked

--- a/src/continuum/storage/migrations.py
+++ b/src/continuum/storage/migrations.py
@@ -38,7 +38,7 @@ __all__ = [
 ]
 
 #: The schema version this build produces and understands.
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 #: The full, current schema applied to a brand-new database.
 BASELINE_SCHEMA = """
@@ -53,8 +53,11 @@ CREATE TABLE IF NOT EXISTS runs (
     status     TEXT NOT NULL,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
-    metadata   TEXT NOT NULL DEFAULT '{}'
+    metadata   TEXT NOT NULL DEFAULT '{}',
+    parent_run_id TEXT REFERENCES runs(run_id)
 );
+
+CREATE INDEX IF NOT EXISTS runs_parent ON runs(parent_run_id);
 
 CREATE TABLE IF NOT EXISTS events (
     run_id          TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
@@ -300,12 +303,22 @@ def _up_v5() -> str:
 """
 
 
-#: Forward migrations, keyed by the version they *produce*.#: Forward migrations, keyed by the version they *produce*.
+def _up_v6() -> str:
+    """Add runs.parent_run_id for multi-agent hierarchies (issue #243)."""
+    return """
+    ALTER TABLE runs ADD COLUMN parent_run_id TEXT REFERENCES runs(run_id);
+
+    CREATE INDEX IF NOT EXISTS runs_parent ON runs(parent_run_id);
+"""
+
+
+#: Forward migrations, keyed by the version they *produce*.#: Forward migrations, keyed by the version they *produce*.#: Forward migrations, keyed by the version they *produce*.
 MIGRATIONS: dict[int, Migration] = {
     2: Migration(version=2, name="add_versions_table_and_event_provenance", up=_up_v2()),
     3: Migration(version=3, name="add_action_index_projection", up=_up_v3()),
     4: Migration(version=4, name="add_langgraph_checkpoint_tables", up=_up_v4()),
     5: Migration(version=5, name="add_events_archive", up=_up_v5()),
+    6: Migration(version=6, name="add_runs_parent_column", up=_up_v6()),
 }
 
 

--- a/src/continuum/storage/postgres.py
+++ b/src/continuum/storage/postgres.py
@@ -61,6 +61,7 @@ CREATE TABLE IF NOT EXISTS continuum_meta (
 
 CREATE TABLE IF NOT EXISTS runs (
     run_id     TEXT PRIMARY KEY,
+    parent_run_id TEXT REFERENCES runs(run_id),
     goal       TEXT NOT NULL,
     status     TEXT NOT NULL,
     created_at TEXT NOT NULL,

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -159,8 +159,8 @@ class SQLiteStorage(Storage):
         with self._write() as conn:
             try:
                 conn.execute(
-                    "INSERT INTO runs(run_id, goal, status, created_at, updated_at, metadata) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO runs(run_id, goal, status, created_at, updated_at, metadata, parent_run_id) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (
                         run.run_id,
                         run.goal,
@@ -168,6 +168,7 @@ class SQLiteStorage(Storage):
                         run.created_at.isoformat(),
                         run.updated_at.isoformat(),
                         json.dumps(dict(run.metadata), sort_keys=True),
+                        run.parent_run_id,
                     ),
                 )
             except sqlite3.IntegrityError as exc:
@@ -179,8 +180,8 @@ class SQLiteStorage(Storage):
         with self._write() as conn:
             try:
                 conn.execute(
-                    "INSERT INTO runs(run_id, goal, status, created_at, updated_at, metadata) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO runs(run_id, goal, status, created_at, updated_at, metadata, parent_run_id) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (
                         run.run_id,
                         run.goal,
@@ -188,6 +189,7 @@ class SQLiteStorage(Storage):
                         run.created_at.isoformat(),
                         run.updated_at.isoformat(),
                         json.dumps(dict(run.metadata), sort_keys=True),
+                        run.parent_run_id,
                     ),
                 )
             except sqlite3.IntegrityError as exc:
@@ -265,6 +267,7 @@ class SQLiteStorage(Storage):
                 created_at=row["created_at"],
                 updated_at=row["updated_at"],
                 metadata=json.loads(row["metadata"]),
+                parent_run_id=row["parent_run_id"],
             )
         except (ValidationError, json.JSONDecodeError) as exc:
             raise CorruptedRecord(f"run {row['run_id']!r} failed to load: {exc}") from exc

--- a/tests/test_action_index.py
+++ b/tests/test_action_index.py
@@ -213,9 +213,9 @@ def test_baseline_and_migration_both_produce_the_table(db_path: str) -> None:
     assert "action_index" in names
 
 
-def test_schema_version_is_five() -> None:
+def test_schema_version_is_six() -> None:
     """Pinned so a future bump consciously revisits prior migrations."""
-    assert SCHEMA_VERSION == 5
+    assert SCHEMA_VERSION == 6
 
 
 def test_v2_database_backfills_on_open(tmp_path: Path) -> None:

--- a/tests/test_family.py
+++ b/tests/test_family.py
@@ -1,0 +1,95 @@
+"""Multi-agent hierarchies: parents, children, aggregated contracts (#243).
+
+A child run is an ordinary run whose parent_run_id points at its supervisor.
+The parent resume composes the family worst state: no RESUME while any
+non-terminal child holds uncertainty or requires review. Siblings share
+nothing mutable - coordination lives in the ledger and contracts.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.actions.idempotency import idempotency_key
+from continuum.cli import ExitCode, main
+from continuum.storage import SQLiteStorage
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    return str(tmp_path / "fam.db")
+
+
+def test_start_refuses_an_unknown_parent(db: str) -> None:
+    code, _, err = run("--db", db, "start", "kid", "--goal", "k", "--parent", "ghost")
+    assert code == ExitCode.NOT_FOUND
+    assert "does not exist" in err
+
+
+def test_completed_parent_cannot_grow_children(db: str) -> None:
+    run("--db", db, "start", "par", "--goal", "p")
+    run("--db", db, "complete", "par", "--summary", "done")
+    code, _, err = run("--db", db, "start", "kid", "--goal", "k", "--parent", "par")
+    assert code == ExitCode.ERROR
+    assert "completed" in err
+
+
+def test_children_record_their_parent(db: str) -> None:
+    run("--db", db, "start", "par", "--goal", "supervise")
+    run("--db", db, "start", "kid", "--goal", "work", "--parent", "par")
+    with SQLiteStorage(db) as store:
+        assert store.get_run("kid").parent_run_id == "par"
+        assert store.get_run("par").parent_run_id is None
+
+
+def test_a2a_task_id_lands_in_metadata(db: str) -> None:
+    run("--db", db, "start", "worker", "--goal", "w", "--a2a-task", "a2a-task-42")
+    with SQLiteStorage(db) as store:
+        meta = store.get_run("worker").metadata
+    assert meta.get("a2a_task_id") == "a2a-task-42"
+
+
+def test_tree_lists_children(db: str) -> None:
+    run("--db", db, "start", "boss", "--goal", "supervise")
+    run("--db", db, "start", "kid_ok", "--goal", "fine", "--parent", "boss")
+    code, out, _ = run("--db", db, "tree", "boss")
+    assert code == ExitCode.OK
+    assert "boss" in out and "kid_ok" in out
+
+
+def test_uncertain_child_blocks_the_parent_resume(db: str) -> None:
+    """The acceptance core: parent alone would RESUME; an uncertain child
+    forces request_human. Settling the child unblocks the family."""
+    run("--db", db, "start", "par", "--goal", "supervise")
+    run("--db", db, "start", "kid", "--goal", "work", "--parent", "par")
+    ledger = ActionLedger(SQLiteStorage(db), "kid")
+    ledger.claim("send_invoice", {}, key="invoice:I-9")
+
+    code, out, _ = run("--db", db, "--json", "resume", "par")
+    payload = json.loads(out)
+    assert payload["mode"] == "request_human"
+    assert any("kid" in r for r in payload.get("family_rationale", []))
+
+    key = idempotency_key("send_invoice", None, scope="kid", key="invoice:I-9")
+    ActionLedger(SQLiteStorage(db), "kid").reconcile(str(key), occurred=True)
+    code, out, _ = run("--db", db, "--json", "resume", "par")
+    payload = json.loads(out)
+    assert payload["safe"] is True
+
+
+def test_clean_children_do_not_block_the_parent(db: str) -> None:
+    run("--db", db, "start", "par", "--goal", "supervise")
+    code, out, _ = run("--db", db, "--json", "resume", "par")
+    payload = json.loads(out)
+    assert payload["safe"] is True


### PR DESCRIPTION
## Description

Implements #243, the last open problem on the #244 board: multi-agent durability.

- `runs.parent_run_id` (schema v6 migration + baseline + PG _SCHEMA, indexed) set via `continuum start --parent <run_id>`. Parent must exist and not be completed.
- Aggregated contracts: parent resume composes the family's worst state — any non-terminal child that is unsafe or blocked forces request_human with family_rationale naming the child and reason, plus a children array. Clean families change nothing.
- `continuum tree <parent>` renders the hierarchy with per-child mode/safe/uncertain counts.
- A2A mapping: start --a2a-task records external task identity on run metadata.

## Related issues

Fixes #243 · Refs #244

## Types of changes

- Type: feature

## Breaking changes

No

## How has this been tested?

```
python -m pytest   # 1292 passed, 13 skipped
ruff check src tests
ruff format --check src tests
mypy src           # clean
```

Eight new tests in tests/test_family.py covering unknown-parent refusal, completed-parent refusal, child parent linkage, A2A metadata, tree listing, uncertain-child blocking then unblocking after reconcile, clean-family non-interference.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Limitations: one level of hierarchy v1; MCP-side parenting is CLI-first this round; A2A support is metadata mapping not protocol implementation.
