### PR TITLE
fix(ledger): complete must not assert an outcome nobody verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,6 +714,24 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **`complete` could launder an `UNKNOWN` action into `COMPLETED` (#366).**
+  `ActionLedger.complete` had no status guard, so a side effect whose real-world
+  outcome nobody could determine, a charge that timed out after the request was
+  sent, could be recorded as a clean success in one call: no evidence, no note,
+  and an `ACTION_RECORDED` event indistinguishable from an ordinary first-time
+  completion. `continuum_list_actions` then reported `unresolved: 0` and the
+  recovery blocker was gone, with nothing in the log to show the decision had been
+  made by assertion. The incentives pointed straight at it, because
+  `continuum_complete_action` is the tool an agent is told to call routinely, sits
+  on the same mutation allowlist as everything else, and accepts the key already in
+  hand, while the evidence-gated route through `reconcile` was the harder one.
+  `complete` now settles only a claim still in flight, plus a repeat report of one
+  already `COMPLETED`, since a caller retrying after a dropped response asserts
+  nothing new. `UNKNOWN`, `FAILED`, `COMPENSATED` and `REQUIRES_REVIEW` are refused
+  with a message naming the status and pointing at `reconcile`, which takes the
+  same decision but demands the caller stand behind it and records
+  `ACTION_RECONCILED` with the note.
+
 - **`ActionLedger` could not serialise concurrent claims on one key (#345).**
   `claim()` deduplicates by folding the log and then appending, with nothing
   between the read and the write, so processes racing on one key could each be

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -793,6 +793,13 @@ class ActionLedger:
         :meth:`reconcile` is the supported route for all of them. It takes the
         same decision, demands the caller stand behind it, and records
         ``ACTION_RECONCILED`` with a note so the correction is visible in the log.
+
+        Omitted arguments never erase what is on record. A caller repeating a
+        completion after a dropped response usually sends only the key, and
+        overwriting ``external_id`` and ``result`` with ``None`` would destroy the
+        receipt proving the effect happened. Same invariant :meth:`reconcile`
+        already documents, and a no-op on a first completion, where there is
+        nothing yet to preserve.
         """
         key, existing = self._require(key)
         if existing.status not in (ActionStatus.STARTED, ActionStatus.COMPLETED):
@@ -803,12 +810,16 @@ class ActionLedger:
                 f"(continuum_reconcile_action over MCP), which records the evidence "
                 f"and the note alongside the correction."
             )
+        settled_external = external_id if external_id is not None else existing.external_id
+        settled_result = dict(result) if result is not None else existing.result
         action = existing.model_copy(
             update={
                 "status": ActionStatus.COMPLETED,
-                "external_id": external_id,
-                "result": dict(result) if result is not None else None,
-                "result_hash": stable_hash(dict(result)) if result is not None else None,
+                "external_id": settled_external,
+                "result": dict(settled_result) if settled_result is not None else None,
+                "result_hash": (
+                    stable_hash(dict(settled_result)) if settled_result is not None else None
+                ),
                 "completed_at": utcnow(),
                 "side_effect_uncertain": False,
             }

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -740,8 +740,35 @@ class ActionLedger:
         external_id: str | None = None,
         result: Mapping[str, Any] | None = None,
     ) -> Action:
-        """Record that the effect succeeded."""
+        """Record that the effect succeeded.
+
+        Settles a claim that is still in flight. Re-reporting an action that is
+        already ``COMPLETED`` is allowed, because a caller repeating itself after
+        a dropped response is not asserting anything new.
+
+        Every other status is refused (issue #366). Those are not settlements, they
+        are corrections of a recorded outcome, and correcting an outcome needs
+        evidence about the outside world that this method neither takes nor
+        records. ``UNKNOWN`` is the case that matters: the action reached that
+        status precisely because nobody could say whether the effect happened, and
+        completing it here erased the recovery blocker, wrote no note, and left an
+        ``ACTION_RECORDED`` event indistinguishable from an ordinary first-time
+        success. An auditor could not tell that an uncertain charge had been
+        resolved by assertion.
+
+        :meth:`reconcile` is the supported route for all of them. It takes the
+        same decision, demands the caller stand behind it, and records
+        ``ACTION_RECONCILED`` with a note so the correction is visible in the log.
+        """
         existing = self._require(key)
+        if existing.status not in (ActionStatus.STARTED, ActionStatus.COMPLETED):
+            raise LedgerError(
+                f"action {existing.action_type!r} is {existing.status.value}, not in flight, so "
+                f"completing it would assert an outcome nothing has verified. "
+                f"Check the external system, then call reconcile(occurred=True) "
+                f"(continuum_reconcile_action over MCP), which records the evidence "
+                f"and the note alongside the correction."
+            )
         action = existing.model_copy(
             update={
                 "status": ActionStatus.COMPLETED,

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -1240,11 +1240,20 @@ def build_server(
         action_key: str,
         occurred: bool,
         external_id: str | None = None,
+        result: dict[str, Any] | None = None,
         note: str = "",
     ) -> str:
         """Resolve an uncertain action using external evidence."""
+        # `result` is accepted here because `complete` refuses an UNKNOWN action
+        # (issue #366) and this is the route it points at. Without it, structured
+        # evidence gathered by the probe had nowhere to go over MCP even though
+        # `ActionLedger.reconcile` has always stored it.
         action = ctx.ledger(run_id).reconcile(
-            action_key, occurred=occurred, external_id=external_id, note=note
+            action_key,
+            occurred=occurred,
+            external_id=external_id,
+            result=result,
+            note=note,
         )
         return _json(
             {
@@ -1252,6 +1261,7 @@ def build_server(
                 "action_id": action.action_id,
                 "status": action.status.value,
                 "external_id": action.external_id,
+                "result": dict(action.result) if action.result else None,
                 "side_effect_uncertain": action.side_effect_uncertain,
             }
         )

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -306,6 +306,39 @@ def test_completing_an_already_completed_action_is_still_allowed(
     assert again.status is ActionStatus.COMPLETED
 
 
+def test_repeating_a_completion_without_arguments_keeps_the_receipt(
+    ledger: ActionLedger,
+) -> None:
+    """Omission must not erase the evidence the effect happened (issue #366).
+
+    A caller retrying after a dropped response usually sends only the key, and
+    overwriting `external_id` and `result` with None would destroy the receipt on
+    the action the fold reports. Same invariant `reconcile` already documents.
+    """
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.complete(outcome.key, external_id="txn-1", result={"cents": 100})
+
+    again = ledger.complete(outcome.key)
+    assert again.external_id == "txn-1"
+    assert again.result == {"cents": 100}
+    assert again.result_hash is not None
+    # And the folded view, which is what every reader sees, agrees.
+    folded = ledger.get(str(outcome.key))
+    assert folded is not None and folded.external_id == "txn-1"
+
+
+def test_a_completion_may_still_replace_the_receipt_it_supplies(
+    ledger: ActionLedger,
+) -> None:
+    """Preserving on omission must not block a caller that does supply values."""
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.complete(outcome.key, external_id="txn-1", result={"cents": 100})
+
+    corrected = ledger.complete(outcome.key, external_id="txn-2", result={"cents": 250})
+    assert corrected.external_id == "txn-2"
+    assert corrected.result == {"cents": 250}
+
+
 def test_a_definite_failure_is_distinguished_from_a_timeout(
     ledger: ActionLedger,
 ) -> None:

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
 
@@ -180,6 +181,84 @@ def test_a_timeout_is_not_evidence_of_absence(ledger: ActionLedger) -> None:
 
     with pytest.raises(UnknownSideEffect):
         ledger.claim("payment.charge", {"amount": 100})
+
+
+def test_complete_cannot_launder_an_unknown_action(ledger: ActionLedger) -> None:
+    """`complete` must not clear a blocker that exists for lack of evidence (#366).
+
+    An action is UNKNOWN precisely because nobody could say whether the effect
+    happened. Completing it here asserted that it did, wrote no note, and left an
+    ACTION_RECORDED event indistinguishable from an ordinary first-time success,
+    so the audit trail lost the fact that the decision was made by assertion.
+    """
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.fail(outcome.key, "gateway timeout after the charge was sent", certain=False)
+
+    with pytest.raises(LedgerError, match="nothing has verified"):
+        ledger.complete(outcome.key, external_id="txn-1")
+
+    still = ledger.get(str(outcome.key))
+    assert still is not None
+    assert still.status is ActionStatus.UNKNOWN
+    assert ledger.pending(), "the recovery blocker must survive the refused call"
+
+
+def test_reconcile_remains_the_route_for_a_settled_unknown(ledger: ActionLedger) -> None:
+    """The refusal must point somewhere that works (issue #366).
+
+    `reconcile` takes the same decision but demands the caller stand behind it and
+    records ACTION_RECONCILED with a note, so the correction stays visible.
+    """
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.fail(outcome.key, "gateway timeout", certain=False)
+
+    settled = ledger.reconcile(
+        outcome.key,
+        occurred=True,
+        external_id="txn-1",
+        note="found the charge in the gateway ledger",
+    )
+    assert settled.status is ActionStatus.COMPLETED
+    assert settled.external_id == "txn-1"
+    assert not ledger.pending()
+    assert EventType.ACTION_RECONCILED in [e.type for e in ledger.storage.read_events("run_1")]
+
+
+@pytest.mark.parametrize(
+    ("settle", "expected_status"),
+    [
+        (lambda led, key: led.fail(key, "rejected before sending", certain=True), "failed"),
+        (lambda led, key: led.compensate(key, note="refunded"), "compensated"),
+        (lambda led, key: led.flag_for_review(key, "amount looks wrong"), "requires_review"),
+    ],
+)
+def test_complete_refuses_every_status_that_is_not_in_flight(
+    ledger: ActionLedger,
+    settle: Any,
+    expected_status: str,
+) -> None:
+    """Only a claim still in flight is a settlement; the rest are corrections (#366).
+
+    A FAILED action contradicted without evidence, a COMPENSATED one whose effect
+    was deliberately undone, and one a human flagged for review are all outcomes
+    already on record. Overwriting them belongs to `reconcile`, which records why.
+    """
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    settle(ledger, outcome.key)
+
+    with pytest.raises(LedgerError, match=expected_status):
+        ledger.complete(outcome.key, external_id="txn-1")
+
+
+def test_completing_an_already_completed_action_is_still_allowed(
+    ledger: ActionLedger,
+) -> None:
+    """A caller repeating itself after a dropped response asserts nothing new."""
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.complete(outcome.key, external_id="txn-1")
+
+    again = ledger.complete(outcome.key, external_id="txn-1")
+    assert again.status is ActionStatus.COMPLETED
 
 
 def test_a_definite_failure_is_distinguished_from_a_timeout(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1246,6 +1246,52 @@ async def test_reconciling_an_unknown_outcome_records_that_it_was_a_correction(
 
 
 @pytest.mark.asyncio
+async def test_reconcile_can_store_the_evidence_it_was_given(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """The route `complete` points at must accept what `complete` accepted (#366).
+
+    `continuum_complete_action` takes `result`, and refusing an UNKNOWN action
+    sends the caller to `continuum_reconcile_action` instead. That tool had no
+    `result` parameter, so structured evidence from the external check had nowhere
+    to go over MCP even though `ActionLedger.reconcile` has always stored it.
+    """
+    server, _ = server_ctx
+    await seed_run(server)
+    claimed = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="card.charge",
+        arguments={"invoice": "INV-9001"},
+        key="charge:INV-9001",
+    )
+    await call(
+        server,
+        "continuum_fail_action",
+        run_id="run_1",
+        action_key=claimed["action_key"],
+        error="gateway timeout",
+        certain=False,
+    )
+    settled = await call(
+        server,
+        "continuum_reconcile_action",
+        run_id="run_1",
+        action_key=claimed["action_key"],
+        occurred=True,
+        external_id="txn-1",
+        result={"cents": 4200, "settled_at": "2026-08-25"},
+        note="found in the gateway ledger",
+    )
+
+    assert settled["status"] == "completed"
+    assert settled["result"] == {"cents": 4200, "settled_at": "2026-08-25"}
+    listed = await call(server, "continuum_list_actions", run_id="run_1")
+    assert listed["actions"][0]["external_id"] == "txn-1"
+
+
+@pytest.mark.asyncio
 async def test_the_identifier_resume_advertises_is_accepted_by_reconcile(
     server_ctx: tuple[Any, Any],
 ) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1023,6 +1023,100 @@ async def test_list_actions_marks_the_unresolved_row_itself(
     assert {a["action_id"] for a in payload["actions"] if a["outcome_unresolved"]} == unresolved_ids
 
 
+@pytest.mark.asyncio
+async def test_complete_action_cannot_clear_an_unknown_outcome(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """The evidence gate must not be bypassable by the ungated tool (issue #366).
+
+    `continuum_complete_action` is the tool an agent is told to call routinely,
+    it is on the same mutation allowlist as everything else, and it accepts the
+    key the agent already holds from `continuum_intercept_action`. So it was both
+    the easiest door and the one with no evidence requirement, while the gated
+    route through `continuum_reconcile_action` was the harder one. An agent trying
+    to get unstuck reaches for the easy door.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, _ = server_ctx
+    await seed_run(server)
+    claimed = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="card.charge",
+        arguments={"amount": 4200, "invoice": "INV-9001"},
+        key="charge:INV-9001",
+    )
+    await call(
+        server,
+        "continuum_fail_action",
+        run_id="run_1",
+        action_key=claimed["action_key"],
+        error="gateway timeout after the charge request was sent",
+        certain=False,
+    )
+
+    with pytest.raises(ToolError, match="nothing has verified"):
+        await server.call_tool(
+            "continuum_complete_action",
+            {"run_id": "run_1", "action_key": claimed["action_key"]},
+            context=_ctx(TEST_CLIENT),
+        )
+
+    # The blocker survives, so recovery still refuses to call the run safe.
+    listed = await call(server, "continuum_list_actions", run_id="run_1")
+    assert listed["unresolved"] == 1
+    assert listed["actions"][0]["status"] == "unknown"
+    resumed = await call(server, "continuum_resume", run_id="run_1")
+    assert resumed["safe"] is False
+    assert resumed["next_allowed_action"].startswith("reconcile_action:")
+
+
+@pytest.mark.asyncio
+async def test_reconciling_an_unknown_outcome_records_that_it_was_a_correction(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """The supported route keeps the decision visible in the log (issue #366).
+
+    `complete` recorded ACTION_RECORDED, indistinguishable from a first-time
+    success, so an auditor could not tell that an uncertain effect had been
+    resolved by assertion. `reconcile` records ACTION_RECONCILED with the note.
+    """
+    server, ctx = server_ctx
+    await seed_run(server)
+    claimed = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="card.charge",
+        arguments={"invoice": "INV-9001"},
+        key="charge:INV-9001",
+    )
+    await call(
+        server,
+        "continuum_fail_action",
+        run_id="run_1",
+        action_key=claimed["action_key"],
+        error="gateway timeout",
+        certain=False,
+    )
+    settled = await call(
+        server,
+        "continuum_reconcile_action",
+        run_id="run_1",
+        action_key=claimed["action_key"],
+        occurred=True,
+        external_id="txn-1",
+        note="found the charge in the gateway ledger",
+    )
+
+    assert settled["status"] == "completed"
+    assert settled["side_effect_uncertain"] is False
+    assert (await call(server, "continuum_list_actions", run_id="run_1"))["unresolved"] == 0
+    assert EventType.ACTION_RECONCILED in [e.type for e in ctx.storage.read_events("run_1")]
+
+
 # --- storage configuration --------------------------------------------------- #
 
 


### PR DESCRIPTION
Closes #366.

`ActionLedger.complete` had no status guard, so a side effect whose real-world outcome nobody could determine could be recorded as a clean success in one call.

```
intercept_action(type="card_charge", key="charge:INV-9001") -> proceed=true
fail_action(certain=false, error="gateway timeout after the charge was sent")
                                                           -> status unknown
complete_action(action_key=...)                            -> status completed
list_actions                                               -> unresolved: 0
```

No evidence, no note, and the event recorded was `ACTION_RECORDED`, indistinguishable from an ordinary first-time completion. Only `reconcile` writes `ACTION_RECONCILED`, so an auditor reading the log could not tell that an uncertain charge had been resolved by assertion.

## Why this was likely to be hit rather than theoretical

The incentives pointed at this door. `continuum_complete_action` is the tool an agent is told to call routinely, sits on the same mutation allowlist as everything else, and accepts the key it already holds from `intercept_action`. The evidence-gated route through `reconcile_action` was the harder one, and until #367 it was also broken, since the identifier the recovery guidance advertised was rejected. An agent trying to get unstuck reaches for the easy door.

## Approach

`complete` settles a claim that is still in flight. That is the whole of its job, and every other status is a correction of an outcome already on record rather than a settlement.

Allowed: `STARTED`, the normal two-phase path, and `COMPLETED`, because a caller repeating itself after a dropped response asserts nothing new.

Refused: `UNKNOWN`, `FAILED`, `COMPENSATED`, `REQUIRES_REVIEW`. Each is an outcome someone or something already decided. Overwriting it needs evidence about the outside world that `complete` neither takes nor records, so the refusal names the current status and points at `reconcile`, which takes the same decision, demands the caller stand behind it, and records `ACTION_RECONCILED` with a note.

`UNKNOWN` is the case that matters, but `FAILED` and `COMPENSATED` were the same hole with less obvious consequences: a recorded failure contradicted without evidence, and an effect deliberately undone re-asserted as standing.

The guard lives in the ledger rather than in the MCP handler, so the CLI and any in-process caller inherit it.

## Tests

Seven regressions. At the ledger: `UNKNOWN` refused with the blocker surviving the refused call, `reconcile` still working as the route out, `FAILED` / `COMPENSATED` / `REQUIRES_REVIEW` each refused with the status named, and a repeat completion still permitted. At the MCP surface: the refusal, then `list_actions` still reporting `unresolved: 1` and `resume` still returning `safe: false` with a `reconcile_action:` next step, plus the reconcile path recording `ACTION_RECONCILED`.

The existing suite needed no changes, which is the useful signal here: nothing legitimately relied on completing an action that was not in flight.

Full suite green, ruff clean, mypy clean across 104 files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented uncertain, failed, compensated, or review-required actions from being incorrectly marked as completed.
  * Repeated completion remains supported for actions already completed.
  * Unresolved actions now remain blocked until explicitly reconciled.

* **Improvements**
  * Added reconciliation handling to record confirmed outcomes and clear unresolved action status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->