### PR TITLE
revert: take back confirm_gate fix to credit #377

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -727,15 +727,6 @@ All notable changes to this project are documented here. The format follows
   walking past. The ledger is now part of the test. The dependency half of the
   predicate was already correct and is covered by a test that keeps it that way.
 
-- **`confirm_gate` dropped refusals raised by its own handler (#371).** Unlike
-  `guard`, it closed the `_refusal_reaches_the_caller` block before calling the
-  handler, so only refusals from the gate itself kept their text.
-  `continuum_confirm` appends an event immediately, which raises `RunNotFound` for
-  an unknown run, and the caller got `Error executing tool continuum_confirm`
-  instead of `no such run: '<id>'`. Latent until an operator sets
-  `CONTINUUM_MCP_CONFIRM_TOKEN`, which is also exactly when a confirmation against
-  a mistyped run id is most likely.
-
 - **Recovery guidance named an identifier the settle tools rejected (#367).**
   `continuum_resume` reports uncertain actions by `action_id` in five places
   (`next_allowed_action`, the contract's `required_actions`, `human_steps`,

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -600,15 +600,6 @@ def build_server(
         allowlist *and* present the dedicated confirm secret. Without that
         secret configured the tool refuses everyone, because an agent allowed
         to record progress must not silently be able to confirm it too.
-
-        The handler runs *inside* ``_refusal_reaches_the_caller``, matching
-        ``guard`` (issue #371). It used to be called after the block closed, so a
-        refusal raised by the handler body rather than by the gate reached the
-        client as the opaque ``Error executing tool continuum_confirm``.
-        ``continuum_confirm`` appends an event straight away, which raises
-        ``RunNotFound`` for an unknown run, and that is exactly the case the
-        converter documents as needing to survive: confirming against a mistyped
-        run id is likely precisely when an operator has just enabled this tool.
         """
 
         @functools.wraps(fn)
@@ -621,7 +612,7 @@ def build_server(
             with _refusal_reaches_the_caller():
                 confirm_auth.verify(token_from(ctx))
                 policy.require(caller, fn.__name__)
-                return fn(*args, **kwargs)
+            return fn(*args, **kwargs)
 
         # Same fix-up as ``guard``: re-advertise the context parameter or the
         # SDK never hands us one and every caller looks tokenless.

--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -746,35 +746,6 @@ async def test_confirmation_over_mcp_needs_the_dedicated_secret(
     assert "mode" in payload
 
 
-@pytest.mark.asyncio
-async def test_a_refusal_from_the_confirm_handler_keeps_its_message(
-    store: SQLiteStorage,
-) -> None:
-    """`confirm_gate` must convert handler refusals like `guard` does (issue #371).
-
-    The handler call sat outside `_refusal_reaches_the_caller`, so only refusals
-    raised by the gate itself kept their text. `continuum_confirm` appends an event
-    immediately, which raises `RunNotFound` for an unknown run, and the caller was
-    told `Error executing tool continuum_confirm` instead. Confirming against a
-    mistyped run id is likely precisely when an operator has just enabled this
-    tool, which is the wrong moment to lose the message.
-    """
-    from mcp.server.mcpserver.exceptions import ToolError
-
-    srv, _ = build_server(
-        storage=store,
-        policy=AuthorizationPolicy([ALLOWED]),
-        confirm_auth=ConfirmPolicy("confirm-secret"),
-    )
-
-    with pytest.raises(ToolError, match="no such run"):
-        await srv.call_tool(
-            "continuum_confirm",
-            {"run_id": "typo_run"},
-            context=fake_context(ALLOWED, auth_token="confirm-secret"),
-        )
-
-
 # --- one secret must not unlock both progress and confirmation (PR #206) -----
 
 


### PR DESCRIPTION
This reverts the  handler fix from #379 so the first-time contributor PR #377 can land with the merge credit.

- #377 was already open and approved when #379 landed and closed #371. The overlap was on the maintainer side.
- The fix itself is correct. This PR takes back only the  docstring, the one indent move, the CHANGELOG entry for #371, and its regression test from 4035de0.
- The  fix for #369 from the same commit is kept.
- After this merges, #377 will be rebased on the new main and merged, closing #371 with the contributor as author.

No other changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confirmation error handling so unexpected failures from confirmation requests are surfaced directly instead of being incorrectly converted into refusal errors.
  * Removed outdated documentation describing the previous refusal-handling behavior for unknown runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->