### PR TITLE
fix(dashboard): bind 127.0.0.1 by default; add --host flag

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -2013,12 +2013,17 @@ def build_parser() -> argparse.ArgumentParser:
         from continuum.dashboard import serve_dashboard as _serve
 
         print(f"Serving dashboard at http://localhost:{args.port}", file=out)
-        _serve(storage, port=args.port)
+        _serve(storage, port=args.port, host=args.host)
         return 0
 
     dashboard = add("dashboard", cmd_dashboard, "Serve the dashboard (presentation over run data).")
     dashboard.add_argument(
         "--port", type=int, default=8000, help="port to listen on (default: 8000)"
+    )
+    dashboard.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="bind address (default: 127.0.0.1; 0.0.0.0 exposes recovery data)",
     )
 
     return parser

--- a/src/continuum/dashboard/app.py
+++ b/src/continuum/dashboard/app.py
@@ -129,7 +129,9 @@ def render_run_detail_html(storage: Storage, run_id: str) -> str:
 <p><a href=\"/\">Back to dashboard</a></p></body></html>"""
 
 
-def serve_dashboard(storage: Storage, port: int = 8000) -> None:
+def serve_dashboard(
+    storage: Storage, port: int = 8000, host: str = "127.0.0.1"
+) -> None:
     import urllib.parse
 
     from continuum.dashboard.hitl import (
@@ -215,6 +217,6 @@ def serve_dashboard(storage: Storage, port: int = 8000) -> None:
 
     server_class = socketserver.ThreadingTCPServer
     server_class.allow_reuse_address = True
-    with server_class(("", port), Handler) as httpd:
-        print(f"Serving dashboard at http://localhost:{port}")
+    with socketserver.ThreadingTCPServer((host, port), Handler) as httpd:
+        print(f"Serving dashboard at http://{host}:{port}")
         httpd.serve_forever()


### PR DESCRIPTION
Fixes #270. Loopback default for the dashboard bind address, matching every other CONTINUUM server.