### PR TITLE
fix: every registry error names an absolute path, completing #333

### DIFF
--- a/src/continuum/budgets.py
+++ b/src/continuum/budgets.py
@@ -48,15 +48,19 @@ def load_budgets(path: Path) -> dict[str, Any]:
     """Read the budget registry. ``{}`` when absent; raise when malformed."""
     if not path.exists():
         return {}
+    # Absolute, so the message names a file the operator can open: the
+    # relative form depends on the cwd of whatever loaded the registry
+    # (a hook, the sidecar, a CI step). Matches gate.py per #333.
+    location = path.resolve()
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        raise BudgetConfigError(f"{path} is not valid JSON ({exc})") from exc
+        raise BudgetConfigError(f"{location} is not valid JSON ({exc})") from exc
     if not isinstance(raw, dict):
-        raise BudgetConfigError(f"{path}: expected a JSON object")
+        raise BudgetConfigError(f"{location}: expected a JSON object")
     action_types = raw.get("action_types", {})
     if not isinstance(action_types, dict):
-        raise BudgetConfigError(f"{path}: 'action_types' must be an object")
+        raise BudgetConfigError(f"{location}: 'action_types' must be an object")
     for name, spec in action_types.items():
         entry = (
             spec
@@ -69,7 +73,7 @@ def load_budgets(path: Path) -> dict[str, Any]:
             )
     default_max = raw.get("default_max_attempts")
     if default_max is not None and (not isinstance(default_max, int) or default_max < 1):
-        raise BudgetConfigError(f"{path}: 'default_max_attempts' must be >= 1")
+        raise BudgetConfigError(f"{location}: 'default_max_attempts' must be >= 1")
     return raw
 
 

