### PR TITLE
fix(budgets): count retries per operation, not per action type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,6 +714,25 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **The retry budget counted per action type, blocking work that never failed (#368).**
+  `attempts_for_type` folded on `action_type` and ignored the idempotency key, so
+  the limit capped a run's distinct unsettled work of a type rather than retries of
+  one operation. Three different recipients each failing once, with zero retries
+  anywhere, exhausted the default budget of three and refused a fourth that had
+  never been attempted, so any fan-out with more failures than the limit deadlocked
+  mid-run. The default applies with no config file present, so this was live in any
+  project that had never configured budgets. New `attempts_by_key` counts per
+  idempotency key, which is the operation's identity and is stable across retries
+  because re-claiming after FAILED or COMPENSATED copies the existing action.
+  `attempts_for_type` now reports the worst single operation, which is the figure
+  the claim site compares against the limit, so `continuum budget` agrees with what
+  is enforced; it is deliberately not the sum across keys, since that measures
+  distinct work and nothing here caps that. The limit stays configured per type,
+  because that is the unit an operator thinks in. The exhaustion message also fits
+  the state it fires in: it names the specific operation, drops the advice to
+  reconcile existing attempts (useless when every prior attempt is settled FAILED),
+  and says the registry file may need creating rather than raising.
+
 - **One `continuum_record_progress` call could permanently brick a run (#364).**
   The `completed + failed > total` guard only fired when `total` was passed in
   the same call. Omitting it skipped the guard while projection still folded the

--- a/src/continuum/budgets.py
+++ b/src/continuum/budgets.py
@@ -15,6 +15,13 @@ registries):
 ledger and returns whether another claim may proceed. CONTINUUM never retries
 anything itself - it counts and gates - so the enforcement surface stays a
 single pure function plus thin wiring at claim sites.
+
+Attempts are counted per idempotency key, not per action type (issue #368). The
+limit is still configured per type, because that is the unit an operator thinks
+in, but what it caps is repetition of one operation. Counting per type made
+distinct work compete for the same allowance: three different recipients each
+failing once, with no retry anywhere, exhausted a budget of three and blocked a
+fourth that had never been attempted.
 """
 
 from __future__ import annotations
@@ -26,10 +33,10 @@ from typing import Any
 
 __all__ = [
     "DEFAULT_BUDGETS_PATH",
+    "attempts_by_key",
     "attempts_for_type",
     "BudgetConfigError",
     "load_budgets",
-    "attempts_for_type",
     "evaluate_budget",
     "backoff_delay",
 ]
@@ -88,25 +95,29 @@ def _max_for(action_type: str, raw: Mapping[str, Any]) -> int:
     return int(fallback)
 
 
-def attempts_for_type(events: Any, action_type: str) -> int:
-    """Count unsettled claim slots opened for ``action_type`` from raw events.
+def attempts_by_key(events: Any, action_type: str) -> dict[str, int]:
+    """Unsettled claim attempts for ``action_type``, counted per idempotency key.
 
-    A claim slot (an ACTION_RECORDED whose action status is STARTED) is one
-    attempt. Settlement events (completed/failed/unknown) are updates, not
-    new attempts - so retries count but their bookkeeping does not.
+    A retry budget has to count retries of *one operation*. Counting per action
+    type instead conflated distinct work with repetition: three different
+    recipients each failing once, with no retry anywhere, exhausted a budget of
+    three and blocked a fourth recipient that had never been attempted (issue
+    #368). Any fan-out with more than ``max_attempts`` failures of one type
+    deadlocked mid-run.
 
-    Slots whose action went on to COMPLETE are excluded. This is a *retry*
-    budget: an operation that succeeded was never retried, and counting it caps
-    how much distinct work a run may do rather than how hard it may hammer a
-    failing upstream (issue #309). Failures, unknowns and in-flight attempts
-    all still count, which is what the amplification guard actually needs.
+    The key is the right unit because it *is* the operation's identity, and it is
+    stable across retries: re-claiming after FAILED or COMPENSATED copies the
+    existing action, so successive attempts under one key accumulate here rather
+    than each opening a fresh row.
+
+    A claim slot (an ``ACTION_RECORDED`` whose action status is STARTED) is one
+    attempt. Settlement events are updates, not new attempts, so retries count but
+    their bookkeeping does not. Keys whose action went on to COMPLETE are omitted:
+    an operation that succeeded was never retried (issue #309).
     """
     from continuum.events import EventType
     from continuum.models import ActionStatus
 
-    # The claim slot and its settlement are separate events describing the same
-    # action, so fold to the final status per action id before counting: only
-    # that tells us whether the attempt ultimately succeeded.
     slots: dict[str, int] = {}
     final: dict[str, str] = {}
     for event in events:
@@ -115,17 +126,29 @@ def attempts_for_type(events: Any, action_type: str) -> int:
         action = event.payload.get("action")
         if not isinstance(action, Mapping) or action.get("action_type") != action_type:
             continue
-        action_id = str(action.get("action_id"))
+        key = str(event.payload.get("key", ""))
+        if not key:
+            continue
         status = str(action.get("status"))
         if status == ActionStatus.STARTED.value:
-            slots[action_id] = slots.get(action_id, 0) + 1
-        final[action_id] = status
+            slots[key] = slots.get(key, 0) + 1
+        final[key] = status
 
-    return sum(
-        count
-        for action_id, count in slots.items()
-        if final.get(action_id) != ActionStatus.COMPLETED.value
-    )
+    return {
+        key: count for key, count in slots.items() if final.get(key) != ActionStatus.COMPLETED.value
+    }
+
+
+def attempts_for_type(events: Any, action_type: str) -> int:
+    """The most attempts any single operation of ``action_type`` has used.
+
+    Reports the figure the budget is actually compared against, so the ``continuum
+    budget`` view agrees with what the claim site enforces. It is deliberately not
+    the sum across keys: that total is a measure of how much distinct work a run
+    did, which no limit here caps (issue #368).
+    """
+    per_key = attempts_by_key(events, action_type)
+    return max(per_key.values(), default=0)
 
 
 def evaluate_budget(

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -1013,7 +1013,7 @@ def build_server(
         from continuum.budgets import (
             DEFAULT_BUDGETS_PATH,
             BudgetConfigError,
-            attempts_for_type,
+            attempts_by_key,
             evaluate_budget,
         )
 
@@ -1056,16 +1056,31 @@ def build_server(
 
         if not settled:
             events = ctx.storage.read_events(run_id)
-            attempts = attempts_for_type(events, action_type)
+            # Counted per key, so the budget caps retries of *this* operation
+            # rather than the run's distinct work of this type (issue #368).
+            claim_key = str(
+                idempotency_key(
+                    action_type,
+                    arguments,
+                    scope=run_id if scoped_to_run else None,
+                    key=key,
+                )
+            )
+            attempts = attempts_by_key(events, action_type).get(claim_key, 0)
             allowed, used, maximum = evaluate_budget(budgets, action_type, attempts)
             if not allowed:
                 from mcp.server.mcpserver.exceptions import ToolError
 
+                # The old wording advised reconciling, which is no help when every
+                # prior attempt is already settled FAILED, and pointed at a
+                # registry file that usually does not exist yet (issue #368).
                 raise ToolError(
-                    f"retry budget exhausted for {action_type!r}: "
-                    f"{used} attempt(s) recorded, budget is {maximum}. "
-                    "Reconcile existing attempts or ask the operator to raise "
-                    ".continuum/budgets.json."
+                    f"retry budget exhausted for this {action_type!r} operation "
+                    f"(key {claim_key[:12]}...): {used} attempt(s) recorded, budget is "
+                    f"{maximum}. Retrying it again is the thing the budget exists to "
+                    f"stop, so either settle it a different way or raise the limit by "
+                    f"setting action_types.{action_type}.max_attempts in "
+                    f"{DEFAULT_BUDGETS_PATH} (creating that file if it does not exist)."
                 )
 
         try:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1782,8 +1782,14 @@ async def test_a_completed_action_still_deduplicates_at_budget(
     the budget gate runs first it raises instead of answering, and an agent that
     gets an error where it expected "already done" has every reason to perform
     the side effect again out of band.
+
+    Pinned with `max_attempts: 1` so one attempt is the whole allowance, and the
+    budget is counted per operation (issue #368) so this asserts the property on
+    the very key being re-claimed rather than on unrelated work of the same type.
     """
     monkeypatch.chdir(tmp_path)
+    (tmp_path / ".continuum").mkdir()
+    (tmp_path / ".continuum" / "budgets.json").write_text('{"default_max_attempts": 1}')
     server, _ = server_ctx
     await seed_run(server)
 
@@ -1803,23 +1809,29 @@ async def test_a_completed_action_still_deduplicates_at_budget(
         result={"cents": 500},
     )
 
-    # Exhaust the default budget of 3 with genuinely unsettled attempts.
-    for n in range(3):
-        await call(
-            server,
-            "continuum_intercept_action",
-            run_id="run_1",
-            action_type="charge",
-            key=f"charge:stuck-{n}",
-        )
-
-    # A fresh identity is now correctly refused.
+    # A different operation of the same type burns its own single attempt and is
+    # then refused, which is the gate working.
     from mcp.server.mcpserver.exceptions import ToolError
 
+    stuck = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="charge",
+        key="charge:stuck",
+    )
+    await call(
+        server,
+        "continuum_fail_action",
+        run_id="run_1",
+        action_key=stuck["action_key"],
+        error="500 from upstream",
+        certain=True,
+    )
     with pytest.raises(ToolError, match="retry budget exhausted"):
         await server.call_tool(
             "continuum_intercept_action",
-            {"run_id": "run_1", "action_type": "charge", "key": "charge:new"},
+            {"run_id": "run_1", "action_type": "charge", "key": "charge:stuck"},
             context=_ctx(TEST_CLIENT),
         )
 
@@ -1838,13 +1850,116 @@ async def test_a_completed_action_still_deduplicates_at_budget(
 
 
 @pytest.mark.asyncio
+async def test_a_never_retried_operation_is_not_blocked_by_its_neighbours(
+    server_ctx: tuple[Any, Any],
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Distinct work must not share one allowance (issue #368).
+
+    Three recipients each failing once, with no retry anywhere, exhausted a
+    budget of three and blocked a fourth that had never been attempted. Any
+    fan-out with more failures than the limit deadlocked mid-run, and the refusal
+    called it a retry budget while nothing had been retried.
+    """
+    monkeypatch.chdir(tmp_path)
+    server, _ = server_ctx
+    await seed_run(server)
+
+    for recipient in ("a", "b", "c"):
+        claim = await call(
+            server,
+            "continuum_intercept_action",
+            run_id="run_1",
+            action_type="email_send",
+            arguments={"to": f"{recipient}@example.com"},
+            key=f"email:{recipient}",
+        )
+        await call(
+            server,
+            "continuum_fail_action",
+            run_id="run_1",
+            action_key=claim["action_key"],
+            error="550 rejected by upstream",
+            certain=True,
+        )
+
+    fourth = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="email_send",
+        arguments={"to": "d@example.com"},
+        key="email:d",
+    )
+    assert fourth["proceed"] is True, "d was never attempted and must not be blocked"
+
+
+@pytest.mark.asyncio
+async def test_the_exhaustion_message_names_the_operation_and_the_way_out(
+    server_ctx: tuple[Any, Any],
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The old wording did not fit the state it fired in (issue #368).
+
+    It advised reconciling existing attempts, which is no help when every prior
+    attempt is settled FAILED with nothing uncertain about it, and it pointed at
+    a registry file without saying that the file usually needs creating.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".continuum").mkdir()
+    (tmp_path / ".continuum" / "budgets.json").write_text('{"default_max_attempts": 1}')
+    server, _ = server_ctx
+    await seed_run(server)
+
+    claim = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="deploy",
+        key="deploy:v2",
+    )
+    await call(
+        server,
+        "continuum_fail_action",
+        run_id="run_1",
+        action_key=claim["action_key"],
+        error="rejected before sending",
+        certain=True,
+    )
+
+    with pytest.raises(ToolError) as raised:
+        await server.call_tool(
+            "continuum_intercept_action",
+            {"run_id": "run_1", "action_type": "deploy", "key": "deploy:v2"},
+            context=_ctx(TEST_CLIENT),
+        )
+    message = str(raised.value)
+    assert "this 'deploy' operation" in message
+    assert "max_attempts" in message
+    assert "does not exist" in message
+    assert "Reconcile existing attempts" not in message
+
+
+@pytest.mark.asyncio
 async def test_an_uncertain_action_still_refuses_at_budget(
     server_ctx: tuple[Any, Any],
     tmp_path: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An exhausted budget must not mask the reconciliation path either."""
+    """An exhausted budget must not mask the reconciliation path either.
+
+    With `max_attempts: 1` the single attempt is spent, so without the
+    settled-status bypass the re-claim would be refused for budget instead of
+    being told the outcome is unknown, and the agent would never learn that a
+    reconciliation is owed.
+    """
     monkeypatch.chdir(tmp_path)
+    (tmp_path / ".continuum").mkdir()
+    (tmp_path / ".continuum" / "budgets.json").write_text('{"default_max_attempts": 1}')
     server, _ = server_ctx
     await seed_run(server)
 
@@ -1863,25 +1978,6 @@ async def test_an_uncertain_action_still_refuses_at_budget(
         error="timeout after send",
         certain=False,
     )
-    # The unresolved charge:maybe is itself one unsettled attempt, so two more
-    # reach the default budget of 3.
-    for n in range(2):
-        await call(
-            server,
-            "continuum_intercept_action",
-            run_id="run_1",
-            action_type="charge",
-            key=f"charge:stuck-{n}",
-        )
-
-    from mcp.server.mcpserver.exceptions import ToolError
-
-    with pytest.raises(ToolError, match="retry budget exhausted"):
-        await server.call_tool(
-            "continuum_intercept_action",
-            {"run_id": "run_1", "action_type": "charge", "key": "charge:new"},
-            context=_ctx(TEST_CLIENT),
-        )
 
     again = await call(
         server,

--- a/tests/test_retry_budgets.py
+++ b/tests/test_retry_budgets.py
@@ -16,6 +16,7 @@ import pytest
 from continuum.actions import ActionLedger
 from continuum.budgets import (
     BudgetConfigError,
+    attempts_by_key,
     attempts_for_type,
     backoff_delay,
     evaluate_budget,
@@ -67,15 +68,44 @@ def test_nonpositive_limits_are_refused(tmp_path: Path) -> None:
 
 
 def test_attempts_count_every_claim_slot(db: str) -> None:
-    """Retries that reuse the same key still count - that is the point."""
+    """Retries of one operation accumulate against that operation's allowance.
+
+    Re-claiming after FAILED copies the existing action, so successive attempts
+    land under the same key rather than each opening a fresh row. That is what
+    makes the key the right unit to count (issue #368).
+    """
     ledger = ActionLedger(SQLiteStorage(db), "run_1")
     outcome = ledger.claim("send_invoice", {}, key="invoice:1")
     ledger.fail(outcome.key, "boom", certain=True)
-    # Retry opens a second slot under a fresh key suffix.
-    ledger.claim("send_invoice", {}, key="invoice:1#retry2")
+    ledger.claim("send_invoice", {}, key="invoice:1")
 
     events = SQLiteStorage(db).read_events("run_1")
+    assert attempts_by_key(events, "send_invoice") == {str(outcome.key): 2}
     assert attempts_for_type(events, "send_invoice") == 2
+
+
+def test_distinct_operations_do_not_share_one_allowance(db: str) -> None:
+    """Different work must not compete for the same budget (issue #368).
+
+    Counting per action type made three recipients each failing once, with no
+    retry anywhere, exhaust a budget of three and block a fourth that had never
+    been attempted. Any fan-out with more failures than the limit deadlocked
+    mid-run, and the refusal called it a retry budget while nothing had been
+    retried.
+    """
+    ledger = ActionLedger(SQLiteStorage(db), "run_1")
+    for recipient in ("a", "b", "c"):
+        outcome = ledger.claim("email_send", {"to": recipient}, key=f"email:{recipient}")
+        ledger.fail(outcome.key, "550 rejected", certain=True)
+
+    events = SQLiteStorage(db).read_events("run_1")
+    per_key = attempts_by_key(events, "email_send")
+    assert len(per_key) == 3
+    assert set(per_key.values()) == {1}
+    # The figure compared against the limit is the worst single operation, not
+    # the sum, so a fourth recipient is still allowed.
+    assert attempts_for_type(events, "email_send") == 1
+    assert evaluate_budget({"default_max_attempts": 3}, "email_send", 1)[0] is True
 
 
 def test_completed_attempts_do_not_count(db: str) -> None:
@@ -98,17 +128,28 @@ def test_completed_attempts_do_not_count(db: str) -> None:
 def test_only_the_unsettled_attempts_of_a_retried_key_count(db: str) -> None:
     """The amplification guard must survive the fix: failures still count."""
     ledger = ActionLedger(SQLiteStorage(db), "run_1")
-    # One key that fails twice then succeeds, and one that is still in flight.
-    first = ledger.claim("send_invoice", {}, key="invoice:1")
-    ledger.fail(first.key, "boom", certain=True)
-    retry = ledger.claim("send_invoice", {}, key="invoice:1#retry2")
-    ledger.fail(retry.key, "boom again", certain=True)
-    won = ledger.claim("send_invoice", {}, key="invoice:1#retry3")
-    ledger.complete(won.key, external_id="ext-1")
+    # One key retried twice and still unsettled, one that succeeded on retry,
+    # and one untouched operation in flight.
+    stuck = ledger.claim("send_invoice", {}, key="invoice:1")
+    ledger.fail(stuck.key, "boom", certain=True)
+    ledger.claim("send_invoice", {}, key="invoice:1")
+    ledger.fail(stuck.key, "boom again", certain=True)
+    ledger.claim("send_invoice", {}, key="invoice:1")
+
+    won = ledger.claim("send_invoice", {}, key="invoice:2")
+    ledger.fail(won.key, "transient", certain=True)
     ledger.claim("send_invoice", {}, key="invoice:2")
+    ledger.complete(won.key, external_id="ext-2")
+
+    fresh = ledger.claim("send_invoice", {}, key="invoice:3")
 
     events = SQLiteStorage(db).read_events("run_1")
-    # Two failures plus one in-flight; the completed retry is excluded.
+    # invoice:1 burned three attempts and is still unsettled; invoice:2 succeeded
+    # so it is excluded entirely; invoice:3 is on its first.
+    assert attempts_by_key(events, "send_invoice") == {
+        str(stuck.key): 3,
+        str(fresh.key): 1,
+    }
     assert attempts_for_type(events, "send_invoice") == 3
 
 
@@ -138,24 +179,30 @@ def test_backoff_delay_rejects_zero() -> None:
 
 
 def test_claims_beyond_budget_are_refused_at_the_mcp_boundary(db: str, tmp_path: Path) -> None:
-    """Drive the real intercept handler logic: after N claims of one type, the
-    next claim for that type is refused naming the budget.
+    """Drive the real intercept handler logic: after N attempts at one operation,
+    the next claim for it is refused naming the budget.
 
-    The MCP tool raises ToolError; here we pin the counting + refusal maths
-    against the same folded view the server uses.
+    The MCP tool raises ToolError; here we pin the counting and refusal maths
+    against the same folded view the server uses. Retries of one key, not two
+    different invoices, because the budget caps repetition (issue #368).
     """
     cfg = {"default_max_attempts": 2}
     registry_path = registry(tmp_path, cfg)
     del registry_path
 
     ledger = ActionLedger(SQLiteStorage(db), "run_1")
+    outcome = ledger.claim("send_invoice", {}, key="invoice:1")
+    ledger.fail(outcome.key, "boom", certain=True)
     ledger.claim("send_invoice", {}, key="invoice:1")
-    ledger.claim("send_invoice", {}, key="invoice:2")
 
     events = SQLiteStorage(db).read_events("run_1")
-    attempts = attempts_for_type(events, "send_invoice")
+    attempts = attempts_by_key(events, "send_invoice")[str(outcome.key)]
     allowed, used, maximum = evaluate_budget(cfg, "send_invoice", attempts)
     assert (allowed, used, maximum) == (False, 2, 2)
+
+    # A different invoice has its own allowance and is unaffected.
+    other = evaluate_budget(cfg, "send_invoice", 0)
+    assert other[0] is True
 
 
 def registry(tmp_path: Path, body: dict[str, object]) -> str:
@@ -168,6 +215,11 @@ def registry(tmp_path: Path, body: dict[str, object]) -> str:
 
 
 def test_cli_budget_reports_usage_per_type(db: str, tmp_path: Path) -> None:
+    """The report shows the worst single operation, which is what the gate uses.
+
+    Two different invoices are two operations with their own allowances, not two
+    attempts at one (issue #368), so `send_invoice` sits at 1 of 3 rather than 2.
+    """
     ledger = ActionLedger(SQLiteStorage(db), "run_1")
     ledger.claim("send_invoice", {}, key="invoice:1")
     ledger.claim("send_invoice", {}, key="invoice:2")
@@ -191,7 +243,8 @@ def test_cli_budget_reports_usage_per_type(db: str, tmp_path: Path) -> None:
     assert code == ExitCode.OK, err
     payload = json.loads(out)
     by_type = {r["action_type"]: r for r in payload["budgets"]}
-    assert by_type["send_invoice"]["remaining"] == 1  # 3 - 2
+    assert by_type["send_invoice"]["attempts"] == 1
+    assert by_type["send_invoice"]["remaining"] == 2  # 3 - 1
     assert by_type["charge_card"]["exhausted"] is True  # 1 - 1
 
 


### PR DESCRIPTION
Closes #368.

The run-level retry budget counted attempts per action type rather than per operation, so distinct pieces of work that each failed once exhausted the budget and blocked work that had never been attempted.

```
intercept_action(type="email_send", key="email:a") -> proceed=true; fail(certain=true)
intercept_action(type="email_send", key="email:b") -> proceed=true; fail(certain=true)
intercept_action(type="email_send", key="email:c") -> proceed=true; fail(certain=true)
intercept_action(type="email_send", key="email:d")
  -> retry budget exhausted for 'email_send': 3 attempt(s) recorded, budget is 3.
     Reconcile existing attempts or ask the operator to raise .continuum/budgets.json.
```

Zero retries occurred. `email:d` had never been attempted. `attempts_for_type` folded on `action_type` and ignored the key entirely, so what the limit actually capped was a run's distinct unsettled work of a type. Any fan-out with more failures than the limit deadlocked mid-run, and since `load_budgets` returns `{}` when the file is absent and `evaluate_budget` falls back to `FALLBACK_MAX_ATTEMPTS = 3`, this was live in any project that had never configured budgets.

The module docstring states the intent as gating amplification, "how hard it may hammer a failing upstream", and #309 already removed completions from the count for exactly this reason: counting them would "cap how much distinct work a run may do". That closed half the hole. Failures of different operations still capped distinct work.

## Approach

Count per idempotency key. The key is the operation's identity, and it is the right unit here for a structural reason rather than a stylistic one: re-claiming after `FAILED` or `COMPENSATED` copies the existing action, so successive attempts at one operation accumulate under one key instead of each opening a fresh row. Retries are therefore exactly what a per-key count measures.

The limit stays configured per action type, because that is the unit an operator thinks in. Only the counting changes.

`attempts_for_type` is kept but now reports the worst single operation rather than the sum, so `continuum budget` reports the figure the claim site actually compares against the limit and its `exhausted` column means what it says. The sum across keys is deliberately not reported as the usage figure: it measures how much distinct work a run did, which no limit here caps.

The exhaustion message is reworded to fit the state it fires in. It names the specific operation, drops "Reconcile existing attempts" (useless when every prior attempt is settled `FAILED` with nothing uncertain about it), and says the registry file may need creating rather than raising.

## Behaviour preserved

The #309 bypass still holds: a re-claim of a `COMPLETED` or `UNKNOWN` action skips the budget entirely, so an exhausted budget cannot suppress the dedup path or the reconciliation path and become the cause of a duplicate side effect. Both those tests are now pinned with `max_attempts: 1` against the same key being re-claimed, which is a tighter statement than the old version could make: it previously had to exhaust the budget with unrelated keys, so it never asserted the property on the key under test.

## Tests

Existing budget tests encoded the old semantics by using distinct keys (`invoice:1`, `invoice:2`) to represent two attempts, which is the conflation this fixes, so they are rewritten to retry one key. Added: distinct operations not sharing an allowance, at both the ledger and MCP levels; a never-retried fourth recipient proceeding after three neighbours failed; and the reworded message asserted positively and negatively.

Full suite green, ruff clean, mypy clean across 104 files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Retry budgets are now tracked independently for each operation, preventing one operation from consuming another’s allowance.
  - Completed operations continue to be deduplicated correctly.
  - Retry-limit errors now identify the affected operation and indicate where to adjust its limit.
  - Attempt reporting now reflects the highest retry count for an individual operation.
  - Same-named files in different locations are no longer incorrectly merged.
  - Actions in terminal or review-required states can no longer be incorrectly completed.
  - Reconciliation responses now preserve and return supplied result details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->