### PR TITLE
fix(ledger): same filename in a different directory is different work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,6 +714,27 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **Same-named files in different directories collapsed into one action (#365).**
+  With no explicit `key` the exact argument hash misses on two differently-spelled
+  paths, so the identity fallback decides, and it compared basenames.
+  `/tenants/acme/report.csv` and `/tenants/globex/report.csv` both reduced to
+  `{report.csv, report}`, containment held both ways, and the second claim was
+  answered `proceed=false` carrying acme's `external_id` and the guidance "Already
+  performed. Reuse the previous result; do not repeat it." Globex was never
+  notified, which is the silent swallow the fallback exists to prevent, and
+  per-directory files with conventional names are a common fan-out shape. Leaf
+  comparison was introduced so a re-rendered path (`invoices/INV-5.pdf` for
+  `/data/invoices/INV-5.pdf`) would still deduplicate, so the container is now set
+  aside rather than discarded: new `location_tokens` returns exactly what
+  `leaf_tokens` drops, and `_identity_match` additionally requires the locations to
+  agree. `same_location` compares by path suffix rather than equality, which is the
+  shape drift actually takes, so the re-rendering case still matches while two
+  fully-qualified paths agreeing on nothing but the filename do not. A side that
+  names no path at all makes no claim about location and so contradicts nothing,
+  which keeps the field-rename case working. Comparison stays purely lexical, with
+  no filesystem or working-directory resolution, so the answer is identical on
+  every machine.
+
 - **`ActionLedger` could not serialise concurrent claims on one key (#345).**
   `claim()` deduplicates by folding the log and then appending, with nothing
   between the read and the write, so processes racing on one key could each be

--- a/src/continuum/actions/idempotency.py
+++ b/src/continuum/actions/idempotency.py
@@ -33,6 +33,10 @@ __all__ = [
     "idempotency_key",
     "arguments_hash",
     "identity_tokens",
+    "leaf_tokens",
+    "location_tokens",
+    "locations_agree",
+    "same_location",
     "IdempotencyKey",
 ]
 
@@ -347,9 +351,67 @@ def leaf_tokens(tokens: frozenset[str]) -> frozenset[str]:
     container would otherwise make the two look like different resources.
 
     Dropping the container is what lets ``_identity_match`` demand containment
-    instead of a single shared token. Note the consequence: identity is decided
-    at basename level, so two same-type actions on same-named files in different
-    directories are treated as one. That is the same assumption the basename
-    token itself has always encoded.
+    instead of a single shared token. On its own it also made two same-type
+    actions on same-named files in *different* directories look like one, which
+    silently swallowed the second side effect (issue #365). The container is
+    therefore not discarded, only set aside: :func:`location_tokens` returns
+    exactly what this drops, and ``_identity_match`` requires the locations to
+    agree before it accepts a leaf-level match.
     """
     return frozenset(t for t in tokens if "/" not in t and "\\" not in t)
+
+
+def location_tokens(tokens: frozenset[str]) -> frozenset[str]:
+    """The path-like tokens :func:`leaf_tokens` sets aside.
+
+    Its exact complement, so between them no token is lost. These say *where* a
+    resource is, which is what distinguishes two files that happen to share a
+    name (issue #365).
+    """
+    return frozenset(t for t in tokens if "/" in t or "\\" in t)
+
+
+def _segments(path: str) -> list[str]:
+    """A path split into comparable segments, separator-agnostic.
+
+    Both separators are split on regardless of platform, because the token being
+    compared was written by whatever machine recorded the action and need not
+    match the one reading it.
+    """
+    normalized = os.path.normpath(os.path.expanduser(path)).replace("\\", "/")
+    return [segment for segment in normalized.split("/") if segment not in ("", ".")]
+
+
+def same_location(left: str, right: str) -> bool:
+    """Whether two path-like tokens can be one file rendered differently.
+
+    Drift makes a path more or less qualified about one resource, so the shorter
+    rendering is a trailing part of the longer one: ``invoices/INV-5.pdf`` inside
+    ``/data/invoices/INV-5.pdf``. Two paths that agree on nothing but the
+    basename are different files, and treating them as one is what let
+    ``/tenants/acme/report.csv`` swallow ``/tenants/globex/report.csv``
+    (issue #365).
+
+    Suffix comparison rather than equality, because that is the shape drift
+    actually takes. Deliberately not a filesystem check: nothing here resolves
+    against a working directory, so the answer is identical on every machine and
+    for paths that no longer exist.
+    """
+    a, b = _segments(left), _segments(right)
+    if not a or not b:
+        return False
+    shorter, longer = (a, b) if len(a) <= len(b) else (b, a)
+    return longer[-len(shorter) :] == shorter
+
+
+def locations_agree(left: frozenset[str], right: frozenset[str]) -> bool:
+    """Whether two token sets locate the same resource, or locate nothing.
+
+    A side carrying no path-like token is making no claim about location, so it
+    cannot contradict one: an argument rename that drops the path entirely still
+    matches on its leaves. When both sides do locate something, at least one pair
+    has to be reconcilable under :func:`same_location`.
+    """
+    if not left or not right:
+        return True
+    return any(same_location(a, b) for a in left for b in right)

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -57,6 +57,8 @@ from continuum.actions.idempotency import (
     idempotency_key,
     identity_tokens,
     leaf_tokens,
+    location_tokens,
+    locations_agree,
 )
 from continuum.concurrency.lease import LeaseCoordinator
 from continuum.events import EventType
@@ -450,6 +452,16 @@ class ActionLedger:
         second side effect would be silently swallowed -- the exact failure this
         ledger exists to prevent.
 
+        Leaf comparison alone was not enough either, for the same reason in a
+        different disguise: two files with the same name in different directories
+        share every leaf, so ``/tenants/acme/report.csv`` matched
+        ``/tenants/globex/report.csv`` and globex was never notified (issue #365).
+        A match therefore also requires the *locations* to agree, which
+        ``locations_agree`` decides by suffix rather than equality so the drift
+        case that motivated leaf comparison (``invoices/INV-5.pdf`` for
+        ``/data/invoices/INV-5.pdf``) still matches. A side carrying no path at
+        all makes no claim about location and so contradicts nothing.
+
         Containment on its own is still too loose: a completed action folds its
         outcome ``external_id`` and any optional descriptive argument into its
         token set, so the stored set is a *superset* of a sparser re-claim even
@@ -470,7 +482,9 @@ class ActionLedger:
         # common to every claim in the run, so it must never count as a
         # resource token when deciding whether two claims are the same work.
         plumbing = leaf_tokens(identity_tokens(external_id=self.run_id))
-        incoming = leaf_tokens(identity_tokens(arguments, volatile=volatile)) - plumbing
+        incoming_all = identity_tokens(arguments, volatile=volatile)
+        incoming = leaf_tokens(incoming_all) - plumbing
+        incoming_where = location_tokens(incoming_all)
         if not incoming:
             return None
 
@@ -483,11 +497,15 @@ class ActionLedger:
             # is never present on the incoming claim, so folding it into ``known``
             # would make the stored set a systematic superset of every sparser
             # re-claim. It is therefore excluded from the comparison (issue #64).
-            known = leaf_tokens(identity_tokens(action.arguments)) - plumbing
+            known_all = identity_tokens(action.arguments)
+            known = leaf_tokens(known_all) - plumbing
             # An empty ``known`` is contained in everything; treat a stored
             # action with no identity of its own as unrecognisable, not as a
             # match for every claim of the same type.
             if not known:
+                continue
+            # Same leaves, different directories, is different work (issue #365).
+            if not locations_agree(incoming_where, location_tokens(known_all)):
                 continue
             if incoming <= known:
                 # The stored action carries more tokens than the claim. That is

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -631,6 +631,65 @@ def test_identity_match_survives_an_absolute_versus_relative_path(
     assert again.external_id == "ext-5"
 
 
+def test_identity_match_does_not_collapse_same_name_files_in_different_directories(
+    ledger: ActionLedger,
+) -> None:
+    """Same basename, different directory, is different work (issue #365).
+
+    Comparing at the leaf is what lets a re-rendered path deduplicate, but it also
+    made every per-tenant file with a conventional name look like one resource.
+    The second tenant was never notified, and the ledger handed back the first
+    tenant's receipt as though it were the second's, which is precisely the silent
+    swallow the identity fallback exists to prevent.
+    """
+    first = ledger.claim("tenant.notify", {"path": "/tenants/acme/report.csv"})
+    ledger.complete(first.key, external_id="notify-acme-001")
+
+    second = ledger.claim("tenant.notify", {"path": "/tenants/globex/report.csv"})
+    assert second.fresh, "globex is a different file and must still be notified"
+    assert second.external_id is None, "acme's receipt must not be reused for globex"
+    assert second.key != first.key
+
+
+def test_identity_match_still_matches_when_only_one_side_names_a_path(
+    ledger: ActionLedger,
+) -> None:
+    """A side with no path makes no claim about location (issue #365).
+
+    Requiring locations to agree must not undo the field-rename case: an argument
+    set that drops the path entirely contradicts nothing, so it still matches on
+    its leaves.
+    """
+    first = ledger.claim("bench.send", {"file": "/data/invoices/INV-5.pdf"})
+    ledger.complete(first.key, external_id="ext-5")
+
+    again = ledger.claim("bench.send", {"invoice": "INV-5.pdf"})
+    assert not again.fresh
+    assert again.external_id == "ext-5"
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "same"),
+    [
+        # Drift: one rendering is a trailing part of the other.
+        ("/data/invoices/INV-5.pdf", "invoices/INV-5.pdf", True),
+        ("/data/invoices/INV-5.pdf", "./invoices/INV-5.pdf", True),
+        ("/data/invoices/INV-5.pdf", "/data/invoices/INV-5.pdf", True),
+        # Different containers for the same filename are different files.
+        ("/tenants/acme/report.csv", "/tenants/globex/report.csv", False),
+        ("a/report.csv", "b/report.csv", False),
+        # Separator style is a rendering difference, not a resource difference.
+        ("data\\invoices\\INV-5.pdf", "invoices/INV-5.pdf", True),
+    ],
+)
+def test_same_location_compares_by_suffix_not_basename(left: str, right: str, same: bool) -> None:
+    """Suffix comparison is the shape path drift actually takes (issue #365)."""
+    from continuum.actions.idempotency import same_location
+
+    assert same_location(left, right) is same
+    assert same_location(right, left) is same, "the comparison must be symmetric"
+
+
 def test_identity_match_does_not_collapse_actions_sharing_one_incidental_value(
     ledger: ActionLedger,
 ) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1023,6 +1023,88 @@ async def test_list_actions_marks_the_unresolved_row_itself(
     assert {a["action_id"] for a in payload["actions"] if a["outcome_unresolved"]} == unresolved_ids
 
 
+@pytest.mark.asyncio
+async def test_two_tenants_with_the_same_filename_are_two_actions(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """Per-directory files with a conventional name are not one action (#365).
+
+    With no explicit `key` the exact argument hash misses, so the identity
+    fallback decides, and it compared basenames. Both paths reduced to
+    `{report.csv, report}`, so the second claim was answered `proceed=false` with
+    the first tenant's `external_id` attached and the guidance "Already
+    performed. Reuse the previous result; do not repeat it." Globex was never
+    notified. Fan-out over `report.csv`, `invoice.pdf`, `index.json` and friends
+    is a common shape, so the exposure is not exotic.
+    """
+    server, _ = server_ctx
+    await seed_run(server)
+    acme = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="tenant.notify",
+        arguments={"path": "/tenants/acme/report.csv"},
+    )
+    assert acme["proceed"] is True
+    await call(
+        server,
+        "continuum_complete_action",
+        run_id="run_1",
+        action_key=acme["action_key"],
+        external_id="notify-acme-001",
+    )
+
+    globex = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="tenant.notify",
+        arguments={"path": "/tenants/globex/report.csv"},
+    )
+    assert globex["proceed"] is True, "globex must still be notified"
+    assert globex["action_key"] != acme["action_key"]
+    assert globex.get("external_id") is None, "acme's receipt must not be reused"
+
+
+@pytest.mark.asyncio
+async def test_a_re_rendered_path_still_deduplicates(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """Fixing #365 must not cost the drift case the fallback exists for.
+
+    An agent that writes an absolute path in one session and a relative one in
+    the next means the same file, so the second claim must still be refused with
+    the first result rather than performing the effect twice.
+    """
+    server, _ = server_ctx
+    await seed_run(server)
+    first = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="bench.send",
+        arguments={"file": "/data/invoices/INV-5.pdf"},
+    )
+    await call(
+        server,
+        "continuum_complete_action",
+        run_id="run_1",
+        action_key=first["action_key"],
+        external_id="ext-5",
+    )
+
+    again = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="bench.send",
+        arguments={"file": "invoices/INV-5.pdf"},
+    )
+    assert again["proceed"] is False
+    assert again["external_id"] == "ext-5"
+
+
 # --- storage configuration --------------------------------------------------- #
 
 


### PR DESCRIPTION
Closes #365.

With no explicit `key`, two genuinely different resources that share a filename were treated as the same action, so the second side effect was never performed and the caller was handed the first one's receipt.

```
intercept_action(type="tenant_notify", arguments={"path": "/tenants/acme/report.csv"})
  -> proceed=true; completed as notify-acme-001

intercept_action(type="tenant_notify", arguments={"path": "/tenants/globex/report.csv"})
  -> proceed=false
     external_id="notify-acme-001"
     guidance="Already performed. Reuse the previous result; do not repeat it."
```

Globex is never notified, and the response hands back acme's receipt as if it were globex's. The exact argument hash misses because the paths differ, which engages `_identity_match`, and that comparison runs on `leaf_tokens`, which discards any token containing a separator. Both claims reduce to `{report.csv, report}`, containment holds both ways, and the claim is answered as a duplicate.

`leaf_tokens` documented this outcome, so it was known. What makes it a defect rather than a tradeoff is that it produces exactly the failure `_identity_match` says it exists to prevent: "Under mere intersection the second side effect would be silently swallowed, the exact failure this ledger exists to prevent." Containment plus leaf reduction swallows it too.

Exposure is not exotic. Per-directory files with conventional names (`report.csv`, `invoice.pdf`, `index.json`, `config.yaml`) are a standard fan-out shape, and the default path is the dangerous one: the tool description frames `key` as being for operations that are legitimately repeated, so nothing warns a caller that omitting it risks dropping distinct work.

## Approach

Leaf comparison exists for a real reason, so keep it. Basename reduction was introduced so a path re-rendered between sessions (`invoices/INV-5.pdf` for `/data/invoices/INV-5.pdf`) would still deduplicate, and that case still has to work.

So the container is set aside rather than discarded. New `location_tokens` returns exactly what `leaf_tokens` drops, and between them no token is lost. `_identity_match` then requires locations to agree on top of the existing leaf containment.

`same_location` compares by path suffix rather than equality, because suffix is the shape drift actually takes. The shorter rendering is a trailing part of the longer one. That accepts `invoices/INV-5.pdf` against `/data/invoices/INV-5.pdf` and rejects `/tenants/acme/report.csv` against `/tenants/globex/report.csv`, which is exactly the line wanted.

Two details worth calling out. A side carrying no path-like token is making no claim about location and so cannot contradict one, which keeps the field-rename case (`{"file": "/data/..."}` matching `{"invoice": "INV-5.pdf"}`) working. And the comparison is purely lexical, with `normpath` plus `~` expansion and no filesystem or working-directory resolution, so the answer is identical on every machine and for paths that no longer exist. Both separators are split on regardless of platform, since the token was written by whatever machine recorded the action.

## Tests

Nine cases, all failing or absent before. The tenant collapse at both the ledger and the MCP surface; the re-rendered path still deduplicating at both, since that is what could regress; one side naming no path still matching; and a parametrised table over `same_location` covering drift, `./` prefixes, exact equality, two different containers, and mixed separators, each asserted symmetrically.

The existing identity-fallback suite needed no changes, which is the signal that the drift behaviour it was written to protect is intact.

Full suite green, ruff clean, mypy clean across 104 files.
