### PR TITLE
fix(state): an unprojectable log can degrade instead of killing every command (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -714,6 +714,32 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **One unprojectable event bricked every projecting command, with no route back (#383).**
+  A log whose fold fails is intact as a chain but dead as a run: because the fold
+  validates each intermediate state, no later event could correct an earlier bad
+  one, so `status`, `resume`, `inspect`, `replay`, `show-contract`, `validate`,
+  `briefing` and `compact` all raised on precisely the runs that needed them,
+  while the action tools (which fold only ACTION_* events) kept authorising real
+  side effects that recovery could not assess. The fold can now degrade instead
+  of raising: `project` and `project_incremental` accept
+  `on_unprojectable="raise"|"degrade"`, defaulting to `"raise"` so every existing
+  caller sees byte-for-byte today's behaviour. Degrade mode stops at the earliest
+  refused event and returns the last-good prefix marked
+  `SemanticState.status = INVALID` with `unprojectable_at_sequence`,
+  `unprojectable_event_type` and a condensed `unprojectable_reason`; it never
+  skips past the break, and if nothing folds before the break it still raises,
+  since a partial answer invented from nothing would be worse than an error. The
+  recovery engine folds with degrade enabled, so a poisoned log yields a
+  `request_human` verdict naming where folding stopped instead of a pydantic
+  traceback, and CLI `status`, `inspect` and `replay` report the same break and
+  exit non-zero. The diagnostic call sites opted in are the engine's restore
+  path, the CLI status/inspect/replay surfaces, the serve sidecar's progress
+  report and dependency dedup, and the benchmark's strategy readout; the MCP
+  write-path guard `_project_candidate` and the checkpoint capture surfaces
+  deliberately keep raising, because accepting or pinning a partial fold would
+  launder it into authoritative state. Repair/amend and fork-from-last-good-prefix
+  remain future work and are not attempted here.
+
 - **`continuum verify` certified a run whose log could not be projected (#382).**
   `verify` re-audits the hash chain, which is a statement about integrity, and an
   unprojectable log is perfectly intact: the offending event was written through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -732,7 +732,12 @@ All notable changes to this project are documented here. The format follows
   recovery engine folds with degrade enabled, so a poisoned log yields a
   `request_human` verdict naming where folding stopped instead of a pydantic
   traceback, and CLI `status`, `inspect` and `replay` report the same break and
-  exit non-zero. The diagnostic call sites opted in are the engine's restore
+  exit non-zero. The break also reaches the machine-readable contract instead of
+  living only in prose: a new `repair_log` repair step makes `required_actions`
+  name real work, `next_allowed_action` points at it rather than falling through
+  to a rendered "continue" over a `requires_human` verdict, `verified` entries
+  are qualified with the last-good sequence, and `invalidated` records the
+  projection itself. The diagnostic call sites opted in are the engine's restore
   path, the CLI status/inspect/replay surfaces, the serve sidecar's progress
   report and dependency dedup, and the benchmark's strategy readout; the MCP
   write-path guard `_project_candidate` and the checkpoint capture surfaces

--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,22 @@ believed, and what is neither.
 
 ---
 
+## In flight: unprojectable logs degrade instead of dying (#383, PR #385)
+
+As of 2026-08-25, PR #383's fix is open on `fix/degrade-unprojectable-fold`
+(three commits), reviewed through two rounds. The fold accepts
+`on_unprojectable="raise"|"degrade"` (default byte-for-byte unchanged);
+degrade returns the last-good prefix marked `SemanticState.status=INVALID`
+naming where folding stopped; recovery decides REQUEST_HUMAN and the contract
+carries a `repair_log` step. Checkpoint digests and persisted bodies exclude
+the projection-bookkeeping fields, so databases written before or after the
+change load either way (cross-version tests pin serialised fixtures in
+`tests/test_checkpoint_compat.py`). Verified on the branch: 1425 passed,
+23 skipped, ruff clean, strict mypy clean on 104 files. Repair/amend (option
+2) and fork-from-last-good-prefix (option 3) remain unbuilt by design.
+
+---
+
 ## Full-gate audit (2026-08-24)
 
 Ran against `main` at `8013f6a` in a clean worktree, Python 3.13

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -531,3 +531,48 @@ features, #266-#285 contributor good-first-issues, #288 provenance graph
 files. Five integration seams, six schema migrations, eleven MCP tools,
 twenty-five CLI commands. Every feature verified against real Claude Code
 sessions with hard kills and live protocol boundaries.
+
+## Session 18, 2026-08-25 (issue #383: degrade instead of die, PR #385)
+
+Fixed #383 in a dedicated worktree (`/tmp/wt-383`, branch
+`fix/degrade-unprojectable-fold`, self-assigned before starting). Three
+commits, each answering one review round.
+
+**The fix (3f2b769).** `project`/`project_incremental` gained
+`on_unprojectable="raise"|"degrade"` (default unchanged). Degrade stops at the
+earliest refused event and returns the last-good prefix marked
+`SemanticState.status=INVALID` with `unprojectable_at_sequence/_event_type/
+_reason`; it never skips past the break, and raises if nothing folds before
+it. Opt-ins limited to diagnostic surfaces (engine restore path, CLI
+status/inspect/replay, serve progress report and dep dedup, benchmark
+readout); the #364 write guard `_project_candidate` and every checkpoint
+capture path deliberately stay on raise. Recovery decides REQUEST_HUMAN.
+Reproduction used the `_poison` helper from tests/test_cli.py; all four dead
+commands confirmed failing before any change.
+
+**Review round 1: the contract must carry the break (0768e38).** Resume's
+prose named the break but `required_actions` was empty and `next_allowed`
+rendered as "continue" over a requires_human verdict. New `RepairKind.
+REPAIR_LOG` step (sorted first) gives the contract real work, qualified
+`verified` entries (`goal (through sequence N)`), a `projection (invalid)`
+entry in `invalidated`, and honest fallbacks at all three `or 'continue'`
+sites (contract render, engine render, dashboard).
+
+**Review round 2: cross-version checkpoint break (39b0756, ddbb6bd).** The
+four added fields changed `StateCheckpoint.content()`, so every pre-existing
+checkpoint failed verification as tampered, and new bodies carried fields old
+readers (`extra="forbid"`) reject. `PROJECTION_BOOKKEEPING` now excludes them
+from the digest and from all four persisted-body write sites (sqlite and
+postgres, checkpoints and versions). Lesson recorded for next time: no
+same-process round-trip can catch a hash-compatibility break, and a naive
+strip-and-reread fixture passes against broken code because pydantic
+re-injects defaults on reload; the fixture must also re-seal the hash over
+the reduced payload, exactly as the old writer did.
+
+Red-before-green proven per round by checking out earlier trees over `src/`
+(stash alone is insufficient once changes are committed). Final gates:
+1425 passed, 23 skipped, ruff clean, 206 files formatted, strict mypy clean
+on 104 files, mcp pinned to 2.1.0 first. All CI checks green on the branch.
+Options 2 (repair/amend) and 3 (fork-from-last-good-prefix) remain open by
+design; the reviewer floated moving the bookkeeping fields off
+`SemanticState` entirely as follow-up scope.

--- a/src/continuum/benchmark/__init__.py
+++ b/src/continuum/benchmark/__init__.py
@@ -225,7 +225,9 @@ def _run_one(method: str, spec: ScenarioSpec, total: int, workdir: Path) -> Meth
         if method == "replay":
             done = 0
         elif method == "naive_checkpoint":
-            done = project(run_id, store.read_events(run_id)).progress.completed
+            done = project(
+                run_id, store.read_events(run_id), on_unprojectable="degrade"
+            ).progress.completed
         else:  # continuum
             assert manager is not None
             restored = manager.restore(run_id)

--- a/src/continuum/checkpoint/manager.py
+++ b/src/continuum/checkpoint/manager.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Literal
 
 from continuum.checkpoint.policy import (
     CheckpointDecision,
@@ -224,12 +225,24 @@ class CheckpointManager:
 
     # -- restoring -------------------------------------------------------- #
 
-    def restore(self, run_id: str, *, replay: bool = True) -> RestoredRun:
+    def restore(
+        self,
+        run_id: str,
+        *,
+        replay: bool = True,
+        on_unprojectable: Literal["raise", "degrade"] = "raise",
+    ) -> RestoredRun:
         """Load the newest checkpoint and catch it up to the log.
 
         With ``replay=False`` the checkpoint is returned as-is, which is what a
         validator wants when it must judge the checkpoint on its own terms
         before trusting anything newer.
+
+        ``on_unprojectable="degrade"`` lets a caller whose job is diagnosis
+        (the recovery engine) get the last-good prefix marked INVALID instead
+        of a ProjectionError, so a poisoned log produces a verdict rather than
+        ending the assessment. Defaults to ``"raise"``: ``restore`` also feeds
+        write paths that must never mistake a partial fold for state.
         """
         checkpoint = self.storage.latest_checkpoint(run_id)
 
@@ -239,7 +252,7 @@ class CheckpointManager:
                 raise CheckpointError(f"run {run_id!r} has no checkpoint and no events")
             return RestoredRun(
                 run_id=run_id,
-                state=project(run_id, events),
+                state=project(run_id, events, on_unprojectable=on_unprojectable),
                 checkpoint=None,
                 pending_events=len(events),
                 replayed=True,
@@ -264,7 +277,9 @@ class CheckpointManager:
 
         from continuum.state.semantic import project_incremental
 
-        state, _ = project_incremental(run_id, pending, base=checkpoint.state)
+        state, _ = project_incremental(
+            run_id, pending, base=checkpoint.state, on_unprojectable=on_unprojectable
+        )
         return RestoredRun(
             run_id=run_id,
             state=state,

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -58,6 +58,8 @@ from continuum.models import (
     RecoveryMode,
     Run,
     RunStatus,
+    SemanticState,
+    StateStatus,
 )
 from continuum.observability import render_dashboard
 from continuum.provenance_map import summarize
@@ -296,12 +298,29 @@ def cmd_runs(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
     return ExitCode.OK
 
 
+def _degraded_lines(state: SemanticState) -> list[str]:
+    """Render a degraded fold's break for status/inspect output.
+
+    Mirrors verify's PROJECTION FAILURE block (#384) so every surface names the
+    same event the same way, and points at verify because it is the one command
+    that already carries the full diagnosis.
+    """
+    return [
+        f"PROJECTION FAILURE: the log stops folding at sequence "
+        f"{state.unprojectable_at_sequence} ({state.unprojectable_event_type})",
+        f"  {state.unprojectable_reason}",
+        f"  Figures cover events through sequence {state.source_sequence} only;",
+        "  they are what was known before the break, not the current state.",
+        "  `continuum verify` reports the offending event.",
+    ]
+
+
 def cmd_inspect(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Show semantic state, optionally at a past version."""
     if args.version is not None:
         state = storage.get_version(args.run_id, args.version)
     else:
-        restored = CheckpointManager(storage).restore(args.run_id)
+        restored = CheckpointManager(storage).restore(args.run_id, on_unprojectable="degrade")
         state = restored.state
 
     payload = state.model_dump(mode="json")
@@ -322,6 +341,15 @@ def cmd_inspect(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
             f"  - {d.resource}: {d.version or 'unversioned'} [{d.status}]"
             for d in state.external_dependencies
         ]
+    degraded = state.status is StateStatus.INVALID
+    if degraded:
+        lines += [""]
+        lines += _degraded_lines(state)
+        payload["projection_failed_at"] = {
+            "sequence": state.unprojectable_at_sequence,
+            "type": state.unprojectable_event_type,
+            "reason": state.unprojectable_reason,
+        }
     _emit(
         payload,
         "\n".join(lines),
@@ -329,13 +357,21 @@ def cmd_inspect(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
         stream=out,
         palette=getattr(args, "_palette", None),
     )
+    if degraded:
+        # Not OK: a run whose tail did not fold is not a usable answer, and
+        # `inspect $RUN && ...` must short-circuit like resume does.
+        return ExitCode.CORRUPTED
     return ExitCode.OK
 
 
 def cmd_status(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Show run status, optionally as a canonical provenance view (issue #148)."""
-    restored = CheckpointManager(storage).restore(args.run_id)
+    restored = CheckpointManager(storage).restore(args.run_id, on_unprojectable="degrade")
     state = restored.state
+    # A degraded fold (issue #383) still answers here, naming the break, but it
+    # must not exit 0: the figures describe a prefix of the log, and piping a
+    # prefix off as "the status" is how a poisoned run gets waved through.
+    degraded = state.status is StateStatus.INVALID
 
     if args.provenance:
         rows: list[dict[str, str]] = []
@@ -361,7 +397,13 @@ def cmd_status(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
                     }
                 )
         if args.json:
-            payload = {"provenance": rows}
+            payload: dict[str, Any] = {"provenance": rows}
+            if degraded:
+                payload["projection_failed_at"] = {
+                    "sequence": state.unprojectable_at_sequence,
+                    "type": state.unprojectable_event_type,
+                    "reason": state.unprojectable_reason,
+                }
             _emit(
                 payload,
                 json.dumps(payload, indent=2),
@@ -371,6 +413,9 @@ def cmd_status(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             )
         else:
             lines = [f"run: {state.run_id}  (provenance view)"]
+            if degraded:
+                lines += _degraded_lines(state)
+                lines.append("")
             for r in rows:
                 lines.append(
                     f"  {r['kind']:<8} {r['id']:<14} who={r['who']:<14} "
@@ -383,7 +428,7 @@ def cmd_status(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
                 stream=out,
                 palette=getattr(args, "_palette", None),
             )
-        return ExitCode.OK
+        return ExitCode.CORRUPTED if degraded else ExitCode.OK
 
     lines = [
         f"run:      {state.run_id}",
@@ -393,8 +438,28 @@ def cmd_status(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         f"{state.progress.pending} pending, {state.progress.failed} failed",
         f"decisions: {len(state.valid_decisions())}/{len(state.decisions)} valid",
     ]
-    _emit({}, "\n".join(lines), as_json=False, stream=out, palette=getattr(args, "_palette", None))
-    return ExitCode.OK
+    if degraded:
+        lines.append("")
+        lines += _degraded_lines(state)
+    text_payload: dict[str, Any] = (
+        {
+            "projection_failed_at": {
+                "sequence": state.unprojectable_at_sequence,
+                "type": state.unprojectable_event_type,
+                "reason": state.unprojectable_reason,
+            }
+        }
+        if degraded
+        else {}
+    )
+    _emit(
+        text_payload,
+        "\n".join(lines),
+        as_json=False,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.CORRUPTED if degraded else ExitCode.OK
 
 
 def cmd_history(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
@@ -1604,6 +1669,7 @@ def cmd_replay(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             args.run_id,
             [e for e in tail if e.sequence <= stored.source_sequence],
             base=base,
+            on_unprojectable="degrade",
         )
         matches = state_fingerprint(at_stored) == state_fingerprint(stored)
         where = f"checkpoint v{stored.version} at sequence {stored.source_sequence}"
@@ -1642,7 +1708,10 @@ def cmd_replay(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             f"beginning"
         )
 
-    state = project(args.run_id, events)
+    # Degrade, not raise (issue #383): replay is a diagnostic, and a poisoned
+    # log is exactly what it is asked about. A partial fold is reported as
+    # such and fails the command below instead of passing as a full replay.
+    state = project(args.run_id, events, on_unprojectable="degrade")
 
     verified, verification = _verify_against_stored(args.run_id, storage)
 
@@ -1659,12 +1728,23 @@ def cmd_replay(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         f"{len(state.decisions)} decision(s), {len(state.findings)} finding(s)\n"
         f"Verification: {verification}"
     )
+    if state.status is StateStatus.INVALID:
+        payload["projection_failed_at"] = {
+            "sequence": state.unprojectable_at_sequence,
+            "type": state.unprojectable_event_type,
+            "reason": state.unprojectable_reason,
+        }
+        text += "\n" + "\n".join(_degraded_lines(state))
     _emit(payload, text, as_json=args.json, stream=out, palette=getattr(args, "_palette", None))
     if verified is False:
         print(
             f"replayed state does not match the stored version for run {args.run_id}",
             file=err,
         )
+        return ExitCode.CORRUPTED
+    if state.status is StateStatus.INVALID:
+        # The prefix folded but the log disagrees with itself past the break,
+        # so this replay certifies nothing and must not exit 0.
         return ExitCode.CORRUPTED
     return ExitCode.OK
 
@@ -1690,8 +1770,17 @@ def _verify_against_stored(run_id: str, storage: Storage) -> tuple[bool | None, 
     if stored is None:
         return None, "skipped (no stored version to compare against)"
     prefix = storage.read_events(run_id, upto=stored.source_sequence)
-    replayed = project(run_id, prefix)
+    replayed = project(run_id, prefix, on_unprojectable="degrade")
     where = f"version {stored.version} at sequence {stored.source_sequence}"
+    if replayed.status is StateStatus.INVALID:
+        # Name the break rather than a bare mismatch: the stored version may be
+        # perfectly sound, and the interesting fact is that the log can no
+        # longer reproduce it (issue #383).
+        return (
+            False,
+            f"log stops folding at sequence {replayed.unprojectable_at_sequence} "
+            f"before reaching stored {where}: {replayed.unprojectable_reason}",
+        )
     if state_fingerprint(replayed) == state_fingerprint(stored):
         return True, f"matches stored {where}"
     return False, f"DOES NOT match stored {where}"

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -646,14 +646,12 @@ class Run(BaseModel):
 #: (both predate #383; hashing them would brand every existing record as
 #: tampered), and omitted from persisted bodies so readers built before #383,
 #: whose SemanticState forbids extra inputs, can still load newer databases.
-PROJECTION_BOOKKEEPING: frozenset[str] = frozenset(
-    {
-        "status",
-        "unprojectable_at_sequence",
-        "unprojectable_event_type",
-        "unprojectable_reason",
-    }
-)
+PROJECTION_BOOKKEEPING: set[str] = {
+    "status",
+    "unprojectable_at_sequence",
+    "unprojectable_event_type",
+    "unprojectable_reason",
+}
 
 
 class StateCheckpoint(BaseModel):

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -639,6 +639,23 @@ class Run(BaseModel):
         return self.model_copy(update={"updated_at": utcnow(), **overrides})
 
 
+#: Fields that describe how an event log was *read*, not what a run's state
+#: is (issue #383). They live on SemanticState so a degraded fold can carry
+#: its diagnosis, but they are outside every durable identity of a state:
+#: excluded from the version fingerprint and from checkpoint integrity hashes
+#: (both predate #383; hashing them would brand every existing record as
+#: tampered), and omitted from persisted bodies so readers built before #383,
+#: whose SemanticState forbids extra inputs, can still load newer databases.
+PROJECTION_BOOKKEEPING: frozenset[str] = frozenset(
+    {
+        "status",
+        "unprojectable_at_sequence",
+        "unprojectable_event_type",
+        "unprojectable_reason",
+    }
+)
+
+
 class StateCheckpoint(BaseModel):
     model_config = Frozen
 
@@ -653,8 +670,28 @@ class StateCheckpoint(BaseModel):
     integrity_hash: str | None = None
 
     def content(self) -> dict[str, Any]:
-        """The sealed portion of the checkpoint (everything but the hash)."""
-        return self.model_dump(mode="json", exclude={"integrity_hash"})
+        """The sealed portion of the checkpoint (everything but the hash).
+
+        Projection bookkeeping is excluded beside the hash itself: it was added
+        after these checkpoints existed (#383), it is default in anything that
+        can be persisted (every capture path refuses a degraded fold), and
+        hashing it would report every checkpoint written by earlier builds as
+        tampered, which is exactly the alarm this hash exists to mean.
+        """
+        return self.model_dump(
+            mode="json", exclude={"integrity_hash": True, "state": PROJECTION_BOOKKEEPING}
+        )
+
+    def canonical_json(self) -> str:
+        """The serialised form written to storage.
+
+        Omits projection bookkeeping for the same reasons ``content`` does,
+        plus one more: readers built before #383 validate ``SemanticState``
+        with ``extra="forbid"`` and would refuse a body carrying fields they
+        have never heard of. Omitting them costs nothing, since they are
+        always default in anything persistable.
+        """
+        return self.model_dump_json(exclude={"state": PROJECTION_BOOKKEEPING})
 
     def digest(self) -> str:
         return stable_hash(self.content())

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -390,6 +390,11 @@ class SemanticState(BaseModel):
     A state is a *projection* of an event prefix. ``source_sequence`` records
     how far into the log the projection consumed, which makes the state
     reproducible: folding the same prefix again must yield an equal state.
+
+    A state whose log stopped folding partway (issue #383) is marked
+    ``status=INVALID`` and names the break in the ``unprojectable_*`` fields.
+    Such a state reports what was known through its last good event; it must
+    never be read as a complete picture of the run.
     """
 
     model_config = Frozen
@@ -408,6 +413,16 @@ class SemanticState(BaseModel):
     version: int = 0
     source_sequence: int = 0
     """Highest event sequence folded into this state (0 = nothing consumed)."""
+    status: StateStatus = StateStatus.VALID
+    """VALID for a complete fold. INVALID marks a degraded projection that
+    stopped at ``unprojectable_at_sequence``."""
+    unprojectable_at_sequence: int | None = None
+    """Sequence of the earliest event the fold refused, or None when the whole
+    log folded."""
+    unprojectable_event_type: str | None = None
+    """Type of the refused event, as ``unprojectable_reason`` alone may not name it."""
+    unprojectable_reason: str | None = None
+    """Single-line statement of the constraint the refused event violated."""
     created_at: datetime = Field(default_factory=utcnow)
     updated_at: datetime = Field(default_factory=utcnow)
 

--- a/src/continuum/observability.py
+++ b/src/continuum/observability.py
@@ -148,7 +148,12 @@ def render_dashboard(decision: RecoveryDecision) -> str:
     lines.append(f"checkpoint:        v{decision.contract.checkpoint_version}")
     lines.append(f"recovery mode:     {decision.mode.value}")
     lines.append(f"safe to resume:     {'yes' if decision.safe else 'no'}")
-    lines.append(f"next allowed:      {decision.next_allowed_action or 'continue'}")
+    # Same rule as render_contract: "continue" only when resuming is actually
+    # permitted; a blocked verdict must not render permission as prose.
+    permitted = decision.next_allowed_action or (
+        "continue" if decision.safe else "none (settle required_actions first)"
+    )
+    lines.append(f"next allowed:      {permitted}")
 
     lines.append("")
     lines.append("STATE COMPONENTS")

--- a/src/continuum/recovery/contract.py
+++ b/src/continuum/recovery/contract.py
@@ -94,12 +94,27 @@ def build_contract(
     verified: list[str] = []
     invalidated: list[str] = []
 
+    # A degraded fold (issue #383) changes what "verified" can claim: those
+    # components were checked against the last-good prefix only, so an
+    # unqualified list would assert an assurance the run cannot support, and a
+    # machine keying on verified/invalidated would read the contract as clean
+    # over a log that stops folding. Qualify every entry and record the break.
+    state = validation.state
+    projection_broken = (
+        state.status is StateStatus.INVALID and state.unprojectable_at_sequence is not None
+    )
     for entry in validation.report.statuses:
         name = _identifier(entry.component, entry.component_id)
         if entry.status is StateStatus.VALID:
+            if projection_broken:
+                name = f"{name} (through sequence {state.source_sequence})"
             verified.append(name)
         else:
             invalidated.append(f"{name} ({entry.status.value})")
+    if projection_broken:
+        invalidated.append(
+            f"projection (invalid: log stops folding at sequence {state.unprojectable_at_sequence})"
+        )
 
     next_action = plan.first.action_name if plan.first else None
 
@@ -107,6 +122,14 @@ def build_contract(
         reason = validation.report.reason
     if evidence is None:
         evidence = _validation_evidence(validation.report)
+    if projection_broken:
+        # The validation details describe the prefix and cannot name the break;
+        # without this the contract's evidence would read as a complete audit.
+        evidence = [
+            *evidence,
+            f"projection stopped at sequence {state.unprojectable_at_sequence} "
+            f"({state.unprojectable_event_type}): {state.unprojectable_reason}",
+        ]
     if scope is not None:
         named = sorted(set(scope))
         if named:
@@ -158,7 +181,15 @@ def render_contract(contract: RecoveryContract) -> str:
     if contract.required_actions:
         lines.append("required_actions:")
         lines += [f"  - {a}" for a in contract.required_actions]
-    lines.append(f"next_allowed:      {contract.next_allowed_action or 'continue'}")
+    # "continue" is only honest when resuming is actually permitted. A
+    # requires_human contract with no next step must not render permission
+    # into prose the gate never issued (issue #385 review).
+    fallback = (
+        "continue"
+        if contract.recovery_status is RecoverySafety.SAFE_TO_RESUME
+        else "none (settle required_actions first)"
+    )
+    lines.append(f"next_allowed:      {contract.next_allowed_action or fallback}")
     if contract.reason:
         lines.append(f"reason:            {contract.reason}")
     if contract.evidence:

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -161,7 +161,12 @@ class RecoveryDecision:
         if self.plan:
             lines += ["", "Repairs required:", self.plan.render()]
 
-        lines += ["", f"Next permitted action: {self.next_allowed_action or 'continue'}"]
+        permitted = self.next_allowed_action or (
+            "continue"
+            if self.mode is RecoveryMode.RESUME
+            else "none (settle the repairs above first)"
+        )
+        lines += ["", f"Next permitted action: {permitted}"]
         return "\n".join(lines)
 
 
@@ -259,10 +264,24 @@ class RecoveryEngine:
                 for path in source_graph.files_using(resource)
             )
 
+        # The degraded fold must reach the plan (issue #383): without a step,
+        # required_actions is empty and the contract's next_allowed falls
+        # through to "continue" over a requires_human verdict.
+        broken = restored.state
+        unprojectable = (
+            (
+                broken.unprojectable_at_sequence,
+                broken.unprojectable_event_type or "unknown event",
+                broken.unprojectable_reason or "unknown projection failure",
+            )
+            if broken.status is StateStatus.INVALID and broken.unprojectable_at_sequence is not None
+            else None
+        )
         plan = plan_repairs(
             validation.report.statuses,
             uncertain_actions=uncertain,
             strict_unknown=self.validator.strict_unknown,
+            unprojectable=unprojectable,
         )
         mode, rationale = self._decide(validation, uncertain, plan, restored, self.strict_unknown)
 

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -207,7 +207,12 @@ class RecoveryEngine:
         :mod:`continuum.analysis`) records on the returned decision every file
         whose imports belong to a scoped dependency.
         """
-        restored = self._manager.restore(run_id, replay=replay)
+        # Degrade, not raise (issue #383): the engine's whole job is to answer
+        # "where does this run stand", and a poisoned log is precisely the run
+        # that needs an answer. An unprojectable tail yields the last-good
+        # prefix marked INVALID; _decide turns that into request_human rather
+        # than letting it pass for a complete state.
+        restored = self._manager.restore(run_id, replay=replay, on_unprojectable="degrade")
         checkpoint_environment = restored.checkpoint.environment if restored.checkpoint else None
         checkpoint_version = restored.checkpoint.version if restored.checkpoint else 0
 
@@ -350,6 +355,26 @@ class RecoveryEngine:
     ) -> tuple[RecoveryMode, tuple[str, ...]]:
         """Collect a proposal per signal and return the most cautious."""
         proposals: list[tuple[RecoveryMode, str]] = []
+
+        # A degraded fold (issue #383) outranks every signal computed below,
+        # which is why it is proposed unconditionally rather than guarded: the
+        # validation below ran on the last-good prefix, so its statuses describe
+        # only what was known before the break. REQUEST_HUMAN, not ABORT: the
+        # log is not necessarily dead (a human can confirm or rewrite the
+        # offending event), and declaring the run permanently unanswerable is
+        # exactly the terminal state #383 exists to remove.
+        state = restored.state
+        if state.unprojectable_at_sequence is not None and state.status is StateStatus.INVALID:
+            proposals.append(
+                (
+                    RecoveryMode.REQUEST_HUMAN,
+                    f"the event log stops folding at sequence "
+                    f"{state.unprojectable_at_sequence} "
+                    f"({state.unprojectable_event_type}: {state.unprojectable_reason}); "
+                    f"this verdict covers events through sequence "
+                    f"{state.source_sequence} only",
+                )
+            )
 
         if validation.safe and not uncertain:
             proposals.append((RecoveryMode.RESUME, "all state verified against the environment"))

--- a/src/continuum/recovery/guidance.py
+++ b/src/continuum/recovery/guidance.py
@@ -126,6 +126,15 @@ def human_steps_for(
                 )
         elif step.kind is RepairKind.HUMAN_REVIEW:
             steps.append(f"verify {step.target} yourself, then run `continuum confirm {run_id}`")
+        elif step.kind is RepairKind.REPAIR_LOG:
+            # No automated surface can settle a refused event yet (that is the
+            # repair/amend command, deliberately unbuilt), so name where to
+            # look and who must decide rather than implying a command exists.
+            steps.append(
+                f"the log stops folding at {step.target}: run `continuum verify {run_id}` "
+                f"for the offending event; settling it needs an operator decision, "
+                f"no amend surface exists yet"
+            )
         elif step.kind is RepairKind.REVALIDATE_DEPENDENCY:
             steps.append(
                 f"re-pin dependency {step.target!r}: rerun with "

--- a/src/continuum/recovery/planner.py
+++ b/src/continuum/recovery/planner.py
@@ -40,6 +40,11 @@ class RepairKind(StrEnum):
     RECONCILE_ACTION = "reconcile_action"
     """Determine whether an external side effect actually happened."""
 
+    REPAIR_LOG = "repair_log"
+    """Correct or authorise the event whose refusal stopped the log folding
+    (issue #383). No automated surface can settle it yet; it is a human step
+    by construction until a repair/amend command exists."""
+
     REVALIDATE_DEPENDENCY = "revalidate_dependency"
     """Re-pin a dependency whose version moved."""
 
@@ -62,17 +67,20 @@ class RepairKind(StrEnum):
     """Something no automated step can settle."""
 
 
-#: Lower sorts earlier. Uncertain side effects first: nothing else is safe
-#: while the world may or may not have been modified.
+#: Lower sorts earlier. An unreadable log first: until the fold can run again,
+#: nothing else about the run can even be assessed, including whether any
+#: other repair did what it claimed. Uncertain side effects come next: nothing
+#: else is safe while the world may or may not have been modified.
 _ORDER: dict[RepairKind, int] = {
-    RepairKind.RECONCILE_ACTION: 0,
-    RepairKind.HUMAN_REVIEW: 1,
-    RepairKind.RENEW_APPROVAL: 2,
-    RepairKind.REVALIDATE_DEPENDENCY: 3,
-    RepairKind.REVALIDATE_MODEL_STATE: 4,
-    RepairKind.REDERIVE_EVIDENCE: 5,
-    RepairKind.REDERIVE_FINDING: 6,
-    RepairKind.REVIEW_DECISION: 7,
+    RepairKind.REPAIR_LOG: 0,
+    RepairKind.RECONCILE_ACTION: 1,
+    RepairKind.HUMAN_REVIEW: 2,
+    RepairKind.RENEW_APPROVAL: 3,
+    RepairKind.REVALIDATE_DEPENDENCY: 4,
+    RepairKind.REVALIDATE_MODEL_STATE: 5,
+    RepairKind.REDERIVE_EVIDENCE: 6,
+    RepairKind.REDERIVE_FINDING: 7,
+    RepairKind.REVIEW_DECISION: 8,
 }
 
 
@@ -194,6 +202,7 @@ def plan_repairs(
     *,
     uncertain_actions: Sequence[Action] = (),
     strict_unknown: bool = True,
+    unprojectable: tuple[int, str, str] | None = None,
 ) -> RepairPlan:
     """Build an ordered repair plan from validation findings and ledger state.
 
@@ -201,8 +210,26 @@ def plan_repairs(
     the work that depends on them. Sorting is stable and total, so the same
     inputs always yield the same plan — a contract that varied between runs
     would be impossible to audit.
+
+    ``unprojectable`` is ``(sequence, event_type, reason)`` for a log whose fold
+    stops partway (issue #383). Without it the plan would be empty on a poisoned
+    run whose last-good prefix validates cleanly, and a contract with no steps
+    renders ``next_allowed: continue`` over a verdict of requires_human: prose
+    and structure disagreeing, with a machine reader most likely to act on the
+    structure. The break becomes a step so required_actions names real work.
     """
     steps: list[RepairStep] = []
+
+    if unprojectable is not None:
+        sequence, event_type, reason = unprojectable
+        steps.append(
+            RepairStep(
+                kind=RepairKind.REPAIR_LOG,
+                target=f"sequence_{sequence}",
+                reason=f"{event_type} refuses to fold: {reason}",
+                requires_human=True,
+            )
+        )
 
     for action in uncertain_actions:
         if action.status not in (

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -37,6 +37,7 @@ from continuum.models import (
     EnvResource,
     Origin,
     Run,
+    StateStatus,
     UnknownSideEffect,
 )
 from continuum.recovery.contract import render_contract
@@ -168,7 +169,9 @@ def _declare_dependencies(server: SidecarServer, run_id: str, env: Any) -> None:
 
     declared = {
         dependency.resource: dependency.version
-        for dependency in project(run_id, server.storage.read_events(run_id)).external_dependencies
+        for dependency in project(
+            run_id, server.storage.read_events(run_id), on_unprojectable="degrade"
+        ).external_dependencies
     }
     for name, version in versions.items():
         if declared.get(name) == version:
@@ -423,8 +426,12 @@ def _h_record_progress(server: SidecarServer, params: dict[str, Any]) -> dict[st
         payload["total"] = total
         payload["pending"] = max(total - completed - failed, 0)
     server.storage.append_event(run_id, EventType.TASK_UPDATED, payload, source=AGENT_SOURCE)
-    state = project(run_id, server.storage.read_events(run_id))
-    return {
+    # Degrade, not raise (issue #383): the event is already committed by the
+    # time this fold runs, so dying here would report an error while leaving
+    # the write in place. Reporting the last-good figures plus the break is the
+    # honest answer; the caller can see the log needs attention.
+    state = project(run_id, server.storage.read_events(run_id), on_unprojectable="degrade")
+    response = {
         "run_id": run_id,
         "completed": state.progress.completed,
         "pending": state.progress.pending,
@@ -432,6 +439,13 @@ def _h_record_progress(server: SidecarServer, params: dict[str, Any]) -> dict[st
         "total": state.progress.total,
         "source_sequence": state.source_sequence,
     }
+    if state.status is StateStatus.INVALID:
+        response["projection_failed_at"] = {
+            "sequence": state.unprojectable_at_sequence,
+            "type": state.unprojectable_event_type,
+            "reason": state.unprojectable_reason,
+        }
+    return response
 
 
 def _h_checkpoint(server: SidecarServer, params: dict[str, Any]) -> dict[str, Any]:

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from continuum.events import Event, EventType
 from continuum.models import (
@@ -390,6 +390,34 @@ class _Accumulator:
     # -- finish ----------------------------------------------------------- #
 
     def build(self) -> SemanticState:
+        return self._build()
+
+    def build_degraded(self, event: Event, reason: str) -> SemanticState:
+        """The last-good prefix, marked INVALID and naming where folding stopped.
+
+        Shares ``build``'s guards deliberately: if even the prefix cannot
+        produce a state (no RUN_STARTED before the break), there is nothing
+        known to report, and degrade mode raises like raise mode. A degraded
+        state that named no break would be worse than an error.
+        """
+        state = self._build()
+        return state.model_copy(
+            update={
+                "status": StateStatus.INVALID,
+                "unprojectable_at_sequence": event.sequence,
+                "unprojectable_event_type": str(event.type),
+                "unprojectable_reason": _condense(reason),
+            }
+        )
+
+    def _build(
+        self,
+        *,
+        status: StateStatus = StateStatus.VALID,
+        unprojectable_at_sequence: int | None = None,
+        unprojectable_event_type: str | None = None,
+        unprojectable_reason: str | None = None,
+    ) -> SemanticState:
         if self.goal is None:
             raise ProjectionError(
                 f"run {self.run_id!r} has no goal: the log never recorded RUN_STARTED"
@@ -411,6 +439,10 @@ class _Accumulator:
             model=self.model,
             version=self.version,
             source_sequence=self.source_sequence,
+            status=status,
+            unprojectable_at_sequence=unprojectable_at_sequence,
+            unprojectable_event_type=unprojectable_event_type,
+            unprojectable_reason=unprojectable_reason,
             created_at=self.created_at or stamp,
             updated_at=stamp,
         )
@@ -484,12 +516,27 @@ def project_incremental(
     events: Iterable[Event],
     *,
     base: SemanticState | None = None,
+    on_unprojectable: Literal["raise", "degrade"] = "raise",
 ) -> tuple[SemanticState, ProjectionReport]:
     """Fold ``events`` onto ``base`` and report what was consumed.
 
     Passing a ``base`` lets a long run advance its state without re-reading the
     whole log; the result must equal a full re-projection of the same prefix.
+
+    ``on_unprojectable="degrade"`` (issue #383) stops at the earliest event the
+    fold refuses and returns the last-good prefix marked ``INVALID``, naming the
+    sequence, event type and condensed reason. It never skips the bad event and
+    keeps going: the state after a skipped write is not a state the run was ever
+    in, so folding resumes nowhere. The default stays ``"raise"`` so every
+    existing caller keeps getting exactly today's behaviour; a silent partial
+    state reads as authoritative, which is worse than a crash.
+
+    The run-mismatch and sequence-order checks above deliberately stay outside
+    that treatment: they mean the caller handed the fold a malformed stream, not
+    that the log contains an event its model rejects.
     """
+    if on_unprojectable not in ("raise", "degrade"):
+        raise ValueError(f"on_unprojectable must be 'raise' or 'degrade', got {on_unprojectable!r}")
     acc = _Accumulator(run_id, base)
     report = ProjectionReport()
     previous_sequence = base.source_sequence if base else 0
@@ -506,12 +553,23 @@ def project_incremental(
         previous_sequence = event.sequence
         report.consumed += 1
 
-        if _dispatch(acc, event):
-            report.applied += 1
-            acc.updated_at = event.timestamp
-        elif event.type not in _NON_PROJECTING:
-            name = str(event.type)
-            report.ignored_types[name] = report.ignored_types.get(name, 0) + 1
+        try:
+            if _dispatch(acc, event):
+                report.applied += 1
+                acc.updated_at = event.timestamp
+            elif event.type not in _NON_PROJECTING:
+                name = str(event.type)
+                report.ignored_types[name] = report.ignored_types.get(name, 0) + 1
+        except Exception as exc:
+            # Deliberately broad, same reasoning as first_unprojectable_event:
+            # any failure here means the log stops folding at this event, no
+            # matter whether it came from a model invariant or a payload shape
+            # nothing anticipated. Narrowing the catch would trade a named
+            # diagnosis for an opaque traceback precisely on the malformed
+            # logs this mode exists to answer.
+            if on_unprojectable != "degrade":
+                raise
+            return acc.build_degraded(event, str(exc)), report
 
         acc.source_sequence = event.sequence
         if acc.created_at is None:
@@ -576,12 +634,18 @@ def project(
     events: Iterable[Event],
     *,
     upto: int | None = None,
+    on_unprojectable: Literal["raise", "degrade"] = "raise",
 ) -> SemanticState:
     """Project a run's events into semantic state.
 
     ``upto`` truncates the fold at a sequence number — the mechanism behind
     ``continuum inspect --version`` and recovery from a partially trusted log.
+
+    ``on_unprojectable`` forwards to :func:`project_incremental`: ``"raise"``
+    (the default) preserves today's behaviour for every existing caller;
+    ``"degrade"`` returns the last-good prefix marked INVALID instead of
+    raising, for callers whose job is to diagnose a log rather than fold it.
     """
     selected = [e for e in events if upto is None or e.sequence <= upto]
-    state, _ = project_incremental(run_id, selected)
+    state, _ = project_incremental(run_id, selected, on_unprojectable=on_unprojectable)
     return state

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -529,7 +529,9 @@ def project_incremental(
     keeps going: the state after a skipped write is not a state the run was ever
     in, so folding resumes nowhere. The default stays ``"raise"`` so every
     existing caller keeps getting exactly today's behaviour; a silent partial
-    state reads as authoritative, which is worse than a crash.
+    state reads as authoritative, which is worse than a crash. Note that
+    ``report.consumed`` counts the refused event too, since it is incremented
+    before the fold is attempted; ``consumed - applied`` therefore includes it.
 
     The run-mismatch and sequence-order checks above deliberately stay outside
     that treatment: they mean the caller handed the fold a malformed stream, not

--- a/src/continuum/state/versioning.py
+++ b/src/continuum/state/versioning.py
@@ -17,10 +17,10 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from continuum.models import SemanticState, utcnow
+from continuum.models import PROJECTION_BOOKKEEPING, SemanticState, utcnow
 from continuum.security.hashing import stable_hash
 
-__all__ = ["VersionEntry", "VersionChain", "state_fingerprint"]
+__all__ = ["VersionEntry", "VersionChain", "canonical_state_json", "state_fingerprint"]
 
 
 def state_fingerprint(state: SemanticState) -> str:
@@ -30,9 +30,9 @@ def state_fingerprint(state: SemanticState) -> str:
     pending work, approvals and dependencies are the same state even if they
     were projected at different times or carry different version numbers.
 
-    The projection-degradation fields are excluded for the same reason: they
-    describe how the log was read (where folding stopped), not what the state
-    says. Including them would break fingerprint dedup across the upgrade for
+    Projection bookkeeping is excluded for the same reason: it describes how
+    the log was read (where folding stopped), not what the state says.
+    Including it would break fingerprint dedup across the #383 upgrade for
     every stored version, and a degraded prefix-state genuinely is the same
     task state as its healthy counterpart.
     """
@@ -43,13 +43,23 @@ def state_fingerprint(state: SemanticState) -> str:
             "created_at",
             "updated_at",
             "source_sequence",
-            "status",
-            "unprojectable_at_sequence",
-            "unprojectable_event_type",
-            "unprojectable_reason",
+            *PROJECTION_BOOKKEEPING,
         },
     )
     return stable_hash(payload)
+
+
+def canonical_state_json(state: SemanticState) -> str:
+    """The serialised form of a state as written to storage.
+
+    Omits projection bookkeeping: it is always default in anything persistable
+    (a degraded fold is refused at every capture path), and carrying it would
+    make databases written after #383 unreadable by readers built before it,
+    whose SemanticState validates with ``extra="forbid"``. The version
+    fingerprint above is computed over the same exclusions, so stripping here
+    cannot desynchronise a stored row from its recorded fingerprint.
+    """
+    return state.model_dump_json(exclude=PROJECTION_BOOKKEEPING)
 
 
 class VersionEntry(BaseModel):

--- a/src/continuum/state/versioning.py
+++ b/src/continuum/state/versioning.py
@@ -29,10 +29,25 @@ def state_fingerprint(state: SemanticState) -> str:
     Two states with the same goal, progress, decisions, findings, evidence,
     pending work, approvals and dependencies are the same state even if they
     were projected at different times or carry different version numbers.
+
+    The projection-degradation fields are excluded for the same reason: they
+    describe how the log was read (where folding stopped), not what the state
+    says. Including them would break fingerprint dedup across the upgrade for
+    every stored version, and a degraded prefix-state genuinely is the same
+    task state as its healthy counterpart.
     """
     payload = state.model_dump(
         mode="json",
-        exclude={"version", "created_at", "updated_at", "source_sequence"},
+        exclude={
+            "version",
+            "created_at",
+            "updated_at",
+            "source_sequence",
+            "status",
+            "unprojectable_at_sequence",
+            "unprojectable_event_type",
+            "unprojectable_reason",
+        },
     )
     return stable_hash(payload)
 

--- a/src/continuum/storage/postgres.py
+++ b/src/continuum/storage/postgres.py
@@ -43,7 +43,7 @@ from continuum.models import (
     utcnow,
 )
 from continuum.security.hashing import make_id
-from continuum.state.versioning import state_fingerprint
+from continuum.state.versioning import canonical_state_json, state_fingerprint
 from continuum.storage.actionindex import index_entry_from_payload
 from continuum.storage.base import (
     CheckpointNotFound,
@@ -953,7 +953,7 @@ class PostgresStorage(Storage):
                     head["fingerprint"] if head else None,
                     reason,
                     utcnow().isoformat(),
-                    stored.model_dump_json(),
+                    canonical_state_json(stored),
                 ),
             )
         return version
@@ -1017,7 +1017,7 @@ class PostgresStorage(Storage):
                         sealed.trigger,
                         sealed.created_at.isoformat(),
                         sealed.integrity_hash,
-                        sealed.model_dump_json(),
+                        sealed.canonical_json(),
                     ),
                 )
             except self._psycopg.IntegrityError as exc:

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -34,7 +34,7 @@ from pydantic import ValidationError
 from continuum.events import Event, EventType, IntegrityReport, IntegrityViolation
 from continuum.models import Action, Origin, Run, RunStatus, SemanticState, StateCheckpoint, utcnow
 from continuum.security.hashing import make_id
-from continuum.state.versioning import state_fingerprint
+from continuum.state.versioning import canonical_state_json, state_fingerprint
 from continuum.storage.actionindex import index_entry_from_payload
 from continuum.storage.base import (
     CheckpointNotFound,
@@ -865,7 +865,7 @@ class SQLiteStorage(Storage):
                     head["fingerprint"] if head else None,
                     reason,
                     utcnow().isoformat(),
-                    stored.model_dump_json(),
+                    canonical_state_json(stored),
                 ),
             )
         return version
@@ -929,7 +929,7 @@ class SQLiteStorage(Storage):
                         sealed.trigger,
                         sealed.created_at.isoformat(),
                         sealed.integrity_hash,
-                        sealed.model_dump_json(),
+                        sealed.canonical_json(),
                     ),
                 )
             except sqlite3.IntegrityError as exc:

--- a/tests/test_checkpoint_compat.py
+++ b/tests/test_checkpoint_compat.py
@@ -1,0 +1,168 @@
+"""Checkpoint and version compatibility across the #383 field addition.
+
+Adding projection bookkeeping (status, unprojectable_*) to SemanticState
+changed what StateCheckpoint.content serialises, which is the input to
+integrity_hash, so every checkpoint written before #383 failed verification
+under the new code: the message says the content does not match its hash,
+which is indistinguishable from tampering. These tests exist because no
+same-process round-trip can catch that class of bug: the hash always agrees
+with itself when one version of the code writes and reads. The only shape
+that catches it is pinning the serialised form of one side.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from continuum.checkpoint.manager import CheckpointManager
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.security.hashing import stable_hash
+from continuum.storage.sqlite import SQLiteStorage
+
+#: Pinned by name, deliberately not imported: these tests freeze the exact
+#: serialised shape that crosses the #383 boundary, so they must not move if
+#: the constant ever does.
+BOOKKEEPING_FIELDS = frozenset(
+    {
+        "status",
+        "unprojectable_at_sequence",
+        "unprojectable_event_type",
+        "unprojectable_reason",
+    }
+)
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Iterator[str]:
+    path = str(tmp_path / "compat.db")
+    storage = SQLiteStorage(path)
+    try:
+        storage.create_run(Run(run_id="run_1", goal="Analyze 100 documents"))
+        storage.append_event(
+            "run_1", EventType.RUN_STARTED, {"goal": "Analyze 100 documents", "total": 100}
+        )
+        CheckpointManager(storage).checkpoint("run_1")
+    finally:
+        storage.close()
+    yield path
+
+
+def _strip_bookkeeping(db: str, table: str, json_column: str) -> None:
+    """Rewrite stored bodies to the exact shape pre-#383 code wrote."""
+    with sqlite3.connect(db) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(f"SELECT rowid, {json_column} AS body FROM {table}").fetchall()
+        for row in rows:
+            body = json.loads(row["body"])
+            state = body.get("state")
+            if state is None:
+                continue
+            for field in BOOKKEEPING_FIELDS:
+                state.pop(field, None)
+            conn.execute(
+                f"UPDATE {table} SET {json_column} = ? WHERE rowid = ?",
+                (json.dumps(body), row["rowid"]),
+            )
+
+
+def test_a_checkpoint_written_before_383_still_verifies(db: str) -> None:
+    """The pre-#383 body hashes identically under the new content().
+
+    Simulating the old writer faithfully takes two steps: strip the fields the
+    old model did not have, and re-seal the hash over that reduced payload,
+    because that is exactly the digest origin/main committed. Getting either
+    half wrong reports healthy old checkpoints as tampered, spending the one
+    alarm this hash exists to mean. Under the first cut of #383 (fields added,
+    not excluded from content()) the reloaded state regains the four keys as
+    defaults, the recomputed payload grows them back, and verify() fails: the
+    exact cross-version mismatch reported in review.
+    """
+    with sqlite3.connect(db) as conn:
+        conn.row_factory = sqlite3.Row
+        (row,) = conn.execute("SELECT rowid, body FROM checkpoints").fetchall()
+        body = json.loads(row["body"])
+        for field in BOOKKEEPING_FIELDS:
+            body["state"].pop(field, None)
+        # Re-seal exactly as the old writer did: digest over everything but
+        # the hash, written back into the body beside the content.
+        body["integrity_hash"] = stable_hash(
+            {k: v for k, v in body.items() if k != "integrity_hash"}
+        )
+        conn.execute(
+            "UPDATE checkpoints SET body = ? WHERE rowid = ?",
+            (json.dumps(body), row["rowid"]),
+        )
+
+    storage = SQLiteStorage(db)
+    try:
+        checkpoint = storage.latest_checkpoint("run_1")
+        assert checkpoint is not None
+        assert checkpoint.verify(), (
+            "a checkpoint written by shipped code must not report as tampered"
+        )
+        restored = CheckpointManager(storage).restore("run_1")
+        assert restored.state.goal.description == "Analyze 100 documents"
+    finally:
+        storage.close()
+
+
+def test_a_version_row_written_before_383_still_loads(db: str) -> None:
+    """Old version rows load with defaults filling the new fields."""
+    _strip_bookkeeping(db, "versions", "state")
+
+    storage = SQLiteStorage(db)
+    try:
+        state = storage.get_version("run_1", 0)
+        assert state.status.value == "valid"
+        assert state.unprojectable_at_sequence is None
+        assert state.goal.description == "Analyze 100 documents"
+    finally:
+        storage.close()
+
+
+def test_new_checkpoints_do_not_persist_projection_bookkeeping(tmp_path: Path) -> None:
+    """Readers built before #383 validate SemanticState with extra="forbid".
+
+    A body carrying fields they have never heard of would make every database
+    written after the upgrade unreadable by older builds, so the canonical
+    form omits them entirely.
+    """
+    path = str(tmp_path / "forward.db")
+    storage = SQLiteStorage(path)
+    try:
+        storage.create_run(Run(run_id="run_1", goal="g"))
+        storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        CheckpointManager(storage).checkpoint("run_1")
+    finally:
+        storage.close()
+
+    with sqlite3.connect(path) as conn:
+        conn.row_factory = sqlite3.Row
+        (row,) = conn.execute("SELECT body FROM checkpoints").fetchall()
+    state_body = json.loads(row["body"])["state"]
+    for field in BOOKKEEPING_FIELDS:
+        assert field not in state_body, f"{field} must stay out of the persisted body"
+
+
+def test_new_version_rows_do_not_persist_projection_bookkeeping(tmp_path: Path) -> None:
+    path = str(tmp_path / "forward-versions.db")
+    storage = SQLiteStorage(path)
+    try:
+        storage.create_run(Run(run_id="run_1", goal="g"))
+        storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g", "total": 10})
+        CheckpointManager(storage).checkpoint("run_1")
+    finally:
+        storage.close()
+
+    with sqlite3.connect(path) as conn:
+        conn.row_factory = sqlite3.Row
+        (row,) = conn.execute("SELECT state FROM versions").fetchall()
+    state_body = json.loads(row["state"])
+    for field in BOOKKEEPING_FIELDS:
+        assert field not in state_body, f"{field} must stay out of the persisted body"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1088,6 +1088,24 @@ def test_resume_on_an_unprojectable_run_answers_instead_of_crashing(db: str) -> 
     assert payload["contract"]["recovery_status"] != "safe_to_resume"
 
 
+def test_show_contract_on_an_unprojectable_run_carries_the_break(db: str) -> None:
+    """The contract is the machine-readable artifact; it must not read clean.
+
+    The prose rationale named the break from day one, but required_actions was
+    empty and next_allowed rendered as "continue" over a requires_human
+    verdict (#385 review): a caller keying on the structure saw nothing to do.
+    """
+    _poison(db)
+    code, out, err = run("--db", db, "show-contract", "run_1")
+
+    assert code == ExitCode.REQUIRES_HUMAN, out
+    assert "repair_log:" in out, "required_actions must name real work"
+    assert "next_allowed:      repair_log:" in out
+    assert "continue" not in out
+    assert "(through sequence " in out, "verified entries are qualified, not unqualified"
+    assert "projection (invalid" in out
+
+
 def test_status_on_an_unprojectable_run_names_the_break_and_fails(db: str) -> None:
     _poison(db)
     code, out, err = run("--db", db, "status", "run_1")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1065,3 +1065,100 @@ def test_verify_projects_a_compacted_run_from_its_archive(db: str) -> None:
     assert code == ExitCode.OK, f"a healthy compacted run must still verify: {out}{err}"
     assert "PROJECTION FAILURE" not in out
     assert json.loads(run("--db", db, "--json", "verify", "run_1")[1])["projectable"] is True
+
+
+# --- degrade instead of raise (issue #383) ----------------------------------- #
+
+
+def test_resume_on_an_unprojectable_run_answers_instead_of_crashing(db: str) -> None:
+    """resume is the command a crashed session reaches for first; on a poisoned
+    log it used to die with the same pydantic traceback as everything else,
+    while the action tools kept authorising side effects."""
+    _poison(db)
+    code, out, err = run("--db", db, "resume", "run_1", "--env", "dataset=v3")
+
+    assert code == ExitCode.REQUIRES_HUMAN, out
+    assert "stops folding at sequence" in out, "name where the log stops folding"
+    assert "exceeds total" in out, "name the constraint, not just the pydantic header"
+    assert "Traceback" not in out and "Traceback" not in err
+
+    payload = json.loads(run("--db", db, "--json", "resume", "run_1", "--env", "dataset=v3")[1])
+    assert payload["mode"] == "request_human"
+    assert payload["safe"] is False
+    assert payload["contract"]["recovery_status"] != "safe_to_resume"
+
+
+def test_status_on_an_unprojectable_run_names_the_break_and_fails(db: str) -> None:
+    _poison(db)
+    code, out, err = run("--db", db, "status", "run_1")
+
+    # Not OK: the figures describe a prefix of the log, and exit 0 would wave
+    # a poisoned run through a pipeline.
+    assert code == ExitCode.CORRUPTED
+    assert "PROJECTION FAILURE" in out
+    assert "TASK_UPDATED" in out
+    assert "Traceback" not in out and "Traceback" not in err
+
+
+def test_inspect_on_an_unprojectable_run_reports_the_known_prefix(db: str) -> None:
+    _poison(db)
+    code, out, _ = run("--db", db, "inspect", "run_1")
+
+    assert code == ExitCode.CORRUPTED
+    assert "PROJECTION FAILURE" in out
+    assert "0 completed" in out, "prefix figures, not the poisoned ones"
+
+
+def test_replay_on_an_unprojectable_run_does_not_certify(db: str) -> None:
+    _poison(db)
+    code, out, err = run("--db", db, "replay", "run_1")
+
+    assert code == ExitCode.CORRUPTED
+    assert "PROJECTION FAILURE" in out
+    assert "Traceback" not in out and "Traceback" not in err
+
+
+def test_a_healthy_run_is_unaffected_in_both_modes(db: str) -> None:
+    """No poison: status stays a clean exit 0 and resume still answers RESUME."""
+    from continuum.state.semantic import project
+
+    with SQLiteStorage(db) as store:
+        raised = project("run_1", store.read_events("run_1"))
+        degraded = project("run_1", store.read_events("run_1"), on_unprojectable="degrade")
+
+    assert degraded == raised
+    assert degraded.status.value == "valid"
+
+    code, out, err = run("--db", db, "status", "run_1")
+    assert code == ExitCode.OK, f"{out}{err}"
+    assert "PROJECTION FAILURE" not in out
+
+    code, out, err = run("--db", db, "resume", "run_1", "--env", "dataset=v3")
+    assert code == ExitCode.OK, f"{out}{err}"
+    assert (
+        json.loads(run("--db", db, "--json", "resume", "run_1", "--env", "dataset=v3")[1])["mode"]
+        == "resume"
+    )
+
+
+def test_a_healthy_compacted_run_still_resumes_after_degrade_landed(db: str) -> None:
+    """Regression guard for constraint 5 (compaction).
+
+    After compaction the live log has no RUN_STARTED; restore works only
+    because the anchor checkpoint covers the prefix. The degrade wiring must
+    not change that, and folding the post-anchor tail must merge nothing less
+    than archive+live when it does run.
+    """
+    assert run("--db", db, "compact", "run_1", "--force")[0] == ExitCode.OK
+
+    code, out, err = run("--db", db, "status", "run_1")
+    assert code == ExitCode.OK, f"a healthy compacted run must read cleanly: {out}{err}"
+    assert "PROJECTION FAILURE" not in out
+
+    # The anchor checkpoint carries no environment snapshot, so the dataset
+    # cannot be re-verified and resume lands on request_human; that is
+    # pre-existing behaviour and must not turn into a projection failure.
+    code, out, err = run("--db", db, "resume", "run_1", "--env", "dataset=v3")
+    assert code in (ExitCode.OK, ExitCode.REQUIRES_HUMAN), f"{out}{err}"
+    assert "PROJECTION FAILURE" not in out
+    assert "Traceback" not in err

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from continuum.events import EventLog, EventType
 from continuum.models import ApprovalStatus, Origin, StateStatus
 from continuum.state.semantic import ProjectionError, project, project_incremental
+from continuum.state.versioning import state_fingerprint
 
 
 def started(log: EventLog, run_id: str = "run_1", total: int | None = 100) -> EventLog:
@@ -293,3 +295,101 @@ def test_dangling_evidence_is_detectable() -> None:
     )
     state = project("run_1", log.events("run_1"))
     assert state.dangling_evidence() == {"paper_404"}
+
+
+# --- degrade instead of raise (issue #383) ---------------------------------- #
+
+
+def _poisoned_log() -> EventLog:
+    """A healthy prefix plus the over-total write #364 used to allow."""
+    log = started(EventLog())
+    log.append("run_1", EventType.WORK_COMPLETED, {})
+    log.append("run_1", EventType.TASK_UPDATED, {"completed": 999, "failed": 0})
+    return log
+
+
+def test_degrade_returns_an_invalid_state_naming_the_break() -> None:
+    log = _poisoned_log()
+
+    state = project("run_1", log.events("run_1"), on_unprojectable="degrade")
+
+    assert state.status is StateStatus.INVALID
+    assert state.unprojectable_at_sequence == 3
+    assert state.unprojectable_event_type == "TASK_UPDATED"
+    assert "exceeds total" in (state.unprojectable_reason or "")
+    # The fold stops at the last good event: it does not skip and continue.
+    assert state.source_sequence == 2
+    assert state.progress.completed == 1
+    assert state.goal.description == "Analyze 100 documents"
+
+
+def test_default_mode_still_raises_the_same_error() -> None:
+    log = _poisoned_log()
+    events = log.events("run_1")
+
+    with pytest.raises(ValidationError) as explicit:
+        project("run_1", events, on_unprojectable="raise")
+    with pytest.raises(ValidationError) as implicit:
+        project("run_1", events)
+
+    # Byte-for-byte unchanged behaviour: the default is the same exception
+    # type callers see today, not a new wrapper.
+    assert type(explicit.value) is type(implicit.value)
+    assert "exceeds total" in str(implicit.value)
+
+
+def test_degrade_on_a_healthy_log_equals_the_raise_result() -> None:
+    log = started(EventLog())
+    log.append("run_1", EventType.WORK_COMPLETED, {})
+
+    raised = project("run_1", log.events("run_1"))
+    degraded = project("run_1", log.events("run_1"), on_unprojectable="degrade")
+
+    assert degraded == raised
+    assert degraded.status is StateStatus.VALID
+    assert degraded.unprojectable_at_sequence is None
+
+
+def test_two_bad_events_report_the_earliest() -> None:
+    log = started(EventLog())
+    # Both writes are individually unprojectable (each counter alone exceeds
+    # total), so wherever the fold stops it has a real choice to report.
+    log.append("run_1", EventType.TASK_UPDATED, {"completed": 999})
+    log.append("run_1", EventType.TASK_UPDATED, {"completed": 500})
+
+    state = project("run_1", log.events("run_1"), on_unprojectable="degrade")
+
+    # A repair aimed at the second break would leave the first in place, so
+    # the diagnosis must name the earliest refusal.
+    assert state.unprojectable_at_sequence == 2
+    assert state.source_sequence == 1
+
+
+def test_degrade_with_no_valid_prefix_still_raises() -> None:
+    log = EventLog()
+    log.append("run_1", EventType.TASK_UPDATED, {"completed": 1})
+
+    # "What is known up to sequence N-1" needs an N-1. With nothing foldable
+    # before the break there is no partial answer to give, and degrading into
+    # an empty-looking state would invent one.
+    with pytest.raises(ProjectionError, match="never recorded RUN_STARTED"):
+        project("run_1", log.events("run_1"), on_unprojectable="degrade")
+
+
+def test_degraded_folds_content_address_like_their_prefix() -> None:
+    """The fingerprint keeps meaning task content; status carries the warning.
+
+    put_version dedupes on this hash, so a degraded fold must not hash
+    differently from the healthy state it actually contains, and it must not
+    be distinguishable from that state by content alone, which is exactly why
+    the INVALID marker lives outside the hashed payload.
+    """
+    poisoned = started(EventLog())
+    poisoned.append("run_1", EventType.TASK_UPDATED, {"completed": 999, "failed": 0})
+    events = poisoned.events("run_1")
+
+    prefix = project("run_1", events, upto=1)
+    degraded = project("run_1", events, on_unprojectable="degrade")
+
+    assert state_fingerprint(degraded) == state_fingerprint(prefix)
+    assert degraded.status is not prefix.status

--- a/tests/test_recovery_engine.py
+++ b/tests/test_recovery_engine.py
@@ -504,3 +504,43 @@ def test_self_certified_runs_are_confirmable(store: SQLiteStorage) -> None:
     assert all(
         e.status is not StateStatus.REQUIRES_REVIEW for e in confirmed.validation.report.statuses
     )
+
+
+# --- unprojectable logs (issue #383) ---------------------------------------- #
+
+
+def test_an_unprojectable_log_requests_a_human_and_names_the_break(store: SQLiteStorage) -> None:
+    """A poisoned log must produce a verdict, not a pydantic traceback.
+
+    The action tools fold only ACTION_* events, so a run whose projection is
+    dead can still authorise real side effects. Recovery has to be able to say
+    what is known, where the log stops folding, and that continuing is not a
+    decision software may take.
+    """
+    seed(store)
+    store.append_event("run_1", EventType.TASK_UPDATED, {"completed": 999, "failed": 0})
+
+    decision = RecoveryEngine(store).assess("run_1", current_environment=env("v3"))
+
+    assert decision.mode is not RecoveryMode.RESUME
+    assert decision.mode is RecoveryMode.REQUEST_HUMAN
+    assert not decision.safe
+    assert decision.contract.recovery_status is RecoverySafety.REQUIRES_HUMAN
+    assert "stops folding at sequence" in " ".join(decision.rationale)
+    # The verdict covers the last-good prefix only, and says so.
+    state = decision.state
+    assert state.status is StateStatus.INVALID
+    assert state.unprojectable_at_sequence == 26
+    assert state.source_sequence == 24
+
+
+def test_a_healthy_log_still_resumes_with_degrade_wired_in(store: SQLiteStorage) -> None:
+    """The engine now folds with degrade enabled everywhere; a sound log must
+    be untouched by that."""
+    seed(store)
+    decision = RecoveryEngine(store).assess("run_1", current_environment=env("v3"))
+
+    assert decision.mode is RecoveryMode.RESUME
+    assert decision.safe
+    assert decision.state.status is StateStatus.VALID
+    assert decision.state.unprojectable_at_sequence is None

--- a/tests/test_recovery_engine.py
+++ b/tests/test_recovery_engine.py
@@ -25,6 +25,7 @@ from continuum.recovery import (
     render_contract,
     verify_contract,
 )
+from continuum.recovery.guidance import human_steps_for
 from continuum.storage import SQLiteStorage
 
 
@@ -534,6 +535,70 @@ def test_an_unprojectable_log_requests_a_human_and_names_the_break(store: SQLite
     assert state.source_sequence == 24
 
 
+def test_the_contract_names_the_break_as_a_required_action(store: SQLiteStorage) -> None:
+    """The structured artifact must carry the break, not just the prose.
+
+    With an empty plan the contract read required_actions=[] and fell through
+    to "continue" over a requires_human verdict (#385 review): prose and
+    structure disagreeing, with a machine reader most likely to act on the
+    structure.
+    """
+    seed(store)
+    store.append_event("run_1", EventType.TASK_UPDATED, {"completed": 999, "failed": 0})
+
+    decision = RecoveryEngine(store).assess("run_1", current_environment=env("v3"))
+
+    steps = decision.plan.of_kind(RepairKind.REPAIR_LOG)
+    assert len(steps) == 1
+    assert steps[0].target == "sequence_26"
+    assert steps[0].requires_human
+    assert decision.next_allowed_action == "repair_log:sequence_26"
+    assert decision.plan.steps[0] is steps[0], "the unreadable log sorts first"
+    assert decision.contract.required_actions[0] == "repair_log:sequence_26"
+    assert decision.contract.next_allowed_action == "repair_log:sequence_26"
+
+
+def test_the_degraded_contract_does_not_claim_unqualified_verification(
+    store: SQLiteStorage,
+) -> None:
+    """verified entries were checked against the last-good prefix only."""
+    seed(store)
+    store.append_event("run_1", EventType.TASK_UPDATED, {"completed": 999, "failed": 0})
+
+    decision = RecoveryEngine(store).assess("run_1", current_environment=env("v3"))
+    contract = decision.contract
+
+    assert all(e.startswith("goal (through sequence 24)") for e in contract.verified if e == "goal")
+    assert any("projection (invalid" in e for e in contract.invalidated)
+    assert any("projection stopped at sequence 26" in e for e in contract.evidence)
+    assert verify_contract(contract)
+
+
+def test_rendered_output_never_offers_continue_on_a_broken_log(store: SQLiteStorage) -> None:
+    """'continue' over requires_human reads as permission the gate never gave."""
+    seed(store)
+    store.append_event("run_1", EventType.TASK_UPDATED, {"completed": 999, "failed": 0})
+
+    decision = RecoveryEngine(store).assess("run_1", current_environment=env("v3"))
+    rendered = render_contract(decision.contract)
+
+    assert "continue" not in rendered
+    assert "next_allowed:      repair_log:sequence_26" in rendered
+    assert "Next permitted action: continue" not in decision.render()
+    assert "Next permitted action: repair_log:sequence_26" in decision.render()
+
+
+def test_guidance_names_the_break_instead_of_the_generic_fallback(store: SQLiteStorage) -> None:
+    seed(store)
+    store.append_event("run_1", EventType.TASK_UPDATED, {"completed": 999, "failed": 0})
+
+    decision = RecoveryEngine(store).assess("run_1", current_environment=env("v3"))
+    steps = human_steps_for(decision, run_id="run_1")
+
+    assert any("stops folding at sequence_26" in s for s in steps)
+    assert not any("nothing further is automatable" in s for s in steps)
+
+
 def test_a_healthy_log_still_resumes_with_degrade_wired_in(store: SQLiteStorage) -> None:
     """The engine now folds with degrade enabled everywhere; a sound log must
     be untouched by that."""
@@ -544,3 +609,8 @@ def test_a_healthy_log_still_resumes_with_degrade_wired_in(store: SQLiteStorage)
     assert decision.safe
     assert decision.state.status is StateStatus.VALID
     assert decision.state.unprojectable_at_sequence is None
+    # Healthy contracts keep their exact shape: bare verified names, no
+    # projection entry, and "continue" remains correct under SAFE_TO_RESUME.
+    assert decision.contract.verified == ["external_dependency:dataset", "goal", "progress"]
+    assert decision.contract.invalidated == []
+    assert "next_allowed:      continue" in render_contract(decision.contract)


### PR DESCRIPTION
## Description

An event whose payload violates a model invariant (for example TASK_UPDATED with completed=999 against total=100) is hashed and appended like any other, but because project_incremental validates every intermediate state while folding, no later event can correct it: the chain verifies clean forever and every projecting command dies on precisely the run that needs them, while the action tools (which fold only ACTION_* events) keep authorising real side effects that recovery cannot assess. I reproduced this before changing anything by seeding a run through SQLiteStorage and appending store.append_event("run_1", EventType.TASK_UPDATED, {"completed": 999, "failed": 0}) (the existing _poison helper from tests/test_cli.py), then running continuum status, continuum compact --force, continuum resume and continuum inspect: all four exited 1 with a raw pydantic "Value error, completed + pending + failed exceeds total" traceback.

The fold can now degrade instead of raising. project() and project_incremental() accept on_unprojectable="raise"|"degrade", defaulting to "raise". Degrade mode stops at the earliest refused event and returns the last-good prefix marked SemanticState.status=StateStatus.INVALID, carrying unprojectable_at_sequence, unprojectable_event_type and unprojectable_reason (condensed to one line by the same logic #384 added). It never skips the bad event and keeps going, since the state after a skipped write is not a state the run was ever in; and if nothing folds at all before the break (no RUN_STARTED before it), degrade mode still raises, because there is no partial answer to invent.

Default behaviour is byte-for-byte unchanged for callers that do not opt in, and the opt-in set is limited to surfaces whose job is diagnosis or reporting: CheckpointManager.restore (both fold paths), driven by RecoveryEngine.assess so resume, validate, show-contract and briefing answer instead of dying; the CLI status, inspect and replay surfaces plus replay's stored-version verification; the serve sidecar's record_progress report (it appends first, so today it crashes after already committing the write) and its dependency dedup read; and the benchmark's naive-checkpoint readout. Deliberately kept raising: mcp/server.py's _project_candidate, because the #364 write guard exists to refuse an unprojectable candidate and degrading there would silently disable that protection; the checkpoint capture surfaces in mcp/server.py and serve/server.py and GenericAgentAdapter.capture_state, because a partial fold must not be pinned as a stored version or compaction anchor; and adapters/generic.py _declare_dependencies together with hooks.py record_file_progress, which already catch ProjectionError with documented fallbacks and would change established behaviour if converted. One correction to the issue's inventory: on current main there are 14 direct project() call sites across 7 files, and recovery/fork.py's hit is a comment, not a call site; every site was inspected individually rather than converted blindly.

For a degraded state the engine decides REQUEST_HUMAN (contract safety REQUIRES_HUMAN). ABORT would restate exactly the terminal state the issue calls wrong ("this run is permanently unanswerable and there is no supported fix"); REQUEST_HUMAN is this system's standing verdict whenever a person must decide, keeps repair possible once option 2 lands, and the severity ordering structurally guarantees a degraded state can never yield RESUME even when every other signal is clean. The decision rationale names the sequence, event type and condensed reason, and states explicitly that the verdict covers events through the last good sequence only.

## Related issues

Closes #383. Options 2 (a repair/amend command) and 3 (fork-from-last-good-prefix) named in the issue are deliberately out of scope and are not attempted here; both depend on this landing first.

## Types of changes

- Type: `bugfix`

## Breaking changes

No, as of the third commit. The second review round correctly blocked on a real break the first two rounds missed: adding four fields to SemanticState changed what StateCheckpoint.content() serialises, so every pre-existing checkpoint failed verification with "integrity hash does not match content" (indistinguishable from tampering), and new bodies carried fields that older readers' extra="forbid" SemanticState rejects. That is fixed: PROJECTION_BOOKKEEPING names the four fields once and they are excluded from content(), from checkpoint digests, and from all four persisted-body write sites (sqlite and postgres, checkpoints and versions), which restores every existing checkpoint (the reviewer verified the digest matches against a real stored row) and keeps new databases readable by older builds. Commands that previously crashed on a poisoned log now answer with the documented non-zero exit codes (CORRUPTED / REQUIRES_HUMAN), which is the stated safety contract rather than a break.

## How has this been tested?

Each new test was verified to fail on unchanged source and pass after the change, proven directly: with the source files stashed (git stash push -- src/, keeping the tests) 13 of the 14 new tests failed (TypeError on the missing keyword, AttributeError on the missing status field, or wrong exit codes); after git stash pop all 14 pass. The 14th, test_a_healthy_compacted_run_still_resumes_after_degrade_landed, is a deliberate regression guard for the compaction merge (constraint 5) and pins behaviour that already holds on main. The contract round added five tests proven the same way (five failed with src/ checked out at this branch's first commit, all pass after). The compatibility round adds four: three fail against the branch's field-adding commit (the tampered-checkpoint reproduction plus both persist-shape assertions) and pass here; the old-version-row load test is a guard pinning behaviour that already holds. Gates on the final commit, Python 3.13.5 in a dedicated worktree venv with mcp upgraded to 2.1.0 beforehand per the known CI resolution trap: .venv/bin/python -m pytest (1425 passed, 23 skipped, 0 failed), .venv/bin/ruff check src tests (pass), .venv/bin/ruff format --check src tests (206 files already formatted), .venv/bin/mypy src/continuum (104 files, zero issues).

## Checklist

Confirmed: tests added or updated for the changed behaviour; CHANGELOG.md updated under Unreleased / Fixed; all four gates listed above pass on the latest commit; no security-relevant surface is weakened (the write-path guard and checkpoint persistence intentionally keep refusing partial folds, stated explicitly above).

## Additional context

state_fingerprint excludes the projection-bookkeeping fields: they describe how the log was read, not what the state says, so excluding them keeps put_version's fingerprint dedup stable across the upgrade, and a degraded prefix-state genuinely is the same task content as its healthy counterpart, which is exactly why the INVALID marker lives outside the hashed payload (covered by test_degraded_folds_content_address_like_their_prefix). Review round two showed that reasoning had to apply everywhere durability touches those fields, not just the fingerprint: StateCheckpoint.content() now excludes them from the integrity hash and all four storage write sites omit them from persisted bodies, with cross-version tests pinning serialised fixtures because no same-process round-trip can catch this class of break. compact --force still refuses an unprojectable run ("could not be anchored") by design: anchoring writes a storage boundary, and archiving past a break belongs with the repair command, not with a partial-fold anchor. One honest wrinkle visible in resume JSON on a poisoned run: next_allowed_action may name an unrelated repair step such as revalidate_dependency:dataset, because the planner works from the last-good validation; the projection break itself is carried in the contract reason and the rationale, and there is deliberately no auto-generated fix action for it until option 2 exists.

Closes #383


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful handling for event logs that cannot be fully projected.
  * CLI inspection, status, replay, serving, and recovery flows now report the last valid state with detailed failure information.
  * Recovery identifies the affected event and requests human intervention with repair guidance.
  * Contracts and dashboards no longer suggest continuing when recovery is unsafe.

* **Bug Fixes**
  * Preserved existing error behavior for authoritative operations and logs without a valid prefix.
  * Healthy and compacted runs continue to behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
