### PR TITLE
feat(provenance): non-amplification invariant for derived artifacts

### DIFF
--- a/src/continuum/provenance_map.py
+++ b/src/continuum/provenance_map.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import Any
 
 from continuum.models import Origin, StateStatus
 from continuum.security.provenance import TrustLevel
@@ -168,6 +169,60 @@ def summarize(
     return ProvenanceView(origin=origin, state_status=state_status, trust=trust)
 
 
+# Authority ranking for the non-amplification invariant (issue #392).
+_AUTHORITY_RANK: dict[CanonicalProvenance, int] = {
+    CanonicalProvenance.AGENT_ASSERTED: 0,
+    CanonicalProvenance.INFERRED: 1,
+    CanonicalProvenance.UNKNOWN: 2,
+    CanonicalProvenance.CONTRADICTED: 3,
+    CanonicalProvenance.STALE: 4,
+    CanonicalProvenance.REQUIRES_REVIEW: 5,
+    CanonicalProvenance.OBSERVED: 6,
+    CanonicalProvenance.VERIFIED: 7,
+}
+
+_CANONICAL_TO_ORIGIN: dict[CanonicalProvenance, Origin] = {
+    CanonicalProvenance.AGENT_ASSERTED: Origin.EXTERNAL_AGENT,
+    CanonicalProvenance.INFERRED: Origin.IMPORTED,
+    CanonicalProvenance.UNKNOWN: Origin.IMPORTED,
+    CanonicalProvenance.CONTRADICTED: Origin.EXTERNAL_AGENT,
+    CanonicalProvenance.STALE: Origin.EXTERNAL_AGENT,
+    CanonicalProvenance.REQUIRES_REVIEW: Origin.EXTERNAL_AGENT,
+    CanonicalProvenance.OBSERVED: Origin.DETERMINISTIC,
+    CanonicalProvenance.VERIFIED: Origin.HUMAN,
+}
+
+
+def min_canonical(provenances: list[CanonicalProvenance]) -> CanonicalProvenance:
+    if not provenances:
+        return CanonicalProvenance.AGENT_ASSERTED
+    return min(provenances, key=lambda p: _AUTHORITY_RANK[p])
+
+
+def derived_origin(origins: list[Origin]) -> Origin:
+    if not origins:
+        return Origin.EXTERNAL_AGENT
+    canonicals = [canonical_origin(o) for o in origins]
+    weakest = min_canonical(canonicals)
+    return _CANONICAL_TO_ORIGIN[weakest]
+
+
+def derived_provenance_for_events(events: Any) -> Origin:
+    origins: list[Origin] = []
+    for e in events:
+        src = getattr(e, "source", None)
+        if isinstance(src, Origin):
+            origins.append(src)
+        elif isinstance(src, str):
+            try:
+                origins.append(Origin(src))
+            except ValueError:
+                origins.append(Origin.EXTERNAL_AGENT)
+        else:
+            origins.append(Origin.EXTERNAL_AGENT)
+    return derived_origin(origins)
+
+
 __all__ = [
     "CanonicalProvenance",
     "ProvenanceView",
@@ -175,4 +230,7 @@ __all__ = [
     "canonical_state_status",
     "canonical_trust",
     "summarize",
+    "min_canonical",
+    "derived_origin",
+    "derived_provenance_for_events",
 ]

--- a/src/continuum/recovery/derived.py
+++ b/src/continuum/recovery/derived.py
@@ -1,0 +1,42 @@
+"""Non-amplification invariant for derived artifacts (issue #392)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from continuum.events import Event
+from continuum.models import Origin
+from continuum.provenance_map import derived_provenance_for_events
+
+__all__ = ["is_derived_unverified", "derived_label", "stamp_derived"]
+
+
+def stamp_derived(payload: dict[str, Any], source_events: list[Event]) -> dict[str, Any]:
+    derived = derived_provenance_for_events(source_events)
+    stamped = dict(payload)
+    stamped["derived_origin"] = derived.value
+    return stamped
+
+
+def derived_label(payload: dict[str, Any]) -> str:
+    raw = payload.get("derived_origin")
+    if raw is None:
+        return "unverified (derived from unverified sources)"
+    try:
+        origin = Origin(raw)
+    except ValueError:
+        return "unverified (derived from unverified sources)"
+    if origin.self_certified:
+        return f"unverified (derived from {origin.value})"
+    return f"derived from {origin.value}"
+
+
+def is_derived_unverified(payload: dict[str, Any]) -> bool:
+    raw = payload.get("derived_origin")
+    if raw is None:
+        return True
+    try:
+        origin = Origin(raw)
+    except ValueError:
+        return True
+    return origin.self_certified

--- a/src/continuum/recovery/summary.py
+++ b/src/continuum/recovery/summary.py
@@ -33,7 +33,8 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from continuum.events import EventType
-from continuum.models import StateStatus
+from continuum.models import Origin, StateStatus
+from continuum.provenance_map import derived_provenance_for_events
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -127,6 +128,7 @@ def build_informed_retry(
 
     avoid = _avoid_rules(failures, uncertain_actions)
 
+    derived_origin = derived_provenance_for_events(events)
     block: dict[str, Any] = {
         "attempts": len(starts),
         "completed_recoveries": len(completions),
@@ -137,6 +139,7 @@ def build_informed_retry(
         "settled_effects": settled_entries,
         "current_failures": current_failures,
         "avoid": avoid,
+        "derived_origin": derived_origin.value,
     }
     return _fit(block)
 
@@ -202,9 +205,25 @@ def _fit(block: dict[str, Any]) -> dict[str, Any]:
     return candidate
 
 
+def _derived_label(block: dict[str, Any]) -> str | None:
+    raw = block.get("derived_origin")
+    if raw is None:
+        return "unverified (derived from unverified sources)"
+    try:
+        origin = Origin(raw)
+    except ValueError:
+        return "unverified (derived from unverified sources)"
+    if origin.self_certified:
+        return f"unverified (derived from {origin.value})"
+    return f"derived from {origin.value}"
+
+
 def render_informed_retry(block: dict[str, Any]) -> list[str]:
     """Human/agent-readable lines for briefing and resume output."""
     lines: list[str] = []
+    label = _derived_label(block)
+    if label:
+        lines.append(f"provenance: {label}")
     attempts = block.get("attempts", 0)
     if attempts:
         lines.append(f"previous attempt(s): {attempts}")

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -90,9 +90,26 @@ def _provenance(event: Event) -> Provenance:
     Previously this hardcoded ``DETERMINISTIC``, which was true of the *fold*
     but said nothing about the event being folded — so an agent's self-report
     projected as indistinguishable from a verified fact.
+
+    For derived artifacts (issue #392) the payload may carry a stamped
+    ``derived_origin`` that is the minimum authority of all source events.
+    When present, that degraded origin is used, so the projection never
+    amplifies weak sources. Missing field degrades to unverified.
     """
+    raw_derived = event.payload.get("derived_origin")
+    if isinstance(raw_derived, str):
+        try:
+            from continuum.models import Origin
+
+            origin = Origin(raw_derived)
+        except ValueError:
+            from continuum.models import Origin
+
+            origin = Origin.EXTERNAL_AGENT
+    else:
+        origin = event.source
     return Provenance(
-        origin=event.source,
+        origin=origin,
         source_sequence=event.sequence,
         source_event_id=event.event_id,
         extractor="deterministic",

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -146,6 +146,7 @@ class StateValidator:
             self._check_approvals(state, entries)
             self._check_model(state, expected_model, entries)
             self._check_evidence(state, entries)
+            self._check_derived(state, entries)
         else:
             # Scoped re-validation: only the named dependency resources are
             # re-checked and only their derivation subtree is allowed to go
@@ -158,6 +159,7 @@ class StateValidator:
                 state, environment_diff, entries, scope=scope_set, observed=observed
             )
             state = self._propagate(state, broken, entries)
+            self._check_derived(state, entries)
 
         blocking = [
             e
@@ -517,6 +519,39 @@ class StateValidator:
                     detail=f"cited but unavailable: {', '.join(dangling)}",
                 )
             )
+
+    def _check_derived(self, state: SemanticState, entries: list[ComponentValidationEntry]) -> None:
+        """Derived artifacts must never amplify weak sources (issue #392)."""
+        for finding in state.findings:
+            if finding.provenance.origin.self_certified and finding.status is StateStatus.VALID:
+                entries.append(
+                    ComponentValidationEntry(
+                        component=Component.FINDING,
+                        component_id=finding.finding_id,
+                        status=StateStatus.REQUIRES_REVIEW,
+                        detail=f"derived from {finding.provenance.origin.value} and not independently verified",
+                    )
+                )
+        for decision in state.decisions:
+            if decision.provenance.origin.self_certified and decision.status is StateStatus.VALID:
+                entries.append(
+                    ComponentValidationEntry(
+                        component=Component.DECISION,
+                        component_id=decision.decision_id,
+                        status=StateStatus.REQUIRES_REVIEW,
+                        detail=f"derived from {decision.provenance.origin.value} and not independently verified",
+                    )
+                )
+        for ev in state.evidence:
+            if ev.provenance.origin.self_certified and ev.status is StateStatus.VALID:
+                entries.append(
+                    ComponentValidationEntry(
+                        component=Component.EVIDENCE,
+                        component_id=ev.evidence_id,
+                        status=StateStatus.REQUIRES_REVIEW,
+                        detail=f"derived from {ev.provenance.origin.value} and not independently verified",
+                    )
+                )
 
 
 def validate_state(

--- a/tests/test_provenance_non_amplification.py
+++ b/tests/test_provenance_non_amplification.py
@@ -1,0 +1,191 @@
+"""Non-amplification invariant for derived artifacts (issue #392)."""
+
+from __future__ import annotations
+
+from continuum.events import Event, EventType
+from continuum.models import Finding, Goal, Origin, Progress, Provenance, SemanticState, StateStatus
+from continuum.provenance_map import derived_origin, derived_provenance_for_events, min_canonical
+from continuum.recovery.derived import derived_label, is_derived_unverified, stamp_derived
+from continuum.recovery.summary import render_informed_retry
+from continuum.state.semantic import project
+from continuum.state.validator import validate_state
+from continuum.storage import SQLiteStorage
+
+
+def test_lesson_sourced_only_from_external_agent_is_unverified() -> None:
+    events = [
+        Event(
+            run_id="r",
+            sequence=1,
+            type=EventType.RUN_STARTED,
+            payload={},
+            source=Origin.EXTERNAL_AGENT,
+        ),
+        Event(
+            run_id="r",
+            sequence=2,
+            type=EventType.TASK_UPDATED,
+            payload={},
+            source=Origin.EXTERNAL_AGENT,
+        ),
+    ]
+    payload = {"falsified": "test", "attempt_id": "a1"}
+    stamped = stamp_derived(payload, events)
+    assert stamped["derived_origin"] == Origin.EXTERNAL_AGENT.value
+    assert is_derived_unverified(stamped)
+    assert "unverified" in derived_label(stamped)
+    finding = Finding(
+        finding_id="lesson_1",
+        claim="lesson",
+        provenance=Provenance(origin=Origin(stamped["derived_origin"])),
+    )
+    state2 = SemanticState(
+        run_id="r",
+        goal=Goal(description="g", provenance=Provenance(origin=Origin.DETERMINISTIC)),
+        progress=Progress(
+            total=10, completed=1, provenance=Provenance(origin=Origin.DETERMINISTIC)
+        ),
+        findings=[finding],
+        source_sequence=1,
+    )
+    outcome = validate_state(state2)
+    assert any(
+        e.component.value == "finding"
+        and e.component_id == "lesson_1"
+        and e.status is StateStatus.REQUIRES_REVIEW
+        for e in outcome.report.statuses
+    )
+    assert not outcome.safe
+
+
+def test_mixing_in_one_trusted_source_does_not_upgrade() -> None:
+    events = [
+        Event(
+            run_id="r",
+            sequence=1,
+            type=EventType.RUN_STARTED,
+            payload={},
+            source=Origin.DETERMINISTIC,
+        ),
+        Event(
+            run_id="r",
+            sequence=2,
+            type=EventType.WORK_COMPLETED,
+            payload={},
+            source=Origin.DETERMINISTIC,
+        ),
+        Event(
+            run_id="r",
+            sequence=3,
+            type=EventType.TASK_UPDATED,
+            payload={},
+            source=Origin.EXTERNAL_AGENT,
+        ),
+    ]
+    origin = derived_origin([e.source for e in events])  # type: ignore[arg-type]
+    assert origin is Origin.EXTERNAL_AGENT
+    payload = stamp_derived({}, events)
+    assert payload["derived_origin"] == Origin.EXTERNAL_AGENT.value
+    assert is_derived_unverified(payload)
+    events2 = [
+        Event(run_id="r", sequence=1, type=EventType.RUN_STARTED, payload={}, source=Origin.HUMAN),
+        Event(
+            run_id="r",
+            sequence=2,
+            type=EventType.TASK_UPDATED,
+            payload={},
+            source=Origin.EXTERNAL_AGENT,
+        ),
+    ]
+    assert derived_provenance_for_events(events2) is Origin.EXTERNAL_AGENT
+
+
+def test_existing_artifact_without_new_field_degrades_to_unverified() -> None:
+    old_block: dict[str, object] = {"attempts": 1, "avoid": []}
+    assert is_derived_unverified(old_block)  # type: ignore[arg-type]
+    label = derived_label(old_block)  # type: ignore[arg-type]
+    assert "unverified" in label
+    assert min_canonical([]).value == "agent_asserted"
+    assert derived_origin([]) is Origin.EXTERNAL_AGENT
+    assert derived_provenance_for_events([]) is Origin.EXTERNAL_AGENT
+
+
+def test_falsifiable_mcp_progress_lesson_stays_request_human(tmp_path=None) -> None:
+    from continuum.models import Run
+    from continuum.recovery import RecoveryEngine
+
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="r", goal="g"))
+    storage.append_event(
+        "r", EventType.RUN_STARTED, {"goal": "g", "total": 10}, source=Origin.EXTERNAL_AGENT
+    )
+    storage.append_event(
+        "r", EventType.TASK_UPDATED, {"completed": 9, "total": 10}, source=Origin.EXTERNAL_AGENT
+    )
+    events = storage.read_events("r")
+    lesson_payload = {"attempt_id": "a1", "falsified": "progress 9/10 was fabricated"}
+    stamped = stamp_derived(lesson_payload, events)
+    assert stamped["derived_origin"] == Origin.EXTERNAL_AGENT.value
+    lesson_finding = Finding(
+        finding_id="lesson_falsified",
+        claim=stamped["falsified"],
+        provenance=Provenance(origin=Origin(stamped["derived_origin"])),
+    )
+    state = project("r", events)
+    state_with_lesson = state.model_copy(update={"findings": [*state.findings, lesson_finding]})
+    outcome = validate_state(state_with_lesson)
+    assert any(
+        e.component_id == "lesson_falsified" and e.status is StateStatus.REQUIRES_REVIEW
+        for e in outcome.report.statuses
+    )
+    engine = RecoveryEngine(storage)
+    decision = engine.assess("r")
+    assert decision.mode.value == "request_human"
+    assert not decision.safe
+    storage.close()
+
+
+def test_informed_retry_block_is_stamped_and_labelled() -> None:
+    storage = SQLiteStorage(":memory:")
+    from continuum.models import Run
+
+    storage.create_run(Run(run_id="r", goal="g"))
+    storage.append_event(
+        "r", EventType.RUN_STARTED, {"goal": "g", "total": 10}, source=Origin.EXTERNAL_AGENT
+    )
+    storage.append_event(
+        "r",
+        EventType.RECOVERY_STARTED,
+        {"mode": "request_human", "plan": []},
+        source=Origin.DETERMINISTIC,
+    )
+    from continuum.recovery import RecoveryEngine
+
+    engine = RecoveryEngine(storage)
+    decision = engine.assess("r")
+    assert decision.informed_retry is not None
+    assert "derived_origin" in decision.informed_retry
+    assert decision.informed_retry["derived_origin"] == Origin.EXTERNAL_AGENT.value
+    rendered = render_informed_retry(decision.informed_retry)
+    assert any("provenance" in line and "unverified" in line for line in rendered)
+    storage.close()
+
+
+def test_trusted_only_sources_yield_verified_derived() -> None:
+    events = [
+        Event(
+            run_id="r",
+            sequence=1,
+            type=EventType.RUN_STARTED,
+            payload={},
+            source=Origin.DETERMINISTIC,
+        ),
+        Event(
+            run_id="r", sequence=2, type=EventType.WORK_COMPLETED, payload={}, source=Origin.HUMAN
+        ),
+    ]
+    origin = derived_provenance_for_events(events)
+    assert origin is Origin.DETERMINISTIC
+    payload = stamp_derived({}, events)
+    assert not is_derived_unverified(payload)
+    assert "derived from deterministic" in derived_label(payload)


