### PR TITLE
[#390] authorization-bound budget registry schema

### DIFF
--- a/src/continuum/budgets.py
+++ b/src/continuum/budgets.py
@@ -22,6 +22,19 @@ in, but what it caps is repetition of one operation. Counting per type made
 distinct work compete for the same allowance: three different recipients each
 failing once, with no retry anywhere, exhausted a budget of three and blocked a
 fourth that had never been attempted.
+
+Authorization-bound budgets (issue #411) add an optional section keyed by
+``(action_type, authorization_id)``, giving one logical authorization a durable
+monotonic counter however many fresh idempotency keys get minted for it (epic
+#390):
+
+    {"authorization_bound": {"send_invoice":
+         {"authz:stripe-cust-1": {"counter": 2, "max_attempts": 5}}}}
+
+Configs written before the section existed load unchanged and read as unbound,
+which is exactly today's behaviour. ``get_remaining``, ``increment`` and
+``would_refuse`` read and maintain entries purely; ``save_budgets`` persists
+them. Nothing gates on the section yet (that wiring lands with issue #413).
 """
 
 from __future__ import annotations
@@ -33,15 +46,23 @@ from typing import Any
 
 __all__ = [
     "DEFAULT_BUDGETS_PATH",
+    "AUTHORIZATION_BOUND_KEY",
     "attempts_by_key",
     "attempts_for_type",
     "BudgetConfigError",
     "load_budgets",
+    "save_budgets",
     "evaluate_budget",
     "backoff_delay",
+    "get_remaining",
+    "increment",
+    "would_refuse",
 ]
 
 DEFAULT_BUDGETS_PATH = ".continuum/budgets.json"
+
+#: Registry key of the optional section keyed by (action_type, authorization_id).
+AUTHORIZATION_BOUND_KEY = "authorization_bound"
 
 #: Fallback when neither the action type nor the registry sets a limit.
 FALLBACK_MAX_ATTEMPTS = 3
@@ -81,6 +102,7 @@ def load_budgets(path: Path) -> dict[str, Any]:
     default_max = raw.get("default_max_attempts")
     if default_max is not None and (not isinstance(default_max, int) or default_max < 1):
         raise BudgetConfigError(f"{location}: 'default_max_attempts' must be >= 1")
+    _validate_authorization_bound(raw, location)
     return raw
 
 
@@ -176,3 +198,122 @@ def backoff_delay(
     if attempt < 1:
         raise ValueError(f"attempt must be >= 1, got {attempt}")
     return float(min(base * (2 ** (attempt - 1)), cap))
+
+
+# --- authorization-bound budgets (issue #411) --------------------------------------- #
+
+
+def _validate_authorization_bound(raw: Mapping[str, Any], location: Path) -> None:
+    """Shape-check the optional authorization-bound section of a loaded registry.
+
+    Absent means unbound, which is valid: configs without authorization data
+    must keep loading exactly as they always did (epic #390).
+    """
+    section = raw.get(AUTHORIZATION_BOUND_KEY)
+    if section is None:
+        return
+    if not isinstance(section, dict):
+        raise BudgetConfigError(f"{location}: '{AUTHORIZATION_BOUND_KEY}' must be an object")
+    for action_type, entries in section.items():
+        if not isinstance(entries, dict):
+            raise BudgetConfigError(
+                f"{location}: authorization-bound entries for {action_type!r} must be an object"
+            )
+        for authorization_id, entry in entries.items():
+            label = f"{location}: authorization-bound entry {action_type!r}/{authorization_id!r}"
+            if not isinstance(entry, dict):
+                raise BudgetConfigError(f"{label} must be an object")
+            counter = entry.get("counter", 0)
+            if not isinstance(counter, int) or counter < 0:
+                raise BudgetConfigError(f"{label} needs a non-negative integer 'counter'")
+            max_attempts = entry.get("max_attempts")
+            if not isinstance(max_attempts, int) or max_attempts < 1:
+                raise BudgetConfigError(f"{label} needs a positive integer 'max_attempts'")
+
+
+def save_budgets(path: Path, data: Mapping[str, Any]) -> None:
+    """Write ``data`` back to the registry as readable JSON.
+
+    Insertion order is preserved so editing one entry does not churn the whole
+    file, and the trailing newline matches how hand-maintained registries end.
+    Keys the loader does not know pass through untouched, exactly as when the
+    file is edited by hand.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _bound_entry(
+    raw: Mapping[str, Any],
+    action_type: str,
+    authorization_id: str,
+) -> dict[str, Any]:
+    """The registry's entry for one authorization; KeyError names a missing one."""
+    section = raw.get(AUTHORIZATION_BOUND_KEY)
+    entries = section.get(action_type, {}) if isinstance(section, dict) else {}
+    entry = entries.get(authorization_id) if isinstance(entries, dict) else None
+    if not isinstance(entry, dict):
+        raise KeyError(f"no authorization-bound budget for {action_type!r} / {authorization_id!r}")
+    return entry
+
+
+def get_remaining(
+    raw: Mapping[str, Any],
+    action_type: str,
+    authorization_id: str,
+) -> int | None:
+    """Attempts still available to this authorization, or ``None`` when unbound.
+
+    Pure: it reads only the mapping :func:`load_budgets` returned. An absent
+    section reads as unbound, which keeps runs without authorization data on
+    today's behaviour (epic #390).
+    """
+    try:
+        entry = _bound_entry(raw, action_type, authorization_id)
+    except KeyError:
+        return None
+    used = int(entry.get("counter", 0))
+    return max(0, int(entry["max_attempts"]) - used)
+
+
+def increment(
+    raw: Mapping[str, Any],
+    action_type: str,
+    authorization_id: str,
+) -> int:
+    """Count one more attempt against the authorization, return what remains.
+
+    Mutates ``raw`` in place; the counter only ever climbs, and persisting the
+    change is the caller's job (:func:`save_budgets`). An authorization the
+    registry does not know raises KeyError rather than receiving an invented
+    cap, because guessing a limit the operator never set is how budgets stop
+    meaning anything.
+    """
+    entry = _bound_entry(raw, action_type, authorization_id)
+    entry["counter"] = int(entry.get("counter", 0)) + 1
+    return max(0, int(entry["max_attempts"]) - int(entry["counter"]))
+
+
+def would_refuse(
+    raw: Mapping[str, Any],
+    action_type: str,
+    authorization_id: str,
+) -> tuple[bool, str]:
+    """Whether one more attempt under this authorization would be refused.
+
+    Returns ``(refused, reason)``. Unbound authorizations never refuse here,
+    matching today's behaviour; exhausted ones refuse with a reason naming the
+    action type, the authorization id and both figures, so a caller can say
+    exactly what ran out.
+    """
+    label = f"{action_type!r} / {authorization_id!r}"
+    try:
+        entry = _bound_entry(raw, action_type, authorization_id)
+    except KeyError:
+        return False, f"no authorization-bound budget for {label}"
+    used = int(entry.get("counter", 0))
+    maximum = int(entry["max_attempts"])
+    if used >= maximum:
+        detail = f"{label} exhausted its authorization-bound budget"
+        return True, f"{detail} ({used} of {maximum} attempts used)"
+    return False, f"{label} has {maximum - used} of {maximum} attempts remaining"

--- a/tests/test_retry_budgets.py
+++ b/tests/test_retry_budgets.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import io
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -20,7 +21,11 @@ from continuum.budgets import (
     attempts_for_type,
     backoff_delay,
     evaluate_budget,
+    get_remaining,
+    increment,
     load_budgets,
+    save_budgets,
+    would_refuse,
 )
 from continuum.cli import ExitCode, main
 from continuum.events import EventType
@@ -62,6 +67,200 @@ def test_nonpositive_limits_are_refused(tmp_path: Path) -> None:
     p.write_text(json.dumps({"action_types": {"x": 0}}))
     with pytest.raises(BudgetConfigError, match="positive"):
         load_budgets(p)
+
+
+# --- authorization-bound registry (issue #411) --------------------------------------- #
+
+
+def bound_registry() -> dict[str, Any]:
+    """Hand-built registry shape, so pure-helper tests need no filesystem."""
+    return {
+        "default_max_attempts": 3,
+        "action_types": {"send_invoice": {"max_attempts": 5}},
+        "authorization_bound": {
+            "send_invoice": {
+                "authz:stripe-cust-1": {"counter": 2, "max_attempts": 5},
+                "authz:stripe-cust-2": {"counter": 5, "max_attempts": 5},
+            },
+        },
+    }
+
+
+def test_authorization_bound_section_round_trips(tmp_path: Path) -> None:
+    """save then load reproduces the registry with the section intact."""
+    reg = bound_registry()
+    p = tmp_path / "budgets.json"
+    save_budgets(p, reg)
+    assert load_budgets(p) == reg
+
+
+def test_increment_then_save_round_trips(tmp_path: Path) -> None:
+    """The mutate-then-persist cycle #413 will use keeps counters durable."""
+    raw = bound_registry()
+    assert increment(raw, "send_invoice", "authz:stripe-cust-1") == 2
+    p = tmp_path / "budgets.json"
+    save_budgets(p, raw)
+    reloaded = load_budgets(p)
+    assert get_remaining(reloaded, "send_invoice", "authz:stripe-cust-1") == 2
+
+
+def test_save_preserves_keys_the_loader_does_not_know(tmp_path: Path) -> None:
+    """Unknown keys pass through today; saving must not drop them either."""
+    body: dict[str, Any] = {"future_section": {"anything": [1, 2]}, "default_max_attempts": 2}
+    p = tmp_path / "budgets.json"
+    save_budgets(p, body)
+    assert load_budgets(p) == body
+
+
+def test_registry_without_the_section_loads_unchanged(tmp_path: Path) -> None:
+    """Old configs gain nothing and lose nothing on load (epic #390)."""
+    body: dict[str, Any] = {"default_max_attempts": 3, "action_types": {"x": 2}}
+    p = tmp_path / "budgets.json"
+    save_budgets(p, body)
+    loaded = load_budgets(p)
+    assert loaded == body
+    assert "authorization_bound" not in loaded
+
+
+def test_absent_section_is_a_noop_for_reads_and_refusal_checks() -> None:
+    """No section means unbound: reads answer None and nothing refuses."""
+    raw: dict[str, Any] = {"default_max_attempts": 3}
+    assert get_remaining(raw, "send_invoice", "authz-1") is None
+    refused, reason = would_refuse(raw, "send_invoice", "authz-1")
+    assert refused is False
+    assert "authz-1" in reason
+
+
+@pytest.mark.parametrize(
+    ("section", "fragment"),
+    [
+        pytest.param([], "must be an object", id="section-not-an-object"),
+        pytest.param(
+            {"deploy": []},
+            "entries for 'deploy' must be an object",
+            id="type-level-not-an-object",
+        ),
+        pytest.param(
+            {"deploy": {"k": "nope"}},
+            "'deploy'/'k' must be an object",
+            id="entry-not-an-object",
+        ),
+        pytest.param(
+            {"deploy": {"k": {"counter": -1, "max_attempts": 2}}},
+            "needs a non-negative integer 'counter'",
+            id="negative-counter",
+        ),
+        pytest.param(
+            {"deploy": {"k": {"counter": "0", "max_attempts": 2}}},
+            "needs a non-negative integer 'counter'",
+            id="counter-not-an-int",
+        ),
+        pytest.param(
+            {"deploy": {"k": {"counter": 0}}},
+            "needs a positive integer 'max_attempts'",
+            id="max-missing",
+        ),
+        pytest.param(
+            {"deploy": {"k": {"counter": 0, "max_attempts": 0}}},
+            "needs a positive integer 'max_attempts'",
+            id="zero-max",
+        ),
+    ],
+)
+def test_malformed_sections_raise_like_the_rest_of_the_file(
+    tmp_path: Path, section: object, fragment: str
+) -> None:
+    """A bad authorization-bound entry is a malformed registry, same contract."""
+    p = tmp_path / "budgets.json"
+    p.write_text(json.dumps({"default_max_attempts": 3, "authorization_bound": section}))
+    with pytest.raises(BudgetConfigError, match=fragment):
+        load_budgets(p)
+
+
+def test_section_error_names_the_file(tmp_path: Path) -> None:
+    """Messages point at an absolute path the operator can open, as elsewhere."""
+    p = tmp_path / "budgets.json"
+    p.write_text(json.dumps({"authorization_bound": []}))
+    with pytest.raises(BudgetConfigError) as excinfo:
+        load_budgets(p)
+    assert str(excinfo.value) == f"{p.resolve()}: 'authorization_bound' must be an object"
+
+
+def test_old_malformations_keep_their_exact_message(tmp_path: Path) -> None:
+    """Pre-existing failures win: the classic message survives byte for byte."""
+    body = {
+        "action_types": {"x": 0},
+        "authorization_bound": {
+            "send_invoice": {"a": {"counter": -1, "max_attempts": 1}},
+        },
+    }
+    p = tmp_path / "b.json"
+    p.write_text(json.dumps(body))
+    with pytest.raises(BudgetConfigError) as excinfo:
+        load_budgets(p)
+    assert str(excinfo.value) == (
+        f"{tmp_path / 'b.json'}: action type 'x' needs a positive integer 'max_attempts'"
+    )
+
+
+def test_get_remaining_and_refusal_math() -> None:
+    """Remaining is max minus counter; refusals name the type, id and figures."""
+    raw = bound_registry()
+    assert get_remaining(raw, "send_invoice", "authz:stripe-cust-1") == 3
+    refused, reason = would_refuse(raw, "send_invoice", "authz:stripe-cust-1")
+    assert refused is False
+    assert "3 of 5" in reason
+    refused, reason = would_refuse(raw, "send_invoice", "authz:stripe-cust-2")
+    assert refused is True
+    assert "authz:stripe-cust-2" in reason
+    assert "5 of 5" in reason
+
+
+def test_increment_counts_monotonically_and_returns_remaining() -> None:
+    """The counter only climbs; past the cap remaining floors at zero."""
+    raw = bound_registry()
+    entry = raw["authorization_bound"]["send_invoice"]["authz:stripe-cust-1"]
+    assert increment(raw, "send_invoice", "authz:stripe-cust-1") == 2
+    assert entry["counter"] == 3
+    assert increment(raw, "send_invoice", "authz:stripe-cust-2") == 0
+    assert increment(raw, "send_invoice", "authz:stripe-cust-2") == 0
+    assert raw["authorization_bound"]["send_invoice"]["authz:stripe-cust-2"]["counter"] == 7
+
+
+def test_increment_without_an_entry_raises_rather_than_inventing_a_cap() -> None:
+    """No entry, no limit to enforce: KeyError beats a silently guessed one."""
+    raw = bound_registry()
+    with pytest.raises(KeyError, match="charge_card"):
+        increment(raw, "charge_card", "authz-9")
+
+
+def test_missing_entry_reads_as_unbound_not_refused() -> None:
+    """One unknown authorization must not be treated as an exhausted one."""
+    raw = bound_registry()
+    assert get_remaining(raw, "send_invoice", "authz-absent") is None
+    refused, _ = would_refuse(raw, "send_invoice", "authz-absent")
+    assert refused is False
+
+
+def test_zero_max_refuses_at_once_and_still_counts() -> None:
+    """A zero allowance refuses immediately; increments stay monotonic."""
+    raw: dict[str, Any] = {
+        "authorization_bound": {"deploy": {"k": {"counter": 0, "max_attempts": 0}}}
+    }
+    refused, reason = would_refuse(raw, "deploy", "k")
+    assert refused is True
+    assert "0 of 0" in reason
+    assert get_remaining(raw, "deploy", "k") == 0
+    assert increment(raw, "deploy", "k") == 0
+    assert raw["authorization_bound"]["deploy"]["k"]["counter"] == 1
+
+
+def test_distinct_authorizations_keep_independent_counters() -> None:
+    """Drawing down one authorization leaves its neighbours untouched."""
+    raw = bound_registry()
+    increment(raw, "send_invoice", "authz:stripe-cust-1")
+    assert get_remaining(raw, "send_invoice", "authz:stripe-cust-1") == 2
+    assert get_remaining(raw, "send_invoice", "authz:stripe-cust-2") == 0
 
 
 # --- counting + evaluation -------------------------------------------------------- #


### PR DESCRIPTION
## Description

Authorization-bound budgets get a durable home in the registry before any behaviour binds to them (epic #390). `.continuum/budgets.json` gains an optional `authorization_bound` section keyed by `(action_type, authorization_id)`, each entry holding a monotonic `counter` plus its `max_attempts`:

```json
{"authorization_bound": {"send_invoice": {"authz:stripe-cust-1": {"counter": 2, "max_attempts": 5}}}}
```

The change is purely additive (340 insertions, 0 deletions):

- `load_budgets` shape-checks the new section when present. An absent section loads as empty and old configs load unchanged; every pre-existing failure keeps its exact error type and message.
- New `save_budgets` writes the registry back as readable JSON, preserving key order and unknown keys.
- Pure helpers `get_remaining`, `increment` and `would_refuse` read and maintain entries over the loaded mapping with no I/O beyond it. `increment` raises KeyError for unknown authorizations rather than inventing a cap.

Nothing gates on the section yet; the claim-path wiring lands with #413.

## Related issues

Refs #411. Parent epic #390. Follow-up work: #412 (identity resolution), #413 (drawdown wiring).

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

Environment: macOS, Python 3.14.5, local `.venv`.

- `pytest`: 1475 passed, 23 skipped (untouched suite stays green)
- `ruff check src/ tests/ examples/`: All checks passed
- `ruff format --check src/ tests/ examples/`: 218 files already formatted
- `mypy src/continuum`: Success: no issues found in 104 source files
- Regression evidence: on the pre-change code, a file with a malformed `authorization_bound` section loads silently (`load_budgets` returned the dict, no error); after the change the same file raises `BudgetConfigError`. The 15 new tests fail at import on pre-change code since the helpers do not exist there.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour (module docstring documents the schema). CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Design tradeoff: entries are nested `action_type -> authorization_id -> entry` rather than a flat composite string key, so authorization ids containing separators cannot collide. Counter defaults to 0 when absent; `max_attempts` must be a positive integer, mirroring the existing `action_types` validation. Incrementing an unknown authorization refuses loudly instead of defaulting to the type cap, because guessing a limit the operator never set would weaken the budget guarantee.