### PR TITLE
fix(mcp): a rejected progress update must not brick the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -731,7 +731,12 @@ All notable changes to this project are documented here. The format follows
   so the write path now rejects exactly what the read path would reject rather
   than approximating it one field at a time. The cheap argument checks are kept
   ahead of it because they answer without touching storage and name the offending
-  argument.
+  argument. The commit passes `expected_sequence`, because validation and append
+  are two statements: a second writer landing `total=50` between the read and the
+  write of a `completed=75` that omits `total` would otherwise compose a log
+  neither payload would have been allowed to produce on its own. Losing that race
+  re-validates against the new head and retries, bounded, since losing it says
+  nothing about whether the update is valid.
 
 
   `claim()` deduplicates by folding the log and then appending, with nothing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,7 +714,26 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
-- **`ActionLedger` could not serialise concurrent claims on one key (#345).**
+- **One `continuum_record_progress` call could permanently brick a run (#364).**
+  The `completed + failed > total` guard only fired when `total` was passed in
+  the same call. Omitting it skipped the guard while projection still folded the
+  `total` recorded earlier, so the invariant was evaluated against a limit the
+  call never mentioned. Worse, the handler appended before it projected, so the
+  rejected event was already durable when validation failed, and because the
+  fold validates each intermediate state no later event could correct it. Every
+  projecting surface for that run then stayed dead permanently: `record_progress`,
+  `checkpoint`, `validate` and `resume` over MCP, plus `status`, `inspect`,
+  `replay`, `show-contract` and `briefing` over the CLI. The action tools kept
+  working throughout, so the run could go on authorising real side effects while
+  recovery was unable to say whether continuing was safe, and `continuum verify`
+  still reported the chain as intact. The new `_project_candidate` helper folds
+  the log with the candidate payload appended and commits only if that succeeds,
+  so the write path now rejects exactly what the read path would reject rather
+  than approximating it one field at a time. The cheap argument checks are kept
+  ahead of it because they answer without touching storage and name the offending
+  argument.
+
+
   `claim()` deduplicates by folding the log and then appending, with nothing
   between the read and the write, so processes racing on one key could each be
   told to proceed: eight threads, eight go-aheads, eight charges. The outcome was

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -239,7 +239,7 @@ def _project_candidate(
     run_id: str,
     event_type: EventType,
     payload: Mapping[str, Any],
-) -> SemanticState:
+) -> tuple[SemanticState, int]:
     """Fold the log with ``payload`` appended, without committing it (issue #364).
 
     The write path must reject exactly what the read path rejects, and the only
@@ -264,19 +264,26 @@ def _project_candidate(
     back. There is no transaction spanning the append here, and a rollback that
     fails would leave behind precisely the state this prevents.
 
-    Returns the projected state so the caller can answer from it instead of
-    folding a second time.
+    Returns the projected state and the head sequence it was validated against.
+    The caller passes that sequence to ``append_event`` as ``expected_sequence``:
+    validation and append are two statements, so a second writer can advance the
+    run in between and two individually-legal payloads can compose into a log
+    neither of them would have been allowed to produce (for example ``total=50``
+    landing between the read and the write of a ``completed=75`` that omits
+    ``total``). One run has one owner by design, but the failure being guarded
+    here is unrecoverable, so it is worth not relying on that.
     """
     history = list(ctx.storage.read_events(run_id))
+    head = history[-1].sequence if history else 0
     candidate = Event(
         run_id=run_id,
-        sequence=(history[-1].sequence + 1) if history else 1,
+        sequence=head + 1,
         type=event_type,
         payload=dict(payload),
         source=AGENT_SOURCE,
     )
     try:
-        return project(run_id, [*history, candidate])
+        return project(run_id, [*history, candidate]), head
     except ValueError as exc:
         # pydantic's ValidationError is a ValueError, so this covers both the
         # model invariants and the projector's own checks. Re-raised with the
@@ -286,6 +293,47 @@ def _project_candidate(
             f"{event_type.value} {dict(payload)} would leave run {run_id!r} unprojectable "
             f"and was not recorded: {exc}"
         ) from exc
+
+
+def _append_projectable(
+    ctx: ContinuumMCP,
+    run_id: str,
+    event_type: EventType,
+    payload: Mapping[str, Any],
+    *,
+    attempts: int = 3,
+) -> tuple[SemanticState, Event]:
+    """Commit ``payload`` only if the fold accepts it against the state it lands on.
+
+    Retries on ``ConcurrentWriteError`` rather than failing, because losing the
+    optimistic-concurrency race says nothing about whether the caller's update is
+    valid. Re-validation against the new head is the point: the update may still
+    be legal, and if the intervening write made it illegal that is exactly what
+    the next fold reports. Bounded, so a permanently busy run answers rather than
+    spinning.
+    """
+    from continuum.storage import ConcurrentWriteError
+
+    for remaining in range(attempts - 1, -1, -1):
+        state, expected = _project_candidate(ctx, run_id, event_type, payload)
+        try:
+            event = ctx.storage.append_event(
+                run_id,
+                event_type,
+                payload,
+                expected_sequence=expected,
+                source=AGENT_SOURCE,
+            )
+        except ConcurrentWriteError:
+            if remaining:
+                continue
+            raise ValueError(
+                f"run {run_id!r} is being written concurrently and this update lost the "
+                f"race {attempts} times; nothing was recorded. One run is meant to have "
+                f"one owner at a time, so check whether another agent holds this run."
+            ) from None
+        return state, event
+    raise AssertionError("unreachable: the loop either returns or raises")
 
 
 def _environment(run_id: str, env: Mapping[str, str] | None) -> EnvironmentSnapshot | None:
@@ -609,13 +657,11 @@ def build_server(
             payload["total"] = total
             payload["pending"] = max(total - completed - failed, 0)
 
-        # Fold with this payload appended before committing it. Appending first
-        # and projecting after leaves a rejected event permanently in the log,
-        # which no later event can correct (issue #364).
-        state = _project_candidate(ctx, run_id, EventType.TASK_UPDATED, payload)
-        event = ctx.storage.append_event(
-            run_id, EventType.TASK_UPDATED, payload, source=AGENT_SOURCE
-        )
+        # Fold with this payload appended before committing it, and commit under
+        # optimistic concurrency so the validated state is the one it lands on.
+        # Appending first and projecting after leaves a rejected event
+        # permanently in the log, which no later event can correct (issue #364).
+        state, event = _append_projectable(ctx, run_id, EventType.TASK_UPDATED, payload)
 
         return _json(
             {
@@ -625,8 +671,8 @@ def build_server(
                 "failed": state.progress.failed,
                 "total": state.progress.total,
                 # From the committed event rather than the candidate: the two
-                # agree on a single-writer run, and reporting the real sequence
-                # keeps the answer honest if they ever diverge.
+                # agree because the append is guarded by expected_sequence, and
+                # reporting the real sequence keeps the answer honest regardless.
                 "source_sequence": event.sequence,
             }
         )

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -59,7 +59,7 @@ from typing import TYPE_CHECKING, Any
 from continuum.actions.ledger import ActionLedger
 from continuum.adapters.generic import GenericAgentAdapter
 from continuum.environment import StaticProvider, capture
-from continuum.events import EventType
+from continuum.events import Event, EventType
 from continuum.mcp.authz import (
     CONFIRM_ENV_VAR,
     AuthorizationPolicy,
@@ -77,6 +77,7 @@ from continuum.models import (
     EnvResource,
     Origin,
     Run,
+    SemanticState,
     UnknownSideEffect,
 )
 from continuum.recovery.contract import render_contract
@@ -231,6 +232,60 @@ def _refusal_reaches_the_caller() -> Iterator[None]:
         yield
     except (PermissionError, ValueError, RunNotFound, MalformedRunLog) as exc:
         raise ToolError(str(exc)) from exc
+
+
+def _project_candidate(
+    ctx: ContinuumMCP,
+    run_id: str,
+    event_type: EventType,
+    payload: Mapping[str, Any],
+) -> SemanticState:
+    """Fold the log with ``payload`` appended, without committing it (issue #364).
+
+    The write path must reject exactly what the read path rejects, and the only
+    way to know what the read path will do is to run it. Validating a field in
+    isolation is not equivalent: a payload is legal or not *relative to the
+    state it lands on*, so a guard that inspects only the arguments is blind to
+    every invariant that spans events.
+
+    ``continuum_record_progress`` demonstrated the cost of getting this wrong.
+    It appended first and projected after, so a payload the fold refused was
+    already durable when the refusal arrived. Because the fold validates each
+    intermediate state, no later event could correct it, and every projecting
+    surface for that run stayed dead permanently: ``record_progress``,
+    ``checkpoint``, ``validate`` and ``resume`` over MCP, plus ``status``,
+    ``inspect``, ``replay``, ``show-contract`` and ``briefing`` over the CLI.
+    Meanwhile the action tools kept working, so the run could still authorise
+    real side effects while recovery was unable to say whether continuing was
+    safe. That inversion is what makes an unprojectable log worse than a
+    rejected call.
+
+    The candidate event is constructed in memory rather than written and rolled
+    back. There is no transaction spanning the append here, and a rollback that
+    fails would leave behind precisely the state this prevents.
+
+    Returns the projected state so the caller can answer from it instead of
+    folding a second time.
+    """
+    history = list(ctx.storage.read_events(run_id))
+    candidate = Event(
+        run_id=run_id,
+        sequence=(history[-1].sequence + 1) if history else 1,
+        type=event_type,
+        payload=dict(payload),
+        source=AGENT_SOURCE,
+    )
+    try:
+        return project(run_id, [*history, candidate])
+    except ValueError as exc:
+        # pydantic's ValidationError is a ValueError, so this covers both the
+        # model invariants and the projector's own checks. Re-raised with the
+        # payload named, because the bare pydantic message reports the folded
+        # figures without saying which call produced them.
+        raise ValueError(
+            f"{event_type.value} {dict(payload)} would leave run {run_id!r} unprojectable "
+            f"and was not recorded: {exc}"
+        ) from exc
 
 
 def _environment(run_id: str, env: Mapping[str, str] | None) -> EnvironmentSnapshot | None:
@@ -536,9 +591,14 @@ def build_server(
         """Record progress for a run."""
         # Reject impossible counters before anything is written, including the
         # run itself: a rejected call must not leave behind a runs row and a
-        # RUN_STARTED event (issue #203). The `Progress` model enforces the
-        # arithmetic at projection time; checking here keeps the bad value out
-        # of the event log in the first place.
+        # RUN_STARTED event (issue #203).
+        #
+        # These two checks are kept even though `_project_candidate` below would
+        # catch the same states, because they can answer without touching
+        # storage and they name the offending argument rather than the folded
+        # figures. They are not sufficient on their own: `total` is only known
+        # here when the caller passes it, and a call that omits it is still
+        # bounded by the `total` already on record (issue #364).
         if completed < 0 or failed < 0:
             raise ValueError("progress counters must be non-negative")
         if total is not None and completed + failed > total:
@@ -548,9 +608,15 @@ def build_server(
         if total is not None:
             payload["total"] = total
             payload["pending"] = max(total - completed - failed, 0)
-        ctx.storage.append_event(run_id, EventType.TASK_UPDATED, payload, source=AGENT_SOURCE)
 
-        state = project(run_id, ctx.storage.read_events(run_id))
+        # Fold with this payload appended before committing it. Appending first
+        # and projecting after leaves a rejected event permanently in the log,
+        # which no later event can correct (issue #364).
+        state = _project_candidate(ctx, run_id, EventType.TASK_UPDATED, payload)
+        event = ctx.storage.append_event(
+            run_id, EventType.TASK_UPDATED, payload, source=AGENT_SOURCE
+        )
+
         return _json(
             {
                 "run_id": run_id,
@@ -558,7 +624,10 @@ def build_server(
                 "pending": state.progress.pending,
                 "failed": state.progress.failed,
                 "total": state.progress.total,
-                "source_sequence": state.source_sequence,
+                # From the committed event rather than the candidate: the two
+                # agree on a single-writer run, and reporting the real sequence
+                # keeps the answer honest if they ever diverge.
+                "source_sequence": event.sequence,
             }
         )
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -358,6 +358,62 @@ async def test_a_rejected_progress_call_leaves_the_run_projectable(
 
 
 @pytest.mark.asyncio
+async def test_a_racing_writer_cannot_compose_an_unprojectable_log(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """Validation and append are two statements, so guard the gap (issue #364).
+
+    Two individually-legal payloads can compose into a log neither would have
+    been allowed to produce. Here `completed=75` is validated against `total=100`
+    and a second writer lands `total=50` before the append. Without
+    `expected_sequence` the stale candidate is committed and the run is
+    unprojectable; with it the append is rejected, re-validated against the new
+    head, and refused on its own merits.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, ctx = server_ctx
+    await seed_run(server, completed=10)  # total=100
+
+    real_read = ctx.storage.read_events
+    real_append = ctx.storage.append_event
+    interposed = {"done": False}
+
+    def read_then_let_a_writer_in(run_id: str, **kwargs: Any) -> Any:
+        history = real_read(run_id, **kwargs)
+        # Only the unbounded read is the one `_project_candidate` validates
+        # against; `ensure_run` reads with `upto=1` earlier in the same call.
+        if not interposed["done"] and not kwargs and run_id == "run_1":
+            interposed["done"] = True
+            # A concurrent writer shrinks the total after we have read it.
+            real_append(
+                "run_1",
+                EventType.TASK_UPDATED,
+                {"completed": 10, "failed": 0, "total": 50, "pending": 40},
+                source=Origin.EXTERNAL_AGENT,
+            )
+        return history
+
+    ctx.storage.read_events = read_then_let_a_writer_in  # type: ignore[method-assign]
+    try:
+        with pytest.raises(ToolError, match="unprojectable"):
+            await server.call_tool(
+                "continuum_record_progress",
+                {"run_id": "run_1", "completed": 75},
+                context=_ctx(TEST_CLIENT),
+            )
+    finally:
+        ctx.storage.read_events = real_read  # type: ignore[method-assign]
+
+    # The run survived the race: the log still folds, and the racing writer's
+    # own event is the one that stands.
+    state = project("run_1", ctx.storage.read_events("run_1"))
+    assert state.progress.total == 50
+    assert state.progress.completed == 10
+    assert await call(server, "continuum_resume", run_id="run_1")
+
+
+@pytest.mark.asyncio
 async def test_recording_progress_for_an_unknown_run_without_a_goal_fails(
     server_ctx: tuple[Any, Any],
 ) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -286,6 +286,78 @@ async def test_a_rejected_progress_call_writes_nothing_at_all(
 
 
 @pytest.mark.asyncio
+async def test_progress_over_the_recorded_total_is_rejected_when_total_is_omitted(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """The `total` guard must apply to the total already on record (issue #364).
+
+    Omitting `total` used to skip the argument check entirely while projection
+    still folded the `total` from an earlier event, so the invariant was
+    evaluated against a limit the call never mentioned. The event was appended
+    before it was projected, which made the rejected value durable.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, ctx = server_ctx
+    await call(
+        server,
+        "continuum_record_progress",
+        run_id="run_1",
+        completed=3,
+        total=6,
+        goal="g",
+    )
+    before = [e.type.value for e in ctx.storage.read_events("run_1")]
+
+    with pytest.raises(ToolError, match="unprojectable"):
+        await server.call_tool(
+            "continuum_record_progress",
+            {"run_id": "run_1", "completed": 99},
+            context=_ctx(TEST_CLIENT),
+        )
+
+    assert [e.type.value for e in ctx.storage.read_events("run_1")] == before
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_progress_call_leaves_the_run_projectable(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """A refused update must not cost the run its recovery surface (issue #364).
+
+    The fold validates each intermediate state, so a single unprojectable event
+    could never be corrected by appending another. Every projecting tool stayed
+    dead for that run while the action tools kept working, which let the run go
+    on authorising side effects that recovery could no longer reason about.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, _ = server_ctx
+    await call(
+        server,
+        "continuum_record_progress",
+        run_id="run_1",
+        completed=3,
+        total=6,
+        goal="g",
+    )
+    with pytest.raises(ToolError):
+        await server.call_tool(
+            "continuum_record_progress",
+            {"run_id": "run_1", "completed": 99},
+            context=_ctx(TEST_CLIENT),
+        )
+
+    # Each of these folds the log, and each was permanently broken before.
+    assert (await call(server, "continuum_record_progress", run_id="run_1", completed=4))[
+        "completed"
+    ] == 4
+    assert await call(server, "continuum_checkpoint", run_id="run_1")
+    assert await call(server, "continuum_validate", run_id="run_1")
+    assert await call(server, "continuum_resume", run_id="run_1")
+
+
+@pytest.mark.asyncio
 async def test_recording_progress_for_an_unknown_run_without_a_goal_fails(
     server_ctx: tuple[Any, Any],
 ) -> None:


### PR DESCRIPTION
Closes #364.

A single `continuum_record_progress` call could append a `TASK_UPDATED` event that no later projection could fold, permanently disabling every projecting surface for that run.

```
record_progress(run_id=R, completed=3, total=6) -> ok
record_progress(run_id=R, completed=99)         -> ToolError from Progress
record_progress(run_id=R, completed=2, total=6) -> same ToolError, forever
```

Two separate faults compounded. The `completed + failed > total` guard only fired when `total` was passed in the same call, so omitting it skipped the check while projection still folded the `total` recorded earlier. And the handler appended before it projected, so the rejected event was already durable when validation failed. Because the fold validates each intermediate state, no subsequent event could correct it.

The blast radius is what makes this critical rather than annoying. Dead for that run: `record_progress`, `checkpoint`, `validate`, `resume` over MCP, plus `status`, `inspect`, `replay`, `show-contract`, `validate`, `resume` and `briefing` over the CLI. Still working: every action tool. So the run could go on authorising and firing real side effects while recovery was unable to answer whether continuing was safe, which inverts the model the ledger is built on. `continuum verify` also reported `Event chain verified, no violations` on the same run, because integrity is a hash-chain property and says nothing about projectability.

## Approach

Rather than adding a second argument check, this validates the candidate against the read path itself. `_project_candidate` builds the event in memory, folds `history + [candidate]`, and returns the projected state; the caller commits only if that succeeds. A payload is legal or not relative to the state it lands on, so any guard that inspects only the arguments is blind to every invariant spanning events. This closes the class rather than the instance.

The candidate is constructed in memory rather than written and rolled back, because there is no transaction spanning the append and a failed rollback would leave behind exactly the state being prevented.

The two cheap argument checks are kept ahead of the fold. They answer without touching storage, and they name the offending argument rather than the folded figures.

The projected state is reused for the response, so this is one fold rather than two and `record_progress` stays as cheap as its description promises. `source_sequence` is taken from the committed event rather than the candidate, so the reported value stays honest if the two ever diverge.

## Tests

Two regressions, both failing before this change:

- `test_progress_over_the_recorded_total_is_rejected_when_total_is_omitted` asserts the refusal and that the event log is byte-identical afterwards.
- `test_a_rejected_progress_call_leaves_the_run_projectable` drives `record_progress`, `checkpoint`, `validate` and `resume` after a refused call. All four were permanently broken before.

Full suite green, ruff clean, mypy clean.

## Not in scope

The issue also raises giving the fold a way to degrade rather than raise on an already-poisoned log, and a repair path for runs currently in that state. Both are worth doing and neither belongs in a fix whose job is to stop new occurrences.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed progress updates that could create invalid completed and failed counts exceeding the total.
  * Invalid progress updates are now rejected before being saved, preserving run integrity.
  * Progress, checkpoint, validation, and resume workflows continue working after rejected updates.

* **Tests**
  * Added regression coverage for invalid progress updates and event preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->