### PR TITLE
Informed retry: engine-authored prior-attempt summaries on recovery surfaces (#265)

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -580,8 +580,16 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         )
     if steps:
         text += "\n\nNext steps:\n" + "\n".join(f"  {i}. {t}" for i, t in enumerate(steps, 1))
-    if steps:
-        text += "\n\nNext steps:\n" + "\n".join(f"  {i}. {t}" for i, t in enumerate(steps, 1))
+
+    # Informed retry (#265): prior-attempt account, derived from recovery-path
+    # events already in the chain. Absent history means no section at all.
+    if decision.informed_retry:
+        from continuum.recovery.summary import render_informed_retry
+
+        text += (
+            "\n\nWhat previous attempts changed (informed retry):\n"
+            + "\n".join(f"  {line}" for line in render_informed_retry(decision.informed_retry))
+        )
 
     # Version pinning drift (issue #241): informational only.
     drift_lines: list[str] = []
@@ -617,6 +625,7 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         "family_rationale": family_rationale,
         "children": [c.__dict__ for c in child_statuses],
         "pinning_drift": drift_lines,
+        "informed_retry": decision.informed_retry,
         "contract": decision.contract.model_dump(mode="json"),
         "repairs": [s.action_name for s in decision.plan.steps],
         "progress": {
@@ -1020,6 +1029,13 @@ def cmd_briefing(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
         lines += [
             f"  [{o.get('status', '?')}] {o.get('path', '')}" for o in obs if not o.get("truncated")
         ]
+    # Informed retry (#265): the engine's account of prior attempts, next to
+    # the agent's own summary above. Absent history means no section.
+    if decision.informed_retry:
+        from continuum.recovery.summary import render_informed_retry
+
+        lines.append("what previous attempts changed (engine-recorded):")
+        lines += [f"  {line}" for line in render_informed_retry(decision.informed_retry)]
     if steps:
         lines.append("next steps:")
         lines += [f"  {i}. {t}" for i, t in enumerate(steps, 1)]

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -752,6 +752,7 @@ def build_server(
                     "total": decision.state.progress.total,
                 },
                 "tail_evidence": tail_evidence,
+                "informed_retry": decision.informed_retry,
                 "contract": decision.contract.model_dump(mode="json"),
                 "contract_text": render_contract(decision.contract),
                 "report": decision.render(),

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 from continuum.actions.ledger import ActionLedger
 from continuum.analysis.depends import DependencyGraph as SourceDependencyGraph
@@ -55,6 +56,7 @@ from continuum.models import (
 from continuum.recovery.contract import build_contract
 from continuum.recovery.observations import collect_observations
 from continuum.recovery.planner import RepairPlan, plan_repairs
+from continuum.recovery.summary import build_informed_retry
 from continuum.state.validator import StateValidator, ValidationOutcome
 from continuum.storage.base import Storage
 
@@ -97,6 +99,10 @@ class RecoveryDecision:
     rationale: tuple[str, ...] = ()
     impacted_files: frozenset[str] = frozenset()
     tail_evidence: str | None = None
+    #: Informed-retry block (#265): a pure projection of prior recovery-path
+    #: events plus current failure signals, or None when there is no history.
+    #: Informational only; presence never changes mode or safety.
+    informed_retry: dict[str, Any] | None = None
 
     @property
     def state(self) -> SemanticState:
@@ -282,6 +288,16 @@ class RecoveryEngine:
                 tail_evidence = ev.summary
                 break
 
+        # Informed retry (#265): derive the prior-attempt account from events
+        # already in the chain. Read-only, deterministic, None without history.
+        informed_retry = build_informed_retry(
+            self.storage,
+            run_id,
+            validation_report=validation.report,
+            uncertain_actions=uncertain,
+            plan=plan,
+        )
+
         return RecoveryDecision(
             run_id=run_id,
             mode=mode,
@@ -293,6 +309,7 @@ class RecoveryEngine:
             rationale=rationale,
             impacted_files=impacted_files,
             tail_evidence=tail_evidence,
+            informed_retry=informed_retry,
         )
 
     # -- the decision rule ------------------------------------------------ #

--- a/src/continuum/recovery/summary.py
+++ b/src/continuum/recovery/summary.py
@@ -1,0 +1,233 @@
+"""Informed retry: what previous attempts did to this run (#265).
+
+AgentRewind (arXiv:2608.14380) shows that a resumed agent which knows why the
+previous attempt failed, an *informed retry*, outperforms a blind one across
+models and harnesses. The recovery contract names what is blocked and the
+single next permitted action; neither it nor the agent-authored reasoning
+summary (#235) carries an engine's account of prior attempts. A fresh session
+could therefore repeat, verbatim, the mistake that caused the rollback.
+
+This module derives that account as a **pure projection** of facts already in
+the hash chain:
+
+- ``RECOVERY_STARTED``  repair plans recorded by ``resume --repair`` (#19)
+- ``RECOVERY_COMPLETED`` / ``RECOVERY_BLOCKED``  how attempts ended
+- ``ACTION_RECONCILED`` settlements of uncertain side effects (#45), whose
+  ``status`` field encodes the verdict (COMPLETED means the effect was found,
+  FAILED means absence was confirmed)
+- ``ACTION_COMPENSATED`` compensating repairs recorded by the ledger
+
+plus the current decision's own failure signals (non-VALID components,
+uncertain actions). Nothing new is written: every input is tamper-evident
+through the existing event chain, identical logs yield byte-identical blocks,
+and a run with no recovery history yields ``None`` so today's output is
+unchanged byte for byte.
+
+The block is informational by contract: presence never gates, absence never
+blocks, and size is capped with deterministic eviction when inputs are large.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from continuum.events import EventType
+from continuum.models import StateStatus
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from continuum.models import Action, StateValidationResult
+    from continuum.recovery.planner import RepairPlan
+    from continuum.storage.base import Storage
+
+__all__ = [
+    "INFORMED_RETRY_CAP_BYTES",
+    "build_informed_retry",
+    "render_informed_retry",
+]
+
+#: Serialized blocks larger than this are shrunk deterministically rather
+#: than allowed to grow with run history (same spirit as the #235 cap).
+INFORMED_RETRY_CAP_BYTES = 4096
+
+_MAX_STEPS = 8
+_MAX_SETTLED = 5
+_MAX_FAILURES = 8
+_MAX_AVOID = 6
+
+
+def build_informed_retry(
+    storage: Storage,
+    run_id: str,
+    *,
+    validation_report: StateValidationResult,
+    uncertain_actions: Sequence[Action] = (),
+    plan: RepairPlan | None = None,
+) -> dict[str, Any] | None:
+    """Derive the informed-retry block for ``run_id``, or ``None`` if clean.
+
+    A run qualifies when its log holds any recovery-path event or any action
+    settlement, or when the current assessment itself reports failures or
+    uncertainty. Otherwise the return is ``None`` and callers must not change
+    their output at all.
+    """
+    events = storage.read_events(run_id)
+    starts = [e for e in events if e.type is EventType.RECOVERY_STARTED]
+    completions = [e for e in events if e.type is EventType.RECOVERY_COMPLETED]
+    blocked = [e for e in events if e.type is EventType.RECOVERY_BLOCKED]
+    settled = [e for e in events if e.type is EventType.ACTION_RECONCILED]
+    compensated = [e for e in events if e.type is EventType.ACTION_COMPENSATED]
+
+    failures = [e for e in validation_report.statuses if e.status is not StateStatus.VALID]
+
+    if not (
+        starts or completions or blocked or settled or compensated or failures or uncertain_actions
+    ):
+        return None
+
+    last_start = starts[-1].payload if starts else None
+
+    def _step_name(step: Any) -> str:
+        # Stored plans carry {kind, target}; the contract's action_name is
+        # reconstructed the same way everywhere else it is displayed.
+        named = step.get("action_name")
+        if named:
+            return str(named)
+        kind = step.get("kind")
+        target = step.get("target")
+        if kind and target:
+            return f"{kind}:{target}"
+        return str(kind or "")
+
+    last_steps = [_step_name(step) for step in ((last_start or {}).get("plan") or [])]
+    last_steps = [s for s in last_steps if s][-_MAX_STEPS:]
+
+    settled_entries = [
+        {
+            "action_id": str(e.payload.get("action_id", "")),
+            "action_type": str(e.payload.get("action_type", "")),
+            # The settlement's status IS the verdict: COMPLETED means the
+            # effect was confirmed to exist, FAILED that absence was confirmed.
+            "occurred": str(e.payload.get("status")) == "completed",
+        }
+        for e in settled[-_MAX_SETTLED:]
+    ]
+
+    current_failures = [
+        {
+            "component": entry.component.value,
+            "id": entry.component_id or "",
+            "status": entry.status.value,
+            "detail": entry.detail or "",
+        }
+        for entry in failures[-_MAX_FAILURES:]
+    ]
+
+    avoid = _avoid_rules(failures, uncertain_actions)
+
+    block: dict[str, Any] = {
+        "attempts": len(starts),
+        "completed_recoveries": len(completions),
+        "blocked_recoveries": len(blocked),
+        "compensations": len(compensated),
+        "last_attempt_mode": (last_start or {}).get("mode"),
+        "last_attempt_steps": last_steps,
+        "settled_effects": settled_entries,
+        "current_failures": current_failures,
+        "avoid": avoid,
+    }
+    return _fit(block)
+
+
+def _avoid_rules(failures: Sequence[Any], uncertain: Sequence[Action]) -> list[str]:
+    """Deterministic one-line rules derived from failure kinds.
+
+    These are generic on purpose: they restate what the validator and ledger
+    already concluded, they never speculate about causes the signals do not
+    contain.
+    """
+    rules: list[str] = []
+    for entry in failures:
+        name = (
+            f"{entry.component.value}:{entry.component_id}"
+            if entry.component_id
+            else entry.component.value
+        )
+        component = entry.component.value
+        if component == "external_dependency":
+            rules.append(
+                f"{name}: changed under the run; re-pin with --env before trusting cached results"
+            )
+        elif component in ("evidence", "finding"):
+            rules.append(f"{name}: stale; re-derive from its source before citing it again")
+        elif component == "goal":
+            rules.append(f"{name}: no longer valid as recorded; restate it before continuing work")
+        elif component == "model":
+            rules.append(f"{name}: model assumptions unverified; confirm which model resumes")
+        elif component == "approval":
+            rules.append(f"{name}: approval does not carry over; obtain a fresh one")
+        else:
+            detail = f" ({entry.detail})" if entry.detail else ""
+            rules.append(f"{name}: needs repair{detail}")
+    for action in uncertain:
+        rules.append(
+            f"{action.action_type} ({action.action_id[:14]}): outcome unknown; "
+            "reconcile before any retry"
+        )
+    return sorted(rules)[:_MAX_AVOID]
+
+
+def _fit(block: dict[str, Any]) -> dict[str, Any]:
+    """Shrink the block below the cap with deterministic eviction."""
+    candidate = dict(block)
+    while len(json.dumps(candidate, sort_keys=True).encode()) > INFORMED_RETRY_CAP_BYTES:
+        if len(candidate["avoid"]) > _MAX_AVOID - 2 and _MAX_AVOID - 2 >= 0:
+            candidate["avoid"] = candidate["avoid"][: max(_MAX_AVOID - 2, 0)]
+        elif len(candidate["current_failures"]) > 1:
+            candidate["current_failures"] = candidate["current_failures"][:-1]
+        elif len(candidate["settled_effects"]) > 1:
+            candidate["settled_effects"] = candidate["settled_effects"][:-1]
+        elif len(candidate["last_attempt_steps"]) > 1:
+            candidate["last_attempt_steps"] = candidate["last_attempt_steps"][:-1]
+        elif any(f.get("detail") for f in candidate["current_failures"]):
+            candidate["current_failures"] = [
+                {**f, "detail": ""} for f in candidate["current_failures"]
+            ]
+        else:
+            # Nothing left to trim without emptying the block; hard-stop with
+            # whatever fits least badly. Unreachable for realistic inputs.
+            break
+    return candidate
+
+
+def render_informed_retry(block: dict[str, Any]) -> list[str]:
+    """Human/agent-readable lines for briefing and resume output."""
+    lines: list[str] = []
+    attempts = block.get("attempts", 0)
+    if attempts:
+        lines.append(f"previous attempt(s): {attempts}")
+        mode = block.get("last_attempt_mode")
+        steps = block.get("last_attempt_steps") or []
+        if mode:
+            lines.append(f"  last plan mode: {mode}")
+        for step in steps:
+            lines.append(f"  planned then: {step}")
+    for key, label in (
+        ("completed_recoveries", "recoveries completed"),
+        ("blocked_recoveries", "recoveries blocked"),
+        ("compensations", "compensations applied"),
+    ):
+        if block.get(key):
+            lines.append(f"{label}: {block[key]}")
+    for s in block.get("settled_effects", []):
+        verdict = "effect confirmed present" if s.get("occurred") else "absence confirmed"
+        lines.append(f"settled {s.get('action_type')}: {verdict}")
+    for f in block.get("current_failures", []):
+        name = f"{f['component']}:{f['id']}" if f.get("id") else f["component"]
+        detail = f" ({f['detail']})" if f.get("detail") else ""
+        lines.append(f"still failing: {name}{detail}")
+    for rule in block.get("avoid", []):
+        lines.append(f"avoid repeating: {rule}")
+    return lines

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -398,6 +398,7 @@ def _decision_payload(decision: Any, *, goal: str) -> dict[str, Any]:
             "total": decision.state.progress.total,
         },
         "tail_evidence": decision.tail_evidence,
+        "informed_retry": getattr(decision, "informed_retry", None),
         "contract": decision.contract.model_dump(mode="json"),
         "contract_text": render_contract(decision.contract),
         "report": decision.render(),

--- a/tests/test_informed_retry.py
+++ b/tests/test_informed_retry.py
@@ -1,0 +1,223 @@
+"""Informed retry (#265): the engine's account of prior attempts.
+
+The block is a pure projection of recovery-path events already in the hash
+chain plus current failure signals. These tests pin: absence on clean runs,
+component naming on failures, repair-history summarising, settlement verdicts,
+determinism, the size cap, and every surface that carries it (CLI resume,
+briefing, serve payload). They also pin the single-Next-steps regression in
+``continuum resume`` output.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.checkpoint import CheckpointManager
+from continuum.cli import ExitCode, main
+from continuum.environment import StaticProvider, capture
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.recovery import RecoveryEngine
+from continuum.recovery.summary import (
+    INFORMED_RETRY_CAP_BYTES,
+    _fit,
+    build_informed_retry,
+    render_informed_retry,
+)
+from continuum.storage import SQLiteStorage
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+def make_storage() -> SQLiteStorage:
+    storage = SQLiteStorage(":memory:")
+    seed(storage)
+    return storage
+
+
+def seed(storage: SQLiteStorage) -> None:
+    storage.create_run(Run(run_id="run_1", goal="Do things"))
+    storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "Do things", "total": 2})
+
+
+def checkpoint_clean(storage: SQLiteStorage) -> None:
+    clean = capture("run_1", StaticProvider(dataset="v1"))
+    CheckpointManager(storage).checkpoint("run_1", environment=clean)
+
+
+# --- pure derivation ---------------------------------------------------------- #
+
+
+def test_a_run_with_no_recovery_history_yields_none() -> None:
+    storage = make_storage()
+    checkpoint_clean(storage)
+    engine = RecoveryEngine(storage)
+    decision = engine.assess("run_1")
+    assert decision.informed_retry is None
+
+
+def test_stale_dependency_names_the_component_and_rule() -> None:
+    storage = make_storage()
+    storage.append_event(
+        "run_1", EventType.DEPENDENCY_DECLARED, {"resource": "dataset", "version": "v1"}
+    )
+    checkpoint_clean(storage)
+
+    drifted = capture("run_1", StaticProvider(dataset="v2"))
+    decision = RecoveryEngine(storage).assess("run_1", current_environment=drifted)
+
+    block = decision.informed_retry
+    assert block is not None
+    components = {f["component"] for f in block["current_failures"]}
+    assert "external_dependency" in components
+    assert any("dataset" in rule and "--env" in rule for rule in block["avoid"])
+
+
+def test_repair_history_is_summarised_on_the_next_resume(tmp_path: Path) -> None:
+    db = str(tmp_path / "r.db")
+    with SQLiteStorage(db) as storage:
+        seed(storage)
+        outcome = ActionLedger(storage, "run_1").claim("send_invoice", {}, key="invoice:1")
+        assert outcome.fresh
+
+    code, _, _ = run("--db", db, "resume", "run_1", "--repair")
+    assert code != 0  # request_human: uncertain side effect blocks resume
+
+    code, out, _ = run("--db", db, "--json", "resume", "run_1")
+    assert code != 0
+    payload = json.loads(out)
+    block = payload["informed_retry"]
+    assert block is not None
+    assert block["attempts"] == 1
+    assert block["last_attempt_mode"] == "request_human"
+    assert block["last_attempt_steps"]
+    assert any("outcome unknown" in rule for rule in block["avoid"])
+
+
+def test_settlement_verdicts_come_from_recorded_status(tmp_path: Path) -> None:
+    db = str(tmp_path / "s.db")
+    with SQLiteStorage(db) as storage:
+        seed(storage)
+        ledger = ActionLedger(storage, "run_1")
+        first = ledger.claim("send_invoice", {}, key="invoice:1")
+        second = ledger.claim("write_file", {}, key="file:a")
+        ledger.reconcile(first.key, occurred=True, external_id="msg-9")
+        ledger.reconcile(second.key, occurred=False)
+
+        decision = RecoveryEngine(storage).assess("run_1")
+
+    block = decision.informed_retry
+    assert block is not None
+    verdicts = {s["action_type"]: s["occurred"] for s in block["settled_effects"]}
+    assert verdicts == {"send_invoice": True, "write_file": False}
+    rendered = render_informed_retry(block)
+    assert any("effect confirmed present" in line for line in rendered)
+    assert any("absence confirmed" in line for line in rendered)
+
+
+def test_identical_logs_produce_identical_blocks() -> None:
+    storage = make_storage()
+    ActionLedger(storage, "run_1").claim("send_invoice", {}, key="invoice:1")
+    first = build_informed_retry(
+        storage,
+        "run_1",
+        validation_report=RecoveryEngine(storage).assess("run_1").validation.report,
+    )
+    second = build_informed_retry(
+        storage,
+        "run_1",
+        validation_report=RecoveryEngine(storage).assess("run_1").validation.report,
+    )
+    assert first == second
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_the_cap_is_enforced_with_deterministic_eviction() -> None:
+    fat = {
+        "attempts": 99,
+        "completed_recoveries": 0,
+        "blocked_recoveries": 0,
+        "compensations": 0,
+        "last_attempt_mode": "x" * 64,
+        "last_attempt_steps": [f"step_{i}_" + "x" * 128 for i in range(50)],
+        "settled_effects": [
+            {"action_id": f"a{i}", "action_type": f"type_{i}", "occurred": True} for i in range(50)
+        ],
+        "current_failures": [
+            {
+                "component": "external_dependency",
+                "id": f"dep{i}",
+                "status": "stale",
+                "detail": "d" * 200,
+            }
+            for i in range(50)
+        ],
+        "avoid": ["rule " + "y" * 200 for _ in range(50)],
+    }
+    fitted = _fit(fat)
+    assert len(json.dumps(fitted, sort_keys=True).encode()) <= INFORMED_RETRY_CAP_BYTES
+
+
+# --- surfaces ------------------------------------------------------------------ #
+
+
+@pytest.fixture
+def history_db(tmp_path: Path) -> str:
+    db = str(tmp_path / "h.db")
+    with SQLiteStorage(db) as storage:
+        seed(storage)
+        ActionLedger(storage, "run_1").claim("send_invoice", {}, key="invoice:1")
+    run("--db", db, "resume", "run_1", "--repair")
+    return db
+
+
+def test_resume_text_carries_the_section(history_db: str) -> None:
+    code, out, _ = run("--db", history_db, "resume", "run_1")
+    assert code != 0
+    assert "What previous attempts changed (informed retry):" in out
+    assert "previous attempt(s): 1" in out
+
+
+def test_briefing_carries_the_section(history_db: str) -> None:
+    code, out, _ = run("--db", history_db, "briefing")
+    assert code == ExitCode.OK or code == ExitCode.ERROR  # briefing exits by mode
+    assert "what previous attempts changed" in out
+
+
+def test_serve_payload_carries_the_block(history_db: str) -> None:
+    from continuum.serve.server import SidecarServer
+
+    srv = SidecarServer(database=history_db)
+    out = srv.dispatch("resume", {"run_id": "run_1"})
+    assert out["mode"] != "resume"
+    assert out["informed_retry"] is not None
+    assert out["informed_retry"]["attempts"] == 1
+
+
+def test_clean_run_output_has_no_section(tmp_path: Path) -> None:
+    db = str(tmp_path / "c.db")
+    with SQLiteStorage(db) as storage:
+        seed(storage)
+        checkpoint_clean(storage)
+    code, out, _ = run("--db", db, "--json", "resume", "run_1")
+    assert code == ExitCode.OK
+    payload = json.loads(out)
+    assert payload["informed_retry"] is None
+    assert "informed retry" not in out
+
+
+# --- regression: duplicated Next steps section ---------------------------------- #
+
+
+def test_resume_prints_next_steps_exactly_once(history_db: str) -> None:
+    _, out, _ = run("--db", history_db, "resume", "run_1")
+    assert out.count("\n\nNext steps:\n") == 1


### PR DESCRIPTION
## Summary

Closes #265.

A resumed agent that knows why the previous attempt failed outperforms a blind retry (AgentRewind, arXiv:2608.14380). CONTINUUM's contract named what is blocked and what to do first, but carried no account of prior attempts, so a fresh session could repeat the mistake that caused the rollback.

New `continuum.recovery.summary` derives that account as a **pure projection** of facts already in the hash chain:

- RECOVERY_STARTED plans recorded by `resume --repair` (#19)
- RECOVERY_COMPLETED / RECOVERY_BLOCKED outcomes
- ACTION_RECONCILED settlements (#45), verdict read from status
- ACTION_COMPENSATED repairs

plus the current decision's failure signals. No new event type: every input is tamper-evident through the existing chain, identical logs produce byte-identical blocks, and runs without history yield None so today's output is unchanged byte for byte. Blocks cap at 4 KB with deterministic eviction (same spirit as the #235 cap).

## Surfaces

| Surface | Change |
|:--|:--|
| `RecoveryDecision.informed_retry` | new field, computed once in assess(), informational only |
| `continuum resume` | text section 'What previous attempts changed (informed retry)' + JSON key |
| Session briefing | block rendered beside the agent-authored summary (#235) |
| MCP `continuum_resume`, serve `resume` | payload gains informed_retry |

## Also fixes

cmd_resume printed the Next steps section twice (merge artifact); regression test asserts exactly one occurrence.

## Verification

- New tests/`test_informed_retry.py`: 11 tests covering absence-on-clean, component naming, repair history, settlement verdicts, determinism, the cap, every surface, and the Next-steps regression.
- Full suite green on this branch (Python 3.14 local; CI will cover 3.11-3.13).
- ruff check + ruff format + mypy strict clean on touched files.