### PR TITLE
fix(cli): verify must not certify a run that cannot be projected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,6 +714,26 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **`continuum verify` certified a run whose log could not be projected (#382).**
+  `verify` re-audits the hash chain, which is a statement about integrity, and an
+  unprojectable log is perfectly intact: the offending event was written through
+  the normal path and hashed like any other. Nothing in that audit evaluates
+  whether the fold satisfies its own invariants, so the one health-shaped command
+  an operator reaches for during an incident answered "13 events, no violations"
+  for a run on which `resume`, `status`, `inspect`, `replay`, `validate` and
+  `briefing` all failed. `verify` now reports both verdicts and exits non-zero
+  when the fold fails, so `continuum verify "$RUN" && ./resume.sh` short-circuits.
+  New `first_unprojectable_event` names the sequence, event type and the specific
+  constraint that failed, folding one event at a time onto the previous state so
+  the scan is a single linear pass rather than a re-projection per prefix.
+  Archived events are folded alongside the live ones, because after compaction
+  (#239) the live log starts at the anchor and no longer contains `RUN_STARTED`;
+  reading only the tail would report every compacted run as broken. The
+  projection is attempted only once the chain verifies, since folding a tampered
+  log to say where it stops projecting would describe events that cannot be
+  trusted to say anything. Repairing such a log is a separate gap, tracked in
+  #383.
+
 - **`self_report_guidance` said nothing was wrong over an unresolved action (#369).**
   The note exists to explain a `request_human` caused only by unverified
   self-reporting, and it is deliberately withheld when anything else is also

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -69,7 +69,7 @@ from continuum.security.attestation import (
 )
 from continuum.serve import cmd_serve
 from continuum.state.diff import diff_states, render_diff
-from continuum.state.semantic import ProjectionError, project
+from continuum.state.semantic import ProjectionError, first_unprojectable_event, project
 from continuum.state.versioning import state_fingerprint
 from continuum.storage import (
     CheckpointNotFound,
@@ -1470,8 +1470,56 @@ def cmd_verify(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         text = text + "\n" + "\n".join(index_lines)
         payload["action_index_drift"] = drift
 
+    # Integrity and coherence are different guarantees, and reporting only the
+    # first let `verify` certify a run no projecting command could read (issue
+    # #382). An unprojectable log is perfectly intact: the offending event was
+    # written through the normal path and hashed like any other, so the chain
+    # audit is right to pass it. Nothing in that audit evaluates whether the fold
+    # satisfies its own invariants, which is the question an operator reaching for
+    # a health command is actually asking.
+    #
+    # Archived events are folded alongside the live ones, because after
+    # compaction (#239) the live log starts at the anchor and no longer contains
+    # RUN_STARTED. Reading only the tail would report every compacted run as
+    # unprojectable. `ActionLedger._replay` merges the two streams for the same
+    # reason; the archive holds the prefix verbatim from sequence 1, so the union
+    # is the whole history.
+    #
+    # Only attempted once the chain verified. Folding a tampered log to report
+    # where it stops projecting would describe events that cannot be trusted to
+    # say anything, the same reasoning that refuses action-index repair above.
+    broken = None
+    if report.ok:
+        whole_log = [
+            *storage.read_archived_events(args.run_id),
+            *storage.read_events(args.run_id),
+        ]
+        broken = first_unprojectable_event(args.run_id, whole_log)
+    if broken is not None:
+        sequence, event_type, reason = broken
+        payload["projectable"] = False
+        payload["projection_failed_at"] = {
+            "sequence": sequence,
+            "type": event_type,
+            "reason": reason,
+        }
+        text += "\n" + "\n".join(
+            [
+                f"PROJECTION FAILURE: the log stops folding at sequence {sequence} ({event_type})",
+                f"  {reason}",
+                "  The chain is intact; the state it folds to is not. Commands that",
+                "  project (resume, status, inspect, replay, validate) fail until this",
+                "  is repaired.",
+            ]
+        )
+    elif report.ok:
+        payload["projectable"] = True
+
     _emit(payload, text, as_json=args.json, stream=out, palette=getattr(args, "_palette", None))
-    return ExitCode.OK if report.ok else ExitCode.CORRUPTED
+    # Non-zero for either failure, so `continuum verify "$RUN" && ./resume.sh`
+    # short-circuits. exitcodes.py states the rule: only a verified, usable run
+    # exits 0, and a run that cannot be projected is not usable.
+    return ExitCode.OK if report.ok and broken is None else ExitCode.CORRUPTED
 
 
 def cmd_actions(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -46,7 +46,13 @@ from continuum.models import (
     StateStatus,
 )
 
-__all__ = ["ProjectionError", "ProjectionReport", "project", "project_incremental"]
+__all__ = [
+    "ProjectionError",
+    "ProjectionReport",
+    "first_unprojectable_event",
+    "project",
+    "project_incremental",
+]
 
 
 class ProjectionError(ValueError):
@@ -512,6 +518,57 @@ def project_incremental(
             acc.created_at = event.timestamp
 
     return acc.build(), report
+
+
+def _condense(reason: str) -> str:
+    """One readable line from a possibly multi-line validation error.
+
+    pydantic renders "1 validation error for Progress" as its first line and puts
+    the constraint that actually failed on the second, followed by a docs URL. So
+    the naive first line is the least informative part. This keeps the header only
+    when there is nothing better, and drops the machine-facing bracket detail and
+    the URL either way.
+    """
+    lines = [line.strip() for line in reason.splitlines() if line.strip()]
+    if not lines:
+        return "unknown projection failure"
+    informative = next(
+        (line for line in lines[1:] if not line.startswith("For further information")),
+        lines[0],
+    )
+    return informative.split(" [type=")[0].rstrip()
+
+
+def first_unprojectable_event(
+    run_id: str,
+    events: Iterable[Event],
+) -> tuple[int, str, str] | None:
+    """Locate the earliest event whose fold fails, or ``None`` if the log folds.
+
+    Returns ``(sequence, event_type, reason)`` with ``reason`` condensed to a
+    single line. Naming the event is what turns "this run cannot be projected"
+    into something an operator can act on: the raw message reports the folded
+    figures without saying which write produced them, and the log may be thousands
+    of events long (issue #382).
+
+    Folds one event at a time carrying the state forward through
+    ``project_incremental``'s ``base``, so this is a single linear pass rather
+    than a re-projection per prefix. That matters because the logs most likely to
+    need this are the long ones.
+
+    Deliberately catches broadly. The question is *where* the log stops folding,
+    and any exception means it stopped there, whether it came from a model
+    invariant, the projector's own ordering checks, or a payload shape nothing
+    anticipated. Re-raising a narrower set would leave the operator holding the
+    same opaque traceback this exists to replace.
+    """
+    state: SemanticState | None = None
+    for event in sorted(events, key=lambda e: e.sequence):
+        try:
+            state, _ = project_incremental(run_id, [event], base=state)
+        except Exception as exc:  # noqa: BLE001 - see docstring
+            return event.sequence, str(event.type), _condense(str(exc))
+    return None
 
 
 def project(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -950,3 +950,118 @@ def test_complete_unknown_run_is_not_found(tmp_path: Path) -> None:
         pass
     code, _, err = run("--db", path, "complete", "ghost")
     assert code == ExitCode.NOT_FOUND
+
+
+# --- verify reports coherence, not only integrity (issue #382) --------------- #
+
+
+def _poison(path: str) -> None:
+    """Append a TASK_UPDATED the fold rejects, through the normal write path.
+
+    Mirrors what #364 allowed before it was fixed: `completed` past the `total`
+    already on record. The event is hashed like any other, so the chain stays
+    intact and only the projection breaks, which is the whole point here.
+    """
+    with SQLiteStorage(path) as store:
+        store.append_event("run_1", EventType.TASK_UPDATED, {"completed": 999, "failed": 0})
+
+
+def test_verify_reports_a_run_whose_log_cannot_be_projected(db: str) -> None:
+    """`verify` certified a run no projecting command could read (issue #382).
+
+    An unprojectable log is perfectly intact, so the chain audit passes it and is
+    right to. Reporting only that verdict meant the one command an operator
+    reaches for during an incident was the one that could not see the incident.
+    """
+    _poison(db)
+    code, out, _ = run("--db", db, "verify", "run_1")
+
+    assert "no violations" in out, "the chain really is intact; do not hide that"
+    assert "PROJECTION FAILURE" in out
+    assert "sequence" in out and "TASK_UPDATED" in out
+    assert "exceeds total" in out, "name the constraint, not just the pydantic header"
+    assert code == ExitCode.CORRUPTED, "verify $RUN && resume must short-circuit"
+
+
+def test_verify_still_passes_a_healthy_run(db: str) -> None:
+    """The new check must not fail a run that folds; that would be worse."""
+    code, out, _ = run("--db", db, "verify", "run_1")
+    assert code == ExitCode.OK
+    assert "PROJECTION FAILURE" not in out
+
+
+def test_verify_json_names_the_offending_event(db: str) -> None:
+    """Scripts read the payload, not the prose."""
+    _poison(db)
+    code, out, _ = run("--db", db, "--json", "verify", "run_1")
+    payload = json.loads(out)
+
+    assert payload["ok"] is True, "chain integrity is unaffected"
+    assert payload["projectable"] is False
+    assert payload["projection_failed_at"]["type"] == "TASK_UPDATED"
+    assert payload["projection_failed_at"]["sequence"] > 0
+    assert code == ExitCode.CORRUPTED
+
+
+def test_verify_json_marks_a_healthy_run_projectable(db: str) -> None:
+    payload = json.loads(run("--db", db, "--json", "verify", "run_1")[1])
+    assert payload["projectable"] is True
+    assert "projection_failed_at" not in payload
+
+
+def test_a_tampered_chain_is_not_also_projected(db: str, tmp_path: Path) -> None:
+    """Do not describe events that cannot be trusted to say anything.
+
+    Same reasoning the action-index repair already uses: folding a tampered log
+    to report where it stops projecting would launder its contents into a
+    diagnosis the operator might act on.
+    """
+    _poison(db)
+    with sqlite3.connect(db) as conn:
+        conn.execute("UPDATE events SET payload = ? WHERE sequence = 2", ('{"tampered": true}',))
+
+    code, out, _ = run("--db", db, "verify", "run_1")
+    assert code == ExitCode.CORRUPTED
+    assert "INTEGRITY FAILURE" in out
+    assert "PROJECTION FAILURE" not in out, "integrity comes first; do not fold a tampered log"
+
+
+def test_first_unprojectable_event_finds_the_earliest_break(db: str) -> None:
+    """Two bad events must report the first, or a repair fixes the wrong one."""
+    from continuum.state.semantic import first_unprojectable_event
+
+    _poison(db)
+    _poison(db)
+    with SQLiteStorage(db) as store:
+        events = list(store.read_events("run_1"))
+        broken = first_unprojectable_event("run_1", events)
+
+    assert broken is not None
+    sequence, event_type, reason = broken
+    bad = [e.sequence for e in events if e.type is EventType.TASK_UPDATED]
+    assert sequence == min(bad)
+    assert event_type == "TASK_UPDATED"
+    assert "\n" not in reason, "the reason is rendered on one line"
+
+
+def test_first_unprojectable_event_returns_none_for_a_sound_log(db: str) -> None:
+    from continuum.state.semantic import first_unprojectable_event
+
+    with SQLiteStorage(db) as store:
+        assert first_unprojectable_event("run_1", store.read_events("run_1")) is None
+
+
+def test_verify_projects_a_compacted_run_from_its_archive(db: str) -> None:
+    """After compaction the live log starts at the anchor (issue #239).
+
+    It no longer contains RUN_STARTED, so folding only the live tail reports
+    every compacted run as unprojectable. The archive holds the prefix verbatim
+    from sequence 1, so the two streams are folded together, the same merge
+    `ActionLedger._replay` does.
+    """
+    assert run("--db", db, "compact", "run_1", "--force")[0] == ExitCode.OK
+
+    code, out, err = run("--db", db, "verify", "run_1")
+    assert code == ExitCode.OK, f"a healthy compacted run must still verify: {out}{err}"
+    assert "PROJECTION FAILURE" not in out
+    assert json.loads(run("--db", db, "--json", "verify", "run_1")[1])["projectable"] is True


### PR DESCRIPTION
Closes #382.

`continuum verify` reported a run as intact when its log could not be folded at all, so the one health-shaped command an operator reaches for during an incident was the one that could not see the incident.

```
$ continuum verify mcp_arch_audit_2026_08_25
Event chain verified: 13 events, no violations.

$ continuum status mcp_arch_audit_2026_08_25
error: 1 validation error for Progress
  Value error, completed + pending + failed exceeds total
```

`resume`, `inspect`, `replay`, `show-contract`, `validate` and `briefing` all failed the same way.

## Why it happened

The two commands ask different questions and only one of them said so. `verify` audits the hash chain: every event links to its predecessor, nothing tampered. That is a statement about integrity and it was correct, because an unprojectable log is perfectly intact. The offending event was written through the normal path and hashed like any other. Nothing in that audit evaluates whether the folded state satisfies its own invariants.

Both checks are worth having. The bug was presenting integrity as though it were health.

## After

```
Event chain verified: 13 events, no violations.
PROJECTION FAILURE: the log stops folding at sequence 10 (TASK_UPDATED)
  Value error, completed + pending + failed exceeds total
  The chain is intact; the state it folds to is not. Commands that
  project (resume, status, inspect, replay, validate) fail until this
  is repaired.
```

Exit 3 (`CORRUPTED`) rather than 0, so `continuum verify "$RUN" && ./resume.sh` short-circuits. That follows the rule `exitcodes.py` states outright: only a verified, usable run exits 0, and a run that cannot be projected is not usable. `--json` gains `projectable` and `projection_failed_at`.

## Three decisions worth reviewing

**Naming the event, not just failing.** `first_unprojectable_event` returns the sequence, type and the constraint that actually failed. The raw pydantic message reports the folded figures without saying which write produced them, and it puts the useful line second, after a `1 validation error for Progress` header, so the naive first line is the least informative part. It folds one event at a time onto the previous state via `project_incremental`'s `base`, so the scan is a single linear pass rather than a re-projection per prefix. The logs most likely to need this are the long ones.

**Archived events are folded too.** This one I got wrong first and `test_compaction` caught it. After compaction (#239) the live log starts at the anchor and no longer contains `RUN_STARTED`, so folding only the live tail reported every healthy compacted run as broken. The archive holds the prefix verbatim from sequence 1, so the two streams are merged, exactly as `ActionLedger._replay` already does. Now pinned by its own test.

**The projection is skipped when the chain failed.** Folding a tampered log to report where it stops projecting would describe events that cannot be trusted to say anything. Same reasoning that already refuses action-index repair on a failed chain.

## Tests

Eight. Five fail without the change; the other three are regression guards (healthy run still passes, compacted run still passes, tampered chain is not also folded). Coverage includes the earliest-of-two-breaks case, since a repair aimed at the wrong event is worse than no diagnosis.

Full suite green, ruff clean, mypy clean across 104 files.

## Not in scope

Repairing an unprojectable log is #383, which is the larger half: every recovery command needs the projection that is broken, so `compact`, `fork` and the rest all fail on exactly the runs that need them. This PR only makes the condition visible and honestly exit-coded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `continuum verify` to validate both event-chain integrity and event-log projection.
  * Reports the earliest event that cannot be projected, including its sequence, type, and reason.
  * Verifies archived events after compaction and provides JSON diagnostics.
* **Bug Fixes**
  * Verification now returns a failure status when projection fails, even if the hash chain remains intact.
* **Tests**
  * Added coverage for healthy, tampered, compacted, and unprojectable event logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->