### PR TITLE
test: regression test for StateCheckpoint.verify with tampered hash

### DIFF
--- a/tests/test_checkpoint_manager.py
+++ b/tests/test_checkpoint_manager.py
@@ -299,3 +299,13 @@ def test_evaluate_does_not_write_anything(store: SQLiteStorage) -> None:
     assert manager.evaluate("run_1", explicit=True).should
     assert store.last_sequence("run_1") == before
     assert manager.history("run_1") == []
+
+
+def test_checkpoint_verify_detects_tampered_hash(store: SQLiteStorage) -> None:
+    cp = CheckpointManager(store).checkpoint("run_1", trigger="manual", reason="")
+    assert cp.verify()
+    bad = cp.model_copy(update={"integrity_hash": "bad"})
+    assert not bad.verify()
+    # Tampering with None also fails (covers the unset case)
+    tampered_none = cp.model_copy(update={"integrity_hash": None})
+    assert not tampered_none.verify()


### PR DESCRIPTION
## Description

Add regression test pinning StateCheckpoint tamper detection. The checkpoint is sealed via CheckpointManager, verify() is true on the sealed copy, and a copy with integrity_hash replaced by "bad" (and None) fails verify(). The test uses the existing store fixture and follows the reproduction from the issue verbatim.

## Related issues

Fixes #357

## Types of changes

- Type: tests

## Breaking changes

No

## How has this been tested?

Environment: Python 3.13, SQLiteStorage :memory:, ruff 0.16.2, mypy strict.

```
PYTHONPATH=src python -m pytest tests/test_checkpoint_manager.py::test_checkpoint_verify_detects_tampered_hash -v
# 1 passed

PYTHONPATH=src python -m pytest tests/test_checkpoint_manager.py -q
# 19 passed (was 18 before, now 19)

ruff check src/ tests/ examples/
# All checks passed!

ruff format --check src/ tests/ examples/
# 229 files already formatted

uv run mypy src/continuum
# Success: no issues found in 107 source files
```

Verified the test fails if "bad" is replaced with the original hash (assert not True).

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour (not needed, test-only). CI passes on the latest commit.

## Additional context

Complements event-chain verify_events tests. No source change, only test. Keeps the tamper property green if a future refactor changes verify() to always return True.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to confirm checkpoint verification detects corrupted or missing integrity hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->