### PR TITLE
fix(cli): make complete idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `continuum complete` idempotent for runs that are already completed (#356).
+
 ## [0.1.0] - 2026-08-27
 
 ### Added

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -917,6 +917,21 @@ def cmd_complete(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
     gates) and flips the run row to COMPLETED.
     """
     run = storage.get_run(args.run_id)  # raises RunNotFound -> NOT_FOUND
+    if run.status is RunStatus.COMPLETED:
+        _emit(
+            {
+                "run_id": args.run_id,
+                "status": run.status.value,
+                "summary": args.summary or "",
+                "already_completed": True,
+            },
+            f"Run {args.run_id} is already completed.",
+            as_json=args.json,
+            stream=out,
+            palette=getattr(args, "_palette", None),
+        )
+        return ExitCode.OK
+
     note = {"summary": args.summary} if args.summary else {}
     storage.append_event(
         args.run_id,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -934,14 +934,23 @@ def test_complete_closes_a_run_and_clears_it_from_active_resolution(
         assert store.get_active_run() is None
 
 
-def test_complete_is_idempotent_enough_for_double_clicks(tmp_path: Path) -> None:
+def test_complete_is_idempotent_for_double_clicks(tmp_path: Path) -> None:
     path = str(tmp_path / "d.db")
     with SQLiteStorage(path) as store:
         store.create_run(Run(run_id="r", goal="g"))
     code, _, err = run("--db", path, "complete", "r")
     assert code == ExitCode.OK
-    code, _, err = run("--db", path, "complete", "r")
+    with SQLiteStorage(path) as store:
+        events_after_first = list(store.read_events("r"))
+
+    code, out, err = run("--db", path, "complete", "r")
     assert code == ExitCode.OK, err
+    assert "already completed" in out
+    code, out, err = run("--db", path, "--json", "complete", "r")
+    assert code == ExitCode.OK, err
+    assert json.loads(out)["already_completed"] is True
+    with SQLiteStorage(path) as store:
+        assert list(store.read_events("r")) == events_after_first
 
 
 def test_complete_unknown_run_is_not_found(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

Makes `continuum complete <run_id>` idempotent when the target run is already completed.

`cmd_complete` now returns early for `RunStatus.COMPLETED` before appending events or updating the run. A repeated completion exits successfully, reports that the run is already completed, and includes `already_completed: true` in structured JSON output.

The first completion path is unchanged.

Regression coverage verifies that repeating `complete` does not append duplicate `REVIEW_CONFIRMED` or `RUN_COMPLETED` events.

## Related issues

Fixes #356

## Types of changes

- Type: `bugfix`

## Breaking changes

No.

## How has this been tested?

Added regression coverage in `tests/test_cli.py` for:

- successful repeated completion
- already-completed text output
- structured JSON output with `already_completed: true`
- exact event-log equality before and after the repeated completion

`git diff --check` passed.

I could not run the Python test and quality-check commands locally because this environment does not have a usable Python installation or virtual environment. `python` and `py` resolve to inaccessible Windows Store aliases, and `pytest`, `ruff`, and `mypy` are unavailable.

The following repository checks therefore need to be verified by CI:

- `pytest`
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy src/continuum`

## Checklist

- [x] Tests added or updated for the changed behaviour.
- [x] Documentation updated where the change affects user-facing behaviour.
- [ ] CI passes on the latest commit.
- [x] Security-relevant changes state known limitations explicitly in this description. (Not security-relevant.)

## Additional context

The fix is intentionally limited to `cmd_complete`. No storage or schema changes are necessary because the duplicate events originate from the CLI completion path.

The changelog was updated under `Unreleased` in accordance with the repository's contribution guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Repeatedly completing an already-completed run now succeeds safely without creating duplicate events or changing its history.
  - Completion responses indicate when the run was already completed, including in JSON output.

- **Documentation**
  - Added an Unreleased changelog entry describing idempotent completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->