### PR DESCRIPTION
Refs #392, parent #392 -> #313 -> #393.

Implements the non-amplification invariant: a derived artifact's effective authority equals the minimum authority of its source events, forever. Every derivation site stamps the minimum origin/trust via the canonical mapping (provenance_map), the projector marks derived components with the degraded origin, the validator treats them exactly like EXTERNAL_AGENT facts (REQUIRES_REVIEW), and the briefing renders them labelled. Existing artifacts without the new field degrade to unverified rather than erroring.

Changes:
- provenance_map.py: adds _AUTHORITY_RANK, min_canonical, derived_origin, derived_provenance_for_events (reuses canonical mapping, no second system).
- recovery/summary.py: stamps informed-retry block with derived_origin from all source events, renders provenance label, handles missing field as unverified.
- recovery/derived.py: new helper for stamping any derived payload (lesson/report) with minimum, plus label and unverified check.
- state/semantic.py: _provenance now respects derived_origin in payload, degrading missing to EXTERNAL_AGENT.
- state/validator.py: _check_derived marks findings/decisions/evidence with self_certified provenance as REQUIRES_REVIEW, so derived lessons cannot clear a gate.
- checkpoint/context.py: comment clarifies that derived lessons appear via REQUIRES_REVIEW and are self-labelling (no new section needed, existing review section already carries them).

Tests (must fail on pre-change code):
- lesson sourced only from EXTERNAL_AGENT is unverified and cannot clear REQUIRES_REVIEW
- mixing in one trusted source does not upgrade (minimum wins)
- existing artifacts without new field degrade to unverified
- falsifiable MCP test: fabricate progress via EXTERNAL_AGENT, derive a lesson, assert it carries EXTERNAL_AGENT marking and resume stays request_human
- informed retry block is stamped and labelled
- trusted-only sources yield verified derived

Gate: ruff check clean, ruff format clean (226 files), mypy src/continuum success (106 files), pytest 6 passed for new tests plus existing validator/informed_retry/projection green.

Closes #392.