### PR TITLE
docs: record 2026-08-24 full-gate audit, refresh README counts, add architecture section 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Verify:
 ```bash
 continuum --help                 # CLI entrypoint
 continuum-mcp --help             # MCP server entrypoint (needs [mcp] or [dev])
-pytest -q                        # ~1,300 passed (exact count and skips vary by environment)
+pytest -q                        # ~1,350 collected (exact count and skips vary by environment)
 ruff check src/ tests/ examples/ && ruff format --check src/ tests/ examples/
 mypy src/continuum               # the three gates CI enforces
 ```
@@ -176,7 +176,7 @@ CONTINUUM is verified against real LLM agents, live protocol boundaries, and har
 - **Third-party clients**: Gemini CLI and Kilo Code connected over stdio JSON-RPC against the live SQLite store, validating multi-agent co-existence and authorization isolation.
 - **Protocol compliance**: driven end to end with `@modelcontextprotocol/inspector --cli` across process deaths; mutating tools deny by default behind `CONTINUUM_MCP_MUTATING_CLIENTS`; external claims degrade to `REQUIRES_REVIEW` (`safe: false`).
 - **Self-healing**: hard-killed servers recover from orphaned SQLite `-wal`/`-shm` sidecars via single-retry cleanup at startup.
-- **Scale**: roughly 1,300 tests passing on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial); CONTINUUM-Bench runs five crash scenarios proving 0 duplicate work and 0 duplicate side effects.
+- **Scale**: roughly 1,330 tests passing on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial); CONTINUUM-Bench runs five crash scenarios proving 0 duplicate work and 0 duplicate side effects.
 - **Adversarial audit**: the full MCP surface was audited over the live protocol; three defects were found and fixed. Method and reproduction steps in [test.md](test.md).
 
 ## MCP Integration
@@ -247,7 +247,7 @@ The system is built on immutable Pydantic v2 models with a cryptographic hash ch
 
 Key guarantees: append-only events, atomic sequence allocation, durability on `append_event` return, write races fail loudly, and corruption is refused rather than returned.
 
-CONTINUUM is one library (`src/continuum`, 100 Python files) plus a large test suite (93 files, roughly 1,300 tests). All modules append to and replay one hash-chained event log:
+CONTINUUM is one library (`src/continuum`, 102 Python files) plus a large test suite (97 files, roughly 1,350 tests). All modules append to and replay one hash-chained event log:
 
 | Module | LOC | Role |
 |:--|--:|:--|
@@ -330,7 +330,7 @@ CONTINUUM sits at the overlap of durable execution, idempotent side-effect track
 
 ## Status and limitations
 
-- **Tested**: roughly 1,300 tests passing across Python 3.11, 3.12, and 3.13; exact counts and skips vary by platform and optional services such as Postgres (see [STATUS.md](STATUS.md)). The MCP surface has also been audited adversarially over the live protocol; see [test.md](test.md).
+- **Tested**: 1,327 passed + 23 skipped on Python 3.13 at the 2026-08-24 audit of `main` (see [STATUS.md](STATUS.md)); counts vary by platform and optional services such as Postgres. The MCP surface has also been audited adversarially over the live protocol; see [test.md](test.md).
 - **Not on PyPI.** Install from a clone, a git URL, a release wheel, or Docker (see Quick Start).
 - **MCP caller authentication is opt-in per deployment.** When `CONTINUUM_MCP_TOKEN` is set, the server refuses every mutating tool unless the caller presents that shared secret in the `initialize` handshake's `_meta.authToken`. Without it, authorization is by declared identity only (the historical default, preserved for local single-user use).
 - **Confirming self-reported state over MCP requires a separate secret.** `continuum_confirm` refuses every caller until the operator sets `CONTINUUM_MCP_CONFIRM_TOKEN`, because an agent allowed to record progress must not also be able to confirm it. The default path stays human-driven: run `continuum confirm <run_id>` on the host.

--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,20 @@ believed, and what is neither.
 
 ---
 
