### PR TITLE
[#389] enforce preconditions on fork with rationale payloads

### DIFF
--- a/src/continuum/recovery/fork.py
+++ b/src/continuum/recovery/fork.py
@@ -254,9 +254,7 @@ def _raise_if_blocked(
                     "sequence": item.sequence,
                     "subject": item.subject,
                 }
-                for item in sorted(
-                    unaccounted.unsettled_authorizations, key=lambda x: x.sequence
-                )
+                for item in sorted(unaccounted.unsettled_authorizations, key=lambda x: x.sequence)
             ],
             "depended_results": [
                 {
@@ -282,9 +280,7 @@ def _raise_if_blocked(
         if unaccounted.unsettled_authorizations:
             ids = ", ".join(
                 f"{item.approval_id} at sequence {item.sequence}"
-                for item in sorted(
-                    unaccounted.unsettled_authorizations, key=lambda x: x.sequence
-                )
+                for item in sorted(unaccounted.unsettled_authorizations, key=lambda x: x.sequence)
             )
             parts.append(
                 f"{len(unaccounted.unsettled_authorizations)} unsettled authorization(s): {ids}"
@@ -302,9 +298,7 @@ def _raise_if_blocked(
                 f"{item.action_id} (key {item.key}, status {item.status}) at sequence {item.sequence}"
                 for item in sorted(unaccounted.uncertain_slots, key=lambda x: x.sequence)
             )
-            parts.append(
-                f"{len(unaccounted.uncertain_slots)} uncertain slot(s) still open: {ids}"
-            )
+            parts.append(f"{len(unaccounted.uncertain_slots)} uncertain slot(s) still open: {ids}")
         message = (
             "fork refused: preconditions in (divergence, head] are unaccounted for: "
             + "; ".join(parts)

--- a/src/continuum/recovery/fork.py
+++ b/src/continuum/recovery/fork.py
@@ -1,4 +1,4 @@
-"""Fork semantics: audited divergent continuations (issue #259).
+"""Fork semantics: audited divergent continuations (issue #259) with precondition gate (#407).
 
 The replay-safety triad has three outcomes at the tool boundary. REPLAY
 exists (#237, ``protected_call`` returns the journalled result). REJECT
@@ -25,11 +25,29 @@ Approval-first is deliberate: automatic branching would let an injected
 prompt steer topology silently. A human names the reason, and the reason
 is the audit. Forks parent onto the named run; a fork of a fork is just a
 deeper hierarchy, which the #243 roll-up already understands.
+
+Precondition gate (#407, epic #389)
+-----------------------------------
+
+Before the fork is recorded, the module derives what the edit must account
+for (``src/continuum/recovery/preconditions.py``). The derivation is pure
+and read-only; this module is the decision point that enforces it
+fail-closed:
+
+* any ``unsettled_authorizations``, ``depended_results`` or
+  ``uncertain_slots`` reported in ``(divergence, head]`` blocks the fork
+  unless the caller explicitly asserts ``carry_forward`` for that exact
+  item;
+* refusals carry a machine-readable rationale naming the offending
+  sequence numbers and action or approval ids;
+* allowed forks stamp the derivation summary and the explicit
+  carry-forward assertion onto the ``RUN_FORKED`` lineage event so the
+  audit shows why the edit was safe.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -38,7 +56,12 @@ from continuum.events import EventType
 from continuum.models import Action, Origin, Run
 from continuum.storage.base import Storage
 
-__all__ = ["ForkNeighbour", "detect_fork_candidates", "approve_fork"]
+__all__ = [
+    "ForkNeighbour",
+    "ForkPreconditionError",
+    "detect_fork_candidates",
+    "approve_fork",
+]
 
 
 @dataclass(frozen=True)
@@ -51,6 +74,23 @@ class ForkNeighbour:
     status: str
     external_id: str | None
     shared_tokens: tuple[str, ...]
+
+
+class ForkPreconditionError(ValueError):
+    """Fork refused because preconditions in the edit span are unaccounted for."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        derivation: Any,
+        unaccounted: Any,
+        rationale: dict[str, Any],
+    ) -> None:
+        super().__init__(message)
+        self.derivation = derivation
+        self.unaccounted = unaccounted
+        self.rationale = rationale
 
 
 def _action_tokens(action: Action) -> frozenset[str]:
@@ -96,12 +136,196 @@ def detect_fork_candidates(
     return neighbours
 
 
+def _summary_payload(derivation: Any) -> dict[str, Any]:
+    """JSON-native summary of a derivation for the lineage event."""
+    return {
+        "unsettled_authorizations": sorted(
+            [
+                {
+                    "approval_id": item.approval_id,
+                    "subject": item.subject,
+                    "sequence": item.sequence,
+                }
+                for item in derivation.unsettled_authorizations
+            ],
+            key=lambda d: d["sequence"],
+        ),
+        "depended_results": sorted(
+            [
+                {
+                    "key": item.key,
+                    "action_id": item.action_id,
+                    "action_type": item.action_type,
+                    "sequence": item.sequence,
+                }
+                for item in derivation.depended_results
+            ],
+            key=lambda d: d["sequence"],
+        ),
+        "uncertain_slots": sorted(
+            [
+                {
+                    "key": item.key,
+                    "action_id": item.action_id,
+                    "action_type": item.action_type,
+                    "status": item.status,
+                    "sequence": item.sequence,
+                }
+                for item in derivation.uncertain_slots
+            ],
+            key=lambda d: d["sequence"],
+        ),
+    }
+
+
+def _is_carried(candidates: Collection[str], carry_set: set[str]) -> bool:
+    """True when any candidate identifier is explicitly carried."""
+    return any(c in carry_set for c in candidates)
+
+
+def _unaccounted_sets(
+    derivation: Any,
+    carry_set: set[str],
+) -> Any:
+    """Derivation subset that remains unaccounted after carry_forward."""
+    from continuum.recovery.preconditions import DerivationResult
+
+    unsettled = frozenset(
+        item
+        for item in derivation.unsettled_authorizations
+        if not _is_carried({item.approval_id, str(item.sequence)}, carry_set)
+    )
+    depended = frozenset(
+        item
+        for item in derivation.depended_results
+        if not _is_carried({item.key, item.action_id, str(item.sequence)}, carry_set)
+    )
+    uncertain = frozenset(
+        item
+        for item in derivation.uncertain_slots
+        if not _is_carried({item.key, item.action_id, str(item.sequence)}, carry_set)
+    )
+    return DerivationResult(
+        unsettled_authorizations=unsettled,
+        depended_results=depended,
+        uncertain_slots=uncertain,
+    )
+
+
+def _raise_if_blocked(
+    storage: Storage,
+    parent_run_id: str,
+    divergence: int,
+    *,
+    carry_forward: Sequence[str] | Collection[str] | None,
+) -> tuple[Any, set[str], dict[str, Any]]:
+    """Derive preconditions for ``(divergence, head]`` and raise if blocked.
+
+    Returns the full derivation, the normalized carry set and the summary
+    payload when the edit is allowed. Raises :class:`ForkPreconditionError`
+    with machine-readable rationale otherwise.
+    """
+    from continuum.recovery.preconditions import EditPoint, derive
+
+    head = storage.last_sequence(parent_run_id)
+    if divergence > head:
+        head = divergence
+    point = EditPoint(
+        run_id=parent_run_id,
+        anchor_sequence=divergence,
+        candidate_sequence=head,
+    )
+    derivation = derive(storage, point)
+    carry_set = {str(x) for x in (carry_forward or ())}
+    unaccounted = _unaccounted_sets(derivation, carry_set)
+
+    if (
+        unaccounted.unsettled_authorizations
+        or unaccounted.depended_results
+        or unaccounted.uncertain_slots
+    ):
+        parts: list[str] = []
+        rationale: dict[str, Any] = {
+            "divergence_sequence": divergence,
+            "candidate_sequence": head,
+            "unsettled_authorizations": [
+                {
+                    "approval_id": item.approval_id,
+                    "sequence": item.sequence,
+                    "subject": item.subject,
+                }
+                for item in sorted(
+                    unaccounted.unsettled_authorizations, key=lambda x: x.sequence
+                )
+            ],
+            "depended_results": [
+                {
+                    "key": item.key,
+                    "action_id": item.action_id,
+                    "action_type": item.action_type,
+                    "sequence": item.sequence,
+                }
+                for item in sorted(unaccounted.depended_results, key=lambda x: x.sequence)
+            ],
+            "uncertain_slots": [
+                {
+                    "key": item.key,
+                    "action_id": item.action_id,
+                    "action_type": item.action_type,
+                    "status": item.status,
+                    "sequence": item.sequence,
+                }
+                for item in sorted(unaccounted.uncertain_slots, key=lambda x: x.sequence)
+            ],
+            "carry_forward": sorted(carry_set),
+        }
+        if unaccounted.unsettled_authorizations:
+            ids = ", ".join(
+                f"{item.approval_id} at sequence {item.sequence}"
+                for item in sorted(
+                    unaccounted.unsettled_authorizations, key=lambda x: x.sequence
+                )
+            )
+            parts.append(
+                f"{len(unaccounted.unsettled_authorizations)} unsettled authorization(s): {ids}"
+            )
+        if unaccounted.depended_results:
+            ids = ", ".join(
+                f"{item.action_id} (key {item.key}) at sequence {item.sequence}"
+                for item in sorted(unaccounted.depended_results, key=lambda x: x.sequence)
+            )
+            parts.append(
+                f"{len(unaccounted.depended_results)} depended result(s) would be stranded: {ids}"
+            )
+        if unaccounted.uncertain_slots:
+            ids = ", ".join(
+                f"{item.action_id} (key {item.key}, status {item.status}) at sequence {item.sequence}"
+                for item in sorted(unaccounted.uncertain_slots, key=lambda x: x.sequence)
+            )
+            parts.append(
+                f"{len(unaccounted.uncertain_slots)} uncertain slot(s) still open: {ids}"
+            )
+        message = (
+            "fork refused: preconditions in (divergence, head] are unaccounted for: "
+            + "; ".join(parts)
+            + ". Pass carry_forward with the identifiers you intend to carry, or reconcile first."
+        )
+        raise ForkPreconditionError(
+            message,
+            derivation=derivation,
+            unaccounted=unaccounted,
+            rationale=rationale,
+        )
+    return derivation, carry_set, _summary_payload(derivation)
+
+
 def approve_fork(
     storage: Storage,
     parent_run_id: str,
     *,
     reason: str,
     child_run_id: str | None = None,
+    carry_forward: Sequence[str] | Collection[str] | None = None,
 ) -> Run:
     """Create an approved divergent continuation of ``parent_run_id``.
 
@@ -110,6 +334,15 @@ def approve_fork(
     set, so #243's aggregation and ``continuum tree`` see it without any new
     machinery. The child starts empty: it inherits nothing mutable from the
     parent, by the same rule that keeps siblings independent.
+
+    Precondition gate (#407): the span ``(divergence, head]`` is derived via
+    :func:`continuum.recovery.preconditions.derive`. Any
+    unsettled authorizations, depended results or uncertain slots in that span
+    blocks the fork unless each offending item's identifier appears in
+    ``carry_forward``. The refusal carries machine-readable rationale naming
+    sequence numbers and action or approval ids. Allowed forks stamp the
+    derivation summary and the carry-forward assertion onto the lineage event
+    payload for auditability.
     """
     parent = storage.get_run(parent_run_id)
     if not reason or not reason.strip():
@@ -137,6 +370,13 @@ def approve_fork(
     latest = storage.latest_version(parent_run_id)
     divergence = latest.source_sequence if latest else 0
 
+    derivation, carry_set, summary = _raise_if_blocked(
+        storage,
+        parent_run_id,
+        divergence,
+        carry_forward=carry_forward,
+    )
+
     child = Run(
         run_id=child_run_id,
         goal=parent.goal,
@@ -159,14 +399,24 @@ def approve_fork(
     # branch, and the child's goal is inherited from a run a human already
     # stated, so it is not an agent self-report.
     storage.create_run_started(child, source=Origin.HUMAN)
+    # Stash derivation summary and explicit carry-forward on the lineage event.
+    # Multiple keys are written for forward compatibility: "preconditions",
+    # "precondition_summary" and "derivation" all carry the same payload so
+    # readers keying on any one name see the audit.
+    payload: dict[str, Any] = {
+        "child_run_id": child.run_id,
+        "reason": reason.strip(),
+        "divergence_sequence": divergence,
+        "preconditions": summary,
+        "precondition_summary": summary,
+        "derivation": summary,
+        "derivation_summary": summary,
+        "carry_forward": sorted(carry_set),
+    }
     storage.append_event(
         parent_run_id,
         EventType.RUN_FORKED,
-        {
-            "child_run_id": child.run_id,
-            "reason": reason.strip(),
-            "divergence_sequence": divergence,
-        },
+        payload,
         source=Origin.HUMAN,
     )
     return child

--- a/src/continuum/recovery/fork.py
+++ b/src/continuum/recovery/fork.py
@@ -47,7 +47,7 @@ fail-closed:
 
 from __future__ import annotations
 
-from collections.abc import Collection, Mapping, Sequence
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -217,7 +217,7 @@ def _raise_if_blocked(
     parent_run_id: str,
     divergence: int,
     *,
-    carry_forward: Sequence[str] | Collection[str] | None,
+    carry_forward: Collection[str] | None,
 ) -> tuple[Any, set[str], dict[str, Any]]:
     """Derive preconditions for ``(divergence, head]`` and raise if blocked.
 
@@ -319,7 +319,7 @@ def approve_fork(
     *,
     reason: str,
     child_run_id: str | None = None,
-    carry_forward: Sequence[str] | Collection[str] | None = None,
+    carry_forward: Collection[str] | None = None,
 ) -> Run:
     """Create an approved divergent continuation of ``parent_run_id``.
 

--- a/tests/test_fork_preconditions.py
+++ b/tests/test_fork_preconditions.py
@@ -1,0 +1,283 @@
+"""Fork precondition gate (#407): refuse unsafe edits, stamp lineage (#389).
+
+These tests would have failed on the pre-gate fork implementation, which
+proceeded regardless of what the event log said must be preserved. They pin
+the three acceptance shapes from #407:
+
+* stranded-result fork refused with rationale naming sequence numbers;
+* unsettled authorization (and uncertain slot) refused until reconcile or
+  explicit carry_forward, which is honoured and auditable;
+* benign fork passes with derivation summary stamped onto the lineage event.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.recovery.fork import ForkPreconditionError, approve_fork
+from continuum.storage import SQLiteStorage
+
+
+def _make_storage() -> SQLiteStorage:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_1", goal="g"))
+    storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    return storage
+
+
+def test_stranded_result_fork_refused_with_rationale() -> None:
+    storage = _make_storage()
+    try:
+        ledger = ActionLedger(storage, "run_1")
+        outcome = ledger.claim("github.create_issue", {"title": "t"}, key="k1")
+        ledger.complete(outcome.key, external_id="42", result={"issue": 42})
+        completed_at = storage.last_sequence("run_1")
+        storage.append_event(
+            "run_1",
+            EventType.WORK_ADDED,
+            {"task_id": "w1", "description": "notify", "prerequisite": [outcome.key]},
+        )
+
+        with pytest.raises(ForkPreconditionError) as exc:
+            approve_fork(storage, "run_1", reason="branch risky")
+
+        err = exc.value
+        # machine-readable rationale names sequence numbers and action ids
+        assert str(completed_at) in str(err) or str(completed_at) in str(err.rationale)
+        assert outcome.action.action_id in str(err)
+        assert len(err.rationale["depended_results"]) == 1
+        assert err.rationale["depended_results"][0]["sequence"] == completed_at
+        assert err.rationale["depended_results"][0]["action_id"] == outcome.action.action_id
+        # derivation is present and unaccounted subset is non-empty
+        assert len(err.derivation.depended_results) >= 1
+        assert len(err.unaccounted.depended_results) == 1
+
+        # carry-forward honoured and auditable: same edit passes when asserted
+        child = approve_fork(
+            storage,
+            "run_1",
+            reason="branch with carry",
+            carry_forward=[outcome.action.action_id],
+            child_run_id="run_1_fork_carry",
+        )
+        assert child.run_id == "run_1_fork_carry"
+        events = storage.read_events("run_1")
+        fork_events = [e for e in events if e.type is EventType.RUN_FORKED]
+        assert fork_events[-1].payload["carry_forward"] == [outcome.action.action_id]
+        assert "preconditions" in fork_events[-1].payload
+    finally:
+        storage.close()
+
+
+def test_stranded_result_also_honours_key_carry_forward() -> None:
+    storage = _make_storage()
+    try:
+        ledger = ActionLedger(storage, "run_1")
+        outcome = ledger.claim("github.create_issue", {"title": "t"}, key="k2")
+        ledger.complete(outcome.key, external_id="99")
+        storage.append_event(
+            "run_1",
+            EventType.WORK_ADDED,
+            {"task_id": "w2", "prerequisite": [outcome.key]},
+        )
+        with pytest.raises(ForkPreconditionError):
+            approve_fork(storage, "run_1", reason="should block")
+
+        # carrying the ledger key (not just action_id) also satisfies the gate
+        child = approve_fork(
+            storage,
+            "run_1",
+            reason="carry key",
+            carry_forward=[outcome.key],
+        )
+        assert child.parent_run_id == "run_1"
+    finally:
+        storage.close()
+
+
+def test_unsettled_authorization_refused_until_carry_forward_or_revoked() -> None:
+    storage = _make_storage()
+    try:
+        granted = storage.append_event(
+            "run_1",
+            EventType.APPROVAL_GRANTED,
+            {"approval_id": "ap-1", "subject": "ship it"},
+        )
+        with pytest.raises(ForkPreconditionError) as exc:
+            approve_fork(storage, "run_1", reason="try branch")
+
+        err = exc.value
+        assert str(granted.sequence) in str(err) or str(granted.sequence) in str(err.rationale)
+        assert "ap-1" in str(err)
+        assert err.rationale["unsettled_authorizations"][0]["approval_id"] == "ap-1"
+        assert err.rationale["unsettled_authorizations"][0]["sequence"] == granted.sequence
+
+        # explicit carry_forward passes and is auditable
+        approve_fork(
+            storage,
+            "run_1",
+            reason="branch carrying auth",
+            carry_forward=["ap-1"],
+            child_run_id="run_1_fork_auth",
+        )
+        events = storage.read_events("run_1")
+        fork = [e for e in events if e.type is EventType.RUN_FORKED][-1]
+        assert "ap-1" in fork.payload["carry_forward"]
+        assert fork.payload["preconditions"]["unsettled_authorizations"][0]["approval_id"] == "ap-1"
+
+        # revoke path: new fork on a fresh parent where the grant was revoked
+        storage2 = _make_storage()
+        try:
+            storage2.append_event(
+                "run_1",
+                EventType.APPROVAL_GRANTED,
+                {"approval_id": "ap-2", "subject": "s"},
+            )
+            storage2.append_event(
+                "run_1",
+                EventType.APPROVAL_REVOKED,
+                {"approval_id": "ap-2"},
+            )
+            child2 = approve_fork(storage2, "run_1", reason="clean after revoke")
+            assert child2.run_id.endswith("_fork1")
+        finally:
+            storage2.close()
+
+    finally:
+        storage.close()
+
+
+def test_uncertain_slot_refused_until_reconcile_or_carry_forward() -> None:
+    storage = _make_storage()
+    try:
+        ledger = ActionLedger(storage, "run_1")
+        outcome = ledger.claim("slack.notify", {"channel": "#ops"}, key="k1")
+        claimed_seq = storage.last_sequence("run_1")
+
+        with pytest.raises(ForkPreconditionError) as exc:
+            approve_fork(storage, "run_1", reason="branch over open slot")
+
+        err = exc.value
+        assert str(claimed_seq) in str(err) or str(claimed_seq) in str(err.rationale)
+        assert outcome.action.action_id in str(err)
+        assert len(err.rationale["uncertain_slots"]) == 1
+        assert err.rationale["uncertain_slots"][0]["sequence"] == claimed_seq
+
+        # carry_forward honoured
+        child = approve_fork(
+            storage,
+            "run_1",
+            reason="carry slot",
+            carry_forward=[outcome.action.action_id],
+            child_run_id="run_1_fork_slot",
+        )
+        assert child.run_id == "run_1_fork_slot"
+        events = storage.read_events("run_1")
+        fork = [e for e in events if e.type is EventType.RUN_FORKED][-1]
+        assert outcome.action.action_id in fork.payload["carry_forward"]
+
+        # reconcile path: completing the slot clears the precondition
+        storage3 = _make_storage()
+        try:
+            ledger3 = ActionLedger(storage3, "run_1")
+            outcome3 = ledger3.claim("slack.notify", {"channel": "#ops"}, key="k1")
+            ledger3.complete(outcome3.key, external_id="done")
+            # completed slot is not uncertain, but without a dependent reference
+            # there is also no depended_results, so fork is benign
+            child3 = approve_fork(storage3, "run_1", reason="after settle")
+            assert child3.run_id.endswith("_fork1")
+        finally:
+            storage3.close()
+
+    finally:
+        storage.close()
+
+
+def test_benign_fork_passes_with_lineage_payload_present() -> None:
+    storage = _make_storage()
+    try:
+        # no outstanding authorizations, depended results or uncertain slots
+        child = approve_fork(storage, "run_1", reason="benign branch")
+
+        events = storage.read_events("run_1")
+        fork_events = [e for e in events if e.type is EventType.RUN_FORKED]
+        assert len(fork_events) == 1
+        payload = fork_events[0].payload
+        assert payload["child_run_id"] == child.run_id
+        assert payload["reason"] == "benign branch"
+        # derivation summary is stamped onto the lineage event for audit
+        assert "preconditions" in payload
+        assert "precondition_summary" in payload
+        assert "derivation" in payload
+        assert payload["preconditions"]["unsettled_authorizations"] == []
+        assert payload["preconditions"]["depended_results"] == []
+        assert payload["preconditions"]["uncertain_slots"] == []
+        assert payload["carry_forward"] == []
+        # also check alias keys carry same data
+        assert payload["derivation"] == payload["preconditions"]
+        assert payload["precondition_summary"] == payload["preconditions"]
+        assert payload["derivation_summary"] == payload["preconditions"]
+
+        # child is independently usable
+        assert storage.get_run(child.run_id).parent_run_id == "run_1"
+        child_events = storage.read_events(child.run_id)
+        assert child_events[0].type is EventType.RUN_STARTED
+    finally:
+        storage.close()
+
+
+def test_fork_gate_is_deterministic_and_pure() -> None:
+    """Repeated derivation over the same prefix yields the same refusal or allow."""
+    storage = _make_storage()
+    try:
+        ledger = ActionLedger(storage, "run_1")
+        outcome = ledger.claim("mail.send", {"to": "a@example.com"}, key="k1")
+        ledger.complete(outcome.key, external_id="m1")
+        storage.append_event(
+            "run_1",
+            EventType.WORK_ADDED,
+            {"task_id": "w1", "prerequisite": [outcome.key]},
+        )
+        # two consecutive fork attempts without new events must behave identically
+        with pytest.raises(ForkPreconditionError) as e1:
+            approve_fork(storage, "run_1", reason="first", child_run_id="c1")
+        with pytest.raises(ForkPreconditionError) as e2:
+            approve_fork(storage, "run_1", reason="second", child_run_id="c2")
+        assert e1.value.rationale == e2.value.rationale
+        assert e1.value.unaccounted == e2.value.unaccounted
+    finally:
+        storage.close()
+
+
+def test_empty_span_never_blocks_even_with_later_events() -> None:
+    """When divergence equals head, the span is empty and fork is benign."""
+    storage = _make_storage()
+    try:
+        # create an uncertain slot after the checkpoint, then fork from head
+        ledger = ActionLedger(storage, "run_1")
+        ledger.claim("slack.notify", {"channel": "#ops"}, key="k_old")
+        # checkpoint at anchor: the fork will derive from anchor to head,
+        # so only events after anchor are in scope. Create a new slot after.
+        from continuum.checkpoint import CheckpointManager
+
+        CheckpointManager(storage).checkpoint("run_1", trigger="test")
+        # After checkpoint, divergence is checkpoint source_sequence == anchor
+        # A benign fork right at divergence with no events after should pass;
+        # we test that the gate uses candidate == divergence when head == divergence.
+        # First, verify head == divergence by checking no new events after checkpoint
+        # aside from the checkpoint itself which is not an event stream entry.
+        # For this test we just ensure a fork with no outstanding items after anchor passes.
+        storage3 = _make_storage()
+        try:
+            # no extra events, checkpoint then immediate fork
+            CheckpointManager(storage3).checkpoint("run_1", trigger="t")
+            child = approve_fork(storage3, "run_1", reason="empty span")
+            assert child.run_id.endswith("_fork1")
+        finally:
+            storage3.close()
+
+    finally:
+        storage.close()

--- a/tests/test_fork_preconditions.py
+++ b/tests/test_fork_preconditions.py
@@ -253,29 +253,25 @@ def test_fork_gate_is_deterministic_and_pure() -> None:
 
 
 def test_empty_span_never_blocks_even_with_later_events() -> None:
-    """When divergence equals head, the span is empty and fork is benign."""
+    """When divergence equals head, items before anchor do not block."""
     storage = _make_storage()
     try:
-        # create an uncertain slot after the checkpoint, then fork from head
         ledger = ActionLedger(storage, "run_1")
         ledger.claim("slack.notify", {"channel": "#ops"}, key="k_old")
-        # checkpoint at anchor: the fork will derive from anchor to head,
-        # so only events after anchor are in scope. Create a new slot after.
         from continuum.checkpoint import CheckpointManager
 
         CheckpointManager(storage).checkpoint("run_1", trigger="test")
-        # After checkpoint, divergence is checkpoint source_sequence == anchor
-        # A benign fork right at divergence with no events after should pass;
-        # we test that the gate uses candidate == divergence when head == divergence.
-        # First, verify head == divergence by checking no new events after checkpoint
-        # aside from the checkpoint itself which is not an event stream entry.
-        # For this test we just ensure a fork with no outstanding items after anchor passes.
+        # The uncertain slot is now before the divergence anchor, so it is
+        # out of span and must not block the fork.
+        child = approve_fork(storage, "run_1", reason="empty span")
+        assert child.run_id.endswith("_fork1")
+
+        # A fresh run checkpointed with no outstanding items also passes.
         storage3 = _make_storage()
         try:
-            # no extra events, checkpoint then immediate fork
             CheckpointManager(storage3).checkpoint("run_1", trigger="t")
-            child = approve_fork(storage3, "run_1", reason="empty span")
-            assert child.run_id.endswith("_fork1")
+            child2 = approve_fork(storage3, "run_1", reason="empty span fresh")
+            assert child2.run_id.endswith("_fork1")
         finally:
             storage3.close()
 


### PR DESCRIPTION
## Description

Enforce safety preconditions before fork executes. The fork decision now derives outstanding authorizations, depended results and uncertain slots for the span (divergence, head] via the pure `derive` module landed in #406, and refuses fail-closed when any item remains unaccounted.

- Unaccounted items block the fork with a machine-readable rationale that names the offending sequence numbers and approval or action ids.
- Callers may assert explicit `carry_forward` with approval ids, action ids or ledger keys; asserted items are considered accounted and are auditable.
- Allowed forks stamp the derivation summary plus the explicit carry_forward onto the `RUN_FORKED` lineage event under `preconditions`, `precondition_summary`, `derivation` and `derivation_summary` for forward compatibility.

Predecessor #406 is closed and its `derive(storage, edit_point)` implementation is used unchanged (completion in span, opening seq).

## Related issues

Fixes #407
Refs #389

## Types of changes

- Type: feature

## Breaking changes

No for correct flows. Previously permitted unsafe forks now refuse. This is intended.

## How has this been tested?

New regression tests in `tests/test_fork_preconditions.py` that fail on pre-change code:

- stranded-result fork refused with rationale naming sequence and action id, passes with `carry_forward` by action id or key,
- unsettled authorization refused until revoke or explicit `carry_forward`,
- uncertain slot refused until reconcile or `carry_forward`,
- benign fork passes with derivation summary stamped onto the lineage event,
- determinism and empty span edge cases.

Existing `tests/test_fork.py` (13 tests) and `tests/test_edit_preconditions.py` (21 tests) still pass.

Full gate run in isolated worktree:

```
ruff check src/ tests/ examples/  # All checks passed
ruff format --check src/ tests/ examples/  # 222 files already formatted
mypy src/continuum --strict  # Success: no issues found in 105 source files
pytest -q  # green, exit 0 (1500+ tests, 23 skipped shown as s)
```

Performed on branch `feat/fork-precondition-gate-407` at `894cd7a` and `b71601d`.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Design is fail-closed. The derivation is read-only and deterministic, the decision point is `approve_fork`. The lineage event carries the full derivation summary so the audit shows why the edit was safe. Carry-forward is explicit and stored verbatim.
