### PR TITLE
fix(budgets): write through a symlinked registry and keep its owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -799,6 +799,21 @@ All notable changes to this project are documented here. The format follows
   loseable by the very crash it guards against. Both steps are best effort: a
   filesystem without permission bits keeps the tighter 0600, and Windows (which
   cannot open a directory as a descriptor) is left exactly as durable as before.
+  Swapping an inode for a rewritten one also changes two further things
+  `write_text` did not, so both are re-established: the path is resolved before
+  staging, because a `budgets.json` that is a symlink to a shared registry was
+  written *through* by `write_text` and would be *replaced* by `os.replace`,
+  leaving every other reader of the shared file - and `load_budgets`, which still
+  reads through the link - on the counters from before; and the replaced inode's
+  uid and gid are put back onto the staged file, because mode 0640 names a group
+  without saying which one, and a fresh `mkstemp` inode belongs to whichever group
+  the saving process sits in. Ownership is written before the mode, since `chown`
+  clears setuid and setgid on some systems and a `chmod` running second would
+  silently undo that. A refused `(uid, gid)` is retried as the gid alone, which is
+  the half that grants access to anyone but the owner, and a `chown` that cannot be
+  performed at all does not fail the save: as with the chmod and the flush, turning
+  an unreproducible permission into a refused claim is the wrong direction for a
+  fail-closed gate.
 
 - **Budget rejections named the rule but not the offending value, and one still
   named the config by relative path (#326, #426).** "needs a positive integer

--- a/src/continuum/budgets.py
+++ b/src/continuum/budgets.py
@@ -382,7 +382,7 @@ def _restore_ownership(name: str, attributes: _StagedAttributes) -> None:
     the wrong direction for a fail-closed gate: the replacement never had that
     group's access to hand out, so nothing is lost that this call could keep.
     """
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: no cover - one arm is dead on either platform
         # Named literally rather than through _CAN_CHOWN, which already keeps the
         # gid out of _staged_attributes here: os.chown does not exist on Windows,
         # so the calls below have to be unreachable to a type checker too.

--- a/src/continuum/budgets.py
+++ b/src/continuum/budgets.py
@@ -40,10 +40,12 @@ Where the registry asks for an integer it means one: JSON ``true`` is refused
 rather than read as a silent cap of 1 (issue #429), and a rejection names the
 offending value and its type (issue #326). ``save_budgets`` stages and renames
 rather than truncating in place, so a process that dies mid-write costs at most
-the last increment, never the registry (issue #427); the staged file inherits
-the target's permissions and the rename is flushed, so replacing the registry
-neither locks other readers out of it nor can be lost by the crash it guards
-against.
+the last increment, never the registry (issue #427). Because that replaces an
+inode instead of rewriting one, the staged file inherits the target's
+permissions and ownership, a symlinked registry is written through rather than
+replaced, and the rename is flushed: swapping the file must not change who can
+read it, which file is written, or whether the write survives the crash it
+guards against.
 """
 
 from __future__ import annotations
@@ -51,10 +53,11 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import sys
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, TypeGuard
+from typing import Any, NamedTuple, TypeGuard
 
 __all__ = [
     "DEFAULT_BUDGETS_PATH",
@@ -82,6 +85,11 @@ FALLBACK_MAX_ATTEMPTS = 3
 #: Where Linux publishes the process umask (kernel 4.7+). Absent elsewhere, and
 #: named rather than inlined so a test can take the fallback path on any platform.
 _UMASK_STATUS_PATH = "/proc/self/status"
+
+#: Whether ownership can be written back at all. There is no POSIX owner or group
+#: on Windows for a replaced registry to lose in the first place, and ``os.chown``
+#: does not exist there.
+_CAN_CHOWN = sys.platform != "win32"
 
 
 class BudgetConfigError(ValueError):
@@ -304,13 +312,31 @@ def _process_umask() -> int | None:
     return mask
 
 
-def _staged_mode(path: Path) -> int | None:
-    """Permissions a rewritten registry should end up with, or ``None`` if unknown.
+class _StagedAttributes(NamedTuple):
+    """What a replaced registry's inode carried and a replacement must re-establish.
 
-    :func:`tempfile.mkstemp` creates its staging file 0600 and :func:`os.replace`
-    carries those bits onto the target, so an atomic rewrite would quietly narrow
-    a registry that :meth:`Path.write_text` left readable: overwriting preserved
-    whatever mode the file already had, and creating honoured the process umask.
+    :func:`os.replace` moves a *new* inode into place, so nothing the old file
+    carried survives on its own. Each field is ``None`` when there is nothing to
+    reproduce or no way to learn it, which the caller reads as "leave the tighter
+    default alone" rather than as a value to guess at.
+    """
+
+    mode: int | None
+    uid: int | None
+    gid: int | None
+
+
+_NOTHING_TO_RESTORE = _StagedAttributes(None, None, None)
+
+
+def _staged_attributes(path: Path) -> _StagedAttributes:
+    """Permissions and ownership a rewritten registry should end up with.
+
+    :func:`tempfile.mkstemp` creates its staging file 0600 under the saving
+    process's own uid and gid, and :func:`os.replace` installs that inode as it
+    is, so an atomic rewrite would quietly narrow a registry that
+    :meth:`Path.write_text` left readable: overwriting preserved the mode, the
+    owner and the group, because it reused the inode instead of replacing it.
     This registry is read by hooks, sidecars and CI steps that may run under
     another uid or gid, and #413 makes a write happen per claim attempt, so the
     first save would lock them out for the rest of the run. That is a worse
@@ -319,20 +345,58 @@ def _staged_mode(path: Path) -> int | None:
     An existing target's own bits win, because they are the operator's decision
     and resetting them on every save is the other half of the same bug. Only the
     permission bits are copied: setuid, setgid and sticky are not carried onto a
-    file the saving process newly owns.
+    file the saving process newly owns. Ownership is read only where it can be
+    written back, so a platform without :func:`os.chown` reports ``None`` rather
+    than a value nothing can act on.
     """
     try:
-        return path.stat().st_mode & 0o777
+        info = path.stat()
     except FileNotFoundError:
-        pass
+        mask = _process_umask()
+        if mask is None:
+            return _NOTHING_TO_RESTORE
+        # 0o666, not 0o644: that is the mode open() passes for a new text file, so
+        # a first save reproduces what write_text produced under the same umask.
+        # A file being created has no previous owner to put back.
+        return _StagedAttributes(0o666 & ~mask, None, None)
     except OSError:
-        return None
-    mask = _process_umask()
-    if mask is None:
-        return None
-    # 0o666, not 0o644: that is the mode open() passes for a new text file, so a
-    # first save reproduces what write_text produced under the same umask.
-    return 0o666 & ~mask
+        return _NOTHING_TO_RESTORE
+    if not _CAN_CHOWN:
+        return _StagedAttributes(info.st_mode & 0o777, None, None)
+    return _StagedAttributes(info.st_mode & 0o777, info.st_uid, info.st_gid)
+
+
+def _restore_ownership(name: str, attributes: _StagedAttributes) -> None:
+    """Put the replaced inode's owner and group onto the staged file.
+
+    The mode is only half of an answer to "who may read this". A registry an
+    operator set to ``0640`` with a shared group grants that group nothing once
+    the group becomes whichever one the saving process happens to sit in, so the
+    permission fix has to carry ownership too or it only looks complete.
+
+    Best effort, like the chmod: a process that is not root cannot give a file
+    away and cannot join a group it is not in, and the gid is attempted on its own
+    when the pair is refused, because the group is the half that grants access to
+    anyone else. Failing the save instead - as opposed to failing to reproduce a
+    group - would turn an unreproducible permission into a refused claim, which is
+    the wrong direction for a fail-closed gate: the replacement never had that
+    group's access to hand out, so nothing is lost that this call could keep.
+    """
+    if sys.platform == "win32":
+        # Named literally rather than through _CAN_CHOWN, which already keeps the
+        # gid out of _staged_attributes here: os.chown does not exist on Windows,
+        # so the calls below have to be unreachable to a type checker too.
+        return
+    if attributes.gid is None:
+        return
+    current = os.stat(name)
+    if (attributes.uid, attributes.gid) == (current.st_uid, current.st_gid):
+        return  # The common case: one process rewriting a registry it owns.
+    with contextlib.suppress(OSError):
+        os.chown(name, attributes.uid if attributes.uid is not None else -1, attributes.gid)
+        return
+    with contextlib.suppress(OSError):
+        os.chown(name, -1, attributes.gid)
 
 
 def _fsync_directory(directory: Path) -> None:
@@ -380,16 +444,27 @@ def save_budgets(path: Path, data: Mapping[str, Any]) -> None:
     increment on an abrupt exit is an acceptable price for a counter registry.
     Losing the registry is not, and #413 makes this a write per claim attempt.
 
-    Staging is not allowed to change *who can read* the registry
-    (:func:`_staged_mode`) or to leave the rename itself unflushed
-    (:func:`_fsync_directory`): a rewrite that survives a crash but locks a hook
-    out of the file, or that is lost by the crash it guards against, has not
-    delivered what the staging file was added for.
+    Staging replaces an inode rather than rewriting one, so three properties of
+    the old file have to be re-established deliberately or the rewrite quietly
+    changes something it was never asked to. Who may read it, owner and group
+    included (:func:`_staged_attributes`, :func:`_restore_ownership`). Which file
+    is written, when the registry is a symlink to a shared one: ``write_text``
+    followed the link and ``os.replace`` would swap the link itself for a regular
+    file, leaving every other consumer of the shared target on stale counters, so
+    the path is resolved first. And whether the rename survives a crash
+    (:func:`_fsync_directory`). A save that outlives a power cut but locks a hook
+    out of the file, or writes past a symlink, has not delivered what the staging
+    file was added for.
     """
+    # Resolved, so a symlinked registry is written through rather than replaced,
+    # matching both write_text and load_budgets, which reads through the link. It
+    # also puts the staging file beside the *real* target, keeping the rename
+    # inside one filesystem.
+    path = path.resolve()
     path.parent.mkdir(parents=True, exist_ok=True)
     body = json.dumps(data, indent=2) + "\n"
     # Read before the replace, while the target is still the file being replaced.
-    mode = _staged_mode(path)
+    attributes = _staged_attributes(path)
     # Same directory as the target: os.replace is only atomic within one
     # filesystem, and the system temp dir is routinely on another.
     handle, name = tempfile.mkstemp(dir=path.parent, prefix=f"{path.name}.", suffix=".tmp")
@@ -399,11 +474,15 @@ def save_budgets(path: Path, data: Mapping[str, Any]) -> None:
             stream.write(body)
             stream.flush()
             os.fsync(stream.fileno())
-        if mode is not None:
+        # Ownership before the mode: the bits mean nothing until they apply to the
+        # identity they were set for, and chown clears setuid and setgid on some
+        # systems, which chmod running second would silently undo.
+        _restore_ownership(name, attributes)
+        if attributes.mode is not None:
             # A filesystem without permission bits keeps mkstemp's 0600: too
             # private is recoverable by hand, a failed save is not.
             with contextlib.suppress(OSError):
-                os.chmod(name, mode)
+                os.chmod(name, attributes.mode)
         os.replace(name, path)
         tmp = None  # Consumed by the replace; there is nothing left to clean up.
         _fsync_directory(path.parent)

--- a/tests/test_retry_budgets.py
+++ b/tests/test_retry_budgets.py
@@ -20,7 +20,9 @@ from continuum.actions import ActionLedger
 from continuum.budgets import (
     BudgetConfigError,
     _process_umask,
-    _staged_mode,
+    _restore_ownership,
+    _staged_attributes,
+    _StagedAttributes,
     attempts_by_key,
     attempts_for_type,
     backoff_delay,
@@ -484,7 +486,7 @@ def test_the_directory_flush_follows_the_replace_and_targets_the_parent(
         lambda directory: calls.append(f"flush {directory}"),
     )
     save_budgets(tmp_path / "budgets.json", bound_registry())
-    assert calls == ["replace", f"flush {tmp_path}"]
+    assert calls == ["replace", f"flush {tmp_path.resolve()}"]
 
 
 @pytest.mark.parametrize(
@@ -538,7 +540,7 @@ def test_a_target_that_cannot_be_stated_keeps_the_tighter_default(
         raise PermissionError("the mode of this file is not readable")
 
     monkeypatch.setattr(Path, "stat", deny)
-    assert _staged_mode(p) is None
+    assert _staged_attributes(p) == (None, None, None)
 
 
 @posix_only
@@ -551,11 +553,168 @@ def test_a_save_whose_mode_cannot_be_determined_still_lands_and_stays_private(
     an operator can widen a file by hand, but cannot un-grant access a rewrite
     handed out, and cannot proceed at all if the save refuses.
     """
-    monkeypatch.setattr("continuum.budgets._staged_mode", lambda path: None)
+    monkeypatch.setattr(
+        "continuum.budgets._staged_attributes", lambda path: _StagedAttributes(None, None, None)
+    )
     p = tmp_path / "budgets.json"
     save_budgets(p, bound_registry())
     assert load_budgets(p) == bound_registry()
     assert stat.S_IMODE(p.stat().st_mode) == 0o600
+
+
+@posix_only
+def test_a_symlinked_registry_is_written_through_not_replaced(tmp_path: Path) -> None:
+    """A registry that is a symlink to a shared file must keep pointing at it.
+
+    ``write_text`` followed the link and wrote the target. ``os.replace`` swaps the
+    link itself for a regular file, so the save lands somewhere no other consumer
+    of the shared registry reads, and each of them keeps the counters from before.
+    Divergent budget counters are worse than a single stale one: every reader
+    believes a different number of attempts is left, which is the opposite of what
+    a shared registry is for. ``load_budgets`` reads through the link, so saving
+    has to write through it or the two halves of the module disagree.
+    """
+    shared = tmp_path / "shared" / "budgets.json"
+    shared.parent.mkdir()
+    save_budgets(shared, {"default_max_attempts": 1})
+    link = tmp_path / "run" / "budgets.json"
+    link.parent.mkdir()
+    link.symlink_to(shared)
+
+    save_budgets(link, bound_registry())
+
+    assert link.is_symlink(), "the link itself must survive the rewrite"
+    assert load_budgets(shared) == bound_registry()
+    assert load_budgets(link) == bound_registry()
+    assert [entry.name for entry in sorted(shared.parent.iterdir())] == ["budgets.json"], (
+        "staging belongs beside the real target, and must not outlive the rename"
+    )
+    assert [entry.name for entry in sorted(link.parent.iterdir())] == ["budgets.json"]
+
+
+@posix_only
+def test_save_keeps_the_group_the_registry_was_given(tmp_path: Path) -> None:
+    """Mode 0640 grants read to a *group*, and the mode alone does not say which.
+
+    ``mkstemp`` creates a fresh inode under the saving process's own uid and gid,
+    and ``os.replace`` installs it as it is, so copying 0640 across hands group
+    read to whichever group that process happens to sit in and takes it from the
+    one the operator chose. Preserving the bits is only half an answer to "who may
+    read this" until ownership comes with them.
+    """
+    p = tmp_path / "budgets.json"
+    save_budgets(p, bound_registry())
+    mine = p.stat().st_gid
+    others = [gid for gid in os.getgroups() if gid != mine]
+    if not others:
+        pytest.skip("the test user is in a single group, so there is nowhere to move the file")
+    os.chown(p, -1, others[0])
+    p.chmod(0o640)
+
+    save_budgets(p, {"default_max_attempts": 7})
+
+    assert p.stat().st_gid == others[0]
+    assert stat.S_IMODE(p.stat().st_mode) == 0o640
+    assert load_budgets(p) == {"default_max_attempts": 7}
+
+
+@posix_only
+def test_a_group_that_cannot_be_restored_does_not_fail_the_save(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A process cannot join a group it is not in, and must not refuse a save over it.
+
+    Aborting before the replace - the other available answer - converts a
+    permission that cannot be reproduced into a claim that cannot proceed, and a
+    budget gate that refuses to record an attempt refuses the attempt. Nothing this
+    call could have kept is lost by continuing: the replacement never had that
+    group's access to hand out in the first place.
+    """
+    p = tmp_path / "budgets.json"
+    save_budgets(p, bound_registry())
+    stranger = p.stat()
+
+    def refuse(*args: object, **kwargs: object) -> None:
+        raise PermissionError("not a member of that group")
+
+    monkeypatch.setattr(os, "chown", refuse)
+    monkeypatch.setattr(
+        "continuum.budgets._staged_attributes",
+        lambda path: _StagedAttributes(0o640, stranger.st_uid + 1, stranger.st_gid + 1),
+    )
+
+    save_budgets(p, {"default_max_attempts": 7})
+    monkeypatch.undo()
+
+    assert load_budgets(p) == {"default_max_attempts": 7}
+    assert stat.S_IMODE(p.stat().st_mode) == 0o640, "the mode is still restored on its own"
+
+
+@posix_only
+def test_ownership_restore_falls_back_to_the_group_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Giving a file away takes root; putting it back in a group you are in does not.
+
+    So a refused ``(uid, gid)`` pair is worth retrying as the gid alone, because the
+    group is the half that grants access to anyone other than the owner. The owner
+    of the replacement is the process that wrote it, which already had access.
+    """
+    p = tmp_path / "budgets.json"
+    p.write_text("{}", encoding="utf-8")
+    mine = p.stat()
+    attempts: list[tuple[int, int]] = []
+    real_chown = os.chown
+
+    def only_the_group(target: object, uid: int, gid: int) -> None:
+        attempts.append((uid, gid))
+        if uid != -1:
+            raise PermissionError("only root may give a file away")
+        real_chown(target, uid, gid)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(os, "chown", only_the_group)
+
+    _restore_ownership(str(p), _StagedAttributes(0o640, mine.st_uid + 1, mine.st_gid))
+
+    assert attempts == [(mine.st_uid + 1, mine.st_gid), (-1, mine.st_gid)]
+
+
+def test_a_registry_with_no_group_recorded_is_left_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing was read, so there is nothing to write back - and on Windows, no owner.
+
+    ``_restore_ownership`` has to be a no-op in that case rather than passing ``None``
+    to ``os.chown``, which would raise and lose a save that had already been staged.
+    """
+    p = tmp_path / "budgets.json"
+    p.write_text("{}", encoding="utf-8")
+
+    def unexpected(*args: object, **kwargs: object) -> None:
+        raise AssertionError("ownership must not be touched when none was recorded")
+
+    if hasattr(os, "chown"):
+        monkeypatch.setattr(os, "chown", unexpected)
+
+    _restore_ownership(str(p), _StagedAttributes(0o640, None, None))
+
+
+def test_a_platform_without_ownership_still_reproduces_the_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows has no POSIX owner for a replaced registry to lose, only bits to keep.
+
+    Reading ``st_uid`` there returns 0 for every file, so writing it back would be a
+    meaningless call that can only fail. The mode is still worth reproducing.
+    """
+    p = tmp_path / "budgets.json"
+    p.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr("continuum.budgets._CAN_CHOWN", False)
+
+    attributes = _staged_attributes(p)
+
+    assert (attributes.uid, attributes.gid) == (None, None)
+    assert attributes.mode == stat.S_IMODE(p.stat().st_mode)
 
 
 def test_reading_the_umask_leaves_it_exactly_as_it_was() -> None:
@@ -589,11 +748,25 @@ def test_a_new_registry_takes_its_bits_from_the_umask_not_from_0600(
     group and other bits an operator's umask allows.
     """
     monkeypatch.setattr("continuum.budgets._process_umask", lambda: 0o027)
-    assert _staged_mode(tmp_path / "never-written.json") == 0o640
+    assert _staged_attributes(tmp_path / "never-written.json").mode == 0o640
     monkeypatch.setattr("continuum.budgets._process_umask", lambda: None)
-    assert _staged_mode(tmp_path / "never-written.json") is None, (
+    assert _staged_attributes(tmp_path / "never-written.json").mode is None, (
         "an unreadable umask must leave mkstemp's tighter 0600 alone, not guess wider"
     )
+
+
+def test_a_registry_being_created_has_no_previous_owner_to_put_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """There is no ownership to reproduce when the file does not exist yet.
+
+    ``None`` rather than the saving process's own uid and gid, so
+    :func:`_restore_ownership` can tell "nothing to restore" apart from "restore
+    these" and skip the ``chown`` entirely instead of setting what is already true.
+    """
+    monkeypatch.setattr("continuum.budgets._process_umask", lambda: 0o022)
+    attributes = _staged_attributes(tmp_path / "never-written.json")
+    assert (attributes.uid, attributes.gid) == (None, None)
 
 
 def test_get_remaining_and_refusal_math() -> None:


### PR DESCRIPTION
## Description

Follow-up to #441, which was merged while CodeRabbit's review was still open. Both of its findings are real and neither was addressed in that PR, so they land here. Both are consequences of the same thing: #441 replaced `Path.write_text` with staging plus `os.replace` for crash-atomicity (#427), and `os.replace` installs a **new inode** rather than rewriting the old one. Three properties of the old file therefore have to be re-established deliberately. #441 handled one of them (the mode); these are the other two.

**A symlinked registry was replaced instead of written through.** `write_text` followed a terminal `budgets.json` symlink and wrote the shared file behind it. `os.replace` swaps the link itself for a regular file. `load_budgets` still reads through the link (`read_text`), so after one save the two halves of the module pointed at different files: the writer saw its own counters, and every other consumer of the shared registry kept the ones from before, diverging further with each save once #413 makes this a write per claim attempt. Divergent budget counters are worse than a single stale set, because each reader believes a different number of attempts is left. `save_budgets` now resolves the path before staging. That also closes an atomicity hole I had not noticed: the staging file was being created next to the *link*, which is not necessarily on the same filesystem as the real target, so `os.replace` was not guaranteed to be atomic there either.

**Preserving the mode without the ownership preserved nothing.** Mode 0640 grants read to a *group* without saying which one, and `mkstemp` creates its inode under the saving process's own uid and gid. Copying 0640 across therefore handed group read to whichever group the saving process happened to sit in and took it from the group the operator chose - so #441's permission fix was only half an answer to "who may read this". `_staged_mode` becomes `_staged_attributes`, returning mode, uid and gid, and `_restore_ownership` writes ownership onto the staged file **before** the chmod: `chown` clears setuid and setgid on some systems, and a chmod running second would silently undo that.

## Related issues

Refs #427
Follow-up to #441
Refs #413 (which turns this into a write per claim attempt)

## Types of changes

- Type: `bugfix`

## Breaking changes

No. Both changes make an atomic save reproduce what `write_text` did before #441: a symlinked registry is written through again, and a registry's group keeps its access. Nothing that loaded or saved before this change behaves differently, except in the direction of the pre-#441 behaviour.

## How has this been tested?

```
.venv/Scripts/python.exe -m pytest -q                    # full suite green
.venv/Scripts/ruff.exe format --check src/ tests/
.venv/Scripts/ruff.exe check src/ tests/
.venv/Scripts/mypy.exe src/continuum                     # strict, 107 files
```

Six tests, in `tests/test_retry_budgets.py`:

- `test_a_symlinked_registry_is_written_through_not_replaced` - a terminal `budgets.json` symlink to a shared registry: the shared target receives the data, `link.is_symlink()` still holds, and neither directory is left with staging litter. This is the regression test CodeRabbit asked for.
- `test_save_keeps_the_group_the_registry_was_given` - a non-primary gid taken from `os.getgroups()`, asserting both `st_gid` and 0640 survive a save. Skips when the test user belongs to a single group, since there is then nowhere to move the file.
- `test_a_group_that_cannot_be_restored_does_not_fail_the_save` - the best-effort contract, and that the mode is still restored on its own.
- `test_ownership_restore_falls_back_to_the_group_alone` - asserts the two `chown` attempts and their order.
- `test_a_registry_with_no_group_recorded_is_left_alone` - no recorded gid means no `chown` call, rather than passing `None` to it.
- `test_a_platform_without_ownership_still_reproduces_the_mode` - Windows keeps the bits and skips the ownership.

Environment caveat, same as on #441: I develop on Windows and could not get a Linux container up locally (no usable WSL distro; `docker pull` failed on a TLS handshake timeout with nothing cached). The POSIX-only tests here - permission bits, ownership, symlinks - skip on my machine and are exercised by the `ubuntu-latest` and `macos-latest` legs of the matrix rather than locally. Everything platform-independent passes locally. The Windows-only path is tested where it differs rather than assumed: `_CAN_CHOWN` keeps the gid out of `_staged_attributes` there, and `_restore_ownership` returns before the `chown` calls, which is also what makes the module type-check under `mypy --strict` on a platform where `os.chown` does not exist.

## Checklist

- Tests added or updated for the changed behaviour: yes. Each fails on the code as merged in #441 - the symlink test finds a regular file where the link was, and the group test finds the saving process's own gid.
- Documentation updated where the change affects user-facing behaviour: yes, the `CHANGELOG.md` entry for #427 is extended with both properties and the best-effort limits, and the module docstring names all three.
- CI passes on the latest commit.
- Security-relevant changes state known limitations explicitly in this description: yes, below.

## Additional context

### One reasoned deviation from the review

CodeRabbit asked for the save to **abort before `os.replace` when the group cannot be restored**. I did not do that, for the same reason the chmod and the directory fsync in #441 are best effort. `save_budgets` is the write side of a fail-closed gate, so a refused save is a refused claim: failing because a *permission could not be reproduced* converts an ownership limitation into blocked work. And nothing is lost by continuing that the abort would have kept - the replacement never had that group's access to hand out, so the group loses access either way; the abort just also loses the increment.

What `_restore_ownership` does instead is try `(uid, gid)`, then retry `(-1, gid)`, both suppressed. A non-root process cannot give a file away but can put a file back into a group it belongs to, and the gid is the half that grants access to anyone other than the owner.

I also decided against narrowing the mode when the chown fails. In the realistic deployment the process is in the shared group and the chown succeeds; when it does not, the original group has lost access regardless of what the bits say, so tightening them would only remove access from the identity that did write the file.

### Known limitations

- A non-root process cannot always reproduce ownership. The save proceeds; the mode is still applied.
- A filesystem without permission bits keeps `mkstemp`'s 0600. Too private is recoverable by hand; a refused save under a fail-closed gate is not.
- setuid, setgid and the sticky bit are deliberately not copied onto the replacement.
- Windows keeps the mode only. There is no POSIX owner or group there for a replaced registry to lose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved budget registry saves when the registry path is a symlink.
  * Preserved file ownership and permissions during atomic saves.
  * Added resilience when ownership cannot be restored or platform support is unavailable.
  * Ensured ownership is applied safely without disrupting special file permissions.
* **Tests**
  * Expanded coverage for symlink handling, ownership preservation, fallback behavior, and permission restoration.
* **Documentation**
  * Updated changelog details for atomic budget saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->