+## Full-gate audit (2026-08-24)
+
+Ran against `main` at `4659693` (merge of #275) in a clean worktree, Python 3.13:
+
+- `pytest`: **1327 passed, 23 skipped, 0 failed** (31s). The suite is green.
+- `ruff check src/ tests/ examples/`: pass. `mypy src/continuum`: pass (102 files).
+- `ruff format --check`: **red**. The informed retry block added in #275
+  (`src/continuum/cli/main.py`, inside `cmd_resume`) is not formatter-canonical,
+  so the `Lint & Type-check` CI job fails on main (run for 4659693). Fix: PR #298.
+- Distribution surfaces verified live: #277 merged, and the GHCR publish
+  workflow ran green on both the #275 and #277 merges, so
+  `docker run --rm ghcr.io/cyrax321/continuum` serves the crash-recovery demo
+  from a published image.
+
 ## Verified
 
 1047 tests collected, 1038 passing, 9 skipped, on Python 3.13 with `mcp 2.0.0` installed. The MCP

--- a/docs/ARCHITECTURE_EVOLUTION.md
+++ b/docs/ARCHITECTURE_EVOLUTION.md
@@ -901,3 +901,45 @@ functional end to end rather than two standalone modules:
 
 - `impacted_files` reports files by import ownership only; it does not attempt
   runtime provenance or trace which files an action actually wrote.
+
+## 19. Informed retry and the distribution layer (2026-08-24)
+
+### 19.1 Informed retry summaries (#265, merged as #275)
+
+Recovery surfaces no longer show only the current decision; they can also
+render an account of what previous attempts changed, derived from events
+already in the hash chain rather than from agent self-report.
+
+- **What changed.** `continuum.recovery.summary` builds a prior-attempt block
+  (`build_informed_retry`) and renders it as lines
+  (`render_informed_retry`). `RecoveryDecision` carries the block
+  (`decision.informed_retry`). `cmd_resume` appends it to human output under
+  "What previous attempts changed (informed retry)"; absent history means no
+  section is rendered at all.
+- **Provenance stays intact.** The block is computed from recovery-path
+  events recorded during earlier attempts, so it inherits the chain's
+  tamper-evidence instead of introducing a new trust boundary.
+- **Tests.** `tests/test_informed_retry.py`, `tests/test_retry_budgets.py`.
+
+### 19.2 Distribution layer (#277)
+
+How the system is obtained and run became part of the architecture:
+
+- **Docker/GHCR.** A slim image whose default command runs the crash-recovery
+  demo end to end; any argument replaces the command, so
+  `docker run --rm ghcr.io/cyrax321/continuum continuum --help` reaches the
+  CLI. CI publishes to GHCR on pushes to `main` and release tags, with a
+  `continuum --version` smoke test after push.
+- **Devcontainer.** One-click Codespaces: dev toolchain installed via
+  `uv sync --extra dev`, dashboard port forwarded.
+- **Installs without PyPI.** pip/uv straight from the git URL, wheels
+  attached to GitHub Releases, `uvx`/`pipx run` off the repo. The PyPI job in
+  the release workflow is opt-in via the `PUBLISH_PYPI` repository variable,
+  so tagging cannot fail on unconfigured trusted publishing.
+
+### 19.3 Known limitations
+
+- The informed retry block summarizes past attempts but does not by itself
+  change any recovery decision; the engine's severity ordering is unchanged.
+- The published image runs as a non-root user and carries no secrets, but it
+  is not yet multi-arch; CI builds for its runner platform only.


### PR DESCRIPTION
## Description

Documents the findings of a full-gate audit of current `main` (`4659693`) and refreshes stale counts:

1. **STATUS.md**: new dated "Full-gate audit (2026-08-24)" section. Verified: 1327 passed / 23 skipped / 0 failed (31s), `ruff check` clean, `mypy` clean (102 files). Found red: `ruff format --check`, caused by the informed retry block #275 added to `cmd_resume`; fix is #298. Also records that #277 merged and GHCR image publishing ran green on both recent main merges.
2. **README.md**: test/source-file counts refreshed against measured values (102 source files, 97 test files, ~1,350 collected; Status bullet now cites the audit directly instead of an approximate count).
3. **docs/ARCHITECTURE_EVOLUTION.md**: new section 19 covering informed retry summaries (#265/#275: `recovery/summary.py`, provenance inherited from the event chain, tests) and the distribution layer (#277: Docker/GHCR demo-first image, devcontainer, git/wheel installs, opt-in PyPI), with known limitations.

## Related issues

Refs #265. The format-gate finding itself ships as #298.

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

All claims come from commands run in a clean worktree at `4659693` on 2026-08-24:

```
uv run pytest            -> 1327 passed, 23 skipped in 31.03s
uv run ruff check ...    -> All checks passed
uv run mypy src/continuum-> Success: no issues found in 102 source files
uv run ruff format --check -> 1 file would be reformatted (cli/main.py)
ls tests/*.py | wc -l    -> 97 ; find src -name "*.py" | wc -l -> 102
pytest --co              -> 1350 tests collected
```

Docs-only change; no code paths touched.

## Checklist

Tests added or updated for the changed behaviour: N/A. Documentation updated where the change affects user-facing behaviour: yes (this PR is documentation). CI passes on the latest commit: expected green; only markdown changed. Security-relevant changes state known limitations explicitly: N/A.

## Additional context

The audit found exactly one gate violation on main (formatting) and zero test failures. If #298 merges first, the STATUS.md wording still reads correctly since it names the fixing PR explicitly.