### PR TITLE
fix: attest-verify must not pass a tampered chain; fork must produce a usable child

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1750,13 +1750,22 @@ def cmd_attest_verify(args: argparse.Namespace, storage: Storage, out: Any, err:
     live_hash = events[-1].hash if events else None
     live_seq = events[-1].sequence if events else 0
 
+    # Recompute the chain before trusting any hash read out of it. `live_hash`
+    # above is the digest *stored* in the row, and an edit made straight through
+    # the database changes the payload while leaving that column untouched, so
+    # comparing the attestation against it reports "chain matches" on content
+    # that has demonstrably been altered. Only the recomputing walk in
+    # verify_events can tell, which is why the verdict has to consult it.
+    integrity = storage.verify_events(args.run_id)
+    chain_intact = integrity.ok
+
     signature_valid = verify_attestation(doc)
     chain_match = doc.get("chain_hash") == live_hash
     seq_match = doc.get("trusted_through_seq") == live_seq
 
     if not signature_valid:
         verdict = "UNTRUSTED"
-    elif not chain_match or not seq_match:
+    elif not chain_intact or not chain_match or not seq_match:
         verdict = "ALTERED"
     else:
         verdict = "SIGNED"
@@ -1766,6 +1775,7 @@ def cmd_attest_verify(args: argparse.Namespace, storage: Storage, out: Any, err:
         "verdict": verdict,
         "signature_valid": signature_valid,
         "chain_match": chain_match,
+        "chain_intact": chain_intact,
         "signer": doc.get("signer"),
         "signed_seq": doc.get("trusted_through_seq"),
         "live_seq": live_seq,
@@ -1776,10 +1786,20 @@ def cmd_attest_verify(args: argparse.Namespace, storage: Storage, out: Any, err:
             f"chain matches."
         )
     elif verdict == "ALTERED":
-        text = (
-            f"Attestation ALTERED: chain changed since signing "
-            f"(signed seq {doc.get('trusted_through_seq')} vs live {live_seq})."
-        )
+        if not chain_intact:
+            # Name the tampering rather than reporting a sequence mismatch that
+            # is not the problem: the head can sit at the signed sequence while
+            # an earlier event's content has been rewritten underneath it.
+            text = (
+                f"Attestation ALTERED: the event chain no longer verifies "
+                f"({len(integrity.violations)} violation(s)); run "
+                f"`continuum verify {args.run_id}` for the specific events."
+            )
+        else:
+            text = (
+                f"Attestation ALTERED: chain changed since signing "
+                f"(signed seq {doc.get('trusted_through_seq')} vs live {live_seq})."
+            )
     else:
         text = "Attestation UNTRUSTED: signature does not verify against the embedded key."
     _emit(payload, text, as_json=args.json, stream=out, palette=getattr(args, "_palette", None))

--- a/src/continuum/dashboard/app.py
+++ b/src/continuum/dashboard/app.py
@@ -42,6 +42,17 @@ def render_dashboard_html(storage: Storage) -> str:
 </table></body></html>"""
 
 
+def _run_exists(storage: Storage, run_id: str) -> bool:
+    """Whether the run is real, so the handler can answer 404 rather than 200."""
+    from continuum.storage import RunNotFound
+
+    try:
+        storage.get_run(run_id)
+    except RunNotFound:
+        return False
+    return True
+
+
 def render_run_detail_html(storage: Storage, run_id: str) -> str:
     try:
         run = storage.get_run(run_id)
@@ -163,9 +174,14 @@ def make_dashboard_server(
             if self.path.startswith("/runs/"):
                 run_id = self.path.split("/runs/")[1].split("?")[0].split("/")[0]
                 content = render_run_detail_html(storage, run_id)
-            else:
-                content = render_dashboard_html(storage)
-            self._html(content)
+                # A run nobody has ever written to must not answer 200. The body
+                # already says "Run not found", but the status is what anything
+                # other than a human reads, and the CLI holds the same line: a
+                # typo'd run name never looks like a clean bill of health.
+                code = 200 if _run_exists(storage, run_id) else 404
+                self._html(content, code=code)
+                return
+            self._html(render_dashboard_html(storage))
 
         def do_POST(self) -> None:  # noqa: N802
             length = int(self.headers.get("Content-Length") or 0)

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -52,7 +52,7 @@ import json
 import os
 import sqlite3
 import sys
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -199,6 +199,38 @@ def _open_server_storage(database: str) -> SQLiteStorage:
     # Nothing was clearable, so the error was something else entirely. Retrying
     # an identical open would fail identically.
     raise error
+
+
+@contextlib.contextmanager
+def _refusal_reaches_the_caller() -> Iterator[None]:
+    """Re-raise a deliberate refusal as ``ToolError`` so its reason survives.
+
+    Refusing a call is part of this server's contract, not a crash: an
+    unauthorized caller, a progress counter that violates its own arithmetic, a
+    run that does not exist, a log that never recorded RUN_STARTED. Each answer
+    is only useful if the caller is told which one it was.
+
+    The SDK draws that line by exception type. From mcp 2.1.0 a handler
+    exception it does not recognise becomes ``UnexpectedToolError`` whose message
+    is just ``"Error executing tool <name>"``, with the cause left on
+    ``__cause__``, while a ``ToolError`` keeps its text. Every refusal here is
+    raised as a domain exception (``PermissionError`` for authz, ``ValueError``
+    for validation, ``RunNotFound``, ``MalformedRunLog``), so under 2.1.0 the
+    caller was told nothing at all: not that it was a permissions problem, not
+    which counter was wrong, and not the CONTINUUM_MCP_MUTATING_CLIENTS setting
+    that fixes the first case. Converting here restores the guidance and states
+    the intent, that these outcomes are expected rather than faults.
+
+    Genuinely unexpected exceptions are deliberately not converted. Those should
+    keep surfacing as unexpected, because a bug in this server is not a message
+    to act on.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    try:
+        yield
+    except (PermissionError, ValueError, RunNotFound, MalformedRunLog) as exc:
+        raise ToolError(str(exc)) from exc
 
 
 def _environment(run_id: str, env: Mapping[str, str] | None) -> EnvironmentSnapshot | None:
@@ -422,9 +454,10 @@ def build_server(
             # Authenticate before authorize: a caller proves the shared secret
             # first, then its declared name is checked against the allowlist.
             # Both must pass; either failure refuses the call before any write.
-            auth.verify(caller, token_from(ctx))
-            policy.require(caller, fn.__name__)
-            return fn(*args, **kwargs)
+            with _refusal_reaches_the_caller():
+                auth.verify(caller, token_from(ctx))
+                policy.require(caller, fn.__name__)
+                return fn(*args, **kwargs)
 
         # The SDK locates the context parameter via get_type_hints(), and
         # functools.wraps copies the *wrapped* function's annotations — which
@@ -462,8 +495,9 @@ def build_server(
             # a caller that cannot present the confirmation secret must not
             # be able to probe the allowlist, or receive its contents in the
             # refusal, by sending requests without a token.
-            confirm_auth.verify(token_from(ctx))
-            policy.require(caller, fn.__name__)
+            with _refusal_reaches_the_caller():
+                confirm_auth.verify(token_from(ctx))
+                policy.require(caller, fn.__name__)
             return fn(*args, **kwargs)
 
         # Same fix-up as ``guard``: re-advertise the context parameter or the

--- a/src/continuum/recovery/fork.py
+++ b/src/continuum/recovery/fork.py
@@ -147,7 +147,18 @@ def approve_fork(
             "fork_parent_sequence": divergence,
         },
     )
-    storage.create_run(child)
+    # create_run_started, not create_run: the child needs its own RUN_STARTED or
+    # it has a row and an empty log, which nothing downstream can read. project()
+    # refuses a log that never recorded RUN_STARTED, so `resume`, `tree`,
+    # `replay` and `inspect` all fail on the child -- including the exact command
+    # this function's own caller prints as the next step. Same defect class as
+    # #47, which fixed it for the OpenAI adapter. The row and its first event are
+    # one fact, so they are written in one transaction.
+    #
+    # Origin.HUMAN matches the RUN_FORKED event below: a person approved this
+    # branch, and the child's goal is inherited from a run a human already
+    # stated, so it is not an agent self-report.
+    storage.create_run_started(child, source=Origin.HUMAN)
     storage.append_event(
         parent_run_id,
         EventType.RUN_FORKED,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 from collections.abc import Iterator
@@ -803,6 +804,66 @@ def test_attest_verify_reports_altered_after_new_event(db: str, tmp_path: Path) 
     code, out, _ = run("--db", db, "attest-verify", "run_1", "--attest", str(attest_file))
     assert code == ExitCode.CORRUPTED
     assert "ALTERED" in out
+
+
+def test_attest_verify_detects_an_in_place_payload_edit(db: str, tmp_path: Path) -> None:
+    """An attestation must not pass on content that was rewritten under it.
+
+    The verdict used to compare the signed ``chain_hash`` against the digest
+    *stored* in the head row. Editing an event's payload straight through the
+    database changes the payload and leaves every ``hash`` column untouched, so
+    the head still matched and the verdict read SIGNED, "chain matches", on a run
+    whose goal had been rewritten. `continuum verify` caught it in the same
+    breath, because it recomputes; attest-verify did not, because it did not.
+
+    This is the attack the signature exists to stop, so it gets its own test:
+    appending an event (covered above) moves the head and is easy to notice,
+    while an in-place edit is silent and is what an attacker with database access
+    would actually do.
+    """
+    from continuum.security.attestation import generate_keypair
+
+    priv_pem, _ = generate_keypair()
+    key_file = tmp_path / "signer.pem"
+    key_file.write_text(priv_pem)
+
+    attest_file = tmp_path / "run_1.attest.json"
+    code, _, _ = run(
+        "--db",
+        db,
+        "attest",
+        "run_1",
+        "--key",
+        str(key_file),
+        "--signer",
+        "ci-bot",
+        "--out",
+        str(attest_file),
+    )
+    assert code == ExitCode.OK
+
+    head_before = _head_hash(db)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "UPDATE events SET payload = ? WHERE run_id = 'run_1' AND sequence = 1",
+            (json.dumps({"goal": "rewritten", "total": 100}),),
+        )
+    # The premise of the bug: the stored head digest is byte-identical, so any
+    # check that trusts it cannot see the edit.
+    assert _head_hash(db) == head_before
+
+    code, out, _ = run("--db", db, "attest-verify", "run_1", "--attest", str(attest_file))
+    assert code == ExitCode.CORRUPTED, f"a tampered chain must not verify: {out}"
+    assert "ALTERED" in out
+    assert "no longer verifies" in out
+
+
+def _head_hash(db: str) -> str:
+    with sqlite3.connect(db) as conn:
+        row = conn.execute(
+            "SELECT hash FROM events WHERE run_id = 'run_1' ORDER BY sequence DESC LIMIT 1"
+        ).fetchone()
+    return str(row[0])
 
 
 # --- provenance view (issue #148) ------------------------------------------- #

--- a/tests/test_dashboard_bind.py
+++ b/tests/test_dashboard_bind.py
@@ -51,3 +51,39 @@ def test_handler_serves_the_dashboard_over_a_real_socket(db: str) -> None:
     finally:
         server.shutdown()
         server.server_close()
+
+
+def test_an_unknown_run_answers_404_not_200(db: str) -> None:
+    """A run nobody wrote to must not answer 200 over HTTP.
+
+    The body already said "Run not found", but the status line said OK, and the
+    status is what anything other than a human reads. The CLI holds the same
+    line: `test_no_command_reports_success_for_a_run_that_does_not_exist` exists
+    so a typo'd run name never looks like a clean bill of health, and the
+    dashboard is that same claim over a different transport.
+    """
+    import threading
+    import urllib.error
+
+    from continuum.events import EventType
+    from continuum.models import Run
+
+    storage = SQLiteStorage(db)
+    storage.create_run(Run(run_id="real_run", goal="g"))
+    storage.append_event("real_run", EventType.RUN_STARTED, {"goal": "g"})
+
+    server = make_dashboard_server(storage, port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        _, port = server.server_address[:2]
+        resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/runs/real_run", timeout=5)
+        assert resp.status == 200
+
+        with pytest.raises(urllib.error.HTTPError) as caught:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/runs/definitely-not-a-run", timeout=5)
+        assert caught.value.code == 404
+        assert "Run not found" in caught.value.read().decode()
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_fork.py
+++ b/tests/test_fork.py
@@ -154,17 +154,48 @@ def test_approve_fork_writes_event_and_linked_child(db: str) -> None:
 
 
 def test_fork_child_is_independently_resumable(db: str) -> None:
+    """The child must be usable straight out of approve_fork.
+
+    This test used to append RUN_STARTED to the child itself before resuming,
+    which meant it proved the fixture's work rather than the code's: fork wrote
+    only a run row, so the child had an empty log and every reader refused it,
+    including the `continuum resume <child>` line that `continuum fork` prints as
+    the next step. Same defect class as #47. approve_fork now writes the row and
+    its RUN_STARTED in one transaction, so nothing is staged here.
+    """
     with SQLiteStorage(db) as store:
         child = approve_fork(store, "run_1", reason="new terms")
-        store.append_event(child.run_id, EventType.RUN_STARTED, {"goal": child.goal, "total": 1})
+        # The child's own log is startable with no help from this test.
+        events = store.read_events(child.run_id)
+        assert [e.type for e in events] == [EventType.RUN_STARTED]
+        assert events[0].source is Origin.HUMAN
 
     code, out, _ = run("--db", db, "resume", child.run_id)
-    # Resume reaches its own verdict about the CHILD: an empty fork with a
-    # consistent start event is cleanly resumable, independent of the parent.
+    # Resume reaches its own verdict about the CHILD, independent of the parent.
     assert code == ExitCode.OK
     assert f"Run: {child.run_id}" in out
     assert "Recovery decision: RESUME" in out
     assert "FAMILY BLOCKED" not in out
+
+
+def test_every_reader_accepts_a_fresh_fork_child(db: str) -> None:
+    """The commands `continuum fork` points the user at must all work.
+
+    `fork` prints "Resume it independently" and "Lineage: continuum tree", so
+    those two at minimum have to succeed on an untouched child. The rest are
+    included because they share the projection path that an empty log breaks.
+    """
+    with SQLiteStorage(db) as store:
+        child = approve_fork(store, "run_1", reason="branching")
+
+    for command in ("resume", "inspect", "replay", "verify", "events", "show-contract"):
+        code, _, err = run("--db", db, command, child.run_id)
+        assert code == ExitCode.OK, f"{command} failed on a fresh fork child: {err}"
+
+    code, out, _ = run("--db", db, "tree", "run_1")
+    assert code == ExitCode.OK
+    assert child.run_id in out
+    assert "assess error" not in out, f"tree still cannot assess the child: {out}"
 
 
 def test_duplicate_child_and_empty_reason_are_refused(db: str) -> None:

--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -797,3 +797,56 @@ def test_an_unconfigured_confirm_secret_never_conflicts(store: SQLiteStorage) ->
         auth=AuthPolicy("session-secret"),
     )
     assert srv is not None
+
+
+# --- a refusal has to say why -------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_is_raised_as_tool_error_carrying_its_reason(
+    store: SQLiteStorage,
+) -> None:
+    """The reason must survive the SDK's error wrapping, not just exist.
+
+    Refusing is part of this server's contract, so the caller has to be told
+    which refusal it hit. The SDK decides that by exception type: from mcp 2.1.0
+    an exception it does not recognise becomes UnexpectedToolError whose message
+    is only "Error executing tool <name>", with the cause demoted to __cause__.
+    Authz raises PermissionError subclasses, so on 2.1.0 a refused caller learned
+    nothing: not that it was a permissions problem, and not the env var that
+    grants access. This asserts the message itself, because asserting only the
+    type would have passed throughout that regression.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, _ = build_server(storage=store, policy=AuthorizationPolicy([ALLOWED]))
+
+    with pytest.raises(ToolError) as caught:
+        await server.call_tool(
+            "continuum_record_progress",
+            {"run_id": "r", "completed": 1, "total": 2, "goal": "g"},
+            context=fake_context("a-stranger"),
+        )
+    message = str(caught.value)
+    assert "not permitted" in message, message
+    assert CLIENT_TOKENS_ENV_VAR in message or "CONTINUUM_MCP_MUTATING_CLIENTS" in message, message
+
+
+@pytest.mark.asyncio
+async def test_a_validation_refusal_also_carries_its_reason(store: SQLiteStorage) -> None:
+    """Same contract for the caller's own mistakes, not only for authz.
+
+    A progress counter that breaks its own arithmetic is a refusal the caller can
+    act on, so the numbers have to reach it. These are ValueError, which the SDK
+    also treats as unexpected.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, _ = build_server(storage=store, policy=AuthorizationPolicy([ALLOWED]))
+
+    with pytest.raises(ToolError, match="exceeds total"):
+        await server.call_tool(
+            "continuum_record_progress",
+            {"run_id": "r", "completed": 999, "total": 10, "goal": "g"},
+            context=fake_context(ALLOWED),
+        )


### PR DESCRIPTION
## Summary

Auditing the CLI and subsystems, which the earlier MCP rounds never touched, surfaced three defects. One is a genuine security hole.

| # | Defect | Severity |
|---|---|---|
| 1 | `attest-verify` reports SIGNED on a tampered chain | High, security |
| 2 | `continuum fork` produces a child no reader can open | Medium |
| 3 | Dashboard answers 200 for a run that does not exist | Low |

## 1. A signed attestation passed on rewritten content

`attest-verify` compared the signed `chain_hash` against the digest **stored** in the head row. Editing an event's payload straight through the database changes the payload and leaves every `hash` column untouched, so the head still matched, the signature still verified, and the verdict read:

```
Attestation SIGNED by ci-bot for seq 2; chain matches.     exit 0
```

on a run whose goal had been rewritten to `EVIL`. The same database, one command later:

```
continuum verify j
INTEGRITY FAILURE: 2 violation(s)
  seq 1: TAMPERED_CONTENT - stored hash does not match recomputed digest
  seq 2: BROKEN_CHAIN - prev_hash does not match predecessor digest
```

`verify` catches it because it recomputes digests. `attest-verify` did not, because it trusted the column an attacker with write access simply leaves alone. That is precisely the attack an event-chain signature exists to stop, which makes a passing verdict worse than no attestation at all.

The verdict now consults `verify_events` before trusting any hash read out of the chain, and names the tampering rather than reporting a sequence mismatch that is not the problem: the head can sit exactly at the signed sequence while an earlier event's content has been rewritten underneath it.

Both existing outcomes are preserved. A clean chain is still SIGNED. An appended event is still ALTERED with its sequence comparison, which `test_attest_verify_reports_altered_after_new_event` continues to assert.

## 2. `continuum fork` created an unusable child

`approve_fork` called `create_run`, which writes a run row and no `RUN_STARTED`. Projection refuses a log that never recorded one, so every reader failed on the child, including both commands `fork` itself prints as the next step:

```
$ continuum fork job1 --reason divergent
Forked job1 into job1_fork1.
Resume it independently: continuum resume job1_fork1
Lineage: continuum tree job1

$ continuum resume job1_fork1
error: run 'job1_fork1' has no checkpoint and no events        exit 2

$ continuum tree job1
job1  [resume, safe=True]  audit
  !! [fork] job1_fork1  [assess error: run 'job1_fork1' has no checkpoint and no events]
```

Same defect class as #47, which fixed it for the OpenAI adapter. It now uses `create_run_started`, which writes the row and its first event in one transaction, with `Origin.HUMAN` to match the `RUN_FORKED` record on the parent.

**Worth flagging how this survived.** Three tests hand-appended `RUN_STARTED` to the child after calling `approve_fork`, so they exercised the fixture rather than the code. `test_fork_child_is_independently_resumable` asserted exactly the property that was broken and passed only because it staged the missing event itself; its own comment gave it away, describing "an empty fork with a consistent start event". That crutch is removed, so the test now proves its name. A second test walks the six readers plus `tree`, so fork's printed advice is covered rather than assumed.

## 3. Dashboard answered 200 for an unknown run

`GET /runs/<unknown>` rendered "Run not found" in the body and returned HTTP 200. The body was honest; the status line was not, and the status is what anything other than a human reads.

The CLI holds this line deliberately, which is what `test_no_command_reports_success_for_a_run_that_does_not_exist` protects. The dashboard is the same claim over a different transport, so it owes the same answer. Real routes are untouched: `/` still lists runs at 200, `/runs/<real>` still renders detail at 200, and the catch-all for unrecognised paths is unchanged because serving the index there is deliberate.

## What was verified working

Not everything I probed was broken. Confirmed sound, and worth recording so the next audit can skip it:

- Every read-only command on a real run: `inspect`, `history`, `events`, `verify`, `actions`, `replay`, `show-contract`, `validate`, `resume`, `briefing`, `budget`, `tree`
- `reconcile` with no probes registered correctly exits 20 and reports the action unsettled rather than guessing
- `gate` defaults to allow with "no gate configured"
- `compact` refuses without `--force` and the chain still verifies afterwards
- The sidecar over its JSON wire protocol, including that `resume` carries `self_report_guidance`, so the MCP and sidecar surfaces remain at parity
- Dashboard index, run detail, and HITL POST refusing an unauthenticated caller with 403
- Attestation keygen and the clean round trip

Two of my probes were my own errors, not defects: `observe` reads its payload from stdin, and `health` is not a command in `main` at all.

## Verification

```
1370 passed, 24 skipped
ruff check / format         clean
mypy src                    25 errors, identical to baseline
```

Each fix is covered by a test that fails without it. I confirmed that by stashing each change and watching the new tests go red:

| Test | Guards |
|---|---|
| `test_attest_verify_detects_an_in_place_payload_edit` | asserts the stored head digest is byte-identical after the edit, so the premise of the bug is pinned, then requires CORRUPTED |
| `test_fork_child_is_independently_resumable` | the child's log is startable with no help from the test |
| `test_every_reader_accepts_a_fresh_fork_child` | six readers plus `tree`, no "assess error" |
| `test_an_unknown_run_answers_404_not_200` | 200 for a real run, 404 for a missing one |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Attestation verification now detects altered event data and reports clear tampering diagnostics, including the number of violations.
  - Dashboard requests for unknown runs now return HTTP 404 instead of a successful response.
  - Approved forked runs now include their own event history and work correctly with resume, inspect, replay, verification, event viewing, and contract commands.
- **Tests**
  - Added regression coverage for event tampering, missing dashboard runs, and fork-child workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->