--- a/src/continuum/gate.py
+++ b/src/continuum/gate.py
@@ -76,18 +76,24 @@ def load_gate_config(path: Path) -> dict[str, dict[str, Any]] | None:
     """
     if not path.exists():
         return None
+    # Resolved once, and used by every message below. The point of #333 is that
+    # an operator debugging a gate refusal needs to know which file to open, and
+    # the relative form depends on the cwd of whatever invoked the hook. Two of
+    # these four messages were still relative, so the same error could name the
+    # file two different ways depending on which validation tripped.
+    location = path.resolve()
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        raise GateConfigError(f"{path.resolve()} is not valid JSON ({exc})") from exc
+        raise GateConfigError(f"{location} is not valid JSON ({exc})") from exc
     if not isinstance(raw, dict) or not isinstance(raw.get("tools", {}), dict):
-        raise GateConfigError(f"{path.resolve()}: expected {{'tools': {{...}}}}")
+        raise GateConfigError(f"{location}: expected {{'tools': {{...}}}}")
     tools = raw.get("tools") or {}
     for tool, spec in tools.items():
         if not isinstance(spec, dict) or not isinstance(spec.get("key_template"), str):
-            raise GateConfigError(f"{path}: tool {tool!r} needs a string 'key_template'")
+            raise GateConfigError(f"{location}: tool {tool!r} needs a string 'key_template'")
         if spec.get("action_type") is not None and not isinstance(spec.get("action_type"), str):
-            raise GateConfigError(f"{path}: tool {tool!r} 'action_type' must be a string")
+            raise GateConfigError(f"{location}: tool {tool!r} 'action_type' must be a string")
     return tools
 
 

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -92,14 +92,18 @@ def load_gateway_config(path: Path) -> list[Route]:
     """Read upstream routes. Empty list when absent; raise when malformed."""
     if not path.exists():
         return []
+    # Absolute, so the message names a file the operator can open: the
+    # relative form depends on the cwd of whatever loaded the registry
+    # (a hook, the sidecar, a CI step). Matches gate.py per #333.
+    location = path.resolve()
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        raise GatewayConfigError(f"{path} is not valid JSON ({exc})") from exc
+        raise GatewayConfigError(f"{location} is not valid JSON ({exc})") from exc
     routes: list[Route] = []
     entries = raw.get("upstreams", []) if isinstance(raw, dict) else None
     if not isinstance(entries, list):
-        raise GatewayConfigError(f"{path}: expected {{'upstreams': [...]}}")
+        raise GatewayConfigError(f"{location}: expected {{'upstreams': [...]}}")
     for entry in entries:
         try:
             routes.append(
@@ -112,7 +116,7 @@ def load_gateway_config(path: Path) -> list[Route]:
                 )
             )
         except KeyError as exc:
-            raise GatewayConfigError(f"{path}: upstream missing required field {exc}") from exc
+            raise GatewayConfigError(f"{location}: upstream missing required field {exc}") from exc
     return routes
 
 

--- a/src/continuum/reconcilers.py
+++ b/src/continuum/reconcilers.py
@@ -63,16 +63,22 @@ def load_reconcilers(path: Path) -> dict[str, dict[str, Any]]:
     """Read the registry. Empty dict when absent; raise when malformed."""
     if not path.exists():
         return {}
+    # Absolute, so the message names a file the operator can open: the
+    # relative form depends on the cwd of whatever loaded the registry
+    # (a hook, the sidecar, a CI step). Matches gate.py per #333.
+    location = path.resolve()
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        raise ReconcilerConfigError(f"{path} is not valid JSON ({exc})") from exc
+        raise ReconcilerConfigError(f"{location} is not valid JSON ({exc})") from exc
     if not isinstance(raw, dict) or not isinstance(raw.get("probes", {}), dict):
-        raise ReconcilerConfigError(f"{path}: expected {{'probes': {{...}}}}")
+        raise ReconcilerConfigError(f"{location}: expected {{'probes': {{...}}}}")
     probes: dict[str, dict[str, Any]] = {}
     for action_type, spec in (raw.get("probes") or {}).items():
         if not isinstance(spec, dict) or not isinstance(spec.get("command"), str):
-            raise ReconcilerConfigError(f"{path}: probe {action_type!r} needs a string 'command'")
+            raise ReconcilerConfigError(
+                f"{location}: probe {action_type!r} needs a string 'command'"
+            )
         timeout = spec.get("timeout", _DEFAULT_TIMEOUT)
         if not isinstance(timeout, (int, float)) or timeout <= 0:
             raise ReconcilerConfigError(

--- a/tests/test_cli_gate.py
+++ b/tests/test_cli_gate.py
@@ -272,3 +272,55 @@ def test_gate_tolerates_an_unparseable_payload(db: str, tmp_path: Path) -> None:
     )
     assert code == ExitCode.OK
     assert "allowing" in err
+
+
+# --- config errors name a file the operator can open (issue #333) ------------- #
+
+
+@pytest.mark.parametrize(
+    "filename,module,loader,error",
+    [
+        ("gate.json", "continuum.gate", "load_gate_config", "GateConfigError"),
+        ("budgets.json", "continuum.budgets", "load_budgets", "BudgetConfigError"),
+        ("reconcilers.json", "continuum.reconcilers", "load_reconcilers", "ReconcilerConfigError"),
+        ("gateway.json", "continuum.gateway", "load_gateway_config", "GatewayConfigError"),
+    ],
+)
+def test_a_registry_error_names_an_absolute_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    filename: str,
+    module: str,
+    loader: str,
+    error: str,
+) -> None:
+    """Every registry loader, not just the gate.
+
+    #333 fixed this for two of the gate's four messages. The rationale is that a
+    relative path depends on the cwd of whatever loaded the registry, which for a
+    hook or the sidecar is not the operator's shell, so the message names a file
+    they cannot find. That reasoning is identical for the budget, reconciler and
+    gateway registries, which all load from `.continuum/` by relative default, so
+    this covers the class rather than the one instance.
+
+    Parameterised deliberately: a fifth registry added later without resolving
+    its path shows up here as a missing case rather than as a support question.
+    """
+    import importlib
+
+    monkeypatch.chdir(tmp_path)
+    relative = Path(".continuum") / filename
+    relative.parent.mkdir(exist_ok=True)
+    relative.write_text("{ this is not valid json")
+
+    mod = importlib.import_module(module)
+    with pytest.raises(getattr(mod, error)) as caught:
+        getattr(mod, loader)(relative)
+
+    message = str(caught.value)
+    # The reported path must be absolute. Asserting the relative form is absent
+    # would be unsound, since the absolute path legitimately ends with it.
+    reported = Path(message.split(" is not valid JSON")[0])
+    assert reported.is_absolute(), message
+    assert reported.name == filename, message
+    assert reported == relative.resolve(), message


### PR DESCRIPTION
## Summary

Follow-up to #340, found while reviewing it before merge. That PR closed #333 for the gate config, but covered two of that loader's four path-bearing messages, and the same gap exists in three sibling registries that were never in scope.

## What #340 left behind

`load_gate_config` raises four errors that name the file. #340 resolved the path in two of them:

```python
raise GateConfigError(f"{path.resolve()} is not valid JSON ({exc})")     # fixed
raise GateConfigError(f"{path.resolve()}: expected {{'tools': {{...}}}}") # fixed
raise GateConfigError(f"{path}: tool {tool!r} needs a string 'key_template'")  # still relative
raise GateConfigError(f"{path}: tool {tool!r} 'action_type' must be a string") # still relative
```

So the same config file could be named two different ways depending on which validation tripped.

## The same defect in the sibling registries

`budgets.py`, `reconcilers.py` and `gateway.py` all load from `.continuum/` by relative default, and all reported errors relative: four, three and three messages respectively. They were outside #333's scope but share its reasoning exactly.

Why it matters: the relative form depends on the cwd of whatever loaded the registry. For a pre-tool-use hook, the sidecar, or a CI step, that is not the operator's shell. Telling someone their config is malformed without telling them which config is most of the way to telling them nothing.

## Change

Each loader resolves the path once, next to the early return, and every message uses it. Errors, their types and their wording are otherwise unchanged.

| Loader | Messages corrected |
|---|---|
| `gate.py` | 2 (completing #340) |
| `budgets.py` | 4 |
| `reconcilers.py` | 3 |
| `gateway.py` | 3 |

## Test

Parameterised across all four loaders rather than written once for the gate, so a fifth registry added later without resolving its path shows up as a missing case here rather than as a support question. I confirmed it fails on the pre-fix code per loader rather than assuming it would.

One assertion is deliberately absent. I first asserted the relative form does not appear in the message, which is unsound: an absolute path legitimately ends with the relative one, so that check fails on correct output. It asserts the reported path is absolute and equals the resolved input instead.

## Verification

```
1381 passed, 24 skipped
ruff check / format    clean
mypy src               25 errors, identical to baseline
```

Credit to @aastha-m22 for #340, which is what surfaced this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation errors now consistently include the full absolute path to the affected registry or configuration file.
  * Improved diagnostics for malformed JSON, invalid structures, and unsupported configuration values.

* **Tests**
  * Added coverage ensuring registry errors identify absolute file paths across supported configuration types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->