### PR TITLE
[#391] projector folds pins into SemanticState

### DIFF
--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -49,6 +49,7 @@ __all__ = [
     "ExternalDependency",
     "ConstraintPinned",
     "ConstraintRetracted",
+    "ConstraintPin",
     "ModelSpecificState",
     "ModelState",
     "Run",
@@ -453,6 +454,45 @@ class ConstraintRetracted(BaseModel):
         return _validated_constraint_id(value)
 
 
+class ConstraintPin(BaseModel):
+    """Projected view of an active constraint pin (issue #417).
+
+    A pin is the durable memory of a standing instruction. The text never
+    enters the log; only the digest does. The projector keeps the active set
+    in ``SemanticState.pins`` so downstream checks can ask which constraints
+    survive context reconstruction without re-reading the whole log.
+    """
+
+    model_config = Frozen
+
+    constraint_id: str = Field(strict=True)
+    """Label of the constraint, same charset as the pinned event."""
+
+    sha256: str = Field(strict=True)
+    """Digest of the exact constraint text, lowercase hex."""
+
+    status: str = "active"
+    """Lifecycle status, always ``active`` for members of the active set."""
+
+    provenance: Provenance = Field(default_factory=Provenance)
+    """Where the pin was asserted, carried from the pin event."""
+
+    pinned_at: datetime = Field(default_factory=utcnow)
+    """When the pin event was recorded."""
+
+    @field_validator("constraint_id")
+    @classmethod
+    def _pin_id_is_a_label(cls, value: str) -> str:
+        return _validated_constraint_id(value)
+
+    @field_validator("sha256")
+    @classmethod
+    def _pin_sha_is_lowercase_hex(cls, value: str) -> str:
+        if not _SHA256_PATTERN.fullmatch(value):
+            raise ValueError("sha256 must be exactly 64 lowercase hex characters")
+        return value
+
+
 class ModelSpecificState(BaseModel):
     """An assumption tied to a specific model; switching models must revalidate."""
 
@@ -499,6 +539,15 @@ class SemanticState(BaseModel):
     pending_work: list[PendingWork] = Field(default_factory=list)
     approvals: list[Approval] = Field(default_factory=list)
     external_dependencies: list[ExternalDependency] = Field(default_factory=list)
+    pins: dict[str, ConstraintPin] = Field(default_factory=dict)
+    """Active constraint pins, keyed by constraint id (issue #417)."""
+    unmatched_pin_retractions: list[str] = Field(default_factory=list)
+    """Constraint ids retracted without a matching active pin.
+
+    Retraction of an unknown id is not a crash; it degrades gracefully and
+    is noted here so the operator can see a mismatch without the fold
+    guessing whether the pin lived in an archived prefix or never existed.
+    """
     model: ModelState | None = None
     version: int = 0
     source_sequence: int = 0
@@ -543,6 +592,12 @@ class SemanticState(BaseModel):
 
     def dependency(self, resource: str) -> ExternalDependency | None:
         return next((d for d in self.external_dependencies if d.resource == resource), None)
+
+    def pin(self, constraint_id: str) -> ConstraintPin | None:
+        return self.pins.get(constraint_id)
+
+    def active_pins(self) -> tuple[ConstraintPin, ...]:
+        return tuple(self.pins.values())
 
     def evidence_ids(self) -> frozenset[str]:
         return frozenset(e.evidence_id for e in self.evidence)

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -32,6 +32,9 @@ from continuum.events import Event, EventType
 from continuum.models import (
     Approval,
     ApprovalStatus,
+    ConstraintPin,
+    ConstraintPinned,
+    ConstraintRetracted,
     Decision,
     Evidence,
     ExternalDependency,
@@ -129,6 +132,10 @@ class _Accumulator:
         self.approvals: list[Approval] = list(base.approvals) if base else []
         self.dependencies: list[ExternalDependency] = (
             list(base.external_dependencies) if base else []
+        )
+        self.pins: dict[str, ConstraintPin] = dict(base.pins) if base else {}
+        self.unmatched_pin_retractions: list[str] = (
+            list(base.unmatched_pin_retractions) if base else []
         )
         self.model: ModelState | None = base.model if base else None
         self.created_at: datetime | None = base.created_at if base else None
@@ -387,6 +394,26 @@ class _Accumulator:
         assumptions.append(assumption)
         self.model = current.model_copy(update={"model_specific_state": assumptions})
 
+    def constraint_pinned(self, event: Event) -> None:
+        payload = ConstraintPinned.model_validate(event.payload)
+        pin = ConstraintPin(
+            constraint_id=payload.constraint_id,
+            sha256=payload.sha256,
+            status="active",
+            provenance=_provenance(event),
+            pinned_at=event.timestamp,
+        )
+        self.pins[payload.constraint_id] = pin
+
+    def constraint_retracted(self, event: Event) -> None:
+        payload = ConstraintRetracted.model_validate(event.payload)
+        constraint_id = payload.constraint_id
+        if constraint_id in self.pins:
+            del self.pins[constraint_id]
+        else:
+            if constraint_id not in self.unmatched_pin_retractions:
+                self.unmatched_pin_retractions.append(constraint_id)
+
     # -- finish ----------------------------------------------------------- #
 
     def build(self) -> SemanticState:
@@ -436,6 +463,8 @@ class _Accumulator:
             pending_work=self.pending_work,
             approvals=self.approvals,
             external_dependencies=self.dependencies,
+            pins=dict(self.pins),
+            unmatched_pin_retractions=list(self.unmatched_pin_retractions),
             model=self.model,
             version=self.version,
             source_sequence=self.source_sequence,
@@ -481,6 +510,10 @@ def _dispatch(acc: _Accumulator, event: Event) -> bool:
             acc.model_changed(event)
         case EventType.MODEL_ASSUMPTION_RECORDED:
             acc.model_assumption_recorded(event)
+        case EventType.CONSTRAINT_PINNED:
+            acc.constraint_pinned(event)
+        case EventType.CONSTRAINT_RETRACTED:
+            acc.constraint_retracted(event)
         case _:
             return False
     return True

--- a/tests/test_projection_pins.py
+++ b/tests/test_projection_pins.py
@@ -1,0 +1,274 @@
+"""Projector folds pins into SemanticState with anchoring-safe lifecycle (#417).
+
+Properties tested:
+- prefix-closed: prefix projection equals incremental fold
+- replayable: identical log prefixes produce identical states
+- anchoring-safe: compacted logs project identically (pins survive anchoring)
+- retraction removes from active set
+- unknown retraction degrades gracefully and is noted
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from continuum.checkpoint import CheckpointManager
+from continuum.events import EventLog, EventType
+from continuum.models import ConstraintPinned, ConstraintRetracted, Run
+from continuum.state.semantic import project, project_incremental
+from continuum.storage import SQLiteStorage
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _started(log: EventLog, run_id: str = "run_1") -> EventLog:
+    log.append(run_id, EventType.RUN_STARTED, {"goal": "g", "total": 10})
+    return log
+
+
+def test_pinned_constraints_appear_in_active_set() -> None:
+    log = _started(EventLog())
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="c1", sha256=_digest("hello")).model_dump(),
+    )
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="c2", sha256=_digest("world")).model_dump(),
+    )
+    state = project("run_1", log.events("run_1"))
+    assert set(state.pins.keys()) == {"c1", "c2"}
+    assert state.pins["c1"].sha256 == _digest("hello")
+    assert state.pins["c1"].status == "active"
+    assert state.pin("c1") is not None
+    assert state.pin("c1").constraint_id == "c1"
+    assert state.unmatched_pin_retractions == []
+
+
+def test_retraction_removes_from_active_set() -> None:
+    log = _started(EventLog())
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="c1", sha256=_digest("hello")).model_dump(),
+    )
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="c2", sha256=_digest("world")).model_dump(),
+    )
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_RETRACTED,
+        ConstraintRetracted(constraint_id="c1").model_dump(),
+    )
+    state = project("run_1", log.events("run_1"))
+    assert "c1" not in state.pins
+    assert "c2" in state.pins
+    assert state.unmatched_pin_retractions == []
+
+
+def test_retraction_of_unknown_id_degrades_gracefully_and_is_noted() -> None:
+    log = _started(EventLog())
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_RETRACTED,
+        ConstraintRetracted(constraint_id="never_pinned").model_dump(),
+    )
+    state = project("run_1", log.events("run_1"))
+    assert state.pins == {}
+    assert "never_pinned" in state.unmatched_pin_retractions
+    # second identical retraction does not duplicate the note
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_RETRACTED,
+        ConstraintRetracted(constraint_id="never_pinned").model_dump(),
+    )
+    state2 = project("run_1", log.events("run_1"))
+    assert state2.unmatched_pin_retractions.count("never_pinned") == 1
+
+
+def test_duplicate_pin_overwrites_with_latest_sha() -> None:
+    log = _started(EventLog())
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="a", sha256=_digest("first")).model_dump(),
+    )
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="a", sha256=_digest("second")).model_dump(),
+    )
+    state = project("run_1", log.events("run_1"))
+    assert state.pins["a"].sha256 == _digest("second")
+
+
+def test_retract_then_repin_restores_active() -> None:
+    log = _started(EventLog())
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="a", sha256=_digest("first")).model_dump(),
+    )
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_RETRACTED,
+        ConstraintRetracted(constraint_id="a").model_dump(),
+    )
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="a", sha256=_digest("third")).model_dump(),
+    )
+    state = project("run_1", log.events("run_1"))
+    assert state.pins["a"].sha256 == _digest("third")
+    assert state.unmatched_pin_retractions == []
+
+
+def test_projection_is_prefix_closed_with_pins() -> None:
+    log = _started(EventLog())
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="a", sha256=_digest("hello")).model_dump(),
+    )
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="b", sha256=_digest("world")).model_dump(),
+    )
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_RETRACTED,
+        ConstraintRetracted(constraint_id="a").model_dump(),
+    )
+    events = list(log.events("run_1"))
+    # full
+    full = project("run_1", events)
+    # prefix upto 2 vs incremental
+    p2 = project("run_1", events[:2])
+    base, _ = project_incremental("run_1", events[:2])
+    # incremental step from base with next event (retraction) should equal prefix 3?
+    # Actually test prefix-closed: project(events[:n]) equals incremental fold
+    for n in range(1, len(events) + 1):
+        prefix = project("run_1", events[:n])
+        # incremental: fold first n-1 as base, then 1 step
+        if n == 1:
+            inc, _ = project_incremental("run_1", events[:1])
+        else:
+            b, _ = project_incremental("run_1", events[: n - 1])
+            inc, _ = project_incremental("run_1", events[n - 1 : n], base=b)
+        assert prefix == inc, f"prefix {n} mismatch"
+    # also full equals incremental from base
+    base2, _ = project_incremental("run_1", events[:2])
+    inc_full, _ = project_incremental("run_1", events[2:], base=base2)
+    assert inc_full == full
+    assert p2.pins == base.pins
+
+
+def test_projection_is_replayable_with_pins() -> None:
+    log = _started(EventLog())
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="a", sha256=_digest("hello")).model_dump(),
+    )
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_RETRACTED,
+        ConstraintRetracted(constraint_id="a").model_dump(),
+    )
+    first = project("run_1", log.events("run_1"))
+    second = project("run_1", log.events("run_1"))
+    assert first == second
+    # incremental replay also identical
+    base, _ = project_incremental("run_1", list(log.events("run_1"))[:2])
+    inc1, _ = project_incremental("run_1", list(log.events("run_1"))[2:], base=base)
+    assert inc1 == first
+
+
+def test_pins_survive_compaction_anchoring_safe() -> None:
+    run_id = "run_1"
+    with SQLiteStorage(":memory:") as store:
+        store.create_run(Run(run_id=run_id, goal="g"))
+        store.append_event(run_id, EventType.RUN_STARTED, {"goal": "g", "total": 10})
+        store.append_event(
+            run_id,
+            EventType.CONSTRAINT_PINNED,
+            ConstraintPinned(constraint_id="c1", sha256=_digest("hello")).model_dump(),
+        )
+        store.append_event(
+            run_id,
+            EventType.CONSTRAINT_PINNED,
+            ConstraintPinned(constraint_id="c2", sha256=_digest("world")).model_dump(),
+        )
+        CheckpointManager(store).checkpoint(run_id)
+        store.append_event(run_id, EventType.WORK_COMPLETED, {})
+        store.append_event(
+            run_id,
+            EventType.CONSTRAINT_RETRACTED,
+            ConstraintRetracted(constraint_id="c1").model_dump(),
+        )
+        # before compaction state
+        before_events = list(store.read_events(run_id))
+        before_state = project(run_id, before_events)
+        assert set(before_state.pins.keys()) == {"c2"}
+
+        store.compact_run(run_id)
+        live = list(store.read_events(run_id))
+        archived = list(store.read_archived_events(run_id))
+        combined = sorted([*archived, *live], key=lambda e: e.sequence)
+        combined_state = project(run_id, combined)
+        # pins survive anchoring
+        assert set(combined_state.pins.keys()) == {"c2"}
+        assert combined_state.pins["c2"].sha256 == _digest("world")
+        # restored via checkpoint also survives
+        restored = CheckpointManager(store).restore(run_id)
+        assert set(restored.state.pins.keys()) == {"c2"}
+
+        # unmatched retractions also survive if they were in archived tail
+        # (add unknown retraction before compaction)
+        store2_run = "run_2"
+        store.create_run(Run(run_id=store2_run, goal="g"))
+        store.append_event(store2_run, EventType.RUN_STARTED, {"goal": "g"})
+        store.append_event(
+            store2_run,
+            EventType.CONSTRAINT_RETRACTED,
+            ConstraintRetracted(constraint_id="ghost").model_dump(),
+        )
+        CheckpointManager(store).checkpoint(store2_run)
+        before2 = project(store2_run, list(store.read_events(store2_run)))
+        assert "ghost" in before2.unmatched_pin_retractions
+        store.compact_run(store2_run)
+        archived2 = list(store.read_archived_events(store2_run))
+        live2 = list(store.read_events(store2_run))
+        combined2 = sorted([*archived2, *live2], key=lambda e: e.sequence)
+        after2 = project(store2_run, combined2)
+        assert "ghost" in after2.unmatched_pin_retractions
+
+
+def test_incremental_with_unmatched_preserves_notes() -> None:
+    log = _started(EventLog())
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_RETRACTED,
+        ConstraintRetracted(constraint_id="ghost").model_dump(),
+    )
+    log.append(
+        "run_1",
+        EventType.CONSTRAINT_PINNED,
+        ConstraintPinned(constraint_id="a", sha256=_digest("x")).model_dump(),
+    )
+    events = list(log.events("run_1"))
+    base, _ = project_incremental("run_1", events[:2])
+    assert "ghost" in base.unmatched_pin_retractions
+    full, _ = project_incremental("run_1", events[2:], base=base)
+    assert "ghost" in full.unmatched_pin_retractions
+    assert "a" in full.pins
+    # full equals direct project
+    assert full == project("run_1", events)


### PR DESCRIPTION
## Description

Projector folds constraint pins into SemanticState per #417 (epic #391).

SemanticState gains active pins view pins: dict[constraint_id, ConstraintPin] with sha256, status, provenance and pinned_at, plus unmatched_pin_retractions for unknown retractions. The fold is prefix-closed, replayable and anchoring-safe.

- ConstraintPinned -> active entry in pins keyed by constraint_id, latest wins and carries provenance from the event.
- ConstraintRetracted -> removes from active set when present; unknown ids degrade gracefully and are noted in unmatched_pin_retractions without crashing or polluting the active set.
- Pins live in the hash-chained log and survive EventLog anchoring like any event: combined archived+live projection equals the pre-compaction state for pins, and checkpoint restore carries pins forward.

## Related issues

Refs #391. Fixes #417.

## Types of changes

- Type: feature

## Breaking changes

No

## How has this been tested?

Environment: local checkout, Python 3.13, ruff 0.16.2, mypy strict with pydantic plugin via direct mypy (dev deps via pip).

Gate before PR (on branch d0050c7):
- pytest tests/test_projection_pins.py -v -> 9 passed
- pytest tests/test_projection.py tests/test_projection_edges.py tests/test_checkpoint_manager.py tests/test_compaction.py -q -> 95 passed
- pytest -q -> exit 0, all tests green (exit code 0, truncated output but 0)
- ruff check src/ tests/ examples/ -> All checks passed!
- ruff format --check src/ tests/ examples/ -> 222 files already formatted
- mypy src/continuum (direct, without dev extra, shows 25 missing-import errors which are pre-existing and not from this change; via uv run mypy with dev deps, 0 errors in 105 files after clearing stale cache)
- Manual compaction test: pins before compaction equals pins after archived+live combined and equals restored checkpoint pins.

New coverage in tests/test_projection_pins.py: pinned appear, retraction removes, unknown retraction noted, duplicate pin overwrites, retract-then-repin, prefix-closed (full vs incremental for every prefix), replayable (identical log), anchoring-safe via SQLiteStorage compact_run and combined archived+live vs before, incremental with unmatched notes.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour (pins are internal state, docs are #420 scope). CI passes on the latest commit (ruff clean, tests green). Security-relevant changes state known limitations explicitly in this description.

## Additional context

Alternatives considered: separate side-table outside log (rejected: breaks single-source-of-truth and tamper-evidence, per issue). Pin text never stored, only sha256, matching #416 hash-only guarantee. Unknown retraction handling is fail-closed: noted but not guessed, matching house rules.