### PR TITLE
style(cli): apply ruff format to informed retry block

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -586,9 +586,8 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
     if decision.informed_retry:
         from continuum.recovery.summary import render_informed_retry
 
-        text += (
-            "\n\nWhat previous attempts changed (informed retry):\n"
-            + "\n".join(f"  {line}" for line in render_informed_retry(decision.informed_retry))
+        text += "\n\nWhat previous attempts changed (informed retry):\n" + "\n".join(
+            f"  {line}" for line in render_informed_retry(decision.informed_retry)
         )
 
     # Version pinning drift (issue #241): informational only.


### PR DESCRIPTION
## Description

One-line formatting fix: the informed retry block added in #275 (`src/continuum/cli/main.py`, `cmd_resume`) fails `ruff format --check`. This is the formatter's canonical rendering of that block; no behavior change.

This is why main's `Lint & Type-check` job is currently red on 4659693:

```
unformatted: File would be reformatted
1 file would be reformatted, 211 files already formatted
##[error]Process completed with exit code 1.
```

## Related issues

No tracking issue; found in a full-gate audit of current main on 2026-08-24 (recorded in STATUS.md).

## Types of changes

- Type: `docs` (formatting only; closest applicable type)

## Breaking changes

No

## How has this been tested?

In a clean worktree at origin/main (4659693):

- Before: `uv run ruff format --check src/ tests/ examples/` reports 1 file would be reformatted.
- After: `ruff format --check` passes (212 files), `ruff check` passes, `pytest tests/test_cli.py` 19 passed.
- Full suite at base for reference: 1327 passed, 23 skipped, 0 failed.

## Checklist

Tests added or updated for the changed behaviour: N/A (formatter output only). Documentation updated where the change affects user-facing behaviour: no user-facing change. CI passes on the latest commit: this PR exists to make that true again. Security-relevant changes state known limitations explicitly in this description: none.

## Additional context

Audit context: tests were fully green on main; this was the only gate violation. STATUS.md gains a dated audit entry pointing here.