### PR TITLE
feat(budgets): refusal surfaces name authorization and budget report shows per-auth rows (Fixes #414)

### DIFF
--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -438,7 +438,7 @@ class ActionLedger:
             raw = load_budgets(path)
         except BudgetConfigError as exc:
             raise LedgerError(f"budget registry invalid: {exc}") from exc
-        ensure_authorization_entry(raw, action_type, authorization_id)
+        entry = ensure_authorization_entry(raw, action_type, authorization_id)
         refused, reason = would_refuse(raw, action_type, authorization_id)
         if refused:
             remaining = 0
@@ -448,9 +448,12 @@ class ActionLedger:
                 remaining = _get_rem(raw, action_type, authorization_id) or 0
             except Exception:
                 remaining = 0
+            counter = int(entry.get("counter", 0))
+            max_attempts = int(entry.get("max_attempts", 0))
             raise LedgerError(
                 f"budget exhausted for {action_type!r} / {authorization_id!r} "
-                f"({reason}, remaining {remaining})"
+                f"({counter} of {max_attempts} used, {remaining} remaining; "
+                f"{reason})"
             )
         increment(raw, action_type, authorization_id)
         save_budgets(path, raw)

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -899,16 +899,16 @@ def cmd_budget(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
                 max_attempts = int(entry.get("max_attempts", 0))
                 rem = get_remaining(raw, atype, auth_id)
                 remaining = rem if rem is not None else max(0, max_attempts - counter)
-            auth_rows.append(
-                {
-                    "action_type": atype,
-                    "authorization_id": auth_id,
-                    "counter": counter,
-                    "max_attempts": max_attempts,
-                    "remaining": remaining,
-                    "exhausted": remaining == 0,
-                }
-            )
+                auth_rows.append(
+                    {
+                        "action_type": atype,
+                        "authorization_id": auth_id,
+                        "counter": counter,
+                        "max_attempts": max_attempts,
+                        "remaining": remaining,
+                        "exhausted": remaining == 0,
+                    }
+                )
     payload: dict[str, Any] = {"run_id": args.run_id, "budgets": rows}
     if auth_rows:
         payload["authorization_budgets"] = auth_rows

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -1100,6 +1100,7 @@ def build_server(
         """Claim an action in the ledger and report whether to proceed."""
         from continuum.actions.grants import GrantDenied, normalize_grant
         from continuum.actions.idempotency import idempotency_key
+        from continuum.actions.ledger import LedgerError
         from continuum.pinning import normalize_pinning
 
         pinning_clean = normalize_pinning(pinning)
@@ -1209,6 +1210,10 @@ def build_server(
                     ),
                 }
             )
+        except LedgerError as exc:
+            from mcp.server.mcpserver.exceptions import ToolError
+
+            raise ToolError(str(exc)) from exc
         except UnknownSideEffect as exc:
             return _json(
                 {


### PR DESCRIPTION
Closes #414.

Budget refusal at claim now includes action_type, authorization_id, counter/max_attempts/remaining via ensure_authorization_entry, would_refuse and get_remaining. MCP ToolError surfaces the same instructive text. continuum budget renders per-authorization rows alongside per-type rows in both JSON authorization_budgets and text table, with no change when the section is absent. Fix indentation bug where auth_rows.append was outside the inner loop so only the last authorization per type was emitted.

Gate: pytest 1637 passed, ruff check + format clean, strict mypy clean (changed modules).

Refs #414, #390