### PR TITLE
fix(budgets): reject bool action type caps

### DIFF
--- a/src/continuum/budgets.py
+++ b/src/continuum/budgets.py
@@ -157,12 +157,12 @@ def load_budgets(path: Path) -> dict[str, Any]:
 def _max_for(action_type: str, raw: Mapping[str, Any]) -> int:
     per_type = raw.get("action_types", {})
     spec = per_type.get(action_type)
-    if isinstance(spec, int):
+    if _is_int(spec):
         # int(), not the value itself: :func:`load_budgets` refuses booleans, but
         # this stays reachable with a hand-built mapping, and a bool leaking out
         # here renders as JSON ``true`` in the `continuum budget` report.
         return int(spec)
-    if isinstance(spec, dict) and isinstance(spec.get("max_attempts"), int):
+    if isinstance(spec, dict) and _is_int(spec.get("max_attempts")):
         return int(spec["max_attempts"])
     fallback = raw.get("default_max_attempts", FALLBACK_MAX_ATTEMPTS)
     return int(fallback)

--- a/tests/test_retry_budgets.py
+++ b/tests/test_retry_budgets.py
@@ -19,6 +19,7 @@ import pytest
 from continuum.actions import ActionLedger
 from continuum.budgets import (
     BudgetConfigError,
+    _max_for,
     _process_umask,
     _restore_ownership,
     _staged_attributes,
@@ -1074,3 +1075,33 @@ def test_hand_built_authorization_max_attempts_bool_is_rejected() -> None:
         match=r"needs a positive integer 'max_attempts', got True \(bool\)",
     ):
         would_refuse(raw, "send_invoice", "authz:stripe-cust-1")
+
+
+def test_hand_built_action_type_bool_uses_fallback() -> None:
+    raw = {"default_max_attempts": 3, "action_types": {"send_invoice": True}}
+
+    assert _max_for("send_invoice", raw) == 3
+
+
+def test_hand_built_action_type_object_bool_uses_fallback() -> None:
+    raw = {
+        "default_max_attempts": 3,
+        "action_types": {"send_invoice": {"max_attempts": True}},
+    }
+
+    assert _max_for("send_invoice", raw) == 3
+
+
+def test_hand_built_action_type_int_is_used() -> None:
+    raw = {"default_max_attempts": 3, "action_types": {"send_invoice": 5}}
+
+    assert _max_for("send_invoice", raw) == 5
+
+
+def test_hand_built_action_type_object_int_is_used() -> None:
+    raw = {
+        "default_max_attempts": 3,
+        "action_types": {"send_invoice": {"max_attempts": 5}},
+    }
+
+    assert _max_for("send_invoice", raw) == 5


### PR DESCRIPTION
## Summary

Fixes #451.

`_max_for()` previously used `isinstance(..., int)` for hand-built action-type budget mappings. Since `bool` is a subclass of `int` in Python, `True` could be interpreted as `max_attempts=1`.

This changes the two checks in `_max_for()` to use the existing `_is_int()` helper, so boolean values are no longer treated as integer caps.

Added regression coverage for both supported hand-built forms:

* `{"action_types": {"send_invoice": True}}`
* `{"action_types": {"send_invoice": {"max_attempts": True}}}`

Both now fall back to the configured default instead of being interpreted as `1`.

## Verification

* `python -m pytest tests/test_retry_budgets.py -q` ✅
* `python -m pytest -q` ✅
* `python -m ruff check src/continuum/budgets.py tests/test_retry_budgets.py` ✅
* `python -m mypy src` ✅
* `git diff --check` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected retry budget handling so boolean values are no longer incorrectly interpreted as numeric attempt limits.
  * Boolean shorthand and per-action boolean limits now correctly fall back to the configured default maximum attempts.

* **Tests**
  * Added coverage for both boolean retry budget formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->