### PR TITLE
fix(actions): serialise ActionLedger claims with the run lease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,6 +714,28 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **`ActionLedger` could not serialise concurrent claims on one key (#345).**
+  `claim()` deduplicates by folding the log and then appending, with nothing
+  between the read and the write, so processes racing on one key could each be
+  told to proceed: eight threads, eight go-aheads, eight charges. The outcome was
+  decided purely by thread scheduling, and the event chain verified clean either
+  way, so no integrity check could catch it. `docs/multi_agent_isolation.md`
+  already specified the remedy ("one run, one owner at a time") and
+  `RecoveryLedger` implemented it, but `ActionLedger` (the class whose entire
+  purpose is at-most-once side effects) had no lease parameter. It now accepts an
+  optional `LeaseCoordinator` and acquires the run's lease around `claim` and
+  every settle method (`complete`, `fail`, `reconcile`, `compensate`,
+  `flag_for_review`), so eight simultaneous claimants collapse to exactly one
+  go-ahead and one `STARTED` slot; the losers raise the new `ClaimLockError`, or
+  `UnknownSideEffect` where the winner's slot was already open, and neither
+  performs the effect. The lease is reentrant for its own holder so an agent that
+  correctly took the run lease first is not locked out of its own ledger, and
+  `holder_id` is required rather than defaulted, because a shared default would
+  make two processes look like one holder and silently defeat the protection.
+  Omitting `lease` leaves the single-process path exactly as it was. Atomic
+  claiming in storage, which would drop the caller's obligation entirely, remains
+  open on #345.
+
 - **Em dash in the CI lint job name.** The `mypy` step in `ci.yml` was named
   with an em dash, violating the no-em-dash house rule (#266); renamed with a
   comma. Found while editing the file for the wheel-artifact job.

--- a/docs/TESTING_MCP.md
+++ b/docs/TESTING_MCP.md
@@ -207,11 +207,19 @@ empirically that the documented remedy is sufficient: wrapping the same eight
 claims in a shared `SQLiteLeaseCoordinator` lease collapses them to exactly one
 winner.
 
-**Partially addressed.** The single-writer requirement is now stated on the
-`ActionLedger` docstring, and two tests pin both halves: that the ledger alone
-does not serialise concurrent claimants, and that the lease restores exactly-once.
-Making the claim atomic in storage, or accepting a `LeaseCoordinator` directly, is
-left to #345.
+**Addressed.** `ActionLedger` now accepts a `LeaseCoordinator` and acquires the
+run's lease itself around `claim` and every settle method, so the eight-thread
+race collapses to exactly one go-ahead and one `STARTED` slot. The losers split
+between `ClaimLockError` (the run was leased elsewhere) and `UnknownSideEffect`
+(the lease was free but the winner's slot was already open and unsettled); both
+are refusals, neither performs the charge. The unleased default is unchanged and
+still pinned by its own test, because a single-process caller has nothing to
+serialise against.
+
+Two things remain, and are tracked rather than implied. The construction sites
+that can face a second writer still build the ledger unleased, so the capability
+is opt-in per caller. And the claim is still not atomic in storage, which is the
+only version of this that would hold without the caller's cooperation.
 
 The event chain stays sound throughout, so these are honestly-recorded duplicate
 attempts rather than corruption. That is precisely why only a lease can prevent
@@ -240,7 +248,7 @@ after every change.
 | Recorded progress and the goal survive a mid-action crash | yes |
 | A completed unscoped effect deduplicates across runs (#34) | yes |
 | A consumed single-use grant cannot be resurrected (#269) | yes |
-| Exactly-once under concurrency, **given the run lease** (#345) | yes |
+| Exactly-once under concurrency, with a lease-aware ledger (#345) | yes |
 
 ## Notes for operators
 
@@ -270,6 +278,9 @@ mypy src
 python -m pytest tests/test_retry_budgets.py tests/test_action_ledger.py \
                  tests/test_validator.py tests/test_mcp_server.py -q
 
+# finding 8, both halves: the unleased race and the lease that closes it
+python -m pytest tests/test_storage_concurrency.py -q
+
 # the security properties that must not move
 python -m pytest tests/test_provenance.py tests/test_toy_task_banner_attack.py \
                  tests/test_trust_gate.py -q
@@ -282,9 +293,11 @@ Stated plainly rather than left implied.
 - **Model drift over MCP is still undetectable.** Finding 3 removes the false
   assurance but adds no write path for the model. Issue #308 remains open for
   that decision.
-- **Concurrent claiming is not atomic.** Finding 8 is documented and pinned by
-  tests, and the lease is proven sufficient, but `ActionLedger` still does not
-  acquire a lease itself. Issue #345.
+- **Concurrent claiming is not atomic.** `ActionLedger` acquires the run lease
+  itself when given a coordinator (finding 8), but the underlying claim is still
+  a fold-then-append rather than a compare-and-set. A caller that omits the
+  lease, or mixes leased and unleased ledgers on one run, gets the weaker
+  guarantee. Atomic claiming in storage stays open on #345.
 - **No Postgres run.** `require_usable_run_id` is wired into the Postgres backend
   but only the SQLite path was executed; the Postgres contract tests need a live
   server.

--- a/docs/api/ledger.md
+++ b/docs/api/ledger.md
@@ -16,7 +16,45 @@ if outcome.fresh:
 
 ## ActionLedger
 
-`continuum.actions.ledger.ActionLedger(storage, run_id)`
+`continuum.actions.ledger.ActionLedger(storage, run_id, *, lease=None, holder_id=None, ttl=None)`
+
+Deduplication is a fold of the log followed by an append, not an atomic
+compare-and-set, so two processes claiming one key at the same instant can both
+read "no prior slot". `lease` closes that window: pass a
+`continuum.concurrency.LeaseCoordinator` and every mutating method acquires the
+run's lease before it reads and releases it after it writes, so concurrent
+claimants collapse to a single winner and the losers raise `ClaimLockError`
+instead of opening a parallel slot.
+
+`holder_id` is required alongside `lease` and must be a stable agent identity. A
+shared default would make two processes look like the same holder and silently
+defeat the serialization. `ttl` overrides the coordinator's default lease
+lifetime.
+
+The lease is reentrant for its own holder, so a caller that already acquired the
+run lease (the pattern in [multi-agent isolation](../multi_agent_isolation.md))
+can use the ledger inside it; the ledger leaves releasing to whoever acquired.
+
+Omitting `lease` keeps the single-process behaviour unchanged: nothing is
+acquired, and exactly-once is only as strong as the caller's own serialization.
+
+```python
+from continuum.actions.ledger import ActionLedger, ClaimLockError
+from continuum.concurrency import SQLiteLeaseCoordinator
+
+ledger = ActionLedger(
+    storage, run_id, lease=SQLiteLeaseCoordinator("leases.db"), holder_id="agent-a"
+)
+try:
+    outcome = ledger.claim("email.send", {"to": "alice"})
+except ClaimLockError:
+    return  # another agent owns this run right now; back off and retry
+```
+
+Two limits are worth knowing. The lease is scoped to one `run_id`, so an
+unscoped claim (`scoped_to_run=False`) racing the same key from another run is
+not covered by this run's lease. And the claim is still not atomic in storage, so
+mixing leased and unleased ledgers on one run yields the weaker guarantee.
 
 ### `claim(action_type, arguments=None, *, volatile=(), scoped_to_run=True, key=None, on_unknown=None) -> ActionOutcome`
 
@@ -52,6 +90,15 @@ Record that a completed effect was deliberately undone (for example a refund).
 ### `flag_for_review(key, reason) -> Action`
 
 Escalate an action a human must judge.
+
+## ClaimLockError
+
+`continuum.actions.ledger.ClaimLockError`
+
+Raised by a lease-aware ledger when the run's lease is held by another holder, in
+place of writing anyway. A subclass of `LedgerError`. Seeing it means another
+agent owns the run: back off and retry rather than forcing the write, because
+whatever that agent is claiming may be the very action this caller wanted.
 
 ### `get(key) -> Action | None`
 

--- a/docs/multi_agent_isolation.md
+++ b/docs/multi_agent_isolation.md
@@ -10,6 +10,7 @@ attempt count, corrupting the high watermark.
 ## Current mechanism
 
 - `RecoveryLedger` can be constructed with a `LeaseCoordinator` (`src/continuum/recovery/ledger.py:209`). `append_decision` and `record_attempt` acquire the lease for the run (`_locked` in `src/continuum/recovery/ledger.py:222`) and raise `LedgerLockError` if the lease is held. The same coordinator is used by `continuum serve` sidecars.
+- `ActionLedger` takes the same optional `LeaseCoordinator` (issue #345). Every mutating method (`claim` and each settle method) acquires the run's lease before folding the log and releases it after appending, raising `ClaimLockError` when the lease is held elsewhere. Unlike `RecoveryLedger` it is reentrant for its own holder, so an agent that acquired the run lease first is not locked out of its own ledger, and a `holder_id` is mandatory rather than defaulted, because a shared default holder would make that reentrancy indistinguishable from two agents colliding.
 - `CheckpointManager` writes checkpoints and versions via `Storage` which is
   transactional in SQLite and Postgres. `prune` and `last_recovery_anchor`
   operate per `run_id` and version.
@@ -69,6 +70,19 @@ ownership model for the state itself.
   and in the walkthrough. If a run is observed without a lease, `reconcile`
   should report `drift` and the run should not be resumed until a lease
   holder validates.
+
+- Wire a coordinator through the `ActionLedger` construction sites that can face
+  a second writer (`continuum serve`, the MCP server, the gateway). The class
+  accepts one now, but those callers still build it unleased, so the operator
+  gets the capability only by constructing the ledger directly. Each needs a
+  decision about where its stable `holder_id` comes from.
+
+- Make the claim atomic in storage, so the guarantee holds without cooperation
+  from callers. A unique constraint over open slots per `(run_id,
+  idempotency_key)` is the shape, but the ledger is event-sourced and a legitimate
+  re-claim after `COMPENSATED` or `FAILED` writes a second record under the same
+  key, so "open" has to be expressed against the fold rather than the table. This
+  is the only option that removes the caller's obligation entirely.
 
 This spec may spawn implementation issues for a `LeaseAwareCheckpointManager`
 wrapper and for per kind lease splitting.

--- a/src/continuum/actions/__init__.py
+++ b/src/continuum/actions/__init__.py
@@ -4,6 +4,7 @@ from continuum.actions.idempotency import IdempotencyKey, arguments_hash, idempo
 from continuum.actions.ledger import (
     ActionLedger,
     ActionOutcome,
+    ClaimLockError,
     DuplicateAction,
     LedgerError,
 )
@@ -22,6 +23,7 @@ __all__ = [
     "ActionLedger",
     "ActionOutcome",
     "AssumeNotOccurredReconciler",
+    "ClaimLockError",
     "DuplicateAction",
     "IdempotencyKey",
     "LedgerError",

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -42,10 +42,13 @@ The distinction is documented rather than marketed away.
 from __future__ import annotations
 
 import os
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import timedelta
+from functools import wraps
 from heapq import merge
-from typing import Any
+from typing import Any, Concatenate, ParamSpec, TypeVar
 
 from continuum.actions.grants import GrantDenied, normalize_grant, scan_grants
 from continuum.actions.idempotency import (
@@ -55,6 +58,7 @@ from continuum.actions.idempotency import (
     identity_tokens,
     leaf_tokens,
 )
+from continuum.concurrency.lease import LeaseCoordinator
 from continuum.events import EventType
 from continuum.models import Action, ActionStatus, UnknownSideEffect, utcnow
 from continuum.security.hashing import stable_hash
@@ -90,6 +94,7 @@ __all__ = [
     "ActionOutcome",
     "LedgerError",
     "DuplicateAction",
+    "ClaimLockError",
 ]
 
 
@@ -212,6 +217,44 @@ class DuplicateAction(LedgerError):
     """A second attempt was made while the first is still in flight."""
 
 
+class ClaimLockError(LedgerError):
+    """The run's lease is held elsewhere, so this ledger must not write.
+
+    Raised instead of proceeding, because the alternative -- claiming anyway --
+    is the duplicate side effect this ledger exists to prevent. A caller seeing
+    this should back off and retry, not force the write: another agent owns the
+    run right now, and whatever it is claiming may be the very action this
+    caller wanted.
+    """
+
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def _single_writer(
+    method: Callable[Concatenate[ActionLedger, _P], _R],
+) -> Callable[Concatenate[ActionLedger, _P], _R]:
+    """Run a mutating ledger method while holding the run's lease.
+
+    Every method that folds the log and then appends to it is a
+    read-modify-write, so every one of them races. Marking them declaratively
+    keeps that list honest: a new mutator without this decorator is visibly
+    missing something, whereas a forgotten ``with self._locked()`` deep inside a
+    hundred-line body is not.
+
+    A ledger built without a lease is unaffected, which is what keeps the
+    single-process path exactly as it was.
+    """
+
+    @wraps(method)
+    def wrapper(self: ActionLedger, /, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+        with self._locked():
+            return method(self, *args, **kwargs)
+
+    return wrapper
+
+
 @dataclass(frozen=True, slots=True)
 class ActionOutcome:
     """What a claim returned.
@@ -246,17 +289,87 @@ class ActionLedger:
     Single-writer per run. Deduplication is a claim-then-check against the
     folded log, not an atomic compare-and-set, so two processes claiming the
     same key at the same instant both read "no prior slot" and both open one.
-    The `docs/multi_agent_isolation.md` ownership model applies: a caller must
-    hold the run's lease (`continuum.concurrency.LeaseCoordinator`) before
-    claiming, exactly as `RecoveryLedger` does. Absent a lease, concurrent
-    claims on one key can each proceed and the exactly-once guarantee is only as
-    strong as the caller's own serialization. This class does not acquire the
-    lease itself yet; see issue tracking for lease-aware claiming.
+    The ``docs/multi_agent_isolation.md`` ownership model applies: one run, one
+    owner at a time.
+
+    Pass ``lease`` to have the ledger enforce that itself. Every mutating
+    method then acquires the run's lease for ``holder_id`` before it folds the
+    log, and releases it after the append, so concurrent claimants on one key
+    collapse to a single winner; the losers raise :class:`ClaimLockError`
+    rather than opening a parallel slot. ``holder_id`` is required alongside a
+    lease and must be a stable agent identity, not a shared constant: a default
+    would make every process look like the same holder and quietly disable the
+    protection it was passed to provide.
+
+    The lease is reentrant for its own holder, so the documented pattern of a
+    caller acquiring the run lease and *then* using the ledger still works --
+    the ledger recognises the lease as already its own, and leaves releasing it
+    to whoever acquired it.
+
+    Without ``lease`` the behaviour is exactly as before: unsynchronised, and
+    only as strong as the caller's own serialization. That remains the default
+    because the single-process path has nothing to serialise against.
+
+    Two limits are worth stating rather than implying. The lease is scoped to
+    one ``run_id``, so an unscoped claim (``scoped_to_run=False``) racing the
+    same key from *another* run is not covered by this run's lease; both
+    claimants would need to agree on a lease to be safe. And the claim is still
+    not atomic in storage, so a caller that mixes leased and unleased ledgers on
+    one run gets the weaker guarantee.
     """
 
-    def __init__(self, storage: Storage, run_id: str) -> None:
+    def __init__(
+        self,
+        storage: Storage,
+        run_id: str,
+        *,
+        lease: LeaseCoordinator | None = None,
+        holder_id: str | None = None,
+        ttl: timedelta | None = None,
+    ) -> None:
+        if lease is not None and not holder_id:
+            raise ValueError(
+                "holder_id is required when a lease is supplied: a shared default "
+                "would make two processes appear to be the same lease holder and "
+                "silently defeat the serialization. Pass a stable agent identity."
+            )
         self.storage = storage
         self.run_id = run_id
+        self._lease = lease
+        self._holder_id = holder_id or ""
+        self._ttl = ttl
+
+    # -- single-writer ---------------------------------------------------- #
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        """Hold the run's lease for the duration of one mutating call.
+
+        Reentrant for the lease's own holder. A caller that already acquired the
+        run lease (the pattern ``docs/multi_agent_isolation.md`` describes, and
+        the one ``continuum serve`` follows) passes straight through, and the
+        lease is left for that caller to release. Without this, the ledger would
+        fail every claim made by an agent that had correctly taken ownership of
+        the run first, which is precisely the well-behaved caller.
+        """
+        if self._lease is None:
+            yield
+            return
+        if self._lease.is_held(self.run_id, self._holder_id):
+            # Already ours. Do not release on the way out: the outer holder owns
+            # the lease's lifetime and may still need it.
+            yield
+            return
+        if not self._lease.acquire(self.run_id, self._holder_id, self._ttl):
+            raise ClaimLockError(
+                f"run {self.run_id!r} is leased to {self._lease.holder(self.run_id)!r}; "
+                f"{self._holder_id!r} must not write to the action ledger while another "
+                f"agent owns the run. Retry once the lease is free."
+            )
+        try:
+            yield
+        finally:
+            self._lease.release(self.run_id, self._holder_id)
 
     # -- reading ---------------------------------------------------------- #
 
@@ -447,6 +560,7 @@ class ActionLedger:
         self.storage.append_event(self.run_id, event_type, payload)
         return action
 
+    @_single_writer
     def claim(
         self,
         action_type: str,
@@ -618,6 +732,7 @@ class ActionLedger:
             f"Reconcile it before retrying."
         )
 
+    @_single_writer
     def complete(
         self,
         key: str,
@@ -639,6 +754,7 @@ class ActionLedger:
         )
         return self._record(key, action)
 
+    @_single_writer
     def fail(self, key: str, error: str, *, certain: bool = True) -> Action:
         """Record that the effect did not happen.
 
@@ -658,6 +774,7 @@ class ActionLedger:
         )
         return self._record(key, action)
 
+    @_single_writer
     def reconcile(
         self,
         key: str,
@@ -720,6 +837,7 @@ class ActionLedger:
             )
         return self._record(key, action, EventType.ACTION_RECONCILED)
 
+    @_single_writer
     def compensate(self, key: str, *, note: str = "", by: str | None = None) -> Action:
         """Record that a completed effect was deliberately undone."""
         existing = self._require(key)
@@ -733,6 +851,7 @@ class ActionLedger:
         )
         return self._record(key, action, EventType.ACTION_COMPENSATED)
 
+    @_single_writer
     def flag_for_review(self, key: str, reason: str) -> Action:
         """Escalate an action a human must judge."""
         existing = self._require(key)

--- a/tests/test_storage_concurrency.py
+++ b/tests/test_storage_concurrency.py
@@ -17,6 +17,7 @@ import os
 import subprocess
 import sys
 import textwrap
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -203,7 +204,7 @@ def _seed(db: Path) -> None:
 def test_concurrent_claims_on_one_key_are_not_serialised_by_the_ledger(
     tmp_path: Path,
 ) -> None:
-    """Deduplication is claim-then-check, not compare-and-set (issue #345).
+    """A ledger built *without* a lease still does not serialise (issue #345).
 
     Pinned deliberately rather than left to be discovered in production. The
     ledger folds the log to decide whether a key was already claimed, and
@@ -216,11 +217,13 @@ def test_concurrent_claims_on_one_key_are_not_serialised_by_the_ledger(
       because an unsettled attempt is genuinely ambiguous
 
     Which of those a given thread gets is not decidable in advance, so this test
-    asserts the shape of the outcome rather than a fixed count. That
-    nondeterminism is the finding: exactly-once rests on the caller holding the
-    run lease, per docs/multi_agent_isolation.md, and
-    ``test_the_run_lease_restores_exactly_once_under_concurrency`` proves the
-    lease is sufficient.
+    asserts the shape of the outcome rather than a fixed count.
+
+    This is now the opt-out path, not the only path: passing ``lease`` makes the
+    ledger acquire the run lease itself, which
+    ``test_a_lease_aware_ledger_admits_exactly_one_concurrent_claimant`` holds to
+    an exact count. The unleased default is kept because a single-process caller
+    has nothing to serialise against, and it must keep behaving as it always did.
 
     If a future change makes claiming atomic in storage, the assertion below
     becomes ``== 1``. That is the signal to tighten it, not to delete it.
@@ -281,3 +284,194 @@ def test_the_run_lease_restores_exactly_once_under_concurrency(tmp_path: Path) -
         outcomes = list(pool.map(claim, range(8)))
 
     assert outcomes.count("fresh") == 1, f"expected one winner, got {outcomes}"
+
+
+# --- the ledger takes the lease itself (issue #345, remaining half) ---------- #
+
+
+def test_a_lease_aware_ledger_refuses_to_claim_a_run_leased_elsewhere(tmp_path: Path) -> None:
+    """The regression guard for issue #345, stated without a race.
+
+    This is the whole fix reduced to its deterministic core: agent-a owns the
+    run, so agent-b's ledger must refuse to claim rather than open a second slot
+    for the same key. Remove the lock from ``ActionLedger`` and this fails on
+    every run and every platform, which is what
+    ``test_a_lease_aware_ledger_admits_exactly_one_concurrent_claimant`` cannot
+    promise: eight real threads on one SQLite file are largely serialised by the
+    GIL and file locking anyway, so the unleased path also tends to produce one
+    winner. Timing is a poor witness. A held lease is a certain one.
+
+    The log is checked as well as the exception, because refusing loudly while
+    still appending would satisfy ``pytest.raises`` and defeat the purpose.
+    """
+    from continuum.actions.ledger import ActionLedger, ClaimLockError
+    from continuum.concurrency import InMemoryLeaseCoordinator
+
+    db = tmp_path / "refused.db"
+    _seed(db)
+    coordinator = InMemoryLeaseCoordinator()
+    assert coordinator.acquire("run_1", "agent-a")
+
+    with SQLiteStorage(db) as store:
+        before = len(store.read_events("run_1"))
+        intruder = ActionLedger(store, "run_1", lease=coordinator, holder_id="agent-b")
+        with pytest.raises(ClaimLockError, match="agent-a"):
+            intruder.claim("charge", {"amt": 100}, key="k")
+
+        assert len(store.read_events("run_1")) == before, "a refused claim must write nothing"
+        assert intruder.get("k") is None
+
+        # The refusal is about the lease, not the key: once agent-a is done the
+        # same ledger claims normally.
+        coordinator.release("run_1", "agent-a")
+        assert intruder.claim("charge", {"amt": 100}, key="k").fresh
+
+
+def test_a_lease_aware_ledger_admits_exactly_one_concurrent_claimant(
+    tmp_path: Path,
+) -> None:
+    """``lease=`` moves the serialization from the caller into the ledger.
+
+    The same eight-thread race as
+    ``test_concurrent_claims_on_one_key_are_not_serialised_by_the_ledger``, with
+    the only difference being that each ledger is handed the shared coordinator.
+    Exactly one claimant is told to proceed, and exactly one ``STARTED`` slot is
+    written, however the threads interleave.
+
+    The barrier matters. Opening the SQLite connection is far slower than the
+    claim itself, so without a rendezvous the threads arrive one at a time and
+    the race never happens. Every thread therefore pays that cost first and only
+    then waits, so all eight enter ``claim`` together.
+
+    The losers split into two safe refusals, and both are correct:
+
+    - ``locked``: the run was leased to someone else, so this ledger did not read
+      or write at all
+    - ``ambiguous``: the lease was free by the time this thread reached it, and
+      the winner's slot was already open and unsettled. ``UnknownSideEffect`` is
+      the right answer to "may I repeat an effect whose outcome nobody knows?",
+      and it is the same answer a sequential caller gets
+
+    Neither refusal performs the charge, which is the guarantee. This test shows
+    the mechanism end to end; the load-bearing regression assertion lives in
+    ``test_a_lease_aware_ledger_refuses_to_claim_a_run_leased_elsewhere``, which
+    does not depend on scheduling.
+    """
+    from continuum.actions.ledger import ActionLedger, ClaimLockError
+    from continuum.concurrency import SQLiteLeaseCoordinator
+
+    db = tmp_path / "self_leased.db"
+    _seed(db)
+    coordinator = SQLiteLeaseCoordinator(tmp_path / "lease.db")
+    start = threading.Barrier(8)
+
+    def claim(n: int) -> str:
+        with SQLiteStorage(db) as store:
+            ledger = ActionLedger(store, "run_1", lease=coordinator, holder_id=f"agent-{n}")
+            start.wait(timeout=10)
+            try:
+                return "fresh" if ledger.claim("charge", {"amt": 100}, key="k").fresh else "dedup"
+            except ClaimLockError:
+                return "locked"
+            except UnknownSideEffect:
+                return "ambiguous"
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        outcomes = list(pool.map(claim, range(8)))
+
+    assert outcomes.count("fresh") == 1, f"expected exactly one winner, got {outcomes}"
+    assert set(outcomes) <= {"fresh", "locked", "ambiguous"}, outcomes
+    with SQLiteStorage(db) as store:
+        opened = [
+            event
+            for event in store.read_events("run_1")
+            if event.type is EventType.ACTION_RECORDED and event.payload.get("status") == "started"
+        ]
+        assert len(opened) == 1, f"one go-ahead must open one slot, got {len(opened)}"
+        assert store.verify_events("run_1").ok
+
+
+def test_a_lease_aware_ledger_is_reentrant_for_its_own_holder(tmp_path: Path) -> None:
+    """A caller that already owns the run lease is not locked out of the ledger.
+
+    This is the pattern docs/multi_agent_isolation.md prescribes -- acquire the
+    run lease, then write -- so it must keep working when the ledger is also
+    lease-aware. Without the reentrancy check the ledger would refuse the one
+    caller that did the right thing, because ``acquire`` reports a lease held by
+    anyone (including the asker) as unavailable.
+
+    The settle call is included because it takes the lease on the same terms: an
+    agent that claims and completes inside one lease must not deadlock halfway.
+    """
+    from continuum.actions.ledger import ActionLedger
+    from continuum.concurrency import InMemoryLeaseCoordinator
+
+    db = tmp_path / "reentrant.db"
+    _seed(db)
+    coordinator = InMemoryLeaseCoordinator()
+    assert coordinator.acquire("run_1", "agent-outer")
+
+    with SQLiteStorage(db) as store:
+        ledger = ActionLedger(store, "run_1", lease=coordinator, holder_id="agent-outer")
+        outcome = ledger.claim("charge", {"amt": 100}, key="k")
+        assert outcome.fresh
+        ledger.complete(outcome.key, external_id="ch_1")
+
+    # The outer holder still owns the lease: the ledger must not release what it
+    # did not acquire, or the caller's remaining work would be unprotected.
+    assert coordinator.holder("run_1") == "agent-outer"
+
+
+def test_a_lease_aware_ledger_guards_the_settle_methods_too(tmp_path: Path) -> None:
+    """Settling folds the log and appends, so it races exactly like claiming.
+
+    ``complete``, ``fail``, ``reconcile``, ``compensate`` and ``flag_for_review``
+    all read-modify-write the same folded state. A lease that covered only
+    ``claim`` would let a second agent overwrite the outcome of an action it does
+    not own, which is the same defect one method further along.
+    """
+    from continuum.actions.ledger import ActionLedger, ClaimLockError
+    from continuum.concurrency import InMemoryLeaseCoordinator
+
+    db = tmp_path / "settle.db"
+    _seed(db)
+    coordinator = InMemoryLeaseCoordinator()
+
+    with SQLiteStorage(db) as store:
+        owner = ActionLedger(store, "run_1", lease=coordinator, holder_id="agent-owner")
+        outcome = owner.claim("charge", {"amt": 100}, key="k")
+        assert outcome.fresh
+
+        # A different agent grabs the run while the owner is mid-flight.
+        assert coordinator.acquire("run_1", "agent-intruder")
+        for settle in (
+            lambda: owner.complete(outcome.key, external_id="ch_1"),
+            lambda: owner.fail(outcome.key, "nope"),
+            lambda: owner.reconcile(outcome.key, occurred=True),
+            lambda: owner.compensate(outcome.key),
+            lambda: owner.flag_for_review(outcome.key, "why"),
+        ):
+            with pytest.raises(ClaimLockError):
+                settle()
+
+        coordinator.release("run_1", "agent-intruder")
+        # With the run free again the owner settles normally.
+        assert owner.complete(outcome.key, external_id="ch_1").external_id == "ch_1"
+
+
+def test_a_lease_without_a_holder_id_is_refused_at_construction() -> None:
+    """A shared default holder would silently defeat the whole mechanism.
+
+    Two processes both defaulting to the same holder string would each see the
+    other's lease as their own reentrant lease and both proceed, which is worse
+    than no lease at all because it looks protected. Failing loudly at
+    construction is the only version of this that cannot be got wrong quietly.
+    """
+    from continuum.actions.ledger import ActionLedger
+    from continuum.concurrency import InMemoryLeaseCoordinator
+
+    with (
+        SQLiteStorage(":memory:") as store,
+        pytest.raises(ValueError, match="holder_id is required"),
+    ):
+        ActionLedger(store, "run_1", lease=InMemoryLeaseCoordinator())


### PR DESCRIPTION
## Description

`ActionLedger.claim()` deduplicates by folding the event log and then appending,
with nothing between the read and the write. Processes racing on one key each
read "no prior slot", so each was told to proceed: eight threads produced eight
go-aheads and eight `ACTION_RECORDED` slots. Eight charges, from the class whose
entire purpose is at-most-once side effects.

The chain verifies clean either way, because these are honestly-recorded
duplicate attempts rather than corruption. That is what makes it dangerous: no
integrity check can catch it, and the outcome is decided purely by thread
scheduling, so a test can pass on one machine and the effect can double on
another.

`docs/multi_agent_isolation.md` already specified the remedy, "one run, one owner
at a time", and `RecoveryLedger` implemented it, but `ActionLedger` had no lease
parameter and no docstring saying one was required.

This takes option 2 from the issue, the one it notes "fits the existing
architecture". `ActionLedger` now accepts an optional `LeaseCoordinator` and
acquires the run's lease itself around `claim` and every settle method
(`complete`, `fail`, `reconcile`, `compensate`, `flag_for_review`). All of them
fold and then append, so a lease covering only `claim` would leave the same
defect one method further along. They are marked with a `_single_writer`
decorator rather than each opening the lock inline, so a future mutator that
forgets it is visibly missing something, whereas a forgotten
`with self._locked()` deep inside a long body is not.

Three decisions worth flagging for review:

- **The lease is reentrant for its own holder.** The pattern the spec prescribes
  is to acquire the run lease and *then* write, so without this the ledger would
  refuse precisely the caller that did the right thing. Reentrant passes do not
  release on the way out; the outer holder owns the lease's lifetime and may
  still need it. This differs from `RecoveryLedger`, which is not reentrant.
- **`holder_id` is required alongside a lease, not defaulted.** A shared constant
  would make two processes look like the same holder, so each would treat the
  other's lease as its own reentrant lease and both would proceed. That is worse
  than no lease, because it looks protected. It raises `ValueError` at
  construction instead.
- **`lease` defaults to `None`,** leaving the single-process path exactly as it
  was. A lone caller has nothing to serialise against, and the eight existing
  construction sites are unaffected.

## Related issues

Addresses #345.

Not "Fixes", deliberately. The issue's option 3, making the claim atomic in
storage, is the only version that holds without cooperation from callers, and it
is not done here. Both remaining pieces are tracked in
`docs/multi_agent_isolation.md` rather than left implied:

- the construction sites that can face a second writer (`continuum serve`, the
  MCP server, the gateway) still build the ledger unleased, so the capability is
  opt-in per caller and each needs a decision about where its stable `holder_id`
  comes from
- atomic claiming in storage. A unique constraint over open slots per
  `(run_id, idempotency_key)` is the shape, but the ledger is event-sourced and a
  legitimate re-claim after `COMPENSATED` or `FAILED` writes a second record
  under the same key, so "open" has to be expressed against the fold rather than
  the table

Refs #311, which filed the finding.

## Types of changes

- Type: `bugfix`

## Breaking changes

No. `lease`, `holder_id` and `ttl` are keyword-only with defaults, and omitting
them reproduces the previous behaviour exactly. The one new failure mode,
`ValueError` when a lease is passed without a `holder_id`, is unreachable for
existing callers because none passes a lease.

## How has this been tested?

Environment: Windows 11 (win32), Python 3.11, `continuum-agent` editable install,
SQLite backend. Commands run from the repository root.

```
python -m pytest                                 1372 passed, 24 skipped
python -m mypy src                               Success: no issues found in 104 source files
python -m ruff check <changed files>             All checks passed!
python -m ruff format --check <changed files>    3 files already formatted
```

`ruff check .` reports 2 pre-existing errors in `_bugaudit/` and
`ruff format --check .` reports 10 pre-existing unformatted files. Both counts
are identical on an unmodified tree at `b2f92ba`, verified by stashing this
branch's changes and re-running, so neither is introduced here.

**Shown failing on the old code path.** The lock in `_locked` was temporarily
removed and the lease tests re-run 10 consecutive times. All three failed on all
10:

```
E   Failed: DID NOT RAISE ClaimLockError
E   AssertionError: expected exactly one winner, got
E     ['fresh', 'fresh', 'fresh', 'fresh', 'fresh', 'fresh', 'fresh', 'fresh']
E   assert 8 == 1
```

That is the issue's reproduction, eight go-aheads on one key. With the lock
restored, 10 of 10 runs clean.

Tests added to `tests/test_storage_concurrency.py`:

| Test | What it holds |
|---|---|
| `..._refuses_to_claim_a_run_leased_elsewhere` | The regression guard, stated without a race: agent-a holds the run, agent-b's claim must raise and must write nothing. Deterministic on every platform. |
| `..._admits_exactly_one_concurrent_claimant` | Eight threads, one key, one shared coordinator: exactly one go-ahead and exactly one `STARTED` slot. |
| `..._is_reentrant_for_its_own_holder` | An agent that took the run lease first can still claim and settle, and the ledger does not release what it did not acquire. |
| `..._guards_the_settle_methods_too` | Each of the five settle methods refuses while the run is leased elsewhere. |
| `..._without_a_holder_id_is_refused_at_construction` | The shared-default footgun fails loudly. |

The pre-existing `test_concurrent_claims_on_one_key_are_not_serialised_by_the_ledger`
is kept and still asserts the unleased shape. It is now the opt-out path rather
than the only path, and its docstring says so.

## Checklist

Tests added or updated for the changed behaviour: yes, five, one per behaviour,
with the primary guard shown failing on the old code path above. Documentation
updated where the change affects user-facing behaviour: `docs/api/ledger.md`
(constructor, `ClaimLockError`, both limits), `docs/multi_agent_isolation.md`
(current mechanism plus the two follow-ups), `docs/TESTING_MCP.md` (finding 8
moved from partially-addressed to addressed, limitations and guarantee table
updated), `CHANGELOG.md`. CI passes on the latest commit: to be confirmed by CI;
locally the full suite, `mypy` and both `ruff` gates are clean as above.
Security-relevant changes state known limitations explicitly: yes, the two limits
are in this description, in the class docstring and in `docs/api/ledger.md`.

## Additional context

**Why the eight-thread test needed a barrier.** Without one it was a poor
regression guard: with the lock removed it caught the bug on only 1 of 12 runs,
because opening the SQLite connection costs far more than the claim, so the
threads arrived one at a time and the race mostly did not happen. The GIL and
SQLite file locking then serialise them anyway, so the unleased path also tended
to produce a single winner. Each thread now opens its connection first and only
then waits on a `threading.Barrier(8)`, so all eight enter `claim` together. That
is what turned 1 of 12 into 10 of 10. The deterministic test carries the
guarantee regardless, which is why it exists alongside.

**An observation, not changed here.** The two coordinators disagree about
re-acquiring your own lease: `SQLiteLeaseCoordinator.acquire` returns `True` for
the current holder, `InMemoryLeaseCoordinator.acquire` returns `False`. The
ledger checks `is_held` explicitly rather than relying on `acquire`, so it is
correct against both, but the divergence looks unintentional and would bite the
next caller that tries reentrancy through `acquire` alone. Left alone as out of
scope; happy to file it separately.

**Alternative considered.** Doing option 3 instead, atomic claiming in storage.
Rejected for this PR: it needs coordinated schema changes across SQLite, Postgres
and the in-memory backend, and it fights the event-sourced model, since a
legitimate re-claim after `COMPENSATED` or `FAILED` writes a second record under
the same key, so "unique among open slots" cannot be a plain table constraint. It
remains the right end state and is recorded as such.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional lease coordination for action claims and settlement operations.
  * Concurrent claimants are serialized so only one can proceed.
  * Added a public `ClaimLockError` for attempts blocked by another active lease.
  * Added reentrant lease support for the current holder.

* **Bug Fixes**
  * Prevented conflicting concurrent claims and settlement writes.

* **Documentation**
  * Documented lease configuration, concurrency behavior, limitations, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
