### PR TITLE
fix(storage): use-after-close must say it was closed, and pin idempotent close

### DIFF
--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -119,23 +119,44 @@ class SQLiteStorage(Storage):
 
     # -- transactions ----------------------------------------------------- #
 
+    def _live_connection(self) -> sqlite3.Connection:
+        """The open connection, or a clear error saying it was closed.
+
+        ``close`` sets ``_connection`` to None so it can be called more than once
+        (#320). Without this check every later operation failed with
+        ``AttributeError: 'NoneType' object has no attribute 'execute'``, which
+        names a symptom rather than the mistake. sqlite3's own wording is the
+        thing worth preserving: use-after-close is a caller bug, and the message
+        should say which bug.
+        """
+        # Annotated because getattr with a default is typed Any, and returning
+        # Any from here would erase the connection type for every caller.
+        connection: sqlite3.Connection | None = getattr(self, "_connection", None)
+        if connection is None:
+            raise sqlite3.ProgrammingError(
+                "Cannot operate on a closed database. This SQLiteStorage was "
+                "closed; open a new handle rather than reusing a closed one."
+            )
+        return connection
+
     @contextmanager
     def _write(self) -> Iterator[sqlite3.Connection]:
         """Exclusive write transaction. Rolls back on any exception."""
         with self._lock:
-            self._connection.execute("BEGIN IMMEDIATE")
+            connection = self._live_connection()
+            connection.execute("BEGIN IMMEDIATE")
             try:
-                yield self._connection
+                yield connection
             except BaseException:
-                self._connection.execute("ROLLBACK")
+                connection.execute("ROLLBACK")
                 raise
             else:
-                self._connection.execute("COMMIT")
+                connection.execute("COMMIT")
 
     @contextmanager
     def _read(self) -> Iterator[sqlite3.Connection]:
         with self._lock:
-            yield self._connection
+            yield self._live_connection()
 
     def close(self) -> None:
         with self._lock:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -252,6 +252,46 @@ def test_a_crashed_writer_leaves_a_readable_prefix(tmp_path: Path) -> None:
         assert project("run_1", recovered.read_events("run_1")).progress.completed == 1
 
 
+def test_close_is_idempotent(tmp_path: Path) -> None:
+    """Closing twice must not raise (#320).
+
+    Shipped in #347 without a test, so the behaviour it fixed was left unpinned.
+    Double-close happens for real: an explicit ``close()`` inside a ``with``
+    block, or a caller closing before ``__del__`` runs.
+    """
+    store = SQLiteStorage(tmp_path / "agent.db")
+    store.create_run(Run(run_id="run_1", goal="g"))
+
+    store.close()
+    store.close()
+    store.close()
+
+
+def test_using_a_closed_store_says_it_was_closed(tmp_path: Path) -> None:
+    """Use-after-close must name the mistake, not a symptom of it.
+
+    Making ``close`` idempotent meant setting ``_connection`` to None, which left
+    every later call failing with ``AttributeError: 'NoneType' object has no
+    attribute 'execute'``. That points at CONTINUUM's internals instead of at the
+    caller's bug, so sqlite3's own wording is restored: reads and writes both go
+    through one accessor that raises ``ProgrammingError``.
+    """
+    db = tmp_path / "agent.db"
+    store = SQLiteStorage(db)
+    store.create_run(Run(run_id="run_1", goal="g"))
+    store.close()
+
+    # A read path and a write path, since they take different routes in.
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        store.get_run("run_1")
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        store.create_run(Run(run_id="run_2", goal="g"))
+
+    # The file itself is untouched: a new handle works normally.
+    with SQLiteStorage(db) as reopened:
+        assert reopened.get_run("run_1").goal == "g"
+
+
 def test_two_connections_to_one_file_see_each_other(tmp_path: Path) -> None:
     db = tmp_path / "agent.db"
     with SQLiteStorage(db) as writer, SQLiteStorage(db) as reader:


### PR DESCRIPTION
## Summary

Found by reviewing #347 properly **after** merging it, which I should have done before. Two gaps, both small, one of them a regression that PR introduced.

## 1. Use-after-close stopped saying it was closed

#347 made `close()` idempotent by setting `_connection = None`. That is the right fix for #320. The side effect is that every subsequent call failed with:

```
AttributeError: 'NoneType' object has no attribute 'execute'
```

Before the change, sqlite3 answered:

```
ProgrammingError: Cannot operate on a closed database.
```

The first points at CONTINUUM's internals. The second names the caller's actual mistake. Use-after-close is a caller bug, and the message should say which bug rather than leaving someone to work out that `None` means "closed".

`_write` and `_read` are the two chokepoints every operation passes through, so one `_live_connection` accessor restores the wording for all of them. The idempotency #347 added is untouched, and I verified that explicitly rather than assuming.

## 2. The behaviour #347 fixed had no test

#347 shipped as a source change only, so idempotent `close()` was unpinned: it could have regressed to raising and nothing would have failed. Both properties are now covered.

| Test | Pins |
|---|---|
| `test_close_is_idempotent` | closing three times does not raise (#320) |
| `test_using_a_closed_store_says_it_was_closed` | `ProgrammingError` naming "closed", on a read path and a write path |

The second test fails on the pre-fix code, which I confirmed by stashing the change rather than assuming it would.

It also asserts the file itself is untouched: a fresh handle still reads the run. Closing a handle must not be mistakable for losing data, and that is worth an assertion rather than an assumption.

## Note on typing

`getattr(self, "_connection", None)` is typed `Any`, so returning it directly tripped `no-any-return` and pushed mypy from its baseline 25 errors to 26. The local is annotated `sqlite3.Connection | None` so the None check narrows properly. `getattr` is kept rather than direct attribute access because `close()` uses the same defensive form for the case where `__del__` runs before `__init__` finishes.

## Verification

```
1383 passed, 24 skipped
ruff check / format    clean
mypy src               25 errors, back to baseline, 0 in the changed file
```

Credit to @VedantMadane for #347, which is what surfaced both of these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite storage now reports a clear error when read or write operations are attempted after the database is closed.
  * Repeatedly closing the database is handled safely.
  * Reopening the database continues to work correctly.

* **Tests**
  * Added coverage for closed-database operations, repeated closures, and successful reopening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->