### PR TITLE
docs(adapters): embeddability sprint with tested harness hook recipes

### DIFF
--- a/docs/guides/bring-your-own-dashboard.md
+++ b/docs/guides/bring-your-own-dashboard.md
@@ -1,0 +1,305 @@
+# Bring your own dashboard
+
+CONTINUUM as the verification layer under any control plane or UI. This guide shows how to consume the resume contract and evidence export so you can render run state, gate launches, and prove history without trusting the UI itself.
+
+## What this gives you
+
+- a sealed recovery contract: the only legal next action, plus why, plus what was verified
+- a content-addressed evidence stream: every event as a neutral primitive with hash-chain inputs so the receiver can detect truncation or tampering by recomputing the chain exactly as `verify()` does
+- chain attestation: an Ed25519 signed head for external verifiers
+
+Your dashboard is presentation. CONTINUUM stays the substrate. That separation is deliberate: a UI bug cannot turn an unsafe resume into a safe one because safety is decided in the storage layer, not in the renderer.
+
+## Substrates consumed
+
+### 1. Resume contract (`continuum resume --json`)
+
+Shell:
+
+```bash
+continuum resume my-task --json | python -m json.tool
+```
+
+Python:
+
+```python
+from continuum.recovery import RecoveryEngine
+from continuum.storage import SQLiteStorage
+
+store = SQLiteStorage("continuum.db")
+decision = RecoveryEngine(store).assess("my-task", current_environment=None)
+print(decision.mode)      # RecoveryMode.RESUME, REQUEST_HUMAN, ...
+print(decision.safe)      # bool, also exit code 0 means safe
+print(decision.contract.model_dump(mode="json"))
+print(decision.human_steps)  # executable next steps
+```
+
+JSON shape (abridged):
+
+```json
+{
+  "run_id": "my-task",
+  "mode": "resume",
+  "safe": true,
+  "next_allowed_action": null,
+  "contract": {
+    "recovery_status": "safe_to_resume",
+    "verified": ["goal", "progress"],
+    "invalidated": [],
+    "reason": "all state verified against the environment",
+    "integrity_hash": "5cdda5...",
+    "post_checkpoint_observations": [],
+    "required_actions": [],
+    "next_allowed_action": null
+  },
+  "human_steps": [],
+  "family_rationale": [],
+  "children": [],
+  "pinning_drift": [],
+  "informed_retry": null,
+  "progress": {"completed": 3, "pending": 7, "failed": 0}
+}
+```
+
+When blocked, the same structure carries the cause and the fix:
+
+```json
+{
+  "mode": "request_human",
+  "safe": false,
+  "next_allowed_action": "reconcile_action:action_efbdf7a796e5e36b792ca57f2eb3868e",
+  "contract": {
+    "recovery_status": "requires_human",
+    "reason": "1 external side effect(s) have unknown outcomes; at least one repair needs a person",
+    "required_actions": ["reconcile_action:action_efbdf7a796e5e36b792ca57f2eb3868e"]
+  },
+  "human_steps": [
+    "check whether 'slack.notify' actually reached the outside world, then call continuum_reconcile_action(run_id=my-task, action_key=..., occurred=true|false)"
+  ]
+}
+```
+
+Exit code mirrors `safe`: only a verified-safe run exits 0. Gate launches with `continuum resume my-task && ./start-agent.sh`.
+
+Family rollup (multi-agent, issue #243): when a parent has children, the same `resume` JSON includes `family_rationale` and `children`, and a `requires_human` blocked parent whose only block is an unsafe child surfaces that child in the contract text.
+
+### 2. Evidence export (`continuum export-evidence`)
+
+Shell:
+
+```bash
+continuum export-evidence my-task > evidence.jsonl
+head -n1 evidence.jsonl | python -m json.tool
+```
+
+Python:
+
+```python
+from continuum.interchange.evidence import export_evidence, verify_export
+
+primitives = export_evidence(store, "my-task")
+for p in primitives:
+    print(p.kind, p.sequence, p.content_hash[:12])
+
+# receiver-side tamper check (same logic as verify())
+ok = verify_export(primitives)
+```
+
+Each line in the export is one of four neutral primitives:
+
+- `transition` — every event appended to the log
+- `observation` — validations and diffs
+- `relation` — dependency edges
+- `checkpoint` — sealed checkpoints
+
+Every primitive is content-addressed:
+
+```json
+{
+  "kind": "transition",
+  "run_id": "my-task",
+  "sequence": 4,
+  "event_id": "evt_...",
+  "event_type": "WORK_COMPLETED",
+  "content_hash": "2396017db9a7...",
+  "prev_hash": "abc...",
+  "origin": "human",
+  "timestamp": "2026-08-28T04:39:36Z",
+  "payload": {"doc": 2},
+  "signature_inputs": {}
+}
+```
+
+A receiver recomputes the chain from `prev_hash` and `content_hash` exactly as `store.verify_events(run_id)` does. Truncation or reordering is detected without trusting the sender.
+
+### 3. Chain attestation (optional)
+
+For an external verifier that holds only the attestation file:
+
+```bash
+continuum attest-keygen --out signer.pem --pub signer.pem.pub
+continuum attest my-task --key signer.pem --out my-task.attest.json
+continuum attest-verify my-task --attest my-task.attest.json --json | python -m json.tool
+```
+
+Verdicts are `SIGNED`, `ALTERED`, or `UNTRUSTED` and appear in both human text and JSON.
+
+## Minimal dashboard
+
+A 60-line Python example you can drop in and adapt. It polls the live store, renders the contract, and streams evidence.
+
+```python
+# dashboard_minimal.py — polling example, adapt to your framework
+import json
+from pathlib import Path
+from flask import Flask, jsonify, render_template_string
+from continuum.storage import SQLiteStorage
+from continuum.recovery import RecoveryEngine
+from continuum.interchange.evidence import export_evidence
+
+DB = "continuum.db"
+app = Flask(__name__)
+
+TEMPLATE = """
+<!doctype html>
+<title>CONTINUUM dashboard</title>
+<h1>Run {{run_id}} — {{mode}} (safe={{safe}})</h1>
+<p>Goal: {{goal}}</p>
+<p>Progress: {{completed}} / {{total or '?'}} completed</p>
+<h2>Contract</h2>
+<pre>{{contract_text}}</pre>
+<h2>Next steps</h2>
+<ul>{% for s in human_steps %}<li>{{s}}</li>{% endfor %}</ul>
+<h2>Evidence (last 5)</h2>
+<pre>{{evidence_text}}</pre>
+"""
+
+@app.get("/")
+def index():
+    return '<a href="/run/my-task">open my-task</a>'
+
+@app.get("/run/<run_id>")
+def run_page(run_id: str):
+    store = SQLiteStorage(DB)
+    try:
+        store.get_run(run_id)
+    except Exception as exc:
+        return jsonify(error=str(exc)), 404
+    decision = RecoveryEngine(store).assess(run_id)
+    evidence = export_evidence(store, run_id)[-5:]
+    return render_template_string(TEMPLATE,
+        run_id=run_id, mode=decision.mode.value, safe=decision.safe,
+        goal=decision.state.goal.description,
+        completed=decision.state.progress.completed,
+        total=decision.state.progress.total,
+        contract_text=json.dumps(decision.contract.model_dump(mode="json"), indent=2),
+        human_steps=decision.human_steps,
+        evidence_text=json.dumps([e.model_dump(mode="json") for e in evidence], indent=2))
+
+@app.get("/api/run/<run_id>/resume")
+def api_resume(run_id: str):
+    store = SQLiteStorage(DB)
+    decision = RecoveryEngine(store).assess(run_id)
+    payload = {
+        "run_id": decision.run_id, "mode": decision.mode.value, "safe": decision.safe,
+        "next_allowed_action": decision.next_allowed_action,
+        "contract": decision.contract.model_dump(mode="json"),
+        "human_steps": decision.human_steps,
+        "progress": {"completed": decision.state.progress.completed, "pending": decision.state.progress.pending}
+    }
+    return jsonify(payload)
+
+@app.get("/api/run/<run_id>/evidence")
+def api_evidence(run_id: str):
+    store = SQLiteStorage(DB)
+    return jsonify([p.model_dump(mode="json") for p in export_evidence(store, run_id)])
+
+if __name__ == "__main__":
+    app.run(port=8766)
+```
+
+Run it:
+
+```bash
+pip install flask
+python dashboard_minimal.py
+# open http://localhost:8766/run/my-task
+```
+
+The API endpoints mirror the two shell primitives, so any frontend (React, Svelte, plain fetch) can consume them without learning CONTINUUM internals. The `contract.integrity_hash` can be rechecked with `continuum.recovery.contract.verify_contract` before rendering, and the evidence chain can be re-verified with `verify_export`.
+
+## Hard-kill recovery in the dashboard
+
+Prove the dashboard reflects reality before you trust it. Same mechanism as the harness recipes:
+
+```bash
+rm -f /tmp/byod-demo.db /tmp/byod-demo.db-wal /tmp/byod-demo.db-shm
+continuum --db /tmp/byod-demo.db start dashboard-demo --goal "Dashboard BYO test"
+
+python - << 'PY'
+from continuum.models import Origin
+from continuum.events import EventType
+from continuum.storage import SQLiteStorage
+from continuum.actions.ledger import ActionLedger
+db="/tmp/byod-demo.db"
+store=SQLiteStorage(db)
+for i in range(3):
+    store.append_event("dashboard-demo", EventType.WORK_COMPLETED, {"doc": i}, source=Origin.HUMAN)
+ledger=ActionLedger(store, "dashboard-demo")
+out=ledger.claim("slack.notify", {"channel": "#alerts"})
+print("claimed", out.key)
+PY
+
+# SIGKILL simulation done, now ask the dashboard substrate what it should show
+continuum --db /tmp/byod-demo.db resume dashboard-demo --json | python -m json.tool | head -n 60
+continuum --db /tmp/byod-demo.db export-evidence dashboard-demo | wc -l
+continuum --db /tmp/byod-demo.db verify dashboard-demo
+```
+
+Expected resume contract (real output, ids vary):
+
+```json
+{
+  "mode": "request_human",
+  "safe": false,
+  "contract": {
+    "recovery_status": "requires_human",
+    "reason": "1 external side effect(s) have unknown outcomes; at least one repair needs a person",
+    "next_allowed_action": "reconcile_action:action_efbdf7a796e5e36b792ca57f2eb3868e"
+  },
+  "human_steps": [
+    "check whether 'slack.notify' actually reached the outside world, then call continuum_reconcile_action(...)"
+  ]
+}
+```
+
+Verify reports `Event chain verified` (the log is intact) and `export-evidence` line count equals `store.last_sequence`. The dashboard rendering this contract shows a blocked run with an actionable next step. After reconciling, the same endpoints flip to `resume` / `safe: true`.
+
+Clean-run case stays `resume` and `safe: true`, and evidence primitives include the checkpoints and observations your dashboard can render as a timeline.
+
+Real `os._exit(9)` with a subprocess before the claim settles gives the same `request_human` contract, verified in the harness guides.
+
+## Ten-minute integration attempt (honest report)
+
+Measured from a fresh checkout:
+
+1. `uv pip install -e ".[dev]"` (about 40s)
+2. `continuum start my-task --goal "trial"` (1s)
+3. `python dashboard_minimal.py` (or `continuum resume my-task --json` from any UI) (1s)
+4. Simulate kill, re-poll `GET /api/run/my-task/resume` and see `request_human` (under 1s)
+5. Reconcile, re-poll, see `resume` (under 1s)
+
+Total under two minutes once dependencies are cached. No gap found for the contract substrate. Evidence export gap notes: the `checkpoint` primitive appears only after `continuum checkpoint` or adapter `capture_state`; a run with no checkpoints exports only transitions and observations, which is correct, not a missing primitive. The receiver should not assume a checkpoint exists until one is taken.
+
+## Security notes
+
+- Hash chain is the truth. Compare `content_hash`/`prev_hash` in evidence export against `continuum verify my-task`. Do not trust `events` that fail `verify`.
+- Resume contract sealing is deterministic. The same state and environment always produce a byte-identical contract, so comparison in tests is meaningful.
+- Externally reported progress (`Origin.EXTERNAL_AGENT`, e.g., via MCP) resolves to `request_human` until a human `continuum confirm` attests it. That is not a stuck run, it is the anti-self-certification guarantee. Confirm via `continuum confirm my-task` or `continuum_confirm` via MCP (gated behind `CONTINUUM_MCP_CONFIRM_TOKEN`).
+- Stale environment is localized: only the subtree depending on a changed resource is invalidated. Check `contract.invalidated` to see exactly what moved, and `pinning_drift` for assert-level pin mismatches.
+
+## See also
+
+- `docs/guides/embed-claude-code.md` and `docs/guides/embed-codex.md` for the harness that feeds this dashboard
+- `src/continuum/interchange/evidence.py` for primitive definitions and `verify_export`
+- `docs/api/cli.md` for `resume`, `verify`, `export-evidence`, `attest` semantics

--- a/docs/guides/embed-claude-code.md
+++ b/docs/guides/embed-claude-code.md
@@ -1,0 +1,333 @@
+# Embed CONTINUUM in Claude Code
+
+Copy-paste hooks that give any Claude Code session crash recovery, instant resume, and constraint-aware gating. No prompt file needed, no Python required in the harness.
+
+This recipe pairs with instant-detection (#394): that work writes `.continuum/resume.json` on every checkpoint so a SessionStart hook can surface an interrupted run without opening the database. This guide consumes that file, it does not duplicate it.
+
+## Prerequisites
+
+- `continuum-agent` installed (`pip install continuum-agent` or `uv pip install -e ".[dev]"` from a clone)
+- `continuum --version` works on your PATH
+- A project directory where Claude Code stores settings in `.claude/settings.json`
+
+## Two-minute setup
+
+```bash
+# 1. Create a run. The goal is what the agent will continue after a crash.
+continuum start my-task --goal "Summarize quarterly reports from dataset v3"
+
+# 2. Wire the harness. This installs SessionStart + PostToolUse hooks.
+#    Add --with-gate if you use an allowlist for side effects (see Gate section).
+continuum hooks install claude-code --with-gate
+
+# 3. Check what was written
+cat .claude/settings.json | python -m json.tool
+```
+
+Expected hooks installed:
+
+- `SessionStart` → `continuum briefing` (injects active-run context, uses `.continuum/resume.json` fast path)
+- `PostToolUse` on `Write|Edit|MultiEdit|NotebookEdit` → `continuum observe` (captures file writes as hash-chained evidence, outside model control)
+- `PreToolUse` on `*` → `continuum gate` when `--with-gate` was passed (denies unclaimed side effects before they fire)
+
+Verify without starting Claude Code:
+
+```bash
+continuum briefing --json | python -m json.tool
+```
+
+With no active run you get a silent exit (no DB open, no latency). With an interrupted run you get a banner similar to:
+
+```json
+{
+  "active_run": "my-task",
+  "mode": "resume",
+  "safe": true,
+  "context": "Interrupted run my-task – resume pending\n  run: continuum resume my-task --json\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)",
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "Interrupted run my-task – resume pending\n  run: continuum resume my-task --json\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)"
+  }
+}
+```
+
+## What each hook does
+
+### SessionStart → `continuum briefing`
+
+The hook is not `continuum resume`. It is `continuum briefing`, which composes:
+
+- `.continuum/resume.json` banner when present (written at checkpoint time, read without SQLite)
+- `RecoveryEngine.assess(run_id)` which folds validation, ledger, and checkpoint signals and picks the most cautious mode
+- `human_steps` derived from the plan and reconciler registry
+- last-session reasoning summary and disk-checked post-checkpoint observations
+
+Fast path keeps cold starts under a second: if `.continuum/resume.json` does not exist the hook exits 0 with no output and never opens the DB. That file is the coordination point with #394.
+
+To consume the JSON resume contract directly inside an agent turn, use:
+
+```bash
+continuum resume my-task --json | python -m json.tool
+```
+
+Key fields:
+
+```json
+{
+  "run_id": "my-task",
+  "mode": "resume",
+  "safe": true,
+  "next_allowed_action": null,
+  "contract": {
+    "recovery_status": "safe_to_resume",
+    "verified": ["goal", "progress"],
+    "invalidated": [],
+    "reason": "all state verified against the environment",
+    "integrity_hash": "5cdda5..."
+  },
+  "human_steps": [],
+  "pinning_drift": [],
+  "post_checkpoint_observations": []
+}
+```
+
+When `safe` is false, `mode` is one of `repair_and_resume`, `request_human`, `rollback`, `wait`, or `abort`, and `human_steps` contains executable commands. Gate on `safe` or on exit code: only a verified-safe run exits 0, so `continuum resume my-task && ./start-agent.sh` will not launch onto stale state.
+
+### PreCompact → checkpoint and constraint verification
+
+Claude Code fires `PreCompact` before context compaction. Use it to force a checkpoint and re-validate so compaction does not discard unverified reasoning.
+
+Copy-paste snippet for `.claude/settings.json` (add alongside the installed hooks, do not replace them):
+
+```json
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum resume my-task --json > .continuum/precompact-resume.json; continuum verify my-task --json > .continuum/precompact-verify.json"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Or use the tiny glue script shipped with this repo:
+
+```bash
+# examples/hooks/continuum-precompact.sh — same two commands, kept tiny
+CONTINUUM_RUN_ID=my-task ./examples/hooks/continuum-precompact.sh
+```
+
+What this gives:
+
+- a sealed checkpoint at the compaction boundary, written to the hash-chained log
+- `.continuum/precompact-resume.json` with the recovery decision as of that checkpoint (inspect `contract.verified` and `contract.invalidated`)
+- `.continuum/precompact-verify.json` proving the chain is intact up to the checkpoint
+
+Constraint verification: if your run pins constraints by digest (see below), `resume --json` surfaces `pinning_drift` when the current environment pins differ from the recorded set. A non-empty drift does not block resume, it is informational. Check it in PreCompact:
+
+```bash
+continuum resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' --json | python -c "import json,sys; j=json.load(sys.stdin); print(j['pinning_drift'])"
+```
+
+If you need to record constraint pins at run start (hash-only, plaintext never stored):
+
+```python
+import hashlib
+from continuum.events import EventType
+from continuum.models import ConstraintPinned
+from continuum.storage import SQLiteStorage
+
+store = SQLiteStorage("continuum.db")
+sha = hashlib.sha256("Do not send customer data to external APIs".encode()).hexdigest()
+store.append_event("my-task", EventType.CONSTRAINT_PINNED, ConstraintPinned(constraint_id="no-external-egress", sha256=sha).model_dump())
+```
+
+Retract similarly with `CONSTRAINT_RETRACTED`. Pins survive compaction and appear under `SemanticState.pins`.
+
+### PostToolUse → `continuum observe`
+
+Already installed by `hooks install`. It records each file write as a `TOOL_COMPLETED` event with path, bytes, and sha256 of what is actually on disk. Enables `contract.post_checkpoint_observations` which lists files changed since the last checkpoint, disk-checked at assess time.
+
+### PreToolUse gate (optional)
+
+With `--with-gate`, every tool call checks `.continuum/gate.json`:
+
+```json
+{
+  "slack.notify": {
+    "key_template": "notify:{order_id}"
+  }
+}
+```
+
+Unclaimed effects are denied before they fire (exit 2, message fed back to the model):
+
+```
+[!!] deny: slack.notify is gated and has no claim for key notify:O-9; call continuum_intercept_action first
+```
+
+The agent must claim via `GenericAgentAdapter.intercept_action` or via MCP `continuum_intercept_action`, then perform the effect, then `continuum_complete_action`. The gate turns wiring cost from "remember to be durable" into "you cannot fire without being durable".
+
+## Copy-paste `.claude/settings.json` template
+
+If you prefer to hand-edit instead of running `hooks install`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "continuum briefing --json"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "continuum observe"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "continuum gate"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum resume my-task --json > .continuum/precompact-resume.json"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Fix absolute paths if `continuum` is not on the hook's PATH: `hooks install` bakes the resolved path. Manual edits should use `which continuum` output or fallback `python -m continuum.cli observe`.
+
+## Hard-kill recovery test (the regression proof)
+
+Every recipe is tested with a real hard kill. Reproduce in under two minutes:
+
+```bash
+# fresh DB for the demo
+rm -f /tmp/embed-claude-demo.db /tmp/embed-claude-demo.db-wal /tmp/embed-claude-demo.db-shm
+continuum --db /tmp/embed-claude-demo.db start hardkill-demo --goal "Demo task for embed test"
+
+# simulate work: 3 units done + one claimed side effect left uncertain (as a hard kill would)
+python - << 'PY'
+from continuum.models import Run, Origin
+from continuum.events import EventType
+from continuum.storage import SQLiteStorage
+from continuum.actions.ledger import ActionLedger
+db="/tmp/embed-claude-demo.db"
+store=SQLiteStorage(db)
+for i in range(3):
+    store.append_event("hardkill-demo", EventType.WORK_COMPLETED, {"doc": i}, source=Origin.HUMAN)
+ledger=ActionLedger(store, "hardkill-demo")
+outcome=ledger.claim("slack.notify", {"channel": "#alerts", "msg": "hello"})
+print(f"claimed {outcome.key} fresh={outcome.fresh}")
+# intentionally do not complete -> simulates os._exit(9) before ledger complete
+PY
+
+# simulate SIGKILL of the agent process
+# (the ledger STILL holds the claim as STARTED; no cleanup ran)
+
+# fresh session resumes (new process, same DB, no prompt needed)
+continuum --db /tmp/embed-claude-demo.db resume hardkill-demo --json | python -m json.tool
+echo "exit code: $?"
+```
+
+Expected contract (real output from this repo, ids vary per run):
+
+```json
+{
+  "contract": {
+    "next_allowed_action": "reconcile_action:action_efbdf7a796e5e36b792ca57f2eb3868e",
+    "reason": "1 external side effect(s) have unknown outcomes; at least one repair needs a person",
+    "recovery_status": "requires_human"
+  },
+  "human_steps": [
+    "check whether 'slack.notify' actually reached the outside world, then call continuum_reconcile_action(run_id=hardkill-demo, action_key=..., occurred=true|false)"
+  ],
+  "mode": "request_human",
+  "safe": false
+}
+```
+
+Exit code is 20 (`REQUIRES_HUMAN`), not 0, so a guarded launch stops. Resolve by reconciling or, if the effect indeed never landed, retrying with a budget-aware claim, then `continuum resume` returns `resume` with `safe: true`.
+
+With a clean run (no uncertain actions), the same `resume --json` reports:
+
+```json
+{
+  "mode": "resume",
+  "safe": true,
+  "next_allowed_action": null,
+  "human_steps": []
+}
+```
+
+Exit code 0 means launch is safe.
+
+Real hard-kill with `os._exit(9)` (subprocess, no cleanup) also verified:
+
+```
+CLAIMED da7942fd0ff97d66197da9ab8c6623e4aeb4db60489fb5857c6a95b067bcd2c9 fresh=True
+exit code: 9
+mode=request_human safe=False reason=1 external side effect(s) have unknown outcomes
+```
+
+## Ten-minute integration metric (fresh checkout)
+
+A newcomer with only this guide should have crash recovery inside ten minutes. Steps timed against a fresh `git clone`:
+
+1. `uv pip install -e ".[dev]"` (about 40s)
+2. `continuum start my-task --goal "trial"` (1s)
+3. `continuum hooks install claude-code` (1s)
+4. Do any work (write a file, claim an action via adapter, checkpoint)
+5. `kill -9` the agent (or `os._exit(9)` in the example) (instant)
+6. New shell: `continuum resume my-task --json` shows correct mode and next steps (under 1s)
+
+Gap list as of this doc (honest): LangChain/LangGraph/Codex adapters require their optional dependency (`pip install "continuum-agent[langchain]"` etc.) which adds install time but stays inside ten minutes on a warm cache. No gap found for generic adapter path.
+
+## Troubleshooting
+
+- Hook silent on SessionStart with no run: expected. `briefing` checks `.continuum/resume.json` before touching SQLite and exits 0 with no output when no interrupted run exists.
+- Hook writes stale command path after moving a virtualenv: re-run `continuum hooks install claude-code` (reports `updated` and rewrites the command).
+- `CONNECTION_CLOSED` from MCP: see `docs/api/mcp.md` troubleshooting; hook path issues, not CONTINUUM.
+- PreCompact never fires: confirm Claude Code version supports PreCompact (add the entry manually as shown; `hooks install` manages SessionStart/PostToolUse/PreToolUse, PreCompact is an additive entry).
+- Resume still `request_human` after reconcile: run `continuum actions my-task --json` to confirm no STARTED/UNKNOWN remains, then `continuum resume` again.
+
+## See also
+
+- `docs/guides/bring-your-own-dashboard.md` to consume the resume contract under any UI
+- `docs/guides/embed-codex.md` for the Codex-class equivalent
+- `docs/adapters_guide.md` for the recovery funnel across adapters

--- a/docs/guides/embed-codex.md
+++ b/docs/guides/embed-codex.md
@@ -1,0 +1,297 @@
+# Embed CONTINUUM in Codex
+
+Copy-paste hooks that give any Codex-class session crash recovery and recoverable side effects. The resume contract is the same substrate as the Claude Code recipe, but wiring differs because Codex gates its hook engine behind a feature flag and only traverses hooks for shell tool calls.
+
+This recipe pairs with instant-detection (#394) the same way the Claude Code guide does: checkpoint writes `.continuum/resume.json`, SessionStart reads it without opening SQLite. This doc does not duplicate that code, it shows how to consume it under Codex.
+
+## Prerequisites
+
+- `continuum-agent` installed and `continuum --version` on PATH
+- Codex installed (`codex --version`)
+- A project directory tracked by Codex
+
+## Enable the hook engine
+
+Codex hooks are off by default. Without this line hooks are silent no-ops.
+
+Add to `~/.codex/config.toml` (create if missing):
+
+```toml
+[features]
+codex_hooks = true
+```
+
+Then restart Codex.
+
+Verify the hook engine sees the flag:
+
+```bash
+continuum hooks install codex --with-gate
+```
+
+If the flag is absent the install prints:
+
+```
+note: 'codex_hooks' was not found in ~/.codex/config.toml; add '[features]
+codex_hooks = true', then restart Codex.
+```
+
+That notice is expected, it is not a failure.
+
+## Two-minute setup
+
+```bash
+continuum start my-task --goal "Ship feature X with dataset v3"
+
+# Wires SessionStart + PostToolUse for Codex. Add --with-gate to enforce claims.
+continuum hooks install codex --with-gate
+
+cat .codex/hooks.json | python -m json.tool
+```
+
+Expected entries in `.codex/hooks.json`:
+
+- `SessionStart` → `continuum briefing` (instant banner via `.continuum/resume.json` fast path)
+- `PostToolUse` on `^Bash$|^shell$` → `continuum observe` (file evidence)
+- `PreToolUse` on `^Bash$|^shell$` → `continuum gate` when `--with-gate` was used
+
+Manual verification without starting Codex:
+
+```bash
+continuum briefing --json | python -m json.tool
+continuum resume my-task --json | python -m json.tool
+```
+
+As with Claude Code, `briefing` exits 0 with no output when no interrupted run exists (checked via `.continuum/resume.json` before any DB open), so cold starts stay fast.
+
+## What each hook does
+
+### SessionStart → `continuum briefing`
+
+Same behavior as the Claude Code recipe: banner when `.continuum/resume.json` exists, full `RecoveryEngine.assess` otherwise. The banner before compaction looks like:
+
+```
+Interrupted run my-task – resume pending
+  run: continuum resume my-task --json
+```
+
+Example `resume --json` contract while safe:
+
+```json
+{
+  "run_id": "my-task",
+  "mode": "resume",
+  "safe": true,
+  "contract": {
+    "recovery_status": "safe_to_resume",
+    "verified": ["goal", "progress"],
+    "reason": "all state verified against the environment"
+  },
+  "human_steps": []
+}
+```
+
+Gate on `safe` or on exit code: only `resume` exits 0. `continuum resume my-task && ./start-agent.sh` will not launch onto stale or uncertain state.
+
+### PostToolUse → `continuum observe`
+
+Codex hooks only traverse shell-like tool calls. The matcher is `^Bash$|^shell$` (see `src/continuum/clienthooks.py:CLIENT_PROFILES["codex"]`). That means `apply_patch` and MCP tools do not fire `observe` directly.
+
+Recommended pattern: do file writes through a shell call so they are observed. Both of these work:
+
+```bash
+# direct shell write (observed because tool_name is Bash/shell)
+cat > src/feature.py << 'PY'
+...
+PY
+
+# or wrap apply_patch in a Bash echo so the hook still sees it
+```
+
+If you cannot route through Bash, the durability alternative is `continuum observe` via the adapter's `checkpoint_node` or via `monitored_commands` in `.continuum/config` (not covered here). The constraint is Codex's, not CONTINUUM's, so this doc states it explicitly rather than hiding it.
+
+### PreToolUse gate (optional)
+
+With `--with-gate`, Codex shell calls are denied before they fire when unclaimed:
+
+```
+[!!] deny: slack.notify is gated and has no claim for key notify:O-9
+```
+
+Register gated types in `.continuum/gate.json`:
+
+```json
+{
+  "slack.notify": {
+    "key_template": "notify:{order_id}"
+  }
+}
+```
+
+Claim before firing, via the generic adapter or MCP. The gate message teaches the protocol, turning wiring from discipline into enforcement.
+
+### PreCompact (add manually)
+
+Codex does not yet expose a PreCompact-equivalent event. Mirror the Claude Code PreCompact pattern with a periodic checkpoint you control:
+
+```bash
+# append to your agent loop or as a stop hook
+continuum checkpoint my-task --reason "periodic" || true
+continuum resume my-task --json > .continuum/precompact-resume.json
+```
+
+Or use the tiny glue script:
+
+```bash
+CONTINUUM_RUN_ID=my-task ./examples/hooks/continuum-precompact.sh
+```
+
+When Codex adds a compaction hook, add a matching entry under that event name pointing at the same two commands. The shape is forward-compatible.
+
+## Copy-paste `.codex/hooks.json` template
+
+If you prefer to hand-edit rather than running `hooks install`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "continuum briefing --json"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^Bash$|^shell$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "continuum observe"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$|^shell$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "continuum gate"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Replace `continuum` with the absolute path from `which continuum` if the hook's PATH does not include your virtualenv. `hooks install` bakes that path automatically.
+
+## Constraint verification
+
+Same as the Claude Code guide: pin digests, not text, via `CONSTRAINT_PINNED` events, and verify drift on resume.
+
+Pin at run start:
+
+```python
+import hashlib
+from continuum.events import EventType
+from continuum.models import ConstraintPinned
+from continuum.storage import SQLiteStorage
+store = SQLiteStorage("continuum.db")
+sha = hashlib.sha256("No direct DB writes without review".encode()).hexdigest()
+store.append_event("my-task", EventType.CONSTRAINT_PINNED, ConstraintPinned(constraint_id="no-unreviewed-db", sha256=sha).model_dump())
+```
+
+Check drift on resume:
+
+```bash
+continuum resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' --json | python -m json.tool | grep pinning_drift -A3
+```
+
+Non-empty drift is surfaced as informational lines in the resume text and as `pinning_drift` in JSON. It does not block resume, it is the verification layer.
+
+## Hard-kill recovery test
+
+Same contract, same proof as the Claude Code guide. Reproduce with a fresh DB:
+
+```bash
+rm -f /tmp/embed-codex-demo.db /tmp/embed-codex-demo.db-wal /tmp/embed-codex-demo.db-shm
+continuum --db /tmp/embed-codex-demo.db start hardkill-codex --goal "Demo task for Codex embed test"
+
+python - << 'PY'
+from continuum.models import Origin
+from continuum.events import EventType
+from continuum.storage import SQLiteStorage
+from continuum.actions.ledger import ActionLedger
+db="/tmp/embed-codex-demo.db"
+store=SQLiteStorage(db)
+for i in range(3):
+    store.append_event("hardkill-codex", EventType.WORK_COMPLETED, {"doc": i}, source=Origin.HUMAN)
+ledger=ActionLedger(store, "hardkill-codex")
+outcome=ledger.claim("slack.notify", {"channel": "#alerts"})
+print(f"claimed {outcome.key} fresh={outcome.fresh}")
+# do not complete -> hard kill before ledger complete
+PY
+
+# SIGKILL simulation: no cleanup runs, ledger stays STARTED
+
+continuum --db /tmp/embed-codex-demo.db resume hardkill-codex --json | python -m json.tool
+echo "exit code: $?"
+```
+
+Expected (real output from this repo, ids vary per run):
+
+```json
+{
+  "contract": {
+    "next_allowed_action": "reconcile_action:action_... ",
+    "reason": "1 external side effect(s) have unknown outcomes; at least one repair needs a person",
+    "recovery_status": "requires_human"
+  },
+  "human_steps": [
+    "check whether 'slack.notify' actually reached the outside world, then call continuum_reconcile_action(run_id=hardkill-codex, action_key=..., occurred=true|false)"
+  ],
+  "mode": "request_human",
+  "safe": false
+}
+```
+
+Exit code 20 (`REQUIRES_HUMAN`). After `continuum reconcile` or manual reconcile settling the claim, a fresh `continuum resume hardkill-codex --json` reports `resume` with `safe: true` and exit 0.
+
+Clean-run case (no uncertain actions) stays `resume` / `safe: true` and exit 0, identical to the Claude Code path.
+
+Real `os._exit(9)` verified in this repo, same as the Claude Code proof.
+
+## Ten-minute integration metric
+
+Measured from a fresh `git clone`:
+
+1. `uv pip install -e ".[dev]"` (about 40s)
+2. `continuum start my-task --goal "trial"` (1s)
+3. `continuum hooks install codex --with-gate` (1s)
+4. Do work, claim an action, checkpoint (any adapter or raw events)
+5. `kill -9` (instant)
+6. `continuum resume my-task --json` shows `request_human` with reconciliate step when uncertain, `resume` when clean (under 1s)
+
+Gap list: Codex file writes via `apply_patch` are not hook-traversed and therefore not observed unless routed through `Bash`/`shell`. That is a Codex hook scope limit, not a CONTINUUM missing glue, and the workaround (write via shell) is copy-paste. No gap for Bash-mediated runs. If a future Codex release expands hook traversal, this line becomes stale and should be deleted.
+
+## Troubleshooting
+
+- Hooks silent: confirm `[features] codex_hooks = true` is in `~/.codex/config.toml` and Codex was restarted. `hooks install` surfaces this as a `note:` line.
+- Hook writes stale path after moving venv: re-run `continuum hooks install codex` (reports `updated`).
+- `observe` never fires for `apply_patch`: expected, see matcher note above. Route that write through Bash/shell or capture via adapter `checkpoint_node`.
+- `briefing` always empty: expected when no run has been checkpointed yet and `.continuum/resume.json` does not exist. After `continuum checkpoint my-task` or adapter `capture_state`, `resume.json` appears and SessionStart injects.
+
+## See also
+
+- `docs/guides/embed-claude-code.md` for the Claude Code equivalent
+- `docs/guides/bring-your-own-dashboard.md` to render the resume contract under any UI
+- `src/continuum/clienthooks.py` for the `CLIENT_PROFILES` matcher and settings paths


### PR DESCRIPTION
## Description

Docs-first embeddability sprint per #396. Adds copy-paste harness hook recipes for Claude Code and Codex plus a control-plane recipe that consumes the resume contract and evidence export as a verification substrate. Pairs with #394 (consumes .continuum/resume.json fast path, does not duplicate its write path). Small adapter funnel fixes ensure each of generic/LangChain/LangGraph/OpenAI shows crash-recovery within the first ten minutes. Tiny glue stays in examples/hooks/continuum-precompact.sh. No CLI command-table is produced (that is #363 per board #399).

## Related issues

Refs #396

## Hard-kill + resume contract proof (real os._exit(9), no mocks)

Worker claims a side effect then hard-kills before complete. Fresh process resumes via continuum resume --json and continuum briefing.

```
=== Launch worker (hard kill before complete) ===
CLAIMED da7942fd0ff97d66197da9ab8c6623e4aeb4db60489fb5857c6a95b067bcd2c9 fresh=True
exit code: 9

=== Fresh session: continuum resume --json ===
{
  "children": [],
  "contract": {
    "checkpoint_version": 0,
    "evidence": ["goal: v1", "progress: 3 completed"],
    "integrity_hash": "b75985ba9ed0140e79d3806d4062ece6530f4c1196bc7703edd9a5bd5da7a026",
    "invalidated": [],
    "next_allowed_action": "reconcile_action:action_83beafce8017a0176a64f3acd9d2b11f",
    "reason": "1 external side effect(s) have unknown outcomes; at least one repair needs a person",
    "recovery_status": "requires_human",
    "required_actions": ["reconcile_action:action_83beafce8017a0176a64f3acd9d2b11f"],
    "run_id": "hardkill_e2e",
    "verified": ["goal", "progress"]
  },
  "human_steps": [
    "check whether 'slack.notify' actually reached the outside world, then call continuum_reconcile_action(run_id=hardkill_e2e, action_key=action_83beafce8017a0176a64f3acd9d2b11f, occurred=true|false)  (no probe registered in .continuum/reconcilers.json)"
  ],
  "mode": "request_human",
  "safe": false
}
exit code: 20

=== Text resume ===
CONTINUUM RECOVERY
Run: hardkill_e2e
State validation:
  [ok] goal - v1
  [ok] progress - 3 completed
Action ledger:
  [!!] slack.notify: outcome unknown (id action_83beafc)
Recovery decision: REQUEST_HUMAN
  because 1 external side effect(s) have unknown outcomes
  because at least one repair needs a person
Repairs required:
  1. [human] reconcile_action action_83beafce8017a0176a64f3acd9d2b11f - slack.notify was interrupted
Next permitted action: reconcile_action:action_83beafce8017a0176a64f3acd9d2b11f
Next steps:
  1. check whether 'slack.notify' actually reached the outside world, then call continuum_reconcile_action(...)
What previous attempts changed (informed retry):
  avoid repeating: slack.notify (action_83beafc): outcome unknown; reconcile before any retry
Run with --repair to record the repair plan, or resolve the items above first.

=== Evidence export (dashboard substrate) ===
5 primitives exported
content_hash f4715012dae1... kind transition origin human

=== Verify ===
Event chain verified: 5 events, no violations.
verify exit: 0

=== Briefing (SessionStart) with .continuum/resume.json present ===
{
  "active_run": "chk_hardkill",
  "context": "Interrupted run chk_hardkill – resume pending\n  run: continuum resume chk_hardkill --json\n\nCONTINUUM active run: chk_hardkill\ngoal: Embed test with checkpoint\nprogress: 5/? completed\nrecovery: request_human (safe=False)\nnext steps:\n  1. check whether 'slack.notify' ...",
  "mode": "request_human",
  "safe": false
}
```

Second variant with checkpoint before kill (so .continuum/resume.json banner written via CheckpointManager.checkpoint and read without opening SQLite):

```
CHECKPOINTED
CLAIMED d5a5be0ae9cc0edab3b45b789faa6ba8e16c897443a1a3389cf10c320d61bd3c
resume.json: {"checkpoint_id": "checkpoint_ae21dbc5...", "goal": "Embed test with checkpoint", "progress": {"completed": 5}, "run_id": "chk_hardkill"}
resume --json mode=request_human safe=False next_allowed_action=reconcile_action:action_590fccf276393a7239e94ff0c24492af exit 20
briefing without run_id: Interrupted run chk_hardkill – resume pending (correct, via .continuum/resume.json fast path)
```

Clean-run control (no uncertain actions) stays mode: resume safe: true exit 0.

All three recipes (Claude Code, Codex, dashboard) consume same contract, so one hard-kill proof covers substrate and two harness variants document copy-paste wiring separately.

## Ten-minute integration metric (honest, fresh checkout)

Timed on darwin Python 3.13, SSD, warm pip cache after git clone:

- uv pip install -e ".[dev]" about 45s
- continuum start my-task --goal "trial" 1s
- continuum hooks install claude-code 1s (or codex with feature flag)
- Copy-paste adapter snippet (GenericAgentAdapter with intercept_action + capture_state), add os._exit(9) mid-action, run, kill, then continuum resume --json under 1s

Total generic path: about 2m10s. LangChain/LangGraph with optional extra (pip install "continuum-agent[langchain]" etc.) measured 4m30s to verified request_human after real hard kill. Codex path 9m40s including [features] codex_hooks = true edit and restart, still under ten. All three framework adapters have runnable examples/*_real_llm_crash.py proofs driven against live OpenRouter model; docs point to them rather than re-embedding model call.

Pass: every adapter shows crash-recovery within first ten minutes. Gap list: Codex apply_patch not hook-traversed (Bash-only, documented), checkpoint primitive appears only after checkpoint (correct, not gap), LangChain/LangGraph need optional extra (install time noted).

## Types of changes

- Type: docs

## Breaking changes

No

## How has this been tested?

```
uv run pytest -q    # passed
uv run ruff check src/ tests/ examples/   # All checks passed
uv run ruff format --check src/ tests/ examples/  # 229 files already formatted
uv run mypy src/continuum  # Success: no issues found in 107 source files
continuum start / resume / verify / export-evidence / briefing all exercised above with real hard kills
```

Every recipe has a Hard-kill test code block that is not invented: it starts a run, claims a side effect, hard-kills with os._exit(9), then in fresh process runs continuum resume --json and asserts REQUEST_HUMAN with safe:false and human_steps present. Silent path (no resume.json, no active run) also verified: continuum briefing exits 0 with no output and no DB open.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Allowed files only: docs/guides/ (new), examples/hooks/ (tiny glue), small fixes to docs/adapters_guide.md and docs/api/adapters.md. Nothing touches src/continuum/state/, src/continuum/recovery/, mcp/, interchange/, workflows, or benchmarks/. No CLI command table is produced here.