### PR TITLE
fix(budgets): reject bool counters in hand-built helpers

### DIFF
--- a/src/continuum/budgets.py
+++ b/src/continuum/budgets.py
@@ -521,8 +521,22 @@ def get_remaining(
         entry = _bound_entry(raw, action_type, authorization_id)
     except KeyError:
         return None
-    used = int(entry.get("counter", 0))
-    return max(0, int(entry["max_attempts"]) - used)
+    counter = entry.get("counter", 0)
+    maximum = entry["max_attempts"]
+
+    if not _is_int(counter) or counter < 0:
+        raise BudgetConfigError(
+            f"authorization-bound budget needs a non-negative integer "
+            f"'counter'{_offending(counter)}"
+        )
+
+    if not _is_int(maximum) or maximum < 0:
+        raise BudgetConfigError(
+            f"authorization-bound budget needs a positive integer "
+            f"'max_attempts'{_offending(maximum)}"
+        )
+
+    return max(0, maximum - counter)
 
 
 def increment(
@@ -539,8 +553,25 @@ def increment(
     meaning anything.
     """
     entry = _bound_entry(raw, action_type, authorization_id)
-    entry["counter"] = int(entry.get("counter", 0)) + 1
-    return max(0, int(entry["max_attempts"]) - int(entry["counter"]))
+
+    counter = entry.get("counter", 0)
+    maximum = entry["max_attempts"]
+
+    if not _is_int(counter) or counter < 0:
+        raise BudgetConfigError(
+            f"authorization-bound budget needs a non-negative integer "
+            f"'counter'{_offending(counter)}"
+        )
+
+    if not _is_int(maximum) or maximum < 0:
+        raise BudgetConfigError(
+            f"authorization-bound budget needs a positive integer "
+            f"'max_attempts'{_offending(maximum)}"
+        )
+
+    counter += 1
+    entry["counter"] = counter
+    return max(0, maximum - counter)
 
 
 def would_refuse(
@@ -560,8 +591,19 @@ def would_refuse(
         entry = _bound_entry(raw, action_type, authorization_id)
     except KeyError:
         return False, f"no authorization-bound budget for {label}"
-    used = int(entry.get("counter", 0))
-    maximum = int(entry["max_attempts"])
+    used = entry.get("counter", 0)
+    maximum = entry["max_attempts"]
+
+    if not _is_int(used) or used < 0:
+        raise BudgetConfigError(
+            f"authorization-bound budget needs a non-negative integer 'counter'{_offending(used)}"
+        )
+
+    if not _is_int(maximum) or maximum < 0:
+        raise BudgetConfigError(
+            f"authorization-bound budget needs a positive integer "
+            f"'max_attempts'{_offending(maximum)}"
+        )
     if used >= maximum:
         detail = f"{label} exhausted its authorization-bound budget"
         return True, f"{detail} ({used} of {maximum} attempts used)"

--- a/tests/test_retry_budgets.py
+++ b/tests/test_retry_budgets.py
@@ -1028,3 +1028,49 @@ def test_cli_budget_exhausted_exit_is_reported_not_raised(db: str, tmp_path: Pat
     assert code == ExitCode.OK
     rows = json.loads(out)["budgets"]
     assert any(r["action_type"] == "deploy" and r["attempts"] >= 1 for r in rows)
+
+
+def test_hand_built_authorization_counter_bool_is_rejected() -> None:
+    raw = bound_registry()
+    raw["authorization_bound"]["send_invoice"]["authz:stripe-cust-1"]["counter"] = True
+
+    with pytest.raises(
+        BudgetConfigError,
+        match=r"needs a non-negative integer 'counter', got True \(bool\)",
+    ):
+        get_remaining(raw, "send_invoice", "authz:stripe-cust-1")
+
+    with pytest.raises(
+        BudgetConfigError,
+        match=r"needs a non-negative integer 'counter', got True \(bool\)",
+    ):
+        increment(raw, "send_invoice", "authz:stripe-cust-1")
+
+    with pytest.raises(
+        BudgetConfigError,
+        match=r"needs a non-negative integer 'counter', got True \(bool\)",
+    ):
+        would_refuse(raw, "send_invoice", "authz:stripe-cust-1")
+
+
+def test_hand_built_authorization_max_attempts_bool_is_rejected() -> None:
+    raw = bound_registry()
+    raw["authorization_bound"]["send_invoice"]["authz:stripe-cust-1"]["max_attempts"] = True
+
+    with pytest.raises(
+        BudgetConfigError,
+        match=r"needs a positive integer 'max_attempts', got True \(bool\)",
+    ):
+        get_remaining(raw, "send_invoice", "authz:stripe-cust-1")
+
+    with pytest.raises(
+        BudgetConfigError,
+        match=r"needs a positive integer 'max_attempts', got True \(bool\)",
+    ):
+        increment(raw, "send_invoice", "authz:stripe-cust-1")
+
+    with pytest.raises(
+        BudgetConfigError,
+        match=r"needs a positive integer 'max_attempts', got True \(bool\)",
+    ):
+        would_refuse(raw, "send_invoice", "authz:stripe-cust-1")


### PR DESCRIPTION
## Summary

Works on: #454.

Hand-built authorization-bound budget mappings previously accepted boolean values for `counter` and `max_attempts` because `bool` is a subclass of `int` in Python.

This change:

* validates `counter` and `max_attempts` with the existing `_is_int` checks in `get_remaining`, `increment`, and `would_refuse`
* rejects boolean values instead of silently coercing them to integers
* preserves the existing `max_attempts=0` behavior for hand-built helper mappings
* adds regression tests covering both boolean fields across all three helpers

## Verification

* `python -m pytest tests/test_retry_budgets.py -q` ✅
* `python -m ruff check src/continuum/budgets.py tests/test_retry_budgets.py` ✅
* `python -m pytest -q` ✅
* `git diff --check` ✅
