### PR TITLE
feat(mcp): record the model behind a run so drift can be detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,6 +714,26 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **`MODEL_CHANGED` had no writer, so `expected_model` could never validate (#370).**
+  The event type was defined, treated as checkpoint-worthy by the trigger policy and
+  projected into `SemanticState.model`, but nothing in `src/` ever emitted it. The
+  validator's model component could therefore only ever answer "no model recorded
+  for this run, cannot compare against ...", the `expected_model` parameter on
+  `continuum_resume` and `continuum_validate` could never do anything, and
+  `RepairKind.REVALIDATE_MODEL_STATE` with its "pass `--model <name>`" guidance was
+  unreachable. A parameter that cannot be satisfied is worse than an absent one,
+  because its presence implies the check is covered, and a different model resuming
+  another model's work is exactly the drift the surrounding architecture exists to
+  catch. `continuum_checkpoint` gains optional `model_id` and `provider`, emitting
+  `MODEL_CHANGED` when the value actually changes, so drift now reports
+  `requires_review` naming both models instead of `unknown`. Attached to
+  checkpointing because it is the same kind of statement as `env`: here is what the
+  world looked like when this state was saved. Recorded as `EXTERNAL_AGENT`, since
+  an agent naming its own model is self-reporting, but the comparison against a
+  later `expected_model` stays independent of that claim. `provider` carries forward
+  when omitted, so naming the model alone cannot erase a provider recorded earlier,
+  and omitting `model_id` records nothing rather than asserting absence.
+
 - **Recovery guidance named an identifier the settle tools rejected (#367).**
   `continuum_resume` reports uncertain actions by `action_id` in five places
   (`next_allowed_action`, the contract's `required_actions`, `human_steps`,

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -347,6 +347,55 @@ def _append_projectable(
     raise AssertionError("unreachable: the loop either returns or raises")
 
 
+def _declare_model(
+    ctx: ContinuumMCP,
+    run_id: str,
+    model_id: str | None,
+    provider: str | None = None,
+) -> None:
+    """Record which model is driving this run, so drift becomes detectable (#370).
+
+    ``MODEL_CHANGED`` was defined, treated as checkpoint-worthy by the trigger
+    policy, and projected into ``SemanticState.model``, but nothing anywhere in
+    the codebase ever emitted it. So the validator's model component could only
+    ever answer "no model recorded for this run, cannot compare against ...", the
+    ``expected_model`` parameter on ``continuum_resume`` and ``continuum_validate``
+    could never do anything, and ``RepairKind.REVALIDATE_MODEL_STATE`` was
+    unreachable. A parameter that cannot be satisfied is worse than an absent one,
+    because its presence implies the check is covered.
+
+    That matters more than an ordinary dead branch: a different model resuming
+    another model's work is exactly the drift the surrounding architecture exists
+    to catch, and model-specific assumptions recorded by one model are not
+    automatically sound for another.
+
+    Attached to checkpointing rather than to progress because it is the same kind
+    of statement as ``env``: here is what the world looked like when this state was
+    saved. Recorded as ``EXTERNAL_AGENT``, since an agent naming its own model is
+    self-reporting, but the *comparison* against a later ``expected_model`` stays
+    independent of that claim, exactly as it does for declared dependencies.
+
+    Only appended when the value actually changes, so an agent checkpointing on a
+    schedule does not add an identical event each time. ``provider`` carries
+    forward when omitted, so naming the model alone cannot silently erase a
+    provider recorded earlier.
+    """
+    if not model_id:
+        return
+    current = project(run_id, ctx.storage.read_events(run_id)).model
+    recorded_model = current.model if current else None
+    recorded_provider = current.provider if current else None
+    settled_provider = provider if provider is not None else recorded_provider
+    if recorded_model == model_id and recorded_provider == settled_provider:
+        return
+    ctx.storage.append_event(
+        run_id,
+        EventType.MODEL_CHANGED,
+        {"model": model_id, "provider": settled_provider},
+        source=AGENT_SOURCE,
+    )
+
+
 def _environment(run_id: str, env: Mapping[str, str] | None) -> EnvironmentSnapshot | None:
     """Build a snapshot from a ``{name: version}`` mapping.
 
@@ -696,7 +745,10 @@ def build_server(
             "Save a durable checkpoint of the current task state. Worth doing at "
             "milestones, before risky or irreversible steps, and before a long gap. "
             "Recovery replays from the newest checkpoint, so checkpointing bounds "
-            "how much work a crash can cost."
+            "how much work a crash can cost.\n\n"
+            "Pass 'model_id' with your own model identifier. It is what later lets "
+            "continuum_resume answer whether the model resuming this work is the one "
+            "that produced it; without it that check can only report 'unknown'."
         ),
         annotations=mutating,
     )
@@ -705,10 +757,13 @@ def build_server(
         run_id: str,
         reason: str = "",
         env: dict[str, str] | None = None,
+        model_id: str | None = None,
+        provider: str | None = None,
     ) -> str:
         """Create a semantic checkpoint."""
         ctx.ensure_run(run_id)
         _declare_dependencies(ctx, run_id, env)
+        _declare_model(ctx, run_id, model_id, provider)
         state = project(run_id, ctx.storage.read_events(run_id))
         checkpoint = ctx.adapter.capture_state(
             run_id,
@@ -723,6 +778,7 @@ def build_server(
                 "version": checkpoint.version,
                 "trigger": checkpoint.trigger,
                 "integrity_hash": checkpoint.integrity_hash,
+                "model": state.model.model if state.model else None,
                 "completed": checkpoint.state.progress.completed,
                 "source_sequence": checkpoint.state.source_sequence,
             }

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -458,8 +458,8 @@ class StateValidator:
             # silently here reads as "no drift" and is indistinguishable from a
             # clean comparison, so a caller passing expected_model believes it
             # got an assurance it never received (issue #308). Report the gap
-            # instead. Note no MCP tool records a model today, so this is the
-            # normal outcome for MCP-originated runs.
+            # instead. Reached whenever no writer named the model: pass model_id
+            # to continuum_checkpoint to make the comparison answerable (#370).
             entries.append(
                 ComponentValidationEntry(
                     component=Component.MODEL,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1256,6 +1256,105 @@ async def test_an_unmatched_identifier_says_which_spaces_were_tried(
         )
 
 
+# --- the model behind a run (issue #370) ------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_records_the_model_so_drift_can_be_detected(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """`expected_model` was unsatisfiable: nothing ever wrote MODEL_CHANGED (#370).
+
+    The event type was defined, treated as checkpoint-worthy and projected, but no
+    MCP tool, CLI command or adapter emitted it, so the validator's model component
+    could only ever answer "no model recorded" and the drift check advertised by
+    `continuum_resume` and `continuum_validate` could never fire.
+    """
+    server, ctx = server_ctx
+    await seed_run(server)
+
+    before = await call(server, "continuum_validate", run_id="run_1", expected_model="model-a")
+    model_before = [c for c in before["components"] if c["component"] == "model"]
+    assert model_before and model_before[0]["status"] == "unknown"
+
+    checkpointed = await call(
+        server,
+        "continuum_checkpoint",
+        run_id="run_1",
+        model_id="model-a",
+        provider="anthropic",
+    )
+    assert checkpointed["model"] == "model-a"
+    assert EventType.MODEL_CHANGED in [e.type for e in ctx.storage.read_events("run_1")]
+
+    # Same model: nothing to review.
+    same = await call(server, "continuum_validate", run_id="run_1", expected_model="model-a")
+    assert not [
+        c for c in same["components"] if c["component"] == "model" and c["status"] != "valid"
+    ]
+
+    # A different model now surfaces as drift rather than as "unknown".
+    drifted = await call(server, "continuum_validate", run_id="run_1", expected_model="model-b")
+    entry = next(c for c in drifted["components"] if c["component"] == "model")
+    assert entry["status"] == "requires_review"
+    assert "model-a" in entry["detail"] and "model-b" in entry["detail"]
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_model_is_not_re_recorded_on_every_checkpoint(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """Checkpointing on a schedule must not append an identical event each time.
+
+    Same reasoning as `_declare_dependencies`: the projection folds every one of
+    them back to the same value, so they are noise in the log.
+    """
+    server, ctx = server_ctx
+    await seed_run(server)
+    for _ in range(3):
+        await call(server, "continuum_checkpoint", run_id="run_1", model_id="model-a")
+
+    changes = [e for e in ctx.storage.read_events("run_1") if e.type is EventType.MODEL_CHANGED]
+    assert len(changes) == 1
+
+    # A genuine switch is recorded.
+    await call(server, "continuum_checkpoint", run_id="run_1", model_id="model-b")
+    changes = [e for e in ctx.storage.read_events("run_1") if e.type is EventType.MODEL_CHANGED]
+    assert len(changes) == 2
+
+
+@pytest.mark.asyncio
+async def test_naming_the_model_alone_keeps_the_recorded_provider(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """A later checkpoint that omits `provider` must not erase it (issue #370)."""
+    server, ctx = server_ctx
+    await seed_run(server)
+    await call(
+        server,
+        "continuum_checkpoint",
+        run_id="run_1",
+        model_id="model-a",
+        provider="anthropic",
+    )
+    await call(server, "continuum_checkpoint", run_id="run_1", model_id="model-a")
+
+    state = project("run_1", ctx.storage.read_events("run_1"))
+    assert state.model is not None
+    assert state.model.model == "model-a"
+    assert state.model.provider == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_omitting_the_model_records_nothing(server_ctx: tuple[Any, Any]) -> None:
+    """The parameter is optional, and silence must not be read as a claim."""
+    server, ctx = server_ctx
+    await seed_run(server)
+    await call(server, "continuum_checkpoint", run_id="run_1")
+
+    assert EventType.MODEL_CHANGED not in [e.type for e in ctx.storage.read_events("run_1")]
+
+
 # --- storage configuration --------------------------------------------------- #
 
 


### PR DESCRIPTION
Closes #370.

`expected_model` is accepted by `continuum_resume` and `continuum_validate`, and the validator reports a `model` component, but nothing anywhere in the codebase ever recorded a model, so the check could only ever return `unknown`:

```
validate(run_id=R, expected_model="model-b")

  {"component": "model",
   "status": "unknown",
   "detail": "no model recorded for this run, cannot compare against 'model-b'"}
```

```
$ grep -rn "MODEL_CHANGED" src/
src/continuum/events.py:84:          MODEL_CHANGED = "MODEL_CHANGED"
src/continuum/checkpoint/policy.py:81:    EventType.MODEL_CHANGED,
src/continuum/state/semantic.py:442:  case EventType.MODEL_CHANGED:
```

Defined, treated as checkpoint-worthy by the trigger policy, and projected into `SemanticState.model`. Never emitted. No MCP tool, no CLI command, no adapter. Downstream, `RepairKind.REVALIDATE_MODEL_STATE` and its guidance string "confirm which model resumes this work, then pass `--model <name>`" were unreachable too.

A parameter that cannot be satisfied is worse than an absent one, because its presence implies the check is covered. And this is not an ordinary dead branch: a different model resuming another model's work is exactly the drift the surrounding architecture exists to catch, and model-specific assumptions recorded by one model are not automatically sound for another.

The validator itself was already complete and correct. It just never had an input.

## Approach

`continuum_checkpoint` gains optional `model_id` and `provider`. This is the issue's option 1.

Attached to checkpointing rather than to `record_progress` because it is the same kind of statement as `env`: here is what the world looked like when this state was saved. The trigger policy already treats `MODEL_CHANGED` as checkpoint-worthy, so the two belong together.

Recorded as `EXTERNAL_AGENT`, since an agent naming its own model is self-reporting. That does not weaken the check, for the same reason declared dependencies do not: the *comparison* against a later `expected_model` is a comparison of two values, so it stays independent of the claim that named the resource.

Three details that keep the write path honest:

- Appended only when the value actually changes, so an agent checkpointing on a schedule does not add an identical event per checkpoint. Same reasoning as `_declare_dependencies`.
- `provider` carries forward when omitted, so a later checkpoint naming only the model cannot silently erase a provider recorded earlier.
- Omitting `model_id` records nothing. Silence is not a claim that no model is involved.

The checkpoint response now returns `model`, and the tool description says what the parameter buys, since an LLM chooses arguments from that text.

I also corrected a now-stale comment in `validator.py` that said "no MCP tool records a model today".

## Result

```
validate(expected_model="model-a")  -> model: valid
validate(expected_model="model-b")  -> model: requires_review
                                       "state was produced by 'model-a' but 'model-b' is now active"
```

## Tests

Four. The full unknown-to-drift transition through the real tool path; no duplicate event across three identical checkpoints plus a real switch still recorded; provider preserved when a later call omits it; and nothing written when `model_id` is absent.

## Not in scope

The CLI has the same gap on the write side (`--model` is a reader). Worth a follow-up so an operator can re-pin the way `--env` re-pins dependencies, but it is a separate surface and this change makes the check reachable for the MCP path where the gap was found.

Full suite green, ruff clean, mypy clean across 104 files.
