### PR TITLE
fix(recovery): do not say nothing is wrong over an unresolved side effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,6 +714,28 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **`self_report_guidance` said nothing was wrong over an unresolved action (#369).**
+  The note exists to explain a `request_human` caused only by unverified
+  self-reporting, and it is deliberately withheld when anything else is also
+  blocking. Its predicate scanned `decision.validation.report.statuses`, but an
+  uncertain action reaches `request_human` through `decision.uncertain_actions` and
+  never appears in the report, so the check saw goal and progress alone and stayed
+  true. The result was a single `continuum_resume` response whose contract read
+  `recovery_status: requires_human` because a side effect's outcome was unknown,
+  next to guidance reading "Nothing is wrong with this run" and "Work is not
+  blocked", pointing the agent past the one thing the system exists to stop it
+  walking past. The ledger is now part of the test. The dependency half of the
+  predicate was already correct and is covered by a test that keeps it that way.
+
+- **`confirm_gate` dropped refusals raised by its own handler (#371).** Unlike
+  `guard`, it closed the `_refusal_reaches_the_caller` block before calling the
+  handler, so only refusals from the gate itself kept their text.
+  `continuum_confirm` appends an event immediately, which raises `RunNotFound` for
+  an unknown run, and the caller got `Error executing tool continuum_confirm`
+  instead of `no such run: '<id>'`. Latent until an operator sets
+  `CONTINUUM_MCP_CONFIRM_TOKEN`, which is also exactly when a confirmation against
+  a mistyped run id is most likely.
+
 - **Recovery guidance named an identifier the settle tools rejected (#367).**
   `continuum_resume` reports uncertain actions by `action_id` in five places
   (`next_allowed_action`, the contract's `required_actions`, `human_steps`,

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -600,6 +600,15 @@ def build_server(
         allowlist *and* present the dedicated confirm secret. Without that
         secret configured the tool refuses everyone, because an agent allowed
         to record progress must not silently be able to confirm it too.
+
+        The handler runs *inside* ``_refusal_reaches_the_caller``, matching
+        ``guard`` (issue #371). It used to be called after the block closed, so a
+        refusal raised by the handler body rather than by the gate reached the
+        client as the opaque ``Error executing tool continuum_confirm``.
+        ``continuum_confirm`` appends an event straight away, which raises
+        ``RunNotFound`` for an unknown run, and that is exactly the case the
+        converter documents as needing to survive: confirming against a mistyped
+        run id is likely precisely when an operator has just enabled this tool.
         """
 
         @functools.wraps(fn)
@@ -612,7 +621,7 @@ def build_server(
             with _refusal_reaches_the_caller():
                 confirm_auth.verify(token_from(ctx))
                 policy.require(caller, fn.__name__)
-            return fn(*args, **kwargs)
+                return fn(*args, **kwargs)
 
         # Same fix-up as ``guard``: re-advertise the context parameter or the
         # SDK never hands us one and every caller looks tokenless.

--- a/src/continuum/recovery/guidance.py
+++ b/src/continuum/recovery/guidance.py
@@ -49,10 +49,21 @@ def self_report_guidance(decision: RecoveryDecision) -> dict[str, str]:
     dependency, an unresolved action) the caller has a real problem to fix and
     this note would only dilute it, so it is omitted.
 
+    "Anything else" has to include the ledger, not just the validation report
+    (issue #369). An uncertain action reaches ``request_human`` through
+    ``decision.uncertain_actions``, never through ``report.statuses``, so scanning
+    only the report found nothing but goal and progress and emitted this note
+    beside a contract that said ``recovery_status: requires_human`` because a side
+    effect's outcome was unknown. The agent was told "Nothing is wrong with this
+    run" and "Work is not blocked" and pointed past the one thing this system
+    exists to stop it walking past.
+
     Returns a mapping to splice into a payload, empty when not applicable, so a
     caller adds the key only when there is something to say.
     """
     if decision.mode is not RecoveryMode.REQUEST_HUMAN:
+        return {}
+    if decision.uncertain_actions:
         return {}
     blocking = [e for e in decision.validation.report.statuses if e.status is not StateStatus.VALID]
     only_self_report = bool(blocking) and all(

--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -746,6 +746,35 @@ async def test_confirmation_over_mcp_needs_the_dedicated_secret(
     assert "mode" in payload
 
 
+@pytest.mark.asyncio
+async def test_a_refusal_from_the_confirm_handler_keeps_its_message(
+    store: SQLiteStorage,
+) -> None:
+    """`confirm_gate` must convert handler refusals like `guard` does (issue #371).
+
+    The handler call sat outside `_refusal_reaches_the_caller`, so only refusals
+    raised by the gate itself kept their text. `continuum_confirm` appends an event
+    immediately, which raises `RunNotFound` for an unknown run, and the caller was
+    told `Error executing tool continuum_confirm` instead. Confirming against a
+    mistyped run id is likely precisely when an operator has just enabled this
+    tool, which is the wrong moment to lose the message.
+    """
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    srv, _ = build_server(
+        storage=store,
+        policy=AuthorizationPolicy([ALLOWED]),
+        confirm_auth=ConfirmPolicy("confirm-secret"),
+    )
+
+    with pytest.raises(ToolError, match="no such run"):
+        await srv.call_tool(
+            "continuum_confirm",
+            {"run_id": "typo_run"},
+            context=fake_context(ALLOWED, auth_token="confirm-secret"),
+        )
+
+
 # --- one secret must not unlock both progress and confirmation (PR #206) -----
 
 

--- a/tests/test_recovery_guidance.py
+++ b/tests/test_recovery_guidance.py
@@ -92,6 +92,51 @@ def test_human_review_points_at_confirm(db: str) -> None:
         assert confirm
 
 
+# --- the self-report note --------------------------------------------------------- #
+
+
+def test_self_report_note_is_withheld_while_an_action_is_unresolved(db: str) -> None:
+    """ "Nothing is wrong" must not be said over an unreconciled side effect (#369).
+
+    An uncertain action reaches `request_human` through
+    `decision.uncertain_actions`, never through `report.statuses`, so a predicate
+    that scanned only the validation report saw goal and progress alone and
+    emitted the note beside a contract blocked on an unknown outcome. The agent
+    was told "Work is not blocked" and pointed straight past the one thing this
+    system exists to stop it walking past.
+    """
+    from continuum.recovery.guidance import self_report_guidance
+
+    seed_uncertain(db)
+    decision = assess(db)
+    assert decision.uncertain_actions, "fixture must leave an unresolved action"
+    assert self_report_guidance(decision) == {}
+
+
+def test_self_report_note_is_given_when_only_provenance_blocks(db: str) -> None:
+    """The note exists for a real case, so keep proving it still appears.
+
+    A run whose only fault is that an agent reported its own goal and progress is
+    not blocked, and the obvious next move (`continuum_confirm`) is refused by
+    design, so without this note the caller is stranded with no legal way forward.
+    """
+    from continuum.models import Origin
+    from continuum.recovery.guidance import self_report_guidance
+
+    with SQLiteStorage(db) as store:
+        store.append_event(
+            "run_1",
+            EventType.TASK_UPDATED,
+            {"completed": 1, "total": 4, "pending": 3, "failed": 0},
+            source=Origin.EXTERNAL_AGENT,
+        )
+    decision = assess(db)
+    assert not decision.uncertain_actions
+    note = self_report_guidance(decision)
+    assert note, decision.mode
+    assert "Nothing is wrong with this run" in note["self_report_guidance"]
+
+
 # --- CLI + MCP surfaces ------------------------------------------------------------ #
 
 


### PR DESCRIPTION
Closes #369. Closes #371.

Two small correctness fixes in the recovery-guidance and confirm-gate paths.

## #369: the note contradicted the contract it shipped beside

`self_report_guidance` explains a `request_human` caused only by unverified self-reporting, and it is deliberately withheld when anything else is also blocking. Its predicate scanned the validation report:

```python
blocking = [e for e in decision.validation.report.statuses if e.status is not StateStatus.VALID]
only_self_report = bool(blocking) and all(
    e.component in (Component.GOAL, Component.PROGRESS) ...
)
```

An uncertain action reaches `request_human` through `decision.uncertain_actions` and never appears in `report.statuses`, so the check saw goal and progress alone and stayed true. One `continuum_resume` response therefore carried both of these:

```
contract.recovery_status: "requires_human"
contract.reason: "1 external side effect(s) have unknown outcomes; ..."
next_allowed_action: "reconcile_action:action_d17ff043..."

self_report_guidance: "Nothing is wrong with this run. ... Work is not blocked ...
                       Say that once and carry on."
```

The agent is told to carry on past an unreconciled side effect, which is the one thing this system exists to stop it doing. The function's own docstring already specified the intended behaviour: withheld "when anything else is also wrong (a conflicted dependency, an unresolved action)". The dependency half worked; the ledger half was never wired up.

Fix is `if decision.uncertain_actions: return {}`. Both halves now have a test, so the working one cannot quietly regress while the broken one is repaired.

## #371: `confirm_gate` dropped refusals raised by its own handler

`guard` calls the handler inside `_refusal_reaches_the_caller`; `confirm_gate` closed the block first:

```python
with _refusal_reaches_the_caller():
    confirm_auth.verify(token_from(ctx))
    policy.require(caller, fn.__name__)
return fn(*args, **kwargs)          # outside
```

`continuum_confirm` appends an event straight away, which raises `RunNotFound` for an unknown run. Under mcp >= 2.1.0 an unrecognised handler exception becomes `Error executing tool continuum_confirm` with the cause hidden on `__cause__`, so the caller learned nothing. That is precisely the case the converter's docstring lists as needing to survive: "a run that does not exist. Each answer is only useful if the caller is told which one it was."

Latent rather than live, because confirmation refuses every caller before the body runs while `CONTINUUM_MCP_CONFIRM_TOKEN` is unset. It becomes reachable the moment an operator opts in, which is also when a confirmation against a mistyped run id is most likely. Reported as found by inspection in the issue; the test here reproduces it.

## Tests

Three, each verified to fail before the change. The suppressed note with an unresolved action, the note still present when only provenance blocks, and the confirm refusal reaching the caller as `no such run` (checked by stashing the fix and re-running: `Actual message: 'Error executing tool continuum_confirm'`).

Full suite green, ruff clean, mypy clean across 104 files.
