### PR TITLE
fix(observations): reject bool in payload bytes field

### DIFF
--- a/src/continuum/recovery/observations.py
+++ b/src/continuum/recovery/observations.py
@@ -60,7 +60,7 @@ def _entry_from_event(event: Event, root: Path) -> dict[str, Any] | None:
     if not isinstance(tool, str) or not isinstance(path, str) or not path:
         return None
     sha = payload.get("sha256") if isinstance(payload.get("sha256"), str) else None
-    size = payload.get("bytes") if isinstance(payload.get("bytes"), int) else None
+    size = payload.get("bytes") if type(payload.get("bytes")) is int else None
     resolved = Path(path)
     if not resolved.is_absolute():
         resolved = root / resolved


### PR DESCRIPTION
## Description

`isinstance(True, int)` is true in Python, so a payload with `{"bytes": true}` was treated as size 1 instead of being ignored as invalid. Use `type() is int` to reject bool values.

## Changes

- `src/continuum/recovery/observations.py:63`: Changed `isinstance(payload.get("bytes"), int)` to `type(payload.get("bytes")) is int`

## Related Issues

Resolves #452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected byte-count handling so boolean values are no longer treated as valid byte counts during recovery observations.
  * Preserved existing behavior for valid numeric byte values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->