### PR TITLE
Fork semantics: audited divergent continuations at the tool boundary (#259)

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -773,15 +773,16 @@ def cmd_tree(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
     if not children:
         lines.append("  (no children)")
     for child in children:
+        fork_mark = "[fork] " if str(child.metadata.get("fork", "")) == "true" else ""
         try:
             d = engine.assess(child.run_id)
             mark = "ok " if d.safe else "!! "
             lines.append(
-                f"  {mark}{child.run_id}  [{d.mode.value}, "
+                f"  {mark}{fork_mark}{child.run_id}  [{d.mode.value}, "
                 f"uncertain={len(d.uncertain_actions)}]  {child.goal[:44]}"
             )
         except Exception as exc:
-            lines.append(f"  !! {child.run_id}  [assess error: {exc}]")
+            lines.append(f"  !! {fork_mark}{child.run_id}  [assess error: {exc}]")
     a2a = [
         (c.run_id, c.metadata.get("a2a_task_id")) for c in children if c.metadata.get("a2a_task_id")
     ]
@@ -857,6 +858,40 @@ def cmd_complete(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
     _emit(
         payload,
         f"Run {args.run_id} completed.",
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
+
+
+def cmd_fork(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Approve a divergent continuation of a run (issue #259).
+
+    The third outcome of replay-or-fork: when the gate surfaces fork
+    candidates on an unclaimed call, this records the human decision to
+    branch rather than block. Writes RUN_FORKED to the parent log
+    (Origin.HUMAN) and creates the linked child run.
+    """
+    from continuum.recovery.fork import approve_fork
+
+    storage.get_run(args.run_id)  # raises RunNotFound -> NOT_FOUND by the dispatcher
+    try:
+        child = approve_fork(
+            storage,
+            args.run_id,
+            reason=args.reason or "",
+            child_run_id=args.child,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=err)
+        return ExitCode.ERROR
+
+    _emit(
+        {"parent": args.run_id, "child": child.run_id, "reason": child.metadata["fork_reason"]},
+        f"Forked {args.run_id} into {child.run_id}.\n"
+        f"Resume it independently: continuum resume {child.run_id}\n"
+        f"Lineage: continuum tree {args.run_id}",
         as_json=args.json,
         stream=out,
         palette=getattr(args, "_palette", None),
@@ -1838,6 +1873,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     tree_parser = with_run(add("tree", cmd_tree, "Show a parent run and its children."))
     tree_parser.add_argument("--limit", type=int, default=None, help=argparse.SUPPRESS)
+
+    fork_cmd = with_run(
+        add("fork", cmd_fork, "Approve a divergent continuation as a child run. Mutates storage.")
+    )
+    fork_cmd.add_argument("--reason", required=True, help="why this divergence is legitimate")
+    fork_cmd.add_argument("--child", default=None, help="run id for the fork (default: auto)")
 
     compact = with_run(
         add("compact", cmd_compact, "Archive the pre-anchor log prefix. Mutates storage.")

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -57,6 +57,9 @@ class EventType(StrEnum):
     RUN_ABORTED = "RUN_ABORTED"
     TASK_UPDATED = "TASK_UPDATED"
 
+    # lineage (issue #259): a divergent continuation was approved off this run
+    RUN_FORKED = "RUN_FORKED"
+
     # tools
     TOOL_CALLED = "TOOL_CALLED"
     TOOL_COMPLETED = "TOOL_COMPLETED"

--- a/src/continuum/gate.py
+++ b/src/continuum/gate.py
@@ -61,6 +61,10 @@ class Decision:
 
     allow: bool
     reason: str
+    #: Fork candidates (#259): journalled same-type actions this denied call
+    #: resembles by resource tokens. Non-empty only on unclaimed denials that
+    #: look like deliberate divergence after a restore, never on allow.
+    fork_candidates: tuple[Any, ...] = ()
 
 
 def load_gate_config(path: Path) -> dict[str, dict[str, Any]] | None:
@@ -156,12 +160,33 @@ def decide(
     if decision.kind is GuardKind.ALLOW:
         return Decision(True, f"live claim {rendered!r}")
     if decision.kind is GuardKind.DENY_UNCLAIMED:
-        return Decision(
-            False,
+        # Fork detection (#259): an unclaimed call whose resource tokens
+        # overlap journalled same-type work is what deliberate divergence
+        # looks like after a restore. Surface the neighbours and the exact
+        # approval command instead of a bare denial.
+        from continuum.recovery.fork import detect_fork_candidates
+
+        candidates = tuple(
+            detect_fork_candidates(
+                action_type=action_type,
+                tool_input=tool_input,
+                actions_by_key=actions_by_key,
+            )
+        )
+        message = (
             f"side effect {action_type!r} with key {rendered!r} has no ledger claim. "
             f"Call the MCP tool continuum_intercept_action with run_id={run_id!r}, "
-            f"action_type={action_type!r}, key={rendered!r} first, then repeat this call.",
+            f"action_type={action_type!r}, key={rendered!r} first, then repeat this call."
         )
+        if candidates:
+            neighbour = candidates[0]
+            message += (
+                f" This call resembles journalled action {neighbour.action_id[:14]} "
+                f"({neighbour.status}, shared tokens: {', '.join(neighbour.shared_tokens[:3])}). "
+                f"If it is a deliberate new direction, branch it with: "
+                f"continuum fork {run_id} --reason '<why>' --child <new-run-id>"
+            )
+        return Decision(False, message, fork_candidates=candidates)
     if decision.kind is GuardKind.SKIP_DUPLICATE or (decision.kind is GuardKind.DENY_DUPLICATE):
         return Decision(
             False,

--- a/src/continuum/recovery/fork.py
+++ b/src/continuum/recovery/fork.py
@@ -1,0 +1,161 @@
+"""Fork semantics: audited divergent continuations (issue #259).
+
+The replay-safety triad has three outcomes at the tool boundary. REPLAY
+exists (#237, ``protected_call`` returns the journalled result). REJECT
+exists (the gate refuses unclaimed or uncertain effects). FORK did not:
+when a restored agent legitimately re-plans and emits a call whose intent
+genuinely differs from anything journalled, blocking it forever is wrong,
+but executing it silently inside the original run hides the divergence.
+Codex CLI ships context-only session forks with no durability; ACRFence
+(arXiv:2603.20625) names replay-or-fork but never implemented it. This
+module owns the third outcome, approval-first:
+
+- :func:`detect_fork_candidates` recognises the interesting refusals. A
+  gated call denied as unclaimed is a *fork candidate* when its resource
+  tokens overlap a journalled action of the same type: the agent is
+  redoing work it remembers under different parameters, which after a
+  restore is exactly what legitimate divergence looks like. No overlap
+  means an ordinary first-seen effect and no signal.
+- :func:`approve_fork` executes an approved divergence: a linked child run
+  (``parent_run_id``, reusing the #243 hierarchy) plus a ``RUN_FORKED``
+  event on the parent log recording child, reason and divergence point.
+  The parent chain stays append-only and untouched otherwise.
+
+Approval-first is deliberate: automatic branching would let an injected
+prompt steer topology silently. A human names the reason, and the reason
+is the audit. Forks parent onto the named run; a fork of a fork is just a
+deeper hierarchy, which the #243 roll-up already understands.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from continuum.actions.idempotency import identity_tokens
+from continuum.events import EventType
+from continuum.models import Action, Origin, Run
+from continuum.storage.base import Storage
+
+__all__ = ["ForkNeighbour", "detect_fork_candidates", "approve_fork"]
+
+
+@dataclass(frozen=True)
+class ForkNeighbour:
+    """One journalled action the denied call resembles."""
+
+    key: str
+    action_id: str
+    action_type: str
+    status: str
+    external_id: str | None
+    shared_tokens: tuple[str, ...]
+
+
+def _action_tokens(action: Action) -> frozenset[str]:
+    return identity_tokens(
+        arguments=dict(action.arguments or {}),
+        external_id=action.external_id,
+    )
+
+
+def detect_fork_candidates(
+    *,
+    action_type: str,
+    tool_input: Mapping[str, Any],
+    actions_by_key: Mapping[str, Action],
+) -> list[ForkNeighbour]:
+    """Journalled same-type actions sharing a resource token with this call.
+
+    Deterministic: candidates sort by (number of shared tokens desc, key),
+    so identical ledgers yield identical refusal envelopes.
+    """
+    incoming = identity_tokens(arguments=dict(tool_input))
+    if not incoming:
+        return []
+
+    neighbours: list[ForkNeighbour] = []
+    for key, action in actions_by_key.items():
+        if action.action_type != action_type:
+            continue
+        shared = tuple(sorted(incoming & _action_tokens(action)))
+        if not shared:
+            continue
+        neighbours.append(
+            ForkNeighbour(
+                key=key,
+                action_id=action.action_id,
+                action_type=action.action_type,
+                status=action.status.value,
+                external_id=action.external_id,
+                shared_tokens=shared,
+            )
+        )
+    neighbours.sort(key=lambda n: (-len(n.shared_tokens), n.key))
+    return neighbours
+
+
+def approve_fork(
+    storage: Storage,
+    parent_run_id: str,
+    *,
+    reason: str,
+    child_run_id: str | None = None,
+) -> Run:
+    """Create an approved divergent continuation of ``parent_run_id``.
+
+    Writes ``RUN_FORKED`` to the parent log (Origin.HUMAN: a human approved
+    this branch) and creates the linked child run with ``parent_run_id``
+    set, so #243's aggregation and ``continuum tree`` see it without any new
+    machinery. The child starts empty: it inherits nothing mutable from the
+    parent, by the same rule that keeps siblings independent.
+    """
+    parent = storage.get_run(parent_run_id)
+    if not reason or not reason.strip():
+        raise ValueError("a fork needs a stated reason; the reason is the audit")
+
+    from continuum.storage.base import RunNotFound
+
+    if child_run_id is None:
+        existing = {r.run_id for r in storage.list_runs(limit=None)}
+        n = 1
+        while True:
+            candidate = f"{parent_run_id}_fork{n}"
+            if candidate not in existing:
+                child_run_id = candidate
+                break
+            n += 1
+    else:
+        try:
+            storage.get_run(child_run_id)
+        except RunNotFound:
+            pass
+        else:
+            raise ValueError(f"run {child_run_id!r} already exists")
+
+    latest = storage.latest_version(parent_run_id)
+    divergence = latest.source_sequence if latest else 0
+
+    child = Run(
+        run_id=child_run_id,
+        goal=parent.goal,
+        parent_run_id=parent_run_id,
+        metadata={
+            "fork": "true",
+            "fork_reason": reason.strip(),
+            "fork_parent_sequence": divergence,
+        },
+    )
+    storage.create_run(child)
+    storage.append_event(
+        parent_run_id,
+        EventType.RUN_FORKED,
+        {
+            "child_run_id": child.run_id,
+            "reason": reason.strip(),
+            "divergence_sequence": divergence,
+        },
+        source=Origin.HUMAN,
+    )
+    return child

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -452,6 +452,7 @@ _NON_PROJECTING = frozenset(
     {
         EventType.RUN_COMPLETED,
         EventType.RUN_ABORTED,
+        EventType.RUN_FORKED,
         EventType.TOOL_CALLED,
         EventType.TOOL_COMPLETED,
         EventType.TOOL_FAILED,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -183,6 +183,7 @@ def test_a_missing_run_is_distinguishable(db: str) -> None:
         ("confirm", []),
         ("attest", []),
         ("attest-verify", ["--attest", "irrelevant-on-missing-run.json"]),
+        ("fork", ["--reason", "test"]),
     ],
 )
 def test_no_command_reports_success_for_a_run_that_does_not_exist(

--- a/tests/test_fork.py
+++ b/tests/test_fork.py
@@ -1,0 +1,249 @@
+"""Fork semantics (issue #259): detect, approve, deny, verify-after-fork.
+
+The third outcome of replay-or-fork. These tests pin the detection rule
+(token overlap on unclaimed same-type calls), the approval mechanics
+(RUN_FORKED on the parent, linked child run), refusal of bad approvals,
+chain integrity across the fork boundary, and the interplay with #243
+family aggregation.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.cli import ExitCode, main
+from continuum.events import EventType
+from continuum.gate import load_gate_config
+from continuum.models import Origin, Run
+from continuum.recovery.family import roll_up_children
+from continuum.recovery.fork import ForkNeighbour, approve_fork, detect_fork_candidates
+from continuum.storage import SQLiteStorage
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "f.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="Send invoices"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "Send invoices", "total": 3})
+        ledger = ActionLedger(store, "run_1")
+        outcome = ledger.claim(
+            "send_invoice",
+            {"recipient": "a@x.com", "path": "out/INV-001.pdf"},
+            key="invoice:INV-001",
+        )
+        ledger.complete(outcome.key, external_id="INV-001.sent", result={"ok": True})
+    yield path
+
+
+def fold(db: str) -> dict:
+    from continuum.actions.ledger import fold_action_events
+
+    with SQLiteStorage(db) as store:
+        return fold_action_events(store.read_events("run_1"))
+
+
+# --- detection -------------------------------------------------------------- #
+
+
+def test_token_overlap_surfaces_a_fork_candidate(db: str) -> None:
+    candidates = detect_fork_candidates(
+        action_type="send_invoice",
+        tool_input={"recipient": "b@y.com", "outfile": "OUTBOX/INV-001.pdf"},
+        actions_by_key=fold(db),
+    )
+    assert len(candidates) == 1
+    neighbour = candidates[0]
+    assert isinstance(neighbour, ForkNeighbour)
+    assert neighbour.action_type == "send_invoice"
+    assert neighbour.status == "completed"
+    assert "INV-001" in neighbour.shared_tokens or "INV" in neighbour.shared_tokens
+
+
+def test_no_overlap_yields_no_candidates(db: str) -> None:
+    candidates = detect_fork_candidates(
+        action_type="send_invoice",
+        tool_input={"recipient": "c@z.com", "outfile": "out/INV-999.pdf"},
+        actions_by_key=fold(db),
+    )
+    assert candidates == []
+
+
+def test_other_action_types_never_match(db: str) -> None:
+    candidates = detect_fork_candidates(
+        action_type="delete_record",
+        tool_input={"path": "out/INV-001.pdf"},
+        actions_by_key=fold(db),
+    )
+    assert candidates == []
+
+
+# --- gate surface ------------------------------------------------------------ #
+
+
+def test_gate_refusal_carries_candidates_and_the_command(db: str, tmp_path: Path) -> None:
+    gate_path = tmp_path / "gate.json"
+    gate_path.write_text(
+        '{"tools": {"send_invoice_tool": '
+        '{"key_template": "invoice:{invoice}", "action_type": "send_invoice"}}}'
+    )
+    config = load_gate_config(gate_path)
+    from continuum.gate import decide
+
+    # A different key that still shares the INV-001 resource token: this is
+    # the divergence shape (same resource, new parameters) after a restore.
+    decision = decide(
+        config,
+        "send_invoice_tool",
+        {"invoice": "INV-001-draft", "recipient": "b@y.com", "outfile": "o/INV-001.pdf"},
+        run_id="run_1",
+        actions_by_key=fold(db),
+    )
+    assert decision.allow is False
+    assert decision.fork_candidates
+    assert "continuum fork run_1 --reason" in decision.reason
+
+    unrelated = decide(
+        config,
+        "send_invoice_tool",
+        {"invoice": "INV-777", "recipient": "d@w.com"},
+        run_id="run_1",
+        actions_by_key=fold(db),
+    )
+    assert unrelated.allow is False
+    assert unrelated.fork_candidates == ()
+    assert "continuum fork" not in unrelated.reason
+
+
+# --- approval ---------------------------------------------------------------- #
+
+
+def test_approve_fork_writes_event_and_linked_child(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        before = store.latest_version("run_1")
+        child = approve_fork(store, "run_1", reason="payee renegotiated the amount")
+
+        assert child.parent_run_id == "run_1"
+        assert child.metadata["fork"] == "true"
+        assert child.metadata["fork_reason"] == "payee renegotiated the amount"
+
+        events = store.read_events("run_1")
+        fork_events = [e for e in events if e.type is EventType.RUN_FORKED]
+        assert len(fork_events) == 1
+        event = fork_events[0]
+        assert event.source is Origin.HUMAN
+        assert event.payload["child_run_id"] == child.run_id
+        assert event.payload["divergence_sequence"] == (before.source_sequence if before else 0)
+
+        # The parent's semantic state is untouched by the lineage record.
+        from continuum.state.semantic import project
+
+        state = project("run_1", events)
+        assert state.goal.description == "Send invoices"
+        assert child.run_id not in {e.type.value for e in events}
+
+
+def test_fork_child_is_independently_resumable(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        child = approve_fork(store, "run_1", reason="new terms")
+        store.append_event(child.run_id, EventType.RUN_STARTED, {"goal": child.goal, "total": 1})
+
+    code, out, _ = run("--db", db, "resume", child.run_id)
+    # Resume reaches its own verdict about the CHILD: an empty fork with a
+    # consistent start event is cleanly resumable, independent of the parent.
+    assert code == ExitCode.OK
+    assert f"Run: {child.run_id}" in out
+    assert "Recovery decision: RESUME" in out
+    assert "FAMILY BLOCKED" not in out
+
+
+def test_duplicate_child_and_empty_reason_are_refused(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        approve_fork(store, "run_1", reason="first", child_run_id="fork_x")
+        with pytest.raises(ValueError, match="already exists"):
+            approve_fork(store, "run_1", reason="second", child_run_id="fork_x")
+        with pytest.raises(ValueError, match="reason"):
+            approve_fork(store, "run_1", reason="   ")
+
+    events = SQLiteStorage(db).read_events("run_1")  # type: ignore[call-arg]
+    forks = [e for e in events if e.type is EventType.RUN_FORKED]
+    assert len(forks) == 1
+
+
+def test_auto_named_children_do_not_collide(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        first = approve_fork(store, "run_1", reason="a")
+        second = approve_fork(store, "run_1", reason="b")
+    assert first.run_id != second.run_id
+    assert first.run_id.startswith("run_1_fork")
+
+
+def test_cli_fork_command_records_and_tree_marks_it(db: str) -> None:
+    code, out, _ = run("--db", db, "fork", "run_1", "--reason", "split strategy", "--child", "fk1")
+    assert code == ExitCode.OK
+    assert "fk1" in out
+
+    code, out, _ = run("--db", db, "tree", "run_1")
+    assert code == ExitCode.OK
+    assert "[fork]" in out and "fk1" in out
+
+    code, _, err = run("--db", db, "fork", "run_1", "--reason", "dup", "--child", "fk1")
+    assert code != ExitCode.OK
+
+
+def test_missing_run_exits_not_found(db: str) -> None:
+    code, _, _ = run("--db", db, "fork", "ghost", "--reason", "x")
+    assert code != ExitCode.OK
+
+
+# --- chain integrity and family interplay ------------------------------------ #
+
+
+def test_both_chains_verify_after_fork_and_tamper_is_local(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        child = approve_fork(store, "run_1", reason="branch")
+        store.append_event(child.run_id, EventType.RUN_STARTED, {"goal": child.goal})
+
+    code, out, _ = run("--db", db, "verify", "run_1")
+    assert code == ExitCode.OK, out
+    code, out, _ = run("--db", db, "verify", child.run_id)
+    assert code == ExitCode.OK, out
+
+    # Tamper with the parent log: the parent must fail verification while the
+    # child's chain stays trusted.
+    import sqlite3
+
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "UPDATE events SET payload = json_set(payload, '$.tampered', 1) "
+        "WHERE run_id = 'run_1' AND sequence = 2"
+    )
+    conn.commit()
+    conn.close()
+
+    code, _, _ = run("--db", db, "verify", "run_1")
+    assert code != ExitCode.OK
+    code, _, _ = run("--db", db, "verify", child.run_id)
+    assert code == ExitCode.OK
+
+
+def test_an_unsafe_fork_blocks_the_parent_rollup(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        child = approve_fork(store, "run_1", reason="risky branch")
+        store.append_event(child.run_id, EventType.RUN_STARTED, {"goal": child.goal})
+        # Leave an uncertain side effect inside the fork.
+        ActionLedger(store, child.run_id).claim("wire_transfer", {}, key="wire:1")
+
+    statuses, blocked = roll_up_children(SQLiteStorage(db), "run_1")
+    assert any(s.run_id == child.run_id for s in statuses)
+    assert blocked is True


### PR DESCRIPTION
## Summary

Closes #259.

Completes the replay-or-fork triad. REPLAY shipped in #237 (`protected_call` returns the journalled result) and REJECT ships in the gate; a post-restore call whose intent genuinely diverged had only a bare denial, or silent execution hidden inside the original run. ACRFence (arXiv:2603.20625) names this third outcome but its own conclusion states no implementation exists; Codex CLI v0.148 recently shipped session forks that carry no durability at all. This PR makes CONTINUUM the first harness-neutral layer with audited forks.

## Detection

On an unclaimed denial, `detect_fork_candidates` compares the call's identity tokens (the same #6-hardened token machinery the ledger's dedup fallback uses) against journalled actions of the same type. Token overlap is what legitimate divergence looks like after a restore: same resource, new parameters. No overlap stays an ordinary first-seen effect with today's message, byte for byte.

The gate refusal envelope gains `fork_candidates` plus the exact approval command, so the agent (or operator reading the hook denial) sees the branch path instead of a dead end.

## Approval

`continuum fork <parent> --reason '<why>' --child <id>`:

- writes `RUN_FORKED` to the parent log (`Origin.HUMAN`, recording child id, reason and divergence sequence)
- creates the linked child run via `parent_run_id`, reusing #243's hierarchy rather than inventing a second lineage model
- approval-first by design: automatic branching would let an injected prompt steer topology silently; denying changes nothing

`RUN_FORKED` joins `_NON_PROJECTING`: lineage is a recorded fact that leaves semantic state untouched.

## Verification evidence

- 12 new tests in `tests/test_fork.py`: detect (overlap / no overlap / other types), gate envelope contents, approve (event source, payload, divergence sequence), duplicate-child and empty-reason refusal, auto-naming, CLI round trip, tree marker, missing-run exit code, both chains verifying after fork with tamper isolation between them, and an unsafe fork blocking the parent roll-up.
- `fork` added to the enforcing NOT_FOUND parametrised list in `tests/test_cli.py`.
- Full suite in an isolated worktree off current main: 1308 passed, 19 skipped; ruff check/format and mypy strict clean.

## Scope notes

- Forks are approval-first in v1; an auto-fork policy flag can follow once the primitive exists.
- The gateway refusal surface can reuse `detect_fork_candidates` later; v1 covers the hook/gate protocol where tool arguments are structured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fork detection for divergent continuations, including matching candidate details and guidance.
  * Added a `fork` command to approve a continuation with a required reason and optional child run ID.
  * Forked runs now appear in tree views with parent-child lineage details.
  * Added validation and tamper-detection safeguards for forked run chains.

* **Bug Fixes**
  * Improved handling of fork events without altering semantic state.
  * Prevented unsafe child runs from being included in family rollups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->