### PR TITLE
test: cover Origin self_certified variants

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,7 +23,6 @@ from continuum.models import (
     SemanticState,
     StateCheckpoint,
     StateStatus,
-    
 )
 from continuum.security.hashing import stable_hash
 
@@ -224,3 +223,4 @@ def test_versions_increase_monotonically(steps: int) -> None:
 )
 def test_self_certified_truth_table(origin, expected) -> None:
     assert origin.self_certified is expected
+    

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -221,6 +221,5 @@ def test_versions_increase_monotonically(steps: int) -> None:
         (Origin.IMPORTED, True),
     ],
 )
-def test_self_certified_truth_table(origin, expected) -> None:
+def test_self_certified_truth_table(origin: Origin, expected: bool) -> None:
     assert origin.self_certified is expected
-    

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,11 +17,13 @@ from continuum.models import (
     Goal,
     ModelSpecificState,
     ModelState,
+    Origin,
     PendingWork,
     Progress,
     SemanticState,
     StateCheckpoint,
     StateStatus,
+    
 )
 from continuum.security.hashing import stable_hash
 
@@ -205,3 +207,20 @@ def test_versions_increase_monotonically(steps: int) -> None:
         versions.append(state.version)
     assert versions == sorted(versions)
     assert versions[-1] == steps
+
+
+# --- provenance ------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "origin,expected",
+    [
+        (Origin.DETERMINISTIC, False),
+        (Origin.HUMAN, False),
+        (Origin.LLM, True),
+        (Origin.EXTERNAL_AGENT, True),
+        (Origin.IMPORTED, True),
+    ],
+)
+def test_self_certified_truth_table(origin, expected) -> None:
+    assert origin.self_certified is expected


### PR DESCRIPTION
## Description

Adds explicit parametrized test coverage for all five `Origin.self_certified` variants.

## Related issues

Fixes #330

## Types of changes

- Type: `tests`

## Breaking changes

No.

## How has this been tested?

```bash
uv run pytest tests/test_models.py -v
```

Environment:
- macOS
- Python 3.11.9
- pytest 9.1.1
- hypothesis 6.165.10

Result: 24 tests passed.

## Checklist

Tests added for the changed behaviour.

No documentation changes required.

CI has not run yet on this PR.

No security-relevant changes.

## Additional context

The new parametrized test covers:
- `DETERMINISTIC -> False`
- `HUMAN -> False`
- `LLM -> True`
- `EXTERNAL_AGENT -> True`
- `IMPORTED -> True`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying which origin types are considered self-certified.
  * Confirmed expected certification behavior for deterministic, human, LLM, external-agent, and imported origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->