### PR TITLE
fix: Improve backoff delay error message

### DIFF
--- a/src/continuum/budgets.py
+++ b/src/continuum/budgets.py
@@ -127,5 +127,5 @@ def backoff_delay(
 ) -> float:
     """Exponential backoff with a ceiling. Pure; jitter is the caller's job."""
     if attempt < 1:
-        raise ValueError("attempt starts at 1")
+        raise ValueError(f"attempt must be >= 1, got {attempt}")
     return float(min(base * (2 ** (attempt - 1)), cap))

--- a/tests/test_retry_budgets.py
+++ b/tests/test_retry_budgets.py
@@ -94,6 +94,7 @@ def test_backoff_delay_is_exponential_with_cap() -> None:
     with pytest.raises(ValueError):
         backoff_delay(0)
 
+
 def test_backoff_delay_rejects_zero() -> None:
     with pytest.raises(ValueError, match="got 0"):
         backoff_delay(0)

--- a/tests/test_retry_budgets.py
+++ b/tests/test_retry_budgets.py
@@ -94,6 +94,10 @@ def test_backoff_delay_is_exponential_with_cap() -> None:
     with pytest.raises(ValueError):
         backoff_delay(0)
 
+def test_backoff_delay_rejects_zero() -> None:
+    with pytest.raises(ValueError, match="got 0"):
+        backoff_delay(0)
+
 
 # --- enforcement through the real ledger path --------------------------------------- #
 


### PR DESCRIPTION
## Description

Improves the `backoff_delay` validation error by including the invalid `attempt` value in the error message. This makes it easier to identify the value that caused the error when `attempt < 1`.

A regression test was also added to verify that calling `backoff_delay(0)` raises a `ValueError` containing the invalid value.

## Related issues

Fixes #336

## Types of changes

* Type: `bugfix`

## Breaking changes

No.

## How has this been tested?

The changes were tested with:

```bash
uv run pytest tests/test_retry_budgets.py -v
```

Environment:

* macOS
* Python 3.11.9
* pytest 9.1.1

Result: 10 tests passed.

## Checklist

Tests were added for the changed behaviour.

Documentation was not updated because this change only improves an existing validation error message and does not affect documented usage.

CI has not run yet on this PR.

No security-relevant changes.

## Additional context

The new regression test verifies that `backoff_delay(0)` raises a `ValueError` whose message includes `got 0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for invalid retry attempt values by including the value that caused the error.

* **Tests**
  * Added coverage verifying that invalid retry attempt values report the expected details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->