### PR TITLE
fix: make SQLiteStorage.close idempotent

### DIFF
--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -139,7 +139,16 @@ class SQLiteStorage(Storage):
 
     def close(self) -> None:
         with self._lock:
-            self._connection.close()
+            conn = getattr(self, "_connection", None)
+            if conn is None:
+                return
+            try:
+                conn.close()
+            except sqlite3.ProgrammingError:
+                # Already closed — safe to call close() more than once.
+                pass
+            finally:
+                self._connection = None  # type: ignore[assignment]
 
     def __del__(self) -> None:
         """Release the connection if the owner never closed it.


### PR DESCRIPTION
## Summary

fix: make SQLiteStorage.close idempotent

## Changes

- Second close() no longer raises ProgrammingError.
- Clear the connection handle after close.

Fixes #320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage shutdown reliability by making connection cleanup safe when called multiple times.
  * Prevented errors when closing an already-closed or unavailable database connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->