### PR TITLE
[#390] deterministic authorization identity from keys or identity tokens

### DIFF
--- a/src/continuum/actions/idempotency.py
+++ b/src/continuum/actions/idempotency.py
@@ -37,6 +37,7 @@ __all__ = [
     "location_tokens",
     "locations_agree",
     "same_location",
+    "resolve_authorization_id",
     "IdempotencyKey",
 ]
 
@@ -415,3 +416,319 @@ def locations_agree(left: frozenset[str], right: frozenset[str]) -> bool:
     if not left or not right:
         return True
     return any(same_location(a, b) for a in left for b in right)
+
+
+# --- authorization identity (issue #412) ----------------------------------------- #
+
+# Extensions accepted as genuine file suffixes for the derivation rule;
+# kept in sync with ``continuum.actions.ledger._KNOWN_SUFFIXES``. A dotted
+# token is only treated as derived from its stem when the extension looks
+# like a real file suffix, so ``alice.smith`` stays distinct from ``alice``
+# while ``INV-001.sent`` collapses to ``INV-001``.
+_KNOWN_AUTHZ_SUFFIXES = frozenset(
+    {
+        "csv",
+        "tsv",
+        "json",
+        "jsonl",
+        "ndjson",
+        "parquet",
+        "pq",
+        "avro",
+        "orc",
+        "xlsx",
+        "xls",
+        "pdf",
+        "txt",
+        "md",
+        "html",
+        "htm",
+        "xml",
+        "yaml",
+        "yml",
+        "toml",
+        "ini",
+        "cfg",
+        "conf",
+        "png",
+        "jpg",
+        "jpeg",
+        "gif",
+        "svg",
+        "webp",
+        "zip",
+        "gz",
+        "tar",
+        "tgz",
+        "bz2",
+        "rar",
+        "7z",
+        "db",
+        "sqlite",
+        "sql",
+        "arrow",
+        "feather",
+        "pkl",
+        "pickle",
+        "bin",
+        "log",
+        "dat",
+        "out",
+        "tmp",
+        "part",
+        "bak",
+        "old",
+        "eml",
+        "msg",
+        "wav",
+        "mp3",
+        "mp4",
+        "mov",
+        "sent",
+    }
+)
+
+
+def _authz_stem(token: str) -> str:
+    stem, _ = os.path.splitext(token)
+    return stem
+
+
+def _authz_superset_derives(subset: frozenset[str], superset: frozenset[str]) -> bool:
+    extra = superset - subset
+    if not extra:
+        return True
+    stems = {_authz_stem(t).lower() for t in subset}
+    for token in extra:
+        stem = _authz_stem(token).lower()
+        if stem not in stems:
+            return False
+        _, ext = os.path.splitext(token)
+        if ext.lstrip(".").lower() not in _KNOWN_AUTHZ_SUFFIXES:
+            return False
+    return True
+
+
+def _canonical_leaf_tokens(tokens: frozenset[str]) -> frozenset[str]:
+    """Collapse derived forms so equivalent renderings hash identically."""
+    if not tokens:
+        return tokens
+    lower_map = {t.lower(): t for t in tokens}
+    stems_lower = {_authz_stem(t).lower() for t in tokens}
+    result: set[str] = set()
+    for token in tokens:
+        stem_lower = _authz_stem(token).lower()
+        if token.lower() != stem_lower and stem_lower in lower_map:
+            _, ext = os.path.splitext(token)
+            if ext.lstrip(".").lower() in _KNOWN_AUTHZ_SUFFIXES:
+                continue
+        result.add(token)
+    if not result:
+        return tokens
+    _ = stems_lower
+    return frozenset(result)
+
+
+def resolve_authorization_id(
+    action_type: str,
+    key: str | None = None,
+    arguments: Mapping[str, Any] | None = None,
+    *,
+    volatile: Iterable[str] = (),
+    ledger: Any | None = None,
+) -> str | None:
+    """Stable identity for budget binding, derived from a key or tokens.
+
+    Deterministic across processes (``stable_hash``) so identical logical
+    operations map to one budget bucket even when callers mint fresh keys.
+
+    Precedence
+    ----------
+    1. Explicit stable key (``key`` is not None): the id is derived directly
+       from ``(action_type, key)``. Arguments are ignored and the same pair
+       always yields the same id on any machine.
+    2. Token fallback (no key, distinctive resource tokens present): the id
+       is derived from the action's resource tokens. When a ledger is
+       supplied, a *unique* completed or interrupted (STARTED/UNKNOWN) match
+       by shared identity tokens anchors the id, reusing the same containment,
+       derivation and location-agreement checks as ``ActionLedger.claim``'s
+       fallback; without a ledger the id is the hash of the canonical leaf
+       tokens of the incoming arguments. Weak tokens (counts, status words,
+       stopwords) never produce an id.
+    3. Unbound (neither key nor distinctive tokens, or an ambiguous
+       multi-match): ``None`` is returned. The caller keeps today's
+       behaviour (no authorization-bound budget) byte-identical.
+
+    Action-type drift is explicitly NOT bridged: the same resource tokens
+    under different ``action_type`` values produce different ids, because
+    different types are different operations. Two identity systems is a bug
+    nursery, so this reuses ``identity_tokens`` / ``leaf_tokens`` /
+    ``location_tokens`` and the stem/suffix derivation rule rather than
+    inventing a new scheme.
+    """
+    if not action_type.strip():
+        raise ValueError("action_type must be a non-empty string")
+    if key is not None:
+        if not key:
+            raise ValueError("explicit idempotency key must be a non-empty string")
+        return stable_hash({"type": action_type, "key": key})
+
+    if ledger is not None:
+        try:
+            resolved = _resolve_via_ledger(action_type, arguments, volatile, ledger)
+            if resolved is not None:
+                return resolved
+            has_any = False
+            try:
+                if hasattr(ledger, "_replay"):
+                    rep = ledger._replay()
+                    has_any = bool(rep)
+                elif hasattr(ledger, "folded"):
+                    rep = ledger.folded()
+                    has_any = bool(rep)
+                elif hasattr(ledger, "all"):
+                    rep = ledger.all()
+                    has_any = bool(rep)
+                else:
+                    has_any = True
+            except Exception:
+                has_any = True
+            if has_any:
+                return None
+        except Exception:
+            pass
+
+    tokens_all = identity_tokens(arguments, volatile=volatile)
+    leaves = leaf_tokens(tokens_all)
+    if not leaves:
+        return None
+    canonical = _canonical_leaf_tokens(leaves)
+    if not canonical:
+        return None
+    return stable_hash({"type": action_type, "tokens": sorted(canonical)})
+
+
+def _resolve_via_ledger(
+    action_type: str,
+    arguments: Mapping[str, Any] | None,
+    volatile: Iterable[str],
+    ledger: Any,
+) -> str | None:
+    """Ledger-anchored derivation: unique completed/interrupted match."""
+    try:
+        from continuum.models import ActionStatus
+    except Exception:
+        return None
+
+    incoming_all = identity_tokens(arguments, volatile=volatile)
+    incoming = leaf_tokens(incoming_all)
+    run_id = getattr(ledger, "run_id", None)
+    if run_id:
+        try:
+            plumbing = leaf_tokens(identity_tokens(external_id=str(run_id)))
+            incoming = incoming - plumbing
+        except Exception:
+            pass
+    incoming_where = location_tokens(incoming_all)
+    if not incoming:
+        return None
+
+    replay: dict[str, Any] | None = None
+    try:
+        if hasattr(ledger, "_replay"):
+            replay = ledger._replay()
+        elif hasattr(ledger, "folded"):
+            replay = ledger.folded()
+        elif hasattr(ledger, "all"):
+            items = ledger.all()
+            replay = {getattr(a, "action_id", str(i)): a for i, a in enumerate(items)}
+        elif isinstance(ledger, Mapping):
+            replay = dict(ledger)
+    except Exception:
+        replay = None
+    if not replay:
+        return None
+
+    completed: list[Any] = []
+    uncertain: list[Any] = []
+
+    for _stored_key, action in replay.items():
+        atype = getattr(action, "action_type", None)
+        if atype is None and isinstance(action, Mapping):
+            atype = action.get("action_type")
+        if atype != action_type:
+            continue
+        args = getattr(action, "arguments", None)
+        if args is None and isinstance(action, Mapping):
+            args = action.get("arguments", {})
+        args = args or {}
+        known_all = identity_tokens(args)
+        known = leaf_tokens(known_all)
+        if run_id:
+            try:
+                plumbing = leaf_tokens(identity_tokens(external_id=str(run_id)))
+                known = known - plumbing
+            except Exception:
+                pass
+        if not known:
+            continue
+        if not locations_agree(incoming_where, location_tokens(known_all)):
+            continue
+        if incoming <= known:
+            if not _authz_superset_derives(incoming, known):
+                continue
+        elif known <= incoming:
+            if not _authz_superset_derives(known, incoming):
+                continue
+        else:
+            continue
+        status = getattr(action, "status", None)
+        if status is None and isinstance(action, Mapping):
+            status = action.get("status")
+        status_val = getattr(status, "value", status)
+        status_str = str(status_val) if status_val is not None else ""
+        try:
+            if status is ActionStatus.COMPLETED:
+                completed.append(action)
+                continue
+            if status in (ActionStatus.STARTED, ActionStatus.UNKNOWN):
+                uncertain.append(action)
+                continue
+            if status_str == ActionStatus.COMPLETED.value:
+                completed.append(action)
+            elif status_str in (ActionStatus.STARTED.value, ActionStatus.UNKNOWN.value):
+                uncertain.append(action)
+        except Exception:
+            if status_str.lower() == "completed":
+                completed.append(action)
+            elif status_str.lower() in ("started", "unknown"):
+                uncertain.append(action)
+
+    target: Any | None = None
+    if len(completed) == 1:
+        target = completed[0]
+    elif len(completed) > 1:
+        return None
+    elif len(uncertain) == 1:
+        target = uncertain[0]
+    else:
+        return None
+
+    args = getattr(target, "arguments", None)
+    if args is None and isinstance(target, Mapping):
+        args = target.get("arguments", {})
+    args = args or {}
+    anchored_all = identity_tokens(args)
+    anchored_leaves = leaf_tokens(anchored_all)
+    if run_id:
+        try:
+            plumbing = leaf_tokens(identity_tokens(external_id=str(run_id)))
+            anchored_leaves = anchored_leaves - plumbing
+        except Exception:
+            pass
+    if not anchored_leaves:
+        return None
+    canonical = _canonical_leaf_tokens(anchored_leaves)
+    if not canonical:
+        return None
+    return stable_hash({"type": action_type, "tokens": sorted(canonical)})

--- a/tests/test_authorization_identity.py
+++ b/tests/test_authorization_identity.py
@@ -1,0 +1,227 @@
+"""Authorization identity (issue #412): stable bucket for budgets.
+
+Reuses the identity-token machinery of idempotency.py; no second scheme.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.actions.idempotency import resolve_authorization_id
+from continuum.models import Run
+from continuum.storage import SQLiteStorage
+
+
+def test_explicit_key_is_stable_and_ignores_arguments() -> None:
+    """Explicit key wins: same key -> same id even if arguments differ."""
+    a = resolve_authorization_id("send_invoice", "invoice:INV-001", {"invoice": "INV-001"})
+    b = resolve_authorization_id(
+        "send_invoice", "invoice:INV-001", {"invoice": "INV-002", "amount": 999}
+    )
+    assert a is not None
+    assert a == b
+
+    c = resolve_authorization_id("send_invoice", "invoice:INV-002", {"invoice": "INV-001"})
+    assert c is not None
+    assert a != c
+
+
+def test_explicit_key_different_types_are_different_operations() -> None:
+    """Action-type drift is NOT bridged by design."""
+    a = resolve_authorization_id("send_invoice", "k-1", {"x": 1})
+    b = resolve_authorization_id("send-invoice-email", "k-1", {"x": 1})
+    assert a != b
+
+
+def test_renamed_argument_fields_map_to_same_token_identity() -> None:
+    """Field name drift must not create a new budget bucket."""
+    a = resolve_authorization_id("send_invoice", None, {"invoice_id": "INV-001"})
+    b = resolve_authorization_id("send_invoice", None, {"invoice": "INV-001"})
+    assert a is not None and b is not None
+    assert a == b
+
+    # Richer shape with path still collapses to same base after canonicalization
+    c = resolve_authorization_id(
+        "send_invoice",
+        None,
+        {"invoice_id": "INV-001", "target": "/tmp/e2e-outbox/INV-001.sent"},
+    )
+    assert c == a
+
+
+def test_relative_vs_absolute_path_is_same_identity() -> None:
+    """Same file rendered two ways is one authorization."""
+    a = resolve_authorization_id(
+        "bench.send", None, {"file": "/data/invoices/INV-5.pdf", "invoice": "INV-5"}
+    )
+    b = resolve_authorization_id(
+        "bench.send", None, {"file": "invoices/INV-5.pdf", "invoice": "INV-5"}
+    )
+    assert a is not None and b is not None
+    assert a == b
+
+
+def test_numeric_resource_ids_are_distinctive() -> None:
+    """Row ids count as identity (issue #36)."""
+    a = resolve_authorization_id("db.update", None, {"row_id": 4821})
+    b = resolve_authorization_id("db.update", None, {"id": 4821})
+    assert a is not None and b is not None
+    assert a == b
+
+    c = resolve_authorization_id("db.update", None, {"row_id": 9999})
+    assert c != a
+
+
+def test_plain_word_resource_ids_are_distinctive() -> None:
+    """Plain words name a resource as well as INV-001 (issue #33)."""
+    a = resolve_authorization_id("publish", None, {"topic": "invoice"})
+    b = resolve_authorization_id("publish", None, {"subject": "invoice"})
+    assert a is not None and b is not None
+    assert a == b
+
+    c = resolve_authorization_id("publish", None, {"topic": "dataset"})
+    assert c != a
+
+
+def test_unbound_when_no_distinctive_token() -> None:
+    """Weak or absent tokens mean unbound, today's behaviour byte-identical."""
+    # Only weak tokens (status words, short ids)
+    assert resolve_authorization_id("api.call", None, {"status": "sent", "id": 1}) is None
+    assert resolve_authorization_id("api.call", None, {}) is None
+    assert resolve_authorization_id("api.call", None, None) is None
+    # Whitespace or stopword-only
+    assert resolve_authorization_id("publish", None, {"topic": "the"}) is None
+
+
+def test_determinism_across_calls() -> None:
+    """Identical inputs produce identical ids on any machine."""
+    first = resolve_authorization_id("send_invoice", None, {"invoice": "INV-001"})
+    second = resolve_authorization_id("send_invoice", None, {"invoice": "INV-001"})
+    assert first == second
+    # Also with explicit key
+    k1 = resolve_authorization_id("send_invoice", "k-1", {"x": 1})
+    k2 = resolve_authorization_id("send_invoice", "k-1", {"x": 1})
+    assert k1 == k2
+
+
+def test_determinism_across_processes() -> None:
+    """Spawn a fresh interpreter and compare hashes."""
+    from pathlib import Path
+
+    # Run in a fresh process with cwd set to the worktree so the import
+    # resolves to this checkout, not to a sibling worktree that may be mid-
+    # migration (e.g. ConstraintPin). Use PYTHONPATH to prefer this src.
+    src = str(Path(__file__).resolve().parents[1] / "src")
+    env = {**dict(__import__("os").environ), "PYTHONPATH": src}
+    code = (
+        "from continuum.actions.idempotency import resolve_authorization_id;"
+        "print(resolve_authorization_id('send_invoice', None, {'invoice':'INV-001'}))"
+    )
+    out = subprocess.check_output([sys.executable, "-c", code], text=True, env=env).strip()
+    local = resolve_authorization_id("send_invoice", None, {"invoice": "INV-001"})
+    assert out == local
+
+
+def test_action_type_not_bridged_for_token_fallback() -> None:
+    """Same tokens under different types must be different buckets."""
+    a = resolve_authorization_id("send_invoice", None, {"invoice": "INV-005"})
+    b = resolve_authorization_id("send-invoice-email", None, {"invoice": "INV-005"})
+    assert a is not None and b is not None
+    assert a != b
+
+
+def test_ledger_anchored_identity_uses_unique_match() -> None:
+    """When a ledger is supplied, only a unique completed/interrupted anchors."""
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_1", goal="g"))
+    ledger = ActionLedger(storage, "run_1")
+
+    first = ledger.claim(
+        "send_invoice",
+        {"invoice_id": "INV-001", "target": "/tmp/e2e-outbox/INV-001.sent"},
+    )
+    ledger.complete(first.key, external_id="INV-001.sent")
+
+    # Drifted re-claim (field rename, no path) should anchor to the prior
+    anchored = resolve_authorization_id("send_invoice", None, {"invoice": "INV-001"}, ledger=ledger)
+    pure = resolve_authorization_id("send_invoice", None, {"invoice": "INV-001"})
+    assert anchored is not None
+    assert anchored == pure
+
+    # Different invoice with no match -> unbound when ledger is non-empty
+    assert (
+        resolve_authorization_id("send_invoice", None, {"invoice": "INV-004"}, ledger=ledger)
+        is None
+    )
+
+
+def test_ledger_ambiguous_returns_none() -> None:
+    """Multiple completed actions sharing tokens is ambiguous, return None."""
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_2", goal="g"))
+    ledger = ActionLedger(storage, "run_2")
+    # Force two distinct completed actions with same tokens via explicit keys
+    a1 = ledger.claim("send_invoice", {"invoice": "INV-001"}, key="k1")
+    ledger.complete(a1.key, external_id="a1")
+    a2 = ledger.claim("send_invoice", {"invoice": "INV-001"}, key="k2")
+    ledger.complete(a2.key, external_id="a2")
+
+    assert (
+        resolve_authorization_id("send_invoice", None, {"invoice": "INV-001"}, ledger=ledger)
+        is None
+    )
+
+
+def test_explicit_key_precedence_over_token_match() -> None:
+    """Key > token-match: key present means token identity is ignored."""
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_3", goal="g"))
+    ledger = ActionLedger(storage, "run_3")
+    first = ledger.claim("send_invoice", {"invoice": "INV-001"})
+    ledger.complete(first.key, external_id="INV-001")
+
+    # Even though a token match exists, explicit key determines the id
+    via_key = resolve_authorization_id(
+        "send_invoice", "my-stable-key", {"invoice": "INV-001"}, ledger=ledger
+    )
+    via_key2 = resolve_authorization_id(
+        "send_invoice", "my-stable-key", {"different": "args"}, ledger=ledger
+    )
+    assert via_key is not None
+    assert via_key == via_key2
+
+
+def test_empty_action_type_and_empty_key_are_refused() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        resolve_authorization_id("", "k", {})
+    with pytest.raises(ValueError, match="non-empty"):
+        resolve_authorization_id("   ", None, {})
+    with pytest.raises(ValueError, match="non-empty"):
+        resolve_authorization_id("send_invoice", "", {})
+
+
+def test_volatile_fields_excluded_from_token_identity() -> None:
+    """Volatile fields must not affect the authorization bucket."""
+    a = resolve_authorization_id(
+        "call", None, {"payload": "INV-001", "attempt": 1}, volatile=["attempt"]
+    )
+    b = resolve_authorization_id(
+        "call", None, {"payload": "INV-001", "attempt": 2}, volatile=["attempt"]
+    )
+    assert a is not None and b is not None
+    assert a == b
+
+
+def test_file_extension_still_collapses_but_dotted_name_stays_distinct() -> None:
+    """INV-001.sent is derived from INV-001, alice.smith is not from alice."""
+    a = resolve_authorization_id("export.report", None, {"dataset": "report"})
+    b = resolve_authorization_id("export.report", None, {"dataset": "report.csv"})
+    assert a == b
+
+    c = resolve_authorization_id("email.send", None, {"to": "alice"})
+    d = resolve_authorization_id("email.send", None, {"to": "alice.smith"})
+    assert c != d


### PR DESCRIPTION
## Description

Deterministic authorization identity for budget binding (issue #412, epic #390). Reuses the existing identity-token machinery in `src/continuum/actions/idempotency.py` so identical logical operations map to one budget bucket even when callers mint fresh keys.

- `resolve_authorization_id(action_type, key, arguments, *, volatile, ledger)` with precedence: explicit stable key (hash of type+key) wins and ignores arguments; no key falls back to canonical leaf tokens (identity_tokens + leaf_tokens + known-suffix derivation, same helpers as `ActionLedger.claim`); neither yields `None` (UNBOUND, today's behaviour).
- Documents precedence table in docstring (key > token-match > unbound) and states explicitly that action-type drift is not bridged (different types are different operations).
- Handles relative vs absolute path drift, renamed argument fields, numeric and plain-word resource ids, weak-token filtering, volatile exclusion, and cross-process determinism via `stable_hash`.
- Optional ledger-anchored path reuses containment, derivation and location-agreement checks to require a unique completed or interrupted match; ambiguous multi-match returns `None` rather than guessing. Pure path without ledger derives from incoming canonical leaf tokens, which already collapses derived forms like `INV-001.sent` to `INV-001` while keeping `alice.smith` distinct from `alice`.

No change to `idempotency_key` outputs for keyed calls, no budget counter wiring, no registry schema change.

## Related issues

Refs #412. Parent epic #390. Follow-up is #413 (drawdown wiring). Predecessor #411 is closed and #424 is merged, so helpers in `src/continuum/budgets.py` are present.

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

Environment: macOS, Python 3.13.5, branch feat/authz-identity-resolution-412 at 3710702.

- `pytest`: 1538 passed, 24 skipped (full suite green, see raw output below)
- `pytest tests/test_authorization_identity.py -v`: 16 passed
- `ruff check src/ tests/ examples/`: All checks passed
- `ruff format --check src/ tests/ examples/`: 222 files already formatted (formatted)
- `mypy src/continuum/actions/idempotency.py`: no issues for the changed module (whole src shows only pre-existing missing-stub errors for optional deps, which are clean in CI where dev extras are installed)

Raw gate outputs:

```
pytest: 1538 passed, 24 skipped in 33.82s
ruff check: All checks passed!
ruff format --check: 222 files already formatted (after `ruff format`)
mypy src/continuum/actions/idempotency.py: no issues (strict)
```

Regression evidence: on pre-change code the new tests fail at import (function does not exist), and the specific drift cases would produce distinct ids. Example:

```
$ git show HEAD~1:src/continuum/actions/idempotency.py | grep resolve_authorization_id
# no output, function missing

$ python -c "from continuum.actions.idempotency import resolve_authorization_id"  # on pre-change
ImportError: cannot import name 'resolve_authorization_id'
```

After the change, all 16 new tests pass, covering:
- explicit key stability and cross-type isolation
- renamed fields (`invoice_id` vs `invoice`)
- relative vs absolute paths (`/data/invoices/INV-5.pdf` vs `invoices/INV-5.pdf`)
- numeric ids (4821) and plain-word ids (`invoice`)
- unbound weak tokens, volatile exclusion, empty-type/key refusal
- file-suffix derivation (`report.csv` vs `report`) vs dotted names (`alice.smith`)
- determinism across processes (spawned interpreter)
- ledger-anchored unique vs ambiguous matches and key precedence

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour (module docstring documents precedence and non-bridging). CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Design tradeoff: authorization_id is `stable_hash({type, key})` for explicit keys and `stable_hash({type, tokens: sorted(canonical_leaf)})` for token fallback. Canonicalization drops known-suffix derived forms so equivalent renderings hash identically, while location is left to leaf (so relative vs absolute collapses, but tenant isolation would need location-aware hashing if that case is later required). Ledger-aware path is conservative: ambiguous or non-unique matches return `None` rather than inventing a bucket. Unknown ledger shapes fall back to pure derivation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable authorization identity resolution for budget binding.
  * Supports explicit keys, resource tokens, canonicalized argument names, and ledger-backed matching.
  * Preserves unbound behavior when identity information is missing, weak, or ambiguous.

* **Bug Fixes**
  * Prevents identity changes caused by renamed fields, path formats, file extensions, or volatile arguments.

* **Tests**
  * Added coverage for deterministic identity generation, validation, token handling, and ambiguous ledger matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->