### PR TITLE
fix: clarify authentication errors

### DIFF
--- a/src/continuum/mcp/authz.py
+++ b/src/continuum/mcp/authz.py
@@ -152,10 +152,22 @@ class AuthPolicy:
             expected = self.expected
         # An empty expected secret cannot be presented, so it must refuse.
         if not expected or not token or token != expected:
-            raise NotAuthenticated(
-                "expected shared secret (set CONTINUUM_MCP_TOKEN on the server "
-                "and pass _meta.authToken during initialize)"
-            )
+            if self.tokens is not None:
+                guidance = (
+                    "expected the secret registered for this caller "
+                    "(pass it in _meta.authToken during initialize)"
+                )
+            elif self.source == "argument":
+                guidance = (
+                    "expected the configured shared secret "
+                    "(pass the auth_token argument's value in _meta.authToken during initialize)"
+                )
+            else:
+                guidance = (
+                    "expected shared secret (set CONTINUUM_MCP_TOKEN on the server "
+                    "and pass _meta.authToken during initialize)"
+                )
+            raise NotAuthenticated(guidance)
 
 
 #: Confirmation of self-reported state over MCP is gated behind its own secret

--- a/src/continuum/mcp/authz.py
+++ b/src/continuum/mcp/authz.py
@@ -152,7 +152,10 @@ class AuthPolicy:
             expected = self.expected
         # An empty expected secret cannot be presented, so it must refuse.
         if not expected or not token or token != expected:
-            raise NotAuthenticated("the caller did not present the expected shared secret")
+            raise NotAuthenticated(
+                "expected shared secret (set CONTINUUM_MCP_TOKEN on the server "
+                "and pass _meta.authToken during initialize)"
+            )
 
 
 #: Confirmation of self-reported state over MCP is gated behind its own secret

--- a/src/continuum/mcp/authz.py
+++ b/src/continuum/mcp/authz.py
@@ -173,7 +173,7 @@ class AuthPolicy:
                 )
             else:
                 guidance = (
-                    "expected shared secret (set CONTINUUM_MCP_TOKEN on the server "
+                    f"expected shared secret (set {AUTH_ENV_VAR} on the server "
                     "and pass _meta.authToken during initialize)"
                 )
             raise NotAuthenticated(guidance)

--- a/src/continuum/mcp/authz.py
+++ b/src/continuum/mcp/authz.py
@@ -153,14 +153,23 @@ class AuthPolicy:
         # An empty expected secret cannot be presented, so it must refuse.
         if not expected or not token or token != expected:
             if self.tokens is not None:
-                guidance = (
-                    "expected the secret registered for this caller "
-                    "(pass it in _meta.authToken during initialize)"
-                )
+                if self.source == CLIENT_TOKENS_ENV_VAR:
+                    guidance = (
+                        "expected the secret registered for this caller "
+                        f"(set {CLIENT_TOKENS_ENV_VAR} on the server and pass the "
+                        "matching value in _meta.authToken during initialize)"
+                    )
+                else:
+                    guidance = (
+                        "expected the secret registered for this caller "
+                        "(configure the per-client token mapping in the embedding "
+                        "application and pass the matching value in _meta.authToken "
+                        "during initialize)"
+                    )
             elif self.source == "argument":
                 guidance = (
-                    "expected the configured shared secret "
-                    "(pass the auth_token argument's value in _meta.authToken during initialize)"
+                    "expected the secret configured by the embedding application "
+                    "(pass it in _meta.authToken during initialize)"
                 )
             else:
                 guidance = (

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -110,7 +110,10 @@ class SidecarAuth:
         if self.disabled:
             return
         if not token or token != self.expected:
-            raise NotAuthorized("the caller did not present the expected shared secret")
+            raise NotAuthorized(
+                "expected shared secret (set CONTINUUM_SERVE_TOKEN on the server "
+                "and pass auth_token on the client)"
+            )
 
 
 def _require(params: dict[str, Any], key: str) -> Any:

--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -367,13 +367,16 @@ def test_a_disabled_auth_policy_is_a_no_op() -> None:
 
 
 def test_a_configured_secret_is_required() -> None:
-    auth = AuthPolicy("secret")
+    auth = AuthPolicy("actual-token-value")
     assert not auth.disabled
     # Correct secret passes.
-    auth.verify(ALLOWED, "secret")
+    auth.verify(ALLOWED, "actual-token-value")
     # Missing, empty, or wrong secret refuses.
-    with pytest.raises(NotAuthenticated, match="shared secret"):
+    with pytest.raises(NotAuthenticated, match="shared secret") as exc_info:
         auth.verify(ALLOWED, None)
+    assert "CONTINUUM_MCP_TOKEN" in str(exc_info.value)
+    assert "_meta.authToken" in str(exc_info.value)
+    assert "actual-token-value" not in str(exc_info.value)
     with pytest.raises(NotAuthenticated, match="shared secret"):
         auth.verify(ALLOWED, "")
     with pytest.raises(NotAuthenticated, match="shared secret"):

--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -402,8 +402,19 @@ def test_per_client_tokens_map_a_secret_to_a_name() -> None:
     with pytest.raises(NotAuthenticated, match="not registered"):
         auth.verify(STRANGER, "a-secret")
     # A registered caller with the wrong token is refused.
-    with pytest.raises(NotAuthenticated, match="shared secret"):
+    with pytest.raises(NotAuthenticated, match="registered for this caller") as exc_info:
         auth.verify(ALLOWED, "nope")
+    assert "CONTINUUM_MCP_TOKEN" not in str(exc_info.value)
+    assert "_meta.authToken" in str(exc_info.value)
+
+
+def test_argument_auth_names_the_matching_client_field() -> None:
+    auth = AuthPolicy("a-secret", source="argument")
+
+    with pytest.raises(NotAuthenticated, match="auth_token argument") as exc_info:
+        auth.verify(ALLOWED, "nope")
+    assert "CONTINUUM_MCP_TOKEN" not in str(exc_info.value)
+    assert "_meta.authToken" in str(exc_info.value)
 
 
 def test_load_auth_reads_the_env_var() -> None:

--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -411,7 +411,7 @@ def test_per_client_tokens_map_a_secret_to_a_name() -> None:
 def test_argument_auth_names_the_matching_client_field() -> None:
     auth = AuthPolicy("a-secret", source="argument")
 
-    with pytest.raises(NotAuthenticated, match="auth_token argument") as exc_info:
+    with pytest.raises(NotAuthenticated, match="embedding application") as exc_info:
         auth.verify(ALLOWED, "nope")
     assert "CONTINUUM_MCP_TOKEN" not in str(exc_info.value)
     assert "_meta.authToken" in str(exc_info.value)
@@ -424,6 +424,16 @@ def test_load_auth_reads_the_env_var() -> None:
     auth.verify(ALLOWED, "s3cr3t")
     with pytest.raises(NotAuthenticated):
         auth.verify(ALLOWED, "nope")
+
+
+def test_per_client_env_auth_names_the_matching_configuration() -> None:
+    auth = load_auth(env={CLIENT_TOKENS_ENV_VAR: f"{ALLOWED}:a-secret"})
+
+    with pytest.raises(NotAuthenticated, match=CLIENT_TOKENS_ENV_VAR) as exc_info:
+        auth.verify(ALLOWED, "nope")
+    assert "CONTINUUM_MCP_TOKEN" not in str(exc_info.value)
+    assert "_meta.authToken" in str(exc_info.value)
+    assert "a-secret" not in str(exc_info.value)
 
 
 def test_load_auth_is_disabled_without_a_secret() -> None:
@@ -572,7 +582,7 @@ async def test_load_auth_wires_per_client_tokens_into_the_server(
     )
     assert json.loads(result.content[0].text)["completed"] == 3
     # Replaying another client's token against this name is refused.
-    with pytest.raises(ToolError, match="shared secret|not registered"):
+    with pytest.raises(ToolError, match="registered for this caller|not registered"):
         await srv.call_tool(
             "continuum_record_progress",
             {"run_id": "run_1", "completed": 1, "goal": "g"},
@@ -603,7 +613,7 @@ async def test_per_client_secret_is_bound_to_its_name(per_client_server: Any) ->
     )
     assert json.loads(result.content[0].text)["completed"] == 3
     # A different client's token replayed under this name is refused.
-    with pytest.raises(ToolError, match="shared secret|not registered"):
+    with pytest.raises(ToolError, match="registered for this caller|not registered"):
         await per_client_server.call_tool(
             "continuum_record_progress",
             {"run_id": "run_1", "completed": 1, "goal": "g"},

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -298,10 +298,13 @@ def test_stdio_resume_needs_no_params_at_all() -> None:
 
 
 def test_auth_refuses_without_token_when_required(monkeypatch) -> None:
-    monkeypatch.setenv("CONTINUUM_SERVE_TOKEN", "secret")
+    monkeypatch.setenv("CONTINUUM_SERVE_TOKEN", "actual-token-value")
     srv = make_server()
-    with pytest.raises(NotAuthorized):
+    with pytest.raises(NotAuthorized) as exc_info:
         srv.dispatch("record_progress", {"run_id": "r1", "completed": 1})
+    assert "CONTINUUM_SERVE_TOKEN" in str(exc_info.value)
+    assert "auth_token" in str(exc_info.value)
+    assert "actual-token-value" not in str(exc_info.value)
 
 
 def test_auth_allows_the_correct_token(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- name the exact server and client token fields in authentication failures
- keep configured secrets out of error responses
- add regression coverage for both auth paths

## Validation
- focused pytest auth tests (2 passed)

Closes #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error messages with clear guidance on required server settings and client-provided credentials.
  * Authentication failures no longer expose configured secret values.
  * Clarified where handshake and authorization tokens must be provided.
  * Progress and dependency responses now handle invalid event data more gracefully, including details when projection fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->