### PR TITLE
docs: restore the Project Structure code fence in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,28 +105,29 @@ pre-commit run --all-files
 Pre-commit hooks run in isolated environments without the project's installed
 dependencies, so a mypy hook there would produce inaccurate results. Instead,
 mypy runs in CI (`mypy src/continuum`, strict mode) against a full environment.
-To check locally, run `pip install -e ".[dev]"` once, then run `mypy
-src/continuum` yourself - or rely on the CI check on your PR.
+To check locally, run `pip install -e ".[dev]"` once, then run
+`mypy src/continuum` yourself, or rely on the CI check on your PR.
 
 ---
 
 ## Project Structure
 
+```
 src/continuum/
-├── init.py # Public API surface
-├── models.py # Immutable Pydantic data models
-├── events.py # Append-only event log
-├── actions/ # Action ledger (idempotency + reconciliation)
-├── checkpoint/ # Checkpoint manager + policies
-├── environment/ # Environment snapshot + diff
-├── recovery/ # Recovery engine + repair planner
-├── security/ # Content hashing, ID generation
-├── state/ # State projection, extraction, diffing, validation
-└── storage/ # Storage interface + SQLite engine
+├── __init__.py          # Public API surface
+├── models.py            # Immutable Pydantic data models
+├── events.py            # Append-only event log
+├── actions/             # Action ledger (idempotency + reconciliation)
+├── checkpoint/          # Checkpoint manager + policies
+├── environment/         # Environment snapshot + diff
+├── recovery/            # Recovery engine + repair planner
+├── security/            # Content hashing, ID generation
+├── state/               # State projection, extraction, diffing, validation
+└── storage/             # Storage interface + SQLite engine
 
-tests/ # Mirrors src/continuum/ structure
-docs/ # Website (deployed to GitHub Pages)
-
+tests/                   # Mirrors src/continuum/ structure
+docs/                    # Website (deployed to GitHub Pages)
+```
 
 ---
 


### PR DESCRIPTION
Follow-up to #354, which landed with the code fences around the Project Structure tree removed. The block currently renders as a run-on paragraph rather than a code listing, the aligned comment column is collapsed to single spaces, and `__init__.py` reads as `init.py`, naming a file that does not exist.

This restores that block verbatim from its state before #354 and puts back the trailing newline at end of file. It also joins the `mypy src/continuum` code span onto a single source line so copying the command out of the raw file does not pick up a line break. The mypy note and the `pre-commit install` step from #354 are otherwise untouched.

CI did not catch this because there is no markdown linter in any workflow and no committed `.pre-commit-config.yaml`, so nothing checks fence balance. Worth a separate issue if we want that covered.
