### PR TITLE
docs: add pre-commit example with ruff hooks to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,40 @@ ruff format --check src/ tests/
 mypy src/continuum
 ```
 
-The CI pipeline runs all three on every PR. A clean PR must pass all checks.
+The CI pipeline runs all three on every PR. A clean PR must pass all checks.  
+### Pre-commit hooks (optional but recommended)
+
+To catch lint and formatting issues automatically before you commit, you can use
+[pre-commit](https://pre-commit.com/):
+
+```bash
+pip install pre-commit
+```
+
+Create a `.pre-commit-config.yaml` in the repo root with:
+
+```yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+```
+
+Then install the git hook:
+
+```bash
+pre-commit install
+```
+
+Now `ruff check --fix` and `ruff format` will run automatically on every `git commit`.
+To run it manually against all files:
+
+```bash
+pre-commit run --all-files
+```  
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Create a `.pre-commit-config.yaml` in the repo root with:
 ```yaml
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.16.3
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
  Adds a documented pre-commit setup using astral-sh/ruff-pre-commit (ruff + ruff-format hooks) to CONTRIBUTING.md, so contributors can auto-check lint/format before committing.

  Closes #337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the contributing guide with instructions for optional pre-commit hooks.
  * Added guidance for installation, Ruff configuration, Git hook setup, and manually running checks across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->