### PR TITLE
[#391] reconstruction accounting present/absent/unverifiable per pin

### DIFF
--- a/src/continuum/checkpoint/context.py
+++ b/src/continuum/checkpoint/context.py
@@ -31,6 +31,7 @@ from continuum.models import (
     SemanticState,
     StateStatus,
 )
+from continuum.state.semantic import account_pins_in_context
 
 __all__ = [
     "RecoveryContext",
@@ -105,6 +106,24 @@ class RecoveryContext:
 
     def __str__(self) -> str:
         return self.render()
+
+
+def _pins_section(state: SemanticState) -> ContextSection:
+    """Active constraint pins with hash-tagged markers (issue #418).
+
+    Each active pin emits a marker like [pin:constraint_id:abc12345] where
+    abc12345 is the first 8 chars of the sha256. The marker is the source
+    of truth for accounting, not a summarizer's self-report.
+    """
+    if not state.pins:
+        return ContextSection("ACTIVE CONSTRAINTS", (), priority=1)
+    from continuum.state.semantic import _pin_marker
+
+    lines = []
+    for pin in sorted(state.pins.values(), key=lambda p: p.constraint_id):
+        marker = _pin_marker(pin)
+        lines.append(f"{pin.constraint_id}:{pin.sha256[:8]} {marker}")
+    return ContextSection("ACTIVE CONSTRAINTS", tuple(lines), priority=1)
 
 
 def _goal_section(state: SemanticState) -> ContextSection:
@@ -209,6 +228,8 @@ def build_recovery_context(
     max_items: int = 10,
     next_action: str | None = None,
     environment_changes: Sequence[str] = (),
+    pin_grace_seconds: int | None = None,
+    pin_strict: bool = False,
 ) -> RecoveryContext:
     """Assemble a bounded briefing for a resuming agent.
 
@@ -219,6 +240,7 @@ def build_recovery_context(
     """
     sections = [
         _goal_section(state),
+        _pins_section(state),
         _progress_section(state),
         _stale_section(state),
         _review_section(state),
@@ -239,7 +261,24 @@ def build_recovery_context(
     populated.sort(key=lambda s: s.priority)
 
     if token_budget is None:
-        return RecoveryContext(run_id=state.run_id, sections=tuple(populated))
+        ctx = RecoveryContext(run_id=state.run_id, sections=tuple(populated))
+        # Accounting: check if any active pin is absent past grace
+        if state.pins:
+            rendered = ctx.render()
+            accounting = account_pins_in_context(
+                state, rendered, grace_seconds=pin_grace_seconds, strict=pin_strict
+            )
+            flags = [info["flag"] for info in accounting.values() if info["flag"]]
+            if flags:
+                # Advisory flag: add to notes, strict escalation is handled by caller
+                ctx = RecoveryContext(
+                    run_id=ctx.run_id,
+                    sections=ctx.sections,
+                    dropped_sections=ctx.dropped_sections,
+                    truncated=ctx.truncated,
+                    notes=tuple(list(ctx.notes) + flags),
+                )
+        return ctx
 
     kept: list[ContextSection] = []
     dropped: list[str] = []
@@ -256,9 +295,25 @@ def build_recovery_context(
         else:
             dropped.append(section.title)
 
-    return RecoveryContext(
+    ctx = RecoveryContext(
         run_id=state.run_id,
         sections=tuple(kept),
         dropped_sections=tuple(dropped),
         truncated=bool(dropped),
     )
+    # Accounting for budgeted context
+    if state.pins:
+        rendered = ctx.render()
+        accounting = account_pins_in_context(
+            state, rendered, grace_seconds=pin_grace_seconds, strict=pin_strict
+        )
+        flags = [info["flag"] for info in accounting.values() if info["flag"]]
+        if flags:
+            ctx = RecoveryContext(
+                run_id=ctx.run_id,
+                sections=ctx.sections,
+                dropped_sections=ctx.dropped_sections,
+                truncated=ctx.truncated,
+                notes=tuple(list(ctx.notes) + flags),
+            )
+    return ctx

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -47,6 +47,7 @@ from continuum.models import (
     Provenance,
     SemanticState,
     StateStatus,
+    utcnow,
 )
 
 __all__ = [
@@ -701,3 +702,145 @@ def project(
     selected = [e for e in events if upto is None or e.sequence <= upto]
     state, _ = project_incremental(run_id, selected, on_unprojectable=on_unprojectable)
     return state
+
+
+# --------------------------------------------------------------------------- #
+# Reconstruction accounting per pin (issue #418)
+# --------------------------------------------------------------------------- #
+
+# Marker format for pins in reconstructed context.
+# Each active pin emits a hash-tagged marker like:
+#   [pin:constraint_id:abc12345]
+# where abc12345 is the first 8 chars of the sha256. The marker is the
+# source of truth for accounting, not a summarizer's self-report.
+_PIN_MARKER_PREFIX = "[pin:"
+_PIN_MARKER_SUFFIX = "]"
+
+
+def _pin_marker(pin: ConstraintPin) -> str:
+    """Hash-tagged marker for a pin, emitted by reconstruction."""
+    return f"{_PIN_MARKER_PREFIX}{pin.constraint_id}:{pin.sha256[:8]}{_PIN_MARKER_SUFFIX}"
+
+
+def _pin_marker_for_id(constraint_id: str, sha256: str) -> str:
+    """Marker for a given id and full sha256."""
+    return f"{_PIN_MARKER_PREFIX}{constraint_id}:{sha256[:8]}{_PIN_MARKER_SUFFIX}"
+
+
+def account_pins_in_context(
+    state: SemanticState,
+    context: str,
+    *,
+    grace_seconds: int | None = None,
+    now: datetime | None = None,
+    strict: bool = False,
+) -> dict[str, dict[str, Any]]:
+    """Classify each active pin as present, absent or unverifiable.
+
+    The classification is computed from what the produced ``context`` actually
+    contains, not from a summarizer's claim. Each active pin must have emitted
+    a hash-tagged marker during reconstruction; the marker is the evidence.
+
+    - present: marker found in context
+    - absent: marker not found, and pin not in a truncated/dropped section
+    - unverifiable: marker not found but context was truncated and the pin
+      would have been in a dropped section (so we cannot tell)
+
+    Grace window: if a pin is absent and the time since ``pinned_at`` exceeds
+    ``grace_seconds``, it is flagged. In strict mode the flag escalates to
+    ``REQUIRES_REVIEW``; otherwise it is advisory.
+
+    Returns a dict mapping constraint_id to a dict with:
+    - status: "present" | "absent" | "unverifiable"
+    - sha256: full digest
+    - sha256_prefix: first 8 chars
+    - pinned_at: timestamp
+    - age_seconds: seconds since pinned_at
+    - past_grace: bool
+    - flag: advisory or strict flag if past grace and absent
+    """
+
+    if now is None:
+        now = utcnow()
+
+    result: dict[str, dict[str, Any]] = {}
+    # Check if context indicates truncation (for unverifiable)
+    is_truncated = "[context truncated" in context or "omitted:" in context
+
+    for pin_id, pin in state.pins.items():
+        marker = _pin_marker(pin)
+        present = marker in context
+        age_seconds = (now - pin.pinned_at).total_seconds() if pin.pinned_at else 0
+        past_grace = grace_seconds is not None and age_seconds > grace_seconds
+
+        if present:
+            status = "present"
+            flag = None
+        else:
+            # If context was truncated, we cannot tell if the pin was in a
+            # dropped section — mark as unverifiable rather than absent
+            if is_truncated:
+                # Heuristic: if the pin's marker would have been in a low-
+                # priority section that was dropped, mark unverifiable
+                # For now, we treat any absent with truncation as unverifiable
+                # unless the pin is in the never-dropped set (goal, etc.)
+                # Since pins are not in the never-dropped set, they are unverifiable
+                status = "unverifiable"
+                flag = None
+                if past_grace:
+                    # Even unverifiable past grace is flagged, but not as absent
+                    flag = f"pin {pin_id}:{pin.sha256[:8]} unverifiable past grace ({int(age_seconds)}s > {grace_seconds}s)"
+            else:
+                status = "absent"
+                flag = None
+                if past_grace:
+                    flag = f"pin {pin_id}:{pin.sha256[:8]} absent past grace ({int(age_seconds)}s > {grace_seconds}s)"
+                    if strict:
+                        # Strict escalation will be handled by caller
+                        pass
+
+        result[pin_id] = {
+            "status": status,
+            "sha256": pin.sha256,
+            "sha256_prefix": pin.sha256[:8],
+            "pinned_at": pin.pinned_at,
+            "age_seconds": age_seconds,
+            "past_grace": past_grace,
+            "flag": flag,
+            "marker": marker,
+        }
+
+    return result
+
+
+def pin_markers_for_state(state: SemanticState) -> list[str]:
+    """Emit hash-tagged markers for each active pin in the state."""
+    return [_pin_marker(pin) for pin in state.pins.values()]
+
+
+def check_pin_accounting(
+    state: SemanticState,
+    context: str,
+    *,
+    grace_seconds: int | None = None,
+    now: datetime | None = None,
+    strict: bool = False,
+) -> tuple[dict[str, dict[str, Any]], list[str], bool]:
+    """Accounting wrapper that also determines if strict escalation is needed.
+
+    Returns (accounting, flags, should_escalate) where:
+    - accounting is the per-pin status dict
+    - flags is a list of advisory/strict flag strings
+    - should_escalate is True if strict and any absent past grace
+    """
+    accounting = account_pins_in_context(
+        state, context, grace_seconds=grace_seconds, now=now, strict=strict
+    )
+    flags: list[str] = []
+    should_escalate = False
+    for _pin_id, info in accounting.items():
+        if info["flag"]:
+            flags.append(info["flag"])
+            if info["status"] == "absent" and info["past_grace"] and strict:
+                should_escalate = True
+    return accounting, flags, should_escalate

--- a/tests/test_pin_reconstruction.py
+++ b/tests/test_pin_reconstruction.py
@@ -1,0 +1,215 @@
+"""Reconstruction accounting per pin (#418).
+
+Tests that the three statuses are reachable, grace window is
+configurable, strict escalation works, and hash-tagged markers are the
+source of truth.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import timedelta
+
+from continuum.checkpoint.context import build_recovery_context
+from continuum.events import EventType
+from continuum.models import ConstraintPinned, Run
+from continuum.state.semantic import (
+    account_pins_in_context,
+    check_pin_accounting,
+    pin_markers_for_state,
+    project,
+)
+from continuum.storage import SQLiteStorage
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _make_storage_with_pins(pin_ids: list[str]) -> tuple[SQLiteStorage, str]:
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_1"
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "g"})
+    for pid in pin_ids:
+        storage.append_event(
+            run_id,
+            EventType.CONSTRAINT_PINNED,
+            ConstraintPinned(constraint_id=pid, sha256=_digest(f"text for {pid}")).model_dump(),
+        )
+    return storage, run_id
+
+
+def test_all_three_statuses_reachable() -> None:
+    storage, run_id = _make_storage_with_pins(["c1", "c2", "c3"])
+    try:
+        from continuum.state.semantic import project
+
+        state = project(run_id, storage.read_events(run_id))
+        assert set(state.pins.keys()) == {"c1", "c2", "c3"}
+
+        # Build a recovery context that includes all pins (present)
+        ctx = build_recovery_context(state)
+        rendered = ctx.render()
+        # All pins should be present
+        accounting = account_pins_in_context(state, rendered)
+        for pid in ["c1", "c2", "c3"]:
+            assert accounting[pid]["status"] == "present", f"{pid} should be present"
+
+        # Build a context that omits one pin (absent) by manually constructing
+        # a context string without the marker for c2
+        rendered_without_c2 = rendered.replace(f"[pin:c2:{_digest('text for c2')[:8]}]", "")
+        accounting2 = account_pins_in_context(state, rendered_without_c2)
+        assert accounting2["c1"]["status"] == "present"
+        assert accounting2["c2"]["status"] == "absent"
+        assert accounting2["c3"]["status"] == "present"
+
+        # Build a truncated context (unverifiable) by simulating truncation
+        truncated = rendered + "\n\n[context truncated to fit budget; omitted: ACTIVE CONSTRAINTS]"
+        # With truncation, absent pins become unverifiable
+        # First, make c2 absent in truncated context
+        truncated_without_c2 = truncated.replace(f"[pin:c2:{_digest('text for c2')[:8]}]", "")
+        accounting4 = account_pins_in_context(state, truncated_without_c2)
+        assert accounting4["c2"]["status"] == "unverifiable"
+
+    finally:
+        storage.close()
+
+
+def test_grace_window_configurable() -> None:
+    storage, run_id = _make_storage_with_pins(["c1"])
+    try:
+        state = project(run_id, storage.read_events(run_id))
+        # Get the pin's pinned_at time
+        pin = state.pins["c1"]
+        # Create a context without the pin (absent)
+        ctx = build_recovery_context(state)
+        rendered = ctx.render()
+        rendered_without = rendered.replace(f"[pin:c1:{pin.sha256[:8]}]", "")
+
+        # Within grace: no flag
+        now_within = pin.pinned_at + timedelta(seconds=10)
+        accounting_within = account_pins_in_context(
+            state, rendered_without, grace_seconds=60, now=now_within
+        )
+        assert accounting_within["c1"]["status"] == "absent"
+        assert not accounting_within["c1"]["past_grace"]
+        assert accounting_within["c1"]["flag"] is None
+
+        # Past grace: flag
+        now_past = pin.pinned_at + timedelta(seconds=100)
+        accounting_past = account_pins_in_context(
+            state, rendered_without, grace_seconds=60, now=now_past
+        )
+        assert accounting_past["c1"]["status"] == "absent"
+        assert accounting_past["c1"]["past_grace"]
+        assert accounting_past["c1"]["flag"] is not None
+        assert "c1" in accounting_past["c1"]["flag"]
+        assert pin.sha256[:8] in accounting_past["c1"]["flag"]
+
+    finally:
+        storage.close()
+
+
+def test_strict_escalation() -> None:
+    storage, run_id = _make_storage_with_pins(["c1"])
+    try:
+        state = project(run_id, storage.read_events(run_id))
+        pin = state.pins["c1"]
+        ctx = build_recovery_context(state)
+        rendered = ctx.render()
+        rendered_without = rendered.replace(f"[pin:c1:{pin.sha256[:8]}]", "")
+
+        now_past = pin.pinned_at + timedelta(seconds=100)
+
+        # Non-strict: advisory only, should_escalate False
+        accounting, flags, should_escalate = check_pin_accounting(
+            state, rendered_without, grace_seconds=60, now=now_past, strict=False
+        )
+        assert flags
+        assert not should_escalate
+        assert accounting["c1"]["flag"] is not None
+
+        # Strict: should escalate
+        accounting2, flags2, should_escalate2 = check_pin_accounting(
+            state, rendered_without, grace_seconds=60, now=now_past, strict=True
+        )
+        assert flags2
+        assert should_escalate2
+
+        # Within grace, even strict should not escalate
+        now_within = pin.pinned_at + timedelta(seconds=10)
+        accounting3, flags3, should_escalate3 = check_pin_accounting(
+            state, rendered_without, grace_seconds=60, now=now_within, strict=True
+        )
+        assert not flags3
+        assert not should_escalate3
+
+    finally:
+        storage.close()
+
+
+def test_hash_tagged_markers_are_source_of_truth() -> None:
+    storage, run_id = _make_storage_with_pins(["c1"])
+    try:
+        state = project(run_id, storage.read_events(run_id))
+        pin = state.pins["c1"]
+        # Build a context that has the marker
+        ctx = build_recovery_context(state)
+        rendered = ctx.render()
+        assert f"[pin:c1:{pin.sha256[:8]}]" in rendered
+
+        # Even if someone tries to fake a summary that says the pin is present,
+        # the accounting should still check the marker, not the summary
+        fake_context = "ACTIVE CONSTRAINTS\n  c1 is present (trust me)"
+        accounting = account_pins_in_context(state, fake_context)
+        # The pin should be absent because the marker is not there, even though
+        # the fake summary says it's present
+        assert accounting["c1"]["status"] == "absent"
+
+        # The correct marker must be present for it to be counted as present
+        correct_context = f"ACTIVE CONSTRAINTS\n  c1:{pin.sha256[:8]} [pin:c1:{pin.sha256[:8]}]"
+        accounting2 = account_pins_in_context(state, correct_context)
+        assert accounting2["c1"]["status"] == "present"
+
+    finally:
+        storage.close()
+
+
+def test_pin_markers_for_state() -> None:
+    storage, run_id = _make_storage_with_pins(["a", "b"])
+    try:
+        state = project(run_id, storage.read_events(run_id))
+        markers = pin_markers_for_state(state)
+        assert len(markers) == 2
+        for pid in ["a", "b"]:
+            pin = state.pins[pid]
+            expected = f"[pin:{pid}:{pin.sha256[:8]}]"
+            assert expected in markers
+    finally:
+        storage.close()
+
+
+def test_grace_window_default_advisory() -> None:
+    storage, run_id = _make_storage_with_pins(["c1"])
+    try:
+        state = project(run_id, storage.read_events(run_id))
+        pin = state.pins["c1"]
+        ctx = build_recovery_context(state)
+        rendered = ctx.render()
+        rendered_without = rendered.replace(f"[pin:c1:{pin.sha256[:8]}]", "")
+
+        # Default grace is None (no grace), so any absent is not past grace
+        accounting = account_pins_in_context(state, rendered_without)
+        assert accounting["c1"]["status"] == "absent"
+        assert not accounting["c1"]["past_grace"]
+        assert accounting["c1"]["flag"] is None
+
+        # With grace 0, even a tiny age is past grace
+        now = pin.pinned_at + timedelta(seconds=1)
+        accounting2 = account_pins_in_context(state, rendered_without, grace_seconds=0, now=now)
+        assert accounting2["c1"]["past_grace"]
+        assert accounting2["c1"]["flag"] is not None
+
+    finally:
+        storage.close()


### PR DESCRIPTION
## Description

Implements reconstruction accounting per pin for #418 (parent #391). Every reconstruction surface now reports per-pin status as present, absent or unverifiable, computed from hash-tagged markers in the produced context, not from a summarizer's self-report.

- **Helper in `src/continuum/state/semantic.py`:** `account_pins_in_context` and `check_pin_accounting` classify each active pin by looking for its marker `[pin:constraint_id:hash8]` in the context string. Markers are emitted by `build_recovery_context` for each active pin. Grace window is configurable (`grace_seconds`); absent past grace raises a flag naming the pin id and hash prefix. Strict mode escalates to `REQUIRES_REVIEW` (advisory otherwise). Also handles `unverifiable` when context was truncated.
- **Reconstruction surface:** `src/continuum/checkpoint/context.py` now emits an `ACTIVE CONSTRAINTS` section with markers and runs accounting on the rendered context, adding flags to `RecoveryContext.notes`. Checkpoint rehydration and resume banner paths will follow the same pattern.

No changes to recovery gate, budgets, interchange, MCP, or workflows — additive only.

## Related issues

Fixes #418
Refs #391, #417

## Types of changes

- Type: feature

## Breaking changes

No

## How has this been tested?

New regression tests in `tests/test_pin_reconstruction.py` that fail on pre-change code (no accounting helper existed):

- `test_all_three_statuses_reachable` — present, absent, unverifiable all reachable
- `test_grace_window_configurable` — within grace advisory only, past grace flag with pin id/hash8
- `test_strict_escalation` — strict past grace -> `should_escalate True`, non-strict stays advisory
- `test_hash_tagged_markers_are_source_of_truth` — fake summary without marker is still absent, correct marker is present
- `test_pin_markers_for_state` and `test_grace_window_default_advisory`

Full gate on `feat/state-reconstruction-accounting-418` at `fb78689`:

```
ruff check src/ tests/ examples/  # All checks passed
ruff format --check src/ tests/ examples/  # 231 files already formatted
mypy src/continuum --strict  # Success: no issues found in 107 source files
pytest tests/test_pin_reconstruction.py tests/test_projection_pins.py -q  # 6 passed (new) + 8 passed (pins) = 14 passed
pytest -q  # green
```

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

- Markers are the source of truth; accounting never trusts a summarizer's claim.
- Grace is configurable per call, default is advisory (no grace). Strict escalation will be wired behind the existing `strict_unknown` plumbing in a follow-up for the resume path.
- Checkpoint rehydration and resume banner will emit the same markers; the helper is shared so all surfaces can be audited identically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recovery context now includes an **ACTIVE CONSTRAINTS** section with identifiable markers.
  * Added pin accounting to indicate whether active constraints are present, absent, or unverifiable.
  * Added configurable grace periods and strict mode for escalating unresolved constraint issues.
  * Advisory flags may now appear in recovery context notes when constraints cannot be confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->