### PR TITLE
ci: deploy docs to Vercel from main only

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,12 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "outputDirectory": "docs",
   "cleanUrls": true,
-  "framework": null
+  "framework": null,
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   "framework": null,
   "git": {
     "deploymentEnabled": {
-      "*": false,
+      "**": false,
       "main": true
     }
   }


### PR DESCRIPTION
## Problem

Every pull request from a fork gets a red Vercel check reading "Authorization required to deploy". Vercel's fork protection refuses to build untrusted code until a team member authorizes it, so that check can never pass for an outside contributor. It is not a required check and blocks nothing, but it reads to a first-time contributor as though they broke the build. Both #353 and #354 currently show it failing.

## Why previews are not worth keeping here

`vercel.json` sets `outputDirectory: docs` with `framework: null`, so a preview deployment is a static copy of the `docs/` folder. There is no application to exercise and no build to validate. The production deploy from `main` is the only one that serves anyone, and it is unaffected by this change.

## Fix

`git.deploymentEnabled` prevents the deployment from being created at all, so no deployment status is reported and no check appears. This is the supported replacement for the deprecated `github.enabled`, and unlike the also-deprecated `github.silent` it removes the check rather than only suppressing the bot comment.

Per the [Vercel docs](https://vercel.com/docs/project-configuration/git-configuration), unspecified branches default to `true`, patterns use minimatch, and a branch matching several rules deploys if any rule is `true`. So `"**": false` with `"main": true` keeps production deploying and disables every other branch, including forks.

The second commit exists because the first attempt used `"*"`, which did not work. minimatch's `*` matches within a single path segment and does not cross `/`, and essentially every branch in this repo is `type/slug`, so the rule matched almost nothing. `"**"` crosses separators.

Also adds `$schema` so editors validate this file.

## Verification

Confirmed on this PR rather than assumed, by comparing the two commits:

| Commit | Pattern | Vercel result |
| --- | --- | --- |
| `43448fc` | `"*": false` | deployed; `Vercel` and `Vercel Preview Comments` both reported |
| `4c0d139` | `"**": false` | no deployment, no check runs, no statuses |

This also settles two open questions. The config takes effect from the branch being deployed, so it does not need to reach `main` first, and `deploymentEnabled` is not being ignored here, which was the risk flagged in [vercel/vercel#11176](https://github.com/vercel/vercel/issues/11176).

Production is the one thing not yet exercised: `main` still matches `"main": true`, but that path only runs once this merges. Worth watching the first deploy after merge.
