### PR TITLE
fix(mcp): reconcile the action the recovery guidance actually names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,6 +714,28 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **Recovery guidance named an identifier the settle tools rejected (#367).**
+  `continuum_resume` reports uncertain actions by `action_id` in five places
+  (`next_allowed_action`, the contract's `required_actions`, `human_steps`,
+  `informed_retry.avoid` and the rendered report), and `human_steps` spelled out
+  a `continuum_reconcile_action(action_key=<action_id>)` call. The ledger keyed
+  only on the idempotency key, so following that instruction verbatim failed with
+  `no action recorded for key ...`, and no MCP surface exposed the value that
+  would have worked: `list_actions` and `uncertain_actions` reported `action_id`,
+  the `UnknownSideEffect` response omitted the key entirely and left a
+  12-character truncated prefix in free text as its only trace, `arguments_hash`
+  from `continuum actions --json` looks like a key but is a different hash, and
+  `continuum reconcile` needs a registered probe. An `UNKNOWN` action created
+  over MCP was therefore unreconcilable through every documented interface.
+  `ActionLedger.resolve_key` now accepts either space and `_require` returns the
+  resolved key, so `complete`, `fail`, `reconcile`, `compensate` and
+  `flag_for_review` all take an `action_id` or a key and settle under the fold's
+  own key either way. `UnknownSideEffect` carries `action_key` and `action_id`,
+  which `continuum_intercept_action` returns on the unknown path, and both
+  `continuum_list_actions` rows and `continuum_resume`'s `uncertain_actions` gain
+  `action_key`. The unmatched-identifier message names both spaces and says how
+  to list them.
+
 - **`ActionLedger` could not serialise concurrent claims on one key (#345).**
   `claim()` deduplicates by folding the log and then appending, with nothing
   between the read and the write, so processes racing on one key could each be

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -423,6 +423,34 @@ class ActionLedger:
     def get(self, key: str) -> Action | None:
         return self._replay().get(key)
 
+    def resolve_key(self, identifier: str) -> str | None:
+        """The ledger key for ``identifier``, which may be a key or an ``action_id``.
+
+        The ledger is keyed by idempotency key, but almost everything a caller
+        reads back is keyed by ``action_id``: ``Action.action_id`` itself, the
+        recovery plan's ``reconcile_action:<target>`` steps, the contract's
+        ``required_actions``, and the rendered report. So the identifier a
+        recovering caller has in hand is usually the one the settle methods did
+        not accept, and the two are indistinguishable by shape (issue #367).
+
+        Resolving both here rather than at one call site means every settle
+        method inherits it, and the recovery guidance that names an ``action_id``
+        becomes executable as written instead of needing to be rewritten in terms
+        of an identifier no output exposes.
+
+        The mapping is unambiguous: one key holds one action, and a re-claim after
+        FAILED or COMPENSATED copies the existing action, so ``action_id`` stays
+        with its key rather than being reissued. Returns ``None`` when neither
+        space matches.
+        """
+        folded = self._replay()
+        if identifier in folded:
+            return identifier
+        for stored_key, action in folded.items():
+            if action.action_id == identifier:
+                return stored_key
+        return None
+
     def _identity_match(
         self,
         action_type: str,
@@ -729,7 +757,13 @@ class ActionLedger:
         raise UnknownSideEffect(
             f"action {existing.action_type!r} (key {key[:12]}...) was interrupted before its "
             f"outcome was recorded; the side effect may or may not have occurred. "
-            f"Reconcile it before retrying."
+            f"Reconcile it before retrying.",
+            # The caller is being told to reconcile, so it needs the identity to
+            # reconcile *with*. Truncating it into the message was the only place
+            # it appeared, which left a recovering session unable to act on its
+            # own instruction (issue #367).
+            action_key=str(key),
+            action_id=uncertain.action_id,
         )
 
     @_single_writer
@@ -741,7 +775,7 @@ class ActionLedger:
         result: Mapping[str, Any] | None = None,
     ) -> Action:
         """Record that the effect succeeded."""
-        existing = self._require(key)
+        key, existing = self._require(key)
         action = existing.model_copy(
             update={
                 "status": ActionStatus.COMPLETED,
@@ -763,7 +797,7 @@ class ActionLedger:
         ``UNKNOWN`` rather than ``FAILED``, because a timeout is not evidence of
         absence.
         """
-        existing = self._require(key)
+        key, existing = self._require(key)
         action = existing.model_copy(
             update={
                 "status": ActionStatus.FAILED if certain else ActionStatus.UNKNOWN,
@@ -804,7 +838,7 @@ class ActionLedger:
         caller does not supply replacements, so confirming an effect happened can
         never erase the receipt proving it did.
         """
-        existing = self._require(key)
+        key, existing = self._require(key)
         if occurred:
             # Fall back to what is already recorded rather than overwriting with
             # None. Confirming an effect occurred must never be the reason its
@@ -840,7 +874,7 @@ class ActionLedger:
     @_single_writer
     def compensate(self, key: str, *, note: str = "", by: str | None = None) -> Action:
         """Record that a completed effect was deliberately undone."""
-        existing = self._require(key)
+        key, existing = self._require(key)
         action = existing.model_copy(
             update={
                 "status": ActionStatus.COMPENSATED,
@@ -854,14 +888,31 @@ class ActionLedger:
     @_single_writer
     def flag_for_review(self, key: str, reason: str) -> Action:
         """Escalate an action a human must judge."""
-        existing = self._require(key)
+        key, existing = self._require(key)
         action = existing.model_copy(
             update={"status": ActionStatus.REQUIRES_REVIEW, "last_error": reason}
         )
         return self._record(key, action)
 
-    def _require(self, key: str) -> Action:
-        existing = self.get(key)
-        if existing is None:
-            raise LedgerError(f"no action recorded for key {key[:12]}...")
-        return existing
+    def _require(self, key: str) -> tuple[str, Action]:
+        """Resolve ``key`` to its stored key and action, or explain what is wrong.
+
+        Returns the *resolved* key alongside the action, because the caller has
+        to record its settlement under the key the fold uses, not under whatever
+        identifier the caller happened to hold (issue #367).
+
+        The message names both identifier spaces. The previous wording,
+        ``no action recorded for key <prefix>...``, left a caller that had passed
+        a perfectly valid ``action_id`` with no way to tell that it had reached
+        for the wrong identifier rather than a nonexistent action.
+        """
+        resolved = self.resolve_key(key)
+        if resolved is None:
+            known = len(self._replay())
+            raise LedgerError(
+                f"no action in run {self.run_id!r} matches {key[:16]!r} as either an "
+                f"idempotency key or an action_id ({known} action(s) recorded). "
+                f"List them with `continuum actions {self.run_id}` or "
+                f"continuum_list_actions, and pass the action_key or action_id from there."
+            )
+        return resolved, self._replay()[resolved]

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -224,12 +224,23 @@ def _refusal_reaches_the_caller() -> Iterator[None]:
     Genuinely unexpected exceptions are deliberately not converted. Those should
     keep surfacing as unexpected, because a bug in this server is not a message
     to act on.
+
+    ``LedgerError`` belongs on the list even though it is a ``RuntimeError``
+    rather than one of the obvious refusal types. Every way the ledger raises it
+    is a deliberate answer: an identifier matching no action in either space, or
+    a settle call on an action whose status makes it a correction rather than a
+    settlement. Under mcp 2.0 its message happened to survive regardless, so the
+    omission was invisible locally; from 2.1.0 the caller was told only "Error
+    executing tool continuum_reconcile_action", which is the least useful possible
+    reply to being handed the wrong identifier (issue #367).
     """
     from mcp.server.mcpserver.exceptions import ToolError
 
+    from continuum.actions.ledger import LedgerError
+
     try:
         yield
-    except (PermissionError, ValueError, RunNotFound, MalformedRunLog) as exc:
+    except (PermissionError, ValueError, RunNotFound, MalformedRunLog, LedgerError) as exc:
         raise ToolError(str(exc)) from exc
 
 

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -770,6 +770,12 @@ def build_server(
             probed_types=probed,
             gate_configured=Path(DEFAULT_GATE_CONFIG_PATH).exists(),
         )
+        # `next_allowed_action` and the plan name actions by `action_id`, which
+        # the settle tools accept only since #367. Carry the ledger key too, so a
+        # caller never has to guess which identifier space it is holding.
+        uncertain_keys = {
+            action.action_id: key for key, action in ctx.ledger(run_id).folded().items()
+        }
         return _json(
             {
                 "run_id": run_id,
@@ -792,6 +798,7 @@ def build_server(
                 "uncertain_actions": [
                     {
                         "action_id": a.action_id,
+                        "action_key": uncertain_keys.get(a.action_id),
                         "action_type": a.action_type,
                         "status": a.status.value,
                     }
@@ -986,12 +993,18 @@ def build_server(
                     "action_type": action_type,
                     "proceed": False,
                     "status": ActionStatus.UNKNOWN.value,
+                    # Both identifiers, because reconciling needs one and every
+                    # other surface reports the other. Omitting them left the
+                    # only copy of the key inside the truncated prefix in
+                    # `reason`, which no caller could act on (issue #367).
+                    "action_key": exc.action_key,
+                    "action_id": exc.action_id,
                     "reason": str(exc),
                     "guidance": (
                         "A previous attempt was interrupted and its outcome is "
                         "unknown. Do not retry. Verify with the external system "
                         "whether it happened, then report via "
-                        "continuum_reconcile_action."
+                        "continuum_reconcile_action with the action_key above."
                     ),
                 }
             )
@@ -1088,7 +1101,10 @@ def build_server(
             "Settle an action whose outcome was unknown, after checking the external "
             "system. occurred=true records it as done (never repeated); "
             "occurred=false frees it to be retried. Only call this with real "
-            "evidence — guessing here causes either a duplicate or lost work."
+            "evidence — guessing here causes either a duplicate or lost work.\n\n"
+            "'action_key' accepts either the action_key from continuum_intercept_action "
+            "or the action_id that continuum_resume and continuum_list_actions report, "
+            "so the identifier named in next_allowed_action can be passed as-is."
         ),
         annotations=mutating,
     )
@@ -1131,7 +1147,11 @@ def build_server(
         # a genuinely unknown run without writing anything.
         ctx.storage.get_run(run_id)
         ledger = ctx.ledger(run_id)
-        actions = ledger.all()
+        folded = ledger.folded()
+        actions = list(folded.values())
+        # The settle tools key on the idempotency key, so a row that omits it
+        # cannot be acted on from this listing alone (issue #367).
+        key_by_action_id = {action.action_id: key for key, action in folded.items()}
         unresolved = {a.action_id for a in ledger.pending()}
         return _json(
             {
@@ -1139,6 +1159,7 @@ def build_server(
                 "actions": [
                     {
                         "action_id": a.action_id,
+                        "action_key": key_by_action_id.get(a.action_id),
                         "action_type": a.action_type,
                         "status": a.status.value,
                         "external_id": a.external_id,

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -498,7 +498,25 @@ class UnknownSideEffect(RuntimeError):
     """Raised when CONTINUUM cannot determine whether an external side effect occurred.
 
     The caller must reconcile (do not blindly retry).
+
+    ``action_key`` and ``action_id`` carry the identity of the action needing
+    reconciliation, when the raiser knows it. Telling a caller to reconcile
+    without telling it *what* to reconcile is not actionable, and a recovering
+    session is by definition the one least able to reconstruct that identity for
+    itself (issue #367). Both are optional: a cross-run refusal is raised about
+    another run's record, which this ledger has no standing to settle.
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        action_key: str | None = None,
+        action_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.action_key = action_key
+        self.action_id = action_id
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -141,8 +141,53 @@ def test_a_compensated_action_may_be_performed_again(ledger: ActionLedger) -> No
 
 
 def test_completing_an_unknown_key_is_refused(ledger: ActionLedger) -> None:
-    with pytest.raises(LedgerError, match="no action recorded"):
+    """The refusal names both identifier spaces (issue #367).
+
+    Settle methods accept either an idempotency key or an ``action_id``, so a
+    failure means neither matched. The old wording said only "no action recorded
+    for key", which left a caller holding a valid identifier of the other kind
+    unable to tell a wrong-space mistake from a nonexistent action.
+    """
+    with pytest.raises(LedgerError, match="idempotency key or an action_id"):
         ledger.complete("nonexistent", external_id="1")
+
+
+def test_settle_methods_accept_an_action_id(ledger: ActionLedger) -> None:
+    """`action_id` is the identifier every read surface reports (issue #367).
+
+    The ledger keys on the idempotency key, but `Action.action_id`, the recovery
+    plan's `reconcile_action:<target>` steps, the contract's `required_actions`
+    and the rendered report all name the action id. Accepting only the key made
+    the project's own recovery guidance unexecutable as written.
+    """
+    outcome = ledger.claim("github.create_issue", ISSUE)
+    settled = ledger.complete(outcome.action.action_id, external_id="issue-7")
+
+    assert settled.status is ActionStatus.COMPLETED
+    assert settled.external_id == "issue-7"
+    # Settled under the ledger's own key, not under the identifier passed in, or
+    # the fold would grow a second entry for one action.
+    assert len(ledger.all()) == 1
+    assert ledger.get(str(outcome.key)) is not None
+
+
+def test_an_unknown_action_reports_the_key_needed_to_reconcile_it(
+    ledger: ActionLedger,
+) -> None:
+    """Telling a caller to reconcile without saying what is not actionable (#367).
+
+    The identity used to appear only as a 12-character truncated prefix inside
+    the exception message, so a recovering session, the one least able to
+    reconstruct it, had no way to follow the instruction it was given.
+    """
+    outcome = ledger.claim("github.create_issue", ISSUE)
+    with pytest.raises(UnknownSideEffect) as raised:
+        ledger.claim("github.create_issue", ISSUE)
+
+    assert raised.value.action_key == str(outcome.key)
+    assert raised.value.action_id == outcome.action.action_id
+    # Usable as passed, rather than merely reported.
+    assert ledger.reconcile(raised.value.action_key, occurred=False).status is ActionStatus.FAILED
 
 
 # --- the crash gap: the reason this module exists -------------------------- #

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1023,6 +1023,111 @@ async def test_list_actions_marks_the_unresolved_row_itself(
     assert {a["action_id"] for a in payload["actions"] if a["outcome_unresolved"]} == unresolved_ids
 
 
+@pytest.mark.asyncio
+async def test_the_identifier_resume_advertises_is_accepted_by_reconcile(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """Recovery guidance must be executable exactly as written (issue #367).
+
+    ``next_allowed_action``, the contract's ``required_actions``, ``human_steps``
+    and the rendered report all name an ``action_id``, and ``human_steps`` spells
+    out a ``continuum_reconcile_action(action_key=<action_id>)`` call. The tool
+    keyed only on the idempotency key, so following the instruction verbatim
+    failed and no MCP surface exposed the value that would have worked.
+    """
+    server, _ = server_ctx
+    await seed_run(server)
+    await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="registry.publish",
+        arguments={"target": "registry://audit"},
+    )
+    resumed = await call(server, "continuum_resume", run_id="run_1")
+    advertised = resumed["next_allowed_action"].removeprefix("reconcile_action:")
+    assert advertised in resumed["human_steps"][0]
+
+    settled = await call(
+        server,
+        "continuum_reconcile_action",
+        run_id="run_1",
+        action_key=advertised,
+        occurred=False,
+        note="checked the registry, nothing landed",
+    )
+    assert settled["status"] == "failed"
+    assert (await call(server, "continuum_list_actions", run_id="run_1"))["unresolved"] == 0
+
+
+@pytest.mark.asyncio
+async def test_the_key_needed_to_reconcile_is_reported_not_truncated(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """Every surface naming an uncertain action must carry a usable key (#367).
+
+    The ``UnknownSideEffect`` response omitted ``action_key`` entirely, leaving a
+    12-character truncated prefix inside the free-text ``reason`` as the only
+    trace. ``list_actions`` and ``uncertain_actions`` reported ``action_id``
+    alone, and ``arguments_hash`` from the CLI looks like a key but is a
+    different hash.
+    """
+    server, _ = server_ctx
+    await seed_run(server)
+    claimed = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="card.charge",
+        arguments={"invoice": "INV-9001"},
+        key="charge:INV-9001",
+    )
+    escalated = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="card.charge",
+        arguments={"invoice": "INV-9001"},
+        key="charge:INV-9001",
+    )
+    assert escalated["proceed"] is False
+    assert escalated["status"] == "unknown"
+    assert escalated["action_key"] == claimed["action_key"]
+
+    listed = await call(server, "continuum_list_actions", run_id="run_1")
+    assert listed["actions"][0]["action_key"] == claimed["action_key"]
+    resumed = await call(server, "continuum_resume", run_id="run_1")
+    assert resumed["uncertain_actions"][0]["action_key"] == claimed["action_key"]
+
+    # Usable as reported, from any of the three.
+    settled = await call(
+        server,
+        "continuum_reconcile_action",
+        run_id="run_1",
+        action_key=escalated["action_key"],
+        occurred=True,
+        external_id="txn-1",
+    )
+    assert settled["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_an_unmatched_identifier_says_which_spaces_were_tried(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """`no action recorded for key <prefix>...` told the caller nothing (#367)."""
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, _ = server_ctx
+    await seed_run(server)
+    with pytest.raises(ToolError, match="idempotency key or an action_id"):
+        await server.call_tool(
+            "continuum_reconcile_action",
+            {"run_id": "run_1", "action_key": "not-an-identifier", "occurred": False},
+            context=_ctx(TEST_CLIENT),
+        )
+
+
 # --- storage configuration --------------------------------------------------- #
 
 


### PR DESCRIPTION
Closes #367.

`continuum_resume` reports an uncertain action by `action_id` in five places, and `human_steps` spells out the call to make:

```
next_allowed_action: "reconcile_action:action_d17ff043eff3b30f26c458220b0b2c70"
human_steps[0]: "... then call continuum_reconcile_action(run_id=..., 
                 action_key=action_d17ff043eff3b30f26c458220b0b2c70, occurred=true|false)"
```

Following it verbatim:

```
reconcile_action(action_key="action_d17ff043eff3b30f26c458220b0b2c70")
  -> no action recorded for key action_d17ff...
```

The ledger keys on the idempotency key, and nothing exposed it. `list_actions` and `uncertain_actions` returned `action_id`. The `UnknownSideEffect` response omitted `action_key` entirely, leaving a 12-character truncated prefix inside free-text `reason` as the only trace. `continuum actions --json` returns `arguments_hash`, which looks like a key, is a plausible guess, and is also rejected because the key here derives from the explicit `key=` override rather than from the arguments. `continuum reconcile` needs a registered probe and settles nothing without one.

Net effect: an `UNKNOWN` action created over MCP was unreconcilable through every documented interface. In the audit that found this, recovery only succeeded because the session still held the pre-crash context, which is exactly what recovery must not assume.

## Approach

Resolve both identifier spaces in the ledger rather than special-casing one tool. `ActionLedger.resolve_key` accepts a key or an `action_id`, and `_require` returns the resolved key alongside the action, so `complete`, `fail`, `reconcile`, `compensate` and `flag_for_review` all inherit it. That makes the guidance already shipping in `next_allowed_action`, `required_actions`, `human_steps` and the rendered report executable as written, instead of rewriting five outputs in terms of an identifier none of them had.

Settlement still records under the fold's own key, so passing an `action_id` cannot grow a second ledger entry for one action. The mapping is unambiguous: one key holds one action, and a re-claim after `FAILED` or `COMPENSATED` copies the existing action rather than reissuing its id.

Then close the reporting gap, so the fix does not depend on the caller guessing right. `UnknownSideEffect` carries `action_key` and `action_id`; `continuum_intercept_action` returns both on the unknown path; `continuum_list_actions` rows and `continuum_resume`'s `uncertain_actions` gain `action_key`. Telling a caller to reconcile without telling it what to reconcile is not actionable, and a recovering session is the one least able to reconstruct the identity itself.

The unmatched-identifier message now names both spaces and how to list them, rather than `no action recorded for key <prefix>...` which could not distinguish a wrong-space mistake from a nonexistent action.

## Tests

Six regressions, all failing before this change. At the ledger: settle by `action_id` without duplicating the entry, `UnknownSideEffect` exposing a key that is usable as reported, and the reworded refusal. At the MCP surface: the identifier `resume` advertises being accepted by `reconcile_action`, `action_key` present and consistent across the unknown path, `list_actions` and `uncertain_actions`, and the error naming both spaces.

Full suite green, ruff clean, mypy clean across 104 files.
