### PR TITLE
[#389] pure precondition derivation over event prefixes

### DIFF
--- a/src/continuum/recovery/__init__.py
+++ b/src/continuum/recovery/__init__.py
@@ -22,6 +22,14 @@ from continuum.recovery.ledger import (
 )
 from continuum.recovery.limits import RecoveryTimeoutError, run_with_limits
 from continuum.recovery.planner import RepairKind, RepairPlan, RepairStep, plan_repairs
+from continuum.recovery.preconditions import (
+    DependedResult,
+    DerivationResult,
+    EditPoint,
+    UncertainSlot,
+    UnsettledAuthorization,
+    derive,
+)
 
 __all__ = [
     "RecoveryTimeoutError",
@@ -29,6 +37,9 @@ __all__ = [
     "run_with_limits",
     "SEVERITY",
     "DependencyGraph",
+    "DependedResult",
+    "DerivationResult",
+    "EditPoint",
     "FileLedgerBackend",
     "ImpactedSet",
     "LedgerBackend",
@@ -44,7 +55,10 @@ __all__ = [
     "RepairKind",
     "RepairPlan",
     "RepairStep",
+    "UncertainSlot",
+    "UnsettledAuthorization",
     "build_contract",
+    "derive",
     "plan_repairs",
     "render_contract",
     "seal_contract",

--- a/src/continuum/recovery/preconditions.py
+++ b/src/continuum/recovery/preconditions.py
@@ -274,7 +274,12 @@ def derive(storage: Storage, edit_point: EditPoint) -> DerivationResult:
             )
             watched.pop(current_key, None)
             updated = slots[current_key]
-            if in_span(updated.first_seq) and updated.action.status is ActionStatus.COMPLETED:
+            # Membership is judged at the completion, the event that creates
+            # the risk: an action claimed before the anchor but completed
+            # inside the span loses its completion to the edit, so a surviving
+            # step referencing its result is stranded exactly as much as one
+            # whose whole lifecycle sat inside the span.
+            if in_span(event.sequence) and updated.action.status is ActionStatus.COMPLETED:
                 watched[current_key] = DependedResult(
                     key=current_key,
                     action_id=updated.action.action_id,

--- a/src/continuum/recovery/preconditions.py
+++ b/src/continuum/recovery/preconditions.py
@@ -1,0 +1,303 @@
+"""Pure precondition derivation over event prefixes (issue #406, epic #389).
+
+Before fork, restore or merge executes, something has to answer one question:
+what does this edit have to account for? This module derives that answer from
+the run record alone. It is a read-only fold in the same family as
+``state.semantic.project``, held to the same two properties and tested for
+them:
+
+**Purity.** Storage is only ever read (the archived and live event streams,
+plus the run row's existence). There are no writes, no mode changes and no
+clock reads here, because a derivation that nudged the world while inspecting
+it could not be trusted at the decision points (#407, #408) that consume it.
+
+**Determinism.** The same prefix always yields an equal result. Nothing reads
+wall-clock time, iterates unordered storage state without sorting, or consults
+anything outside the events at or before the candidate point.
+
+What is derived
+---------------
+
+Three sets, every item carrying the sequence number of the event that asserts
+the fact the item reports:
+
+* ``unsettled_authorizations``: approvals granted inside the span and never
+  revoked through the candidate point. These are live permissions that would
+  silently carry into a new branch, so the same effect could be authorized
+  twice across the two halves of the edit.
+* ``depended_results``: actions completed inside the span whose recorded
+  outcome a surviving later step still references, by ledger key or action id.
+  An edit that discards such a completion strands the step waiting on it.
+* ``uncertain_slots``: ledger slots opened inside the span still holding an
+  unresolved outcome (``STARTED`` or ``UNKNOWN``, matching
+  ``ActionLedger.pending()``) at the candidate point. The outside world may or
+  may not have been changed; no branch may be cut across that doubt.
+
+Scope rules
+-----------
+
+The span reported on is the half-open range ``(anchor_sequence,
+candidate_sequence]``. Facts at or before the anchor survive any edit between
+the two points intact, so they are not the edit's to account for. Everything
+after the candidate is presumed rewritten by the edit and is invisible here:
+settlement is honoured only up to the candidate, so a revocation or
+reconciliation recorded after the proposed edit point cannot settle anything
+inside the span.
+
+Each set qualifies by its own characteristic event lying in the span: the
+grant for authorizations, the completion for depended results, the slot's
+opening record for uncertain slots. Membership is deliberately judged at the
+event that creates the risk, not at later restatements of it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from heapq import merge
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from continuum.events import Event, EventType
+from continuum.models import Action, ActionStatus
+from continuum.storage.base import Storage
+
+__all__ = [
+    "DependedResult",
+    "DerivationResult",
+    "EditPoint",
+    "UncertainSlot",
+    "UnsettledAuthorization",
+    "derive",
+]
+
+_ACTION_EVENT_TYPES = frozenset(
+    {
+        EventType.ACTION_RECORDED,
+        EventType.ACTION_RECONCILED,
+        EventType.ACTION_COMPENSATED,
+    }
+)
+
+#: Statuses whose real-world outcome is not known. Deliberately the same pair
+#: ``ActionLedger.pending()`` reports, so the derivation and the ledger can
+#: never disagree about what counts as outstanding.
+_OPEN_SLOT_STATUSES = (ActionStatus.STARTED, ActionStatus.UNKNOWN)
+
+
+class EditPoint(BaseModel):
+    """Where an execution edit sits on a run's timeline.
+
+    ``anchor_sequence`` is the point the edit is anchored to (a restore
+    target, a divergence base); ``candidate_sequence`` is the proposed edit
+    point. Sequences start at 1 per run, so 0 means "before anything".
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    run_id: str = Field(min_length=1)
+    anchor_sequence: int = Field(ge=0)
+    candidate_sequence: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _ordered(self) -> EditPoint:
+        if self.candidate_sequence < self.anchor_sequence:
+            raise ValueError(
+                f"candidate_sequence ({self.candidate_sequence}) is before "
+                f"anchor_sequence ({self.anchor_sequence}); the derivation span "
+                f"would be inverted"
+            )
+        return self
+
+
+class UnsettledAuthorization(BaseModel):
+    """An approval granted inside the span and not revoked at the candidate."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    approval_id: str
+    subject: str
+    """What was approved, as recorded on the grant (empty if never stated)."""
+
+    sequence: int
+    """Sequence of the ``APPROVAL_GRANTED`` event."""
+
+
+class DependedResult(BaseModel):
+    """A completed action whose recorded outcome a later step references."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    key: str
+    action_id: str
+    action_type: str
+    sequence: int
+    """Sequence of the ``ACTION_*`` event asserting the completion."""
+
+
+class UncertainSlot(BaseModel):
+    """A ledger slot opened inside the span whose outcome is still open."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    key: str
+    action_id: str
+    action_type: str
+    status: str
+    sequence: int
+    """Sequence of the ``ACTION_*`` event asserting the open status."""
+
+
+class DerivationResult(BaseModel):
+    """Everything an edit between the two points must account for.
+
+    Empty sets mean the edit crosses nothing outstanding; they do not mean the
+    edit is safe. Judging safety from these sets is the consumer's job
+    (#407/#408), not this module's.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    unsettled_authorizations: frozenset[UnsettledAuthorization] = Field(default_factory=frozenset)
+    depended_results: frozenset[DependedResult] = Field(default_factory=frozenset)
+    uncertain_slots: frozenset[UncertainSlot] = Field(default_factory=frozenset)
+
+
+@dataclass(slots=True)
+class _SlotTrack:
+    """Working state for one ledger key while folding the prefix."""
+
+    first_seq: int
+    latest_seq: int
+    action: Action
+
+
+def _payload_strings(payload: Mapping[str, Any]) -> frozenset[str]:
+    """Every string value reachable in a JSON-native event payload.
+
+    Whole-string equality only: identifiers are atomic tokens, and substring
+    matching would manufacture dependencies out of prose that merely contains
+    an id-shaped fragment. Non-string scalars cannot name an action or an
+    approval and are skipped.
+    """
+    found: set[str] = set()
+    stack: list[Any] = [payload]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, Mapping):
+            stack.extend(current.values())
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+        elif isinstance(current, str):
+            found.add(current)
+    return frozenset(found)
+
+
+def derive(storage: Storage, edit_point: EditPoint) -> DerivationResult:
+    """Derive what an edit between the anchor and the candidate must account for.
+
+    Single pass over the run's merged event prefix (archived stream first, then
+    live, both already sequence-sorted), stopping at ``candidate_sequence``.
+    Reads storage; never writes, never changes modes, never reads the clock.
+
+    Raises ``RunNotFound`` for a run the store does not know: a phantom run
+    would derive empty sets and read as "nothing to account for", which is a
+    guess in favour of proceeding and is refused here instead.
+    """
+    run_id = edit_point.run_id
+    anchor = edit_point.anchor_sequence
+    candidate = edit_point.candidate_sequence
+
+    # Existence check, not state use: see the docstring. A run whose events
+    # have all been archived still has its run row and derives correctly.
+    storage.get_run(run_id)
+
+    def in_span(sequence: int) -> bool:
+        return anchor < sequence <= candidate
+
+    # approval_id -> (sequence of the grant, subject). A revocation removes
+    # the entry; a re-grant after a revocation re-enters with the new sequence.
+    granted: dict[str, tuple[int, str]] = {}
+    slots: dict[str, _SlotTrack] = {}
+    # Ledger key -> result item awaiting a surviving reference. Entries enter
+    # on completion and leave on any later record for the same key, so the
+    # newest status always decides.
+    watched: dict[str, DependedResult] = {}
+    depended: set[DependedResult] = set()
+
+    stream: Iterator[Event] = merge(
+        storage.read_archived_events(run_id),
+        storage.read_events(run_id),
+        key=lambda event: event.sequence,
+    )
+    for event in stream:
+        if event.sequence > candidate:
+            break
+
+        strings = _payload_strings(event.payload)
+        current_key: str | None = None
+        if event.type in _ACTION_EVENT_TYPES:
+            raw_key = event.payload.get("key")
+            current_key = str(raw_key) if raw_key else None
+
+        # References are matched against the watch as it stood before this
+        # event, so an action can never be its own dependency and nothing can
+        # depend on a result before it existed. A later record for the same
+        # key (a compensation, a reconcile) is excluded too: settling or
+        # undoing an action is not depending on it.
+        if watched and strings:
+            for key, item in watched.items():
+                if key == current_key:
+                    continue
+                if key in strings or item.action_id in strings:
+                    depended.add(item)
+
+        if event.type is EventType.APPROVAL_GRANTED:
+            approval_id = event.payload.get("approval_id")
+            if approval_id:
+                granted[str(approval_id)] = (
+                    event.sequence,
+                    str(event.payload.get("subject", "")),
+                )
+        elif event.type is EventType.APPROVAL_REVOKED:
+            approval_id = event.payload.get("approval_id")
+            if approval_id:
+                granted.pop(str(approval_id), None)
+        elif current_key is not None:
+            action = Action.model_validate(event.payload["action"])
+            track = slots.get(current_key)
+            slots[current_key] = _SlotTrack(
+                first_seq=track.first_seq if track else event.sequence,
+                latest_seq=event.sequence,
+                action=action,
+            )
+            watched.pop(current_key, None)
+            updated = slots[current_key]
+            if in_span(updated.first_seq) and updated.action.status is ActionStatus.COMPLETED:
+                watched[current_key] = DependedResult(
+                    key=current_key,
+                    action_id=updated.action.action_id,
+                    action_type=updated.action.action_type,
+                    sequence=event.sequence,
+                )
+
+    return DerivationResult(
+        unsettled_authorizations=frozenset(
+            UnsettledAuthorization(approval_id=approval_id, subject=subject, sequence=sequence)
+            for approval_id, (sequence, subject) in granted.items()
+            if in_span(sequence)
+        ),
+        depended_results=frozenset(depended),
+        uncertain_slots=frozenset(
+            UncertainSlot(
+                key=key,
+                action_id=track.action.action_id,
+                action_type=track.action.action_type,
+                status=track.action.status.value,
+                sequence=track.latest_seq,
+            )
+            for key, track in slots.items()
+            if in_span(track.first_seq) and track.action.status in _OPEN_SLOT_STATUSES
+        ),
+    )

--- a/tests/test_edit_preconditions.py
+++ b/tests/test_edit_preconditions.py
@@ -150,6 +150,46 @@ def test_completed_action_referenced_by_a_later_step_is_reported(store: SQLiteSt
     )
 
 
+def test_action_claimed_before_the_anchor_but_completed_inside_the_span_is_reported(
+    store: SQLiteStorage,
+) -> None:
+    """Membership is judged at the completion (#416 review thread, gitar-bot).
+
+    The claim predates the anchor and survives the edit; the completion does
+    not. A surviving step referencing the result would wait on an outcome the
+    edit discarded, so the result belongs in the report even though the slot
+    was opened before the anchor.
+    """
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("mail.send", {"to": "a@example.com"}, key="k1")
+    anchor = store.last_sequence(RUN_ID)
+    ledger.complete(outcome.key, external_id="m1")
+    completed_at = store.last_sequence(RUN_ID)
+    store.append_event(
+        RUN_ID,
+        EventType.WORK_ADDED,
+        {"task_id": "w2", "description": "tell the requester", "prerequisite": [outcome.key]},
+    )
+    result = derive(
+        store,
+        EditPoint(
+            run_id=RUN_ID,
+            anchor_sequence=anchor,
+            candidate_sequence=store.last_sequence(RUN_ID),
+        ),
+    )
+    assert result.depended_results == frozenset(
+        {
+            DependedResult(
+                key=outcome.key,
+                action_id=outcome.action.action_id,
+                action_type="mail.send",
+                sequence=completed_at,
+            )
+        }
+    )
+
+
 def test_action_id_reference_counts_as_a_dependency(store: SQLiteStorage) -> None:
     ledger = ActionLedger(store, RUN_ID)
     outcome = ledger.claim("mail.send", {"to": "a@example.com"}, key="k1")

--- a/tests/test_edit_preconditions.py
+++ b/tests/test_edit_preconditions.py
@@ -1,0 +1,507 @@
+"""Tests for pure precondition derivation over event prefixes (issue #406).
+
+Covers the three derivable sets (unsettled authorizations, depended results,
+uncertain slots), the span semantics ((anchor, candidate], prefix visibility
+stops at the candidate), the empty-range edge, the purity contract (storage is
+only ever read) and the determinism property: identical prefixes derive equal
+results, at every anchor and candidate pair.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from continuum.actions import ActionLedger
+from continuum.events import Event, EventLog, EventType
+from continuum.models import Run
+from continuum.recovery.preconditions import (
+    DependedResult,
+    DerivationResult,
+    EditPoint,
+    UncertainSlot,
+    UnsettledAuthorization,
+    derive,
+)
+from continuum.storage import SQLiteStorage
+from continuum.storage.base import RunNotFound
+
+RUN_ID = "run_1"
+
+
+@pytest.fixture
+def store() -> Iterator[SQLiteStorage]:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id=RUN_ID, goal="g"))
+    storage.append_event(RUN_ID, EventType.RUN_STARTED, {"goal": "g"})
+    yield storage
+    storage.close()
+
+
+def grant(storage: SQLiteStorage, approval_id: str, subject: str = "deploy") -> Event:
+    return storage.append_event(
+        RUN_ID,
+        EventType.APPROVAL_GRANTED,
+        {"approval_id": approval_id, "subject": subject},
+    )
+
+
+def revoke(storage: SQLiteStorage, approval_id: str) -> Event:
+    return storage.append_event(RUN_ID, EventType.APPROVAL_REVOKED, {"approval_id": approval_id})
+
+
+def full_span(storage: SQLiteStorage, *, anchor: int = 1) -> EditPoint:
+    """The span covering everything after ``anchor - 1`` up to the log head."""
+    return EditPoint(
+        run_id=RUN_ID, anchor_sequence=anchor - 1, candidate_sequence=storage.last_sequence(RUN_ID)
+    )
+
+
+# --- edit point validation -------------------------------------------------- #
+
+
+def test_candidate_before_anchor_is_refused() -> None:
+    with pytest.raises(ValidationError):
+        EditPoint(run_id=RUN_ID, anchor_sequence=5, candidate_sequence=4)
+
+
+def test_unknown_run_is_refused(store: SQLiteStorage) -> None:
+    point = EditPoint(run_id="ghost", anchor_sequence=0, candidate_sequence=10)
+    with pytest.raises(RunNotFound):
+        derive(store, point)
+
+
+# --- unsettled authorizations ------------------------------------------------
+
+
+def test_grant_in_range_without_revocation_is_reported(store: SQLiteStorage) -> None:
+    event = grant(store, "ap-1", subject="ship it")
+    result = derive(store, full_span(store))
+    assert result.unsettled_authorizations == frozenset(
+        {UnsettledAuthorization(approval_id="ap-1", subject="ship it", sequence=event.sequence)}
+    )
+
+
+def test_revoked_authorization_is_not_reported(store: SQLiteStorage) -> None:
+    grant(store, "ap-1")
+    revoke(store, "ap-1")
+    result = derive(store, full_span(store))
+    assert result.unsettled_authorizations == frozenset()
+
+
+def test_revocation_after_the_candidate_does_not_settle(store: SQLiteStorage) -> None:
+    granted = grant(store, "ap-1")
+    revoke(store, "ap-1")
+    point = EditPoint(run_id=RUN_ID, anchor_sequence=0, candidate_sequence=granted.sequence)
+    result = derive(store, point)
+    assert {a.approval_id for a in result.unsettled_authorizations} == {"ap-1"}
+
+
+def test_grant_at_or_before_the_anchor_is_not_reported(store: SQLiteStorage) -> None:
+    early = grant(store, "ap-early")
+    grant(store, "ap-late")
+    point = EditPoint(
+        run_id=RUN_ID,
+        anchor_sequence=early.sequence,
+        candidate_sequence=store.last_sequence(RUN_ID),
+    )
+    result = derive(store, point)
+    assert {a.approval_id for a in result.unsettled_authorizations} == {"ap-late"}
+
+
+def test_regrant_after_revocation_carries_the_new_sequence(store: SQLiteStorage) -> None:
+    grant(store, "ap-1")
+    revoke(store, "ap-1")
+    again = grant(store, "ap-1", subject="second time")
+    result = derive(store, full_span(store))
+    assert result.unsettled_authorizations == frozenset(
+        {UnsettledAuthorization(approval_id="ap-1", subject="second time", sequence=again.sequence)}
+    )
+
+
+# --- depended results ---------------------------------------------------------
+
+
+def test_completed_action_referenced_by_a_later_step_is_reported(store: SQLiteStorage) -> None:
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("github.create_issue", {"title": "t"}, key="k1")
+    ledger.complete(outcome.key, external_id="42", result={"issue": 42})
+    completed_at = store.last_sequence(RUN_ID)
+    store.append_event(
+        RUN_ID,
+        EventType.WORK_ADDED,
+        {"task_id": "w1", "description": "notify requester", "prerequisite": [outcome.key]},
+    )
+    result = derive(store, full_span(store))
+    assert result.depended_results == frozenset(
+        {
+            DependedResult(
+                key=outcome.key,
+                action_id=outcome.action.action_id,
+                action_type="github.create_issue",
+                sequence=completed_at,
+            )
+        }
+    )
+
+
+def test_action_id_reference_counts_as_a_dependency(store: SQLiteStorage) -> None:
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("mail.send", {"to": "a@example.com"}, key="k1")
+    ledger.complete(outcome.key, external_id="m1")
+    completed_at = store.last_sequence(RUN_ID)
+    store.append_event(
+        RUN_ID,
+        EventType.DECISION_CREATED,
+        {
+            "decision_id": "d1",
+            "decision": "proceed",
+            "evidence": [outcome.action.action_id],
+        },
+    )
+    result = derive(store, full_span(store))
+    assert {d.sequence for d in result.depended_results} == {completed_at}
+
+
+def test_unreferenced_completion_is_not_reported(store: SQLiteStorage) -> None:
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("github.create_issue", {"title": "t"}, key="k1")
+    ledger.complete(outcome.key, external_id="42")
+    result = derive(store, full_span(store))
+    assert result.depended_results == frozenset()
+    assert result.uncertain_slots == frozenset()
+
+
+def test_compensation_past_the_candidate_does_not_release_the_result(store: SQLiteStorage) -> None:
+    """A compensation recorded past the edit point is presumed rewritten by it."""
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("github.create_issue", {"title": "t"}, key="k1")
+    ledger.complete(outcome.key, external_id="42")
+    store.append_event(
+        RUN_ID,
+        EventType.WORK_ADDED,
+        {"task_id": "w1", "description": "d", "prerequisite": [outcome.key]},
+    )
+    candidate = store.last_sequence(RUN_ID)
+    ledger.compensate(outcome.key, note="undone later")
+    point = EditPoint(run_id=RUN_ID, anchor_sequence=0, candidate_sequence=candidate)
+    assert len(derive(store, point).depended_results) == 1
+
+
+# --- uncertain slots -----------------------------------------------------------
+
+
+def test_claim_never_settled_holds_an_uncertain_slot(store: SQLiteStorage) -> None:
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("slack.notify", {"channel": "#ops"}, key="k1")
+    claimed_at = store.last_sequence(RUN_ID)
+    result = derive(store, full_span(store))
+    assert result.uncertain_slots == frozenset(
+        {
+            UncertainSlot(
+                key=outcome.key,
+                action_id=outcome.action.action_id,
+                action_type="slack.notify",
+                status="started",
+                sequence=claimed_at,
+            )
+        }
+    )
+
+
+def test_uncertain_failure_keeps_the_slot_open_with_the_latest_status(store: SQLiteStorage) -> None:
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("mail.send", {"to": "a@example.com"}, key="k1")
+    ledger.fail(outcome.key, "timeout after send", certain=False)
+    failed_at = store.last_sequence(RUN_ID)
+    result = derive(store, full_span(store))
+    assert len(result.uncertain_slots) == 1
+    slot = next(iter(result.uncertain_slots))
+    assert slot.status == "unknown"
+    assert slot.sequence == failed_at
+
+
+def test_certain_failure_closes_the_slot(store: SQLiteStorage) -> None:
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("mail.send", {"to": "a@example.com"}, key="k1")
+    ledger.fail(outcome.key, "rejected before send", certain=True)
+    result = derive(store, full_span(store))
+    assert result.uncertain_slots == frozenset()
+
+
+def test_slot_opened_before_the_anchor_is_not_reported(store: SQLiteStorage) -> None:
+    ledger = ActionLedger(store, RUN_ID)
+    ledger.claim("slack.notify", {"channel": "#ops"}, key="k-old")
+    anchor = store.last_sequence(RUN_ID)
+    late = ledger.claim("slack.notify", {"channel": "#dev"}, key="k-new")
+    point = EditPoint(
+        run_id=RUN_ID, anchor_sequence=anchor, candidate_sequence=store.last_sequence(RUN_ID)
+    )
+    result = derive(store, point)
+    assert {s.key for s in result.uncertain_slots} == {late.key}
+
+
+# --- span edges -----------------------------------------------------------------
+
+
+def test_empty_range_returns_all_empty_sets(store: SQLiteStorage) -> None:
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("slack.notify", {"channel": "#ops"}, key="k1")
+    grant(store, "ap-1")
+    ledger.complete(outcome.key)
+    store.append_event(
+        RUN_ID,
+        EventType.WORK_ADDED,
+        {"task_id": "w1", "description": "d", "prerequisite": [outcome.key]},
+    )
+    head = store.last_sequence(RUN_ID)
+    point = EditPoint(run_id=RUN_ID, anchor_sequence=head, candidate_sequence=head)
+    assert derive(store, point) == DerivationResult()
+
+
+def test_events_after_the_candidate_are_invisible(store: SQLiteStorage) -> None:
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("github.create_issue", {"title": "t"}, key="k1")
+    ledger.complete(outcome.key)
+    candidate = store.last_sequence(RUN_ID)
+    grant(store, "ap-late")
+    ledger.claim("slack.notify", {"channel": "#ops"}, key="k-late")
+    store.append_event(
+        RUN_ID,
+        EventType.WORK_ADDED,
+        {"task_id": "w1", "description": "d", "prerequisite": [outcome.key]},
+    )
+    point = EditPoint(run_id=RUN_ID, anchor_sequence=0, candidate_sequence=candidate)
+    result = derive(store, point)
+    assert result == DerivationResult()
+
+
+def test_archived_events_inside_the_span_are_still_seen(store: SQLiteStorage) -> None:
+    ledger = ActionLedger(store, RUN_ID)
+    outcome = ledger.claim("github.create_issue", {"title": "t"}, key="k1")
+    ledger.complete(outcome.key)
+    compacted_through = store.last_sequence(RUN_ID)
+    store.append_event(
+        RUN_ID,
+        EventType.WORK_ADDED,
+        {"task_id": "w1", "description": "d", "prerequisite": [outcome.key]},
+    )
+    grant(store, "ap-1")
+    store.compact_run(RUN_ID, through_sequence=compacted_through)
+    result = derive(store, full_span(store))
+    assert {d.key for d in result.depended_results} == {outcome.key}
+    assert {a.approval_id for a in result.unsettled_authorizations} == {"ap-1"}
+
+
+# --- purity -----------------------------------------------------------------------
+
+
+class _RecordingStorage(SQLiteStorage):
+    """SQLite storage that records every method the derivation touches."""
+
+    def __init__(self) -> None:
+        super().__init__(":memory:")
+        self.calls: list[str] = []
+
+    def _note(self, name: str) -> None:
+        self.calls.append(name)
+
+    # readers
+    def get_run(self, run_id: str) -> Run:
+        self._note("get_run")
+        return super().get_run(run_id)
+
+    def read_events(self, run_id: str, *, after_sequence: int = 0, upto: int | None = None) -> Any:
+        self._note("read_events")
+        return super().read_events(run_id, after_sequence=after_sequence, upto=upto)
+
+    def read_archived_events(self, run_id: str) -> Any:
+        self._note("read_archived_events")
+        return super().read_archived_events(run_id)
+
+    # mutators
+    def append_event(self, *args: Any, **kwargs: Any) -> Any:
+        self._note("append_event")
+        return super().append_event(*args, **kwargs)
+
+    def append_sealed(self, event: Event) -> Any:
+        self._note("append_sealed")
+        return super().append_sealed(event)
+
+    def extend_events(self, events: Iterable[Event]) -> int:
+        self._note("extend_events")
+        return super().extend_events(events)
+
+    def put_version(self, *args: Any, **kwargs: Any) -> Any:
+        self._note("put_version")
+        return super().put_version(*args, **kwargs)
+
+    def put_checkpoint(self, *args: Any, **kwargs: Any) -> Any:
+        self._note("put_checkpoint")
+        return super().put_checkpoint(*args, **kwargs)
+
+    def delete_checkpoint(self, *args: Any, **kwargs: Any) -> Any:
+        self._note("delete_checkpoint")
+        return super().delete_checkpoint(*args, **kwargs)
+
+    def compact_run(self, *args: Any, **kwargs: Any) -> Any:
+        self._note("compact_run")
+        return super().compact_run(*args, **kwargs)
+
+    def create_run(self, *args: Any, **kwargs: Any) -> Any:
+        self._note("create_run")
+        return super().create_run(*args, **kwargs)
+
+    def create_run_started(self, *args: Any, **kwargs: Any) -> Any:
+        self._note("create_run_started")
+        return super().create_run_started(*args, **kwargs)
+
+    def update_run(self, *args: Any, **kwargs: Any) -> Any:
+        self._note("update_run")
+        return super().update_run(*args, **kwargs)
+
+
+def test_derive_only_reads_storage() -> None:
+    storage = _RecordingStorage()
+    try:
+        storage.create_run(Run(run_id=RUN_ID, goal="g"))
+        storage.append_event(RUN_ID, EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(storage, RUN_ID)
+        outcome = ledger.claim("slack.notify", {"channel": "#ops"}, key="k1")
+        grant(storage, "ap-1")
+        ledger.complete(outcome.key)
+        storage.append_event(
+            RUN_ID,
+            EventType.WORK_ADDED,
+            {"task_id": "w1", "description": "d", "prerequisite": [outcome.key]},
+        )
+        storage.calls.clear()
+
+        point = EditPoint(
+            run_id=RUN_ID, anchor_sequence=0, candidate_sequence=storage.last_sequence(RUN_ID)
+        )
+        derive(storage, point)
+
+        assert set(storage.calls) <= {"get_run", "read_events", "read_archived_events"}
+    finally:
+        storage.close()
+
+
+# --- determinism property ------------------------------------------------------------
+
+
+def _action_payload(
+    key: str, action_id: str, action_type: str, status: str, n: int
+) -> dict[str, Any]:
+    action = {
+        "run_id": RUN_ID,
+        "action_id": action_id,
+        "action_type": action_type,
+        "status": status,
+        "arguments": {"n": str(n)},
+    }
+    return {
+        "key": key,
+        "action_id": action_id,
+        "action_type": action_type,
+        "status": status,
+        "action": action,
+    }
+
+
+def _build_events(ops: list[tuple[Any, ...]]) -> tuple[Event, ...]:
+    """Fold an operation script into one concrete, sealed event prefix."""
+    log = EventLog()
+    log.append(RUN_ID, EventType.RUN_STARTED, {"goal": "property"})
+    claimed: set[int] = set()
+    for op in ops:
+        kind = op[0]
+        n = op[1]
+        if kind == "grant":
+            log.append(
+                RUN_ID,
+                EventType.APPROVAL_GRANTED,
+                {"approval_id": f"ap{n}", "subject": f"s{n}"},
+            )
+        elif kind == "revoke":
+            log.append(RUN_ID, EventType.APPROVAL_REVOKED, {"approval_id": f"ap{n}"})
+        elif kind == "claim":
+            claimed.add(n)
+            log.append(
+                RUN_ID,
+                EventType.ACTION_RECORDED,
+                _action_payload(f"k{n}", f"act{n}", f"type{op[2] % 3}", "started", n),
+            )
+        elif kind == "complete" and n in claimed:
+            log.append(
+                RUN_ID,
+                EventType.ACTION_RECORDED,
+                _action_payload(f"k{n}", f"act{n}", f"type{n % 3}", "completed", n),
+            )
+        elif kind == "abandon" and n in claimed:
+            log.append(
+                RUN_ID,
+                EventType.ACTION_RECORDED,
+                _action_payload(f"k{n}", f"act{n}", f"type{n % 3}", "unknown", n),
+            )
+        elif kind == "depend":
+            log.append(
+                RUN_ID,
+                EventType.WORK_ADDED,
+                {"task_id": f"w{n}-{op[2]}", "description": "step", "prerequisite": [f"k{n}"]},
+            )
+        elif kind == "noise":
+            log.append(
+                RUN_ID,
+                EventType.EVIDENCE_ADDED,
+                {"evidence_id": f"e{n}-{len(log)}", "summary": "nothing"},
+            )
+    return tuple(log.events(RUN_ID))
+
+
+_op = st.integers(0, 2)
+_script = st.lists(
+    st.one_of(
+        st.tuples(st.just("grant"), _op),
+        st.tuples(st.just("revoke"), _op),
+        st.tuples(st.just("claim"), _op, _op),
+        st.tuples(st.just("complete"), _op),
+        st.tuples(st.just("abandon"), _op),
+        st.tuples(st.just("depend"), _op, _op),
+        st.tuples(st.just("noise"), _op),
+    ),
+    max_size=10,
+)
+
+
+def _store_with_prefix(events: tuple[Event, ...]) -> SQLiteStorage:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id=RUN_ID, goal="property"))
+    storage.extend_events(events)
+    return storage
+
+
+@settings(max_examples=25, deadline=None)
+@given(ops=_script)
+def test_identical_prefixes_derive_identically(ops: list[tuple[Any, ...]]) -> None:
+    events = _build_events(ops)
+    left = _store_with_prefix(events)
+    right = _store_with_prefix(events)
+    try:
+        head = len(events)
+        for anchor in range(head + 1):
+            for candidate in range(anchor, head + 1):
+                point = EditPoint(
+                    run_id=RUN_ID, anchor_sequence=anchor, candidate_sequence=candidate
+                )
+                assert derive(left, point) == derive(right, point)
+        point = EditPoint(run_id=RUN_ID, anchor_sequence=0, candidate_sequence=head)
+        assert derive(left, point) == derive(left, point)
+    finally:
+        left.close()
+        right.close()


### PR DESCRIPTION
## Description

Adds a pure, read-only derivation module beside recovery/fork: given an
`EditPoint` (run id, anchor sequence, candidate sequence), `derive(storage,
edit_point)` reports what the edit must account for, as three frozensets whose
items each carry the sequence number of the event asserting their fact:

- `unsettled_authorizations`: approvals granted inside the span and never
  revoked through the candidate point;
- `depended_results`: actions completed inside the span whose ledger key or
  action id a surviving later step still references (whole-string match on
  payload strings);
- `uncertain_slots`: ledger slots opened inside the span still holding
  `STARTED` or `UNKNOWN` at the candidate point, matching
  `ActionLedger.pending()`.

The span is `(anchor_sequence, candidate_sequence]`. Facts at or before the
anchor survive any edit between the two points; everything past the candidate
is presumed rewritten by it, so settlement is honoured only up to the
candidate. An unknown run raises `RunNotFound` rather than deriving empty sets.

Purity contract: one pass over the merged archived and live event streams plus
one run-row read. No writes, no mode changes, no clock reads. Identical
prefixes derive equal results (property-tested over every anchor/candidate
pair). This module only derives; enforcement wiring is #407/#408.

## Related issues

Refs #406, parent epic #389. Enforcement lands in #407 and #408; CLI rendering in #409.

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

pytest tests/test_edit_preconditions.py -q   (20 passed)
pytest -q                                    (1495 passed, 23 skipped)
ruff check src/ tests/ examples/             (clean)
ruff format --check src/ tests/ examples/    (220 files already formatted)
mypy src/continuum                           (Success: no issues found in 105 source files)

Environment: local checkout, Python 3.14.5, pytest 9.1.1, hypothesis 6.165.10.
Tests cover: one fixture per set type with sequence numbers asserted, span
boundary edges, empty-range returning all-empty sets, prefix invisibility past
the candidate, archived events inside the span, a recording storage asserting
derive() calls only get_run/read_events/read_archived_events, inverted-span
validation, unknown-run refusal, and a hypothesis property that identical
prefixes derive identically across independent stores for every anchor and
candidate pair.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Membership rules judge each set by the event that creates its risk (the grant,
the completion, the slot-opening record). Reference matching accepts either
the ledger key or the action_id, since outputs expose action ids to callers
(#367). Approval expiry timestamps are deliberately not consulted: reading the
wall clock would break the determinism contract, so grants are reported as
unsettled until a revocation event says otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery precondition analysis for execution edits.
  * Reports unsettled authorizations, dependencies on completed results, and uncertain action slots.
  * Validates edit points, event history, run boundaries, and archived activity.
  * Exposes recovery analysis results through the public recovery interface.

* **Tests**
  * Added comprehensive coverage for validation, event ordering, boundary conditions, dependencies, authorization changes, and deterministic results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->