### PR TITLE
feat(state): durable structured plan via PLAN_UPSERT (Refs #312)

### DIFF
--- a/examples/plan_milestones.py
+++ b/examples/plan_milestones.py
@@ -1,0 +1,52 @@
+"""Plan milestones example (issue #312)."""
+
+from __future__ import annotations
+
+import tempfile
+
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.state.semantic import project
+from continuum.storage import SQLiteStorage
+
+
+def main() -> None:
+    db = tempfile.mktemp(suffix=".db")
+    storage = SQLiteStorage(db)
+    run_id = "plan-run-1"
+    storage.create_run(Run(run_id=run_id, goal="5 milestones"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "5 milestones"})
+    units = [
+        {
+            "id": f"u{i}",
+            "title": f"milestone {i}",
+            "status": "pending",
+            "depends_on": [f"u{i - 1}"] if i > 1 else [],
+        }
+        for i in range(1, 6)
+    ]
+    storage.append_event(run_id, EventType.PLAN_UPSERT, {"plan_id": "p1", "units": units})
+    print("initial plan:", [p.step_id for p in project(run_id, storage.read_events(run_id)).plan])
+    storage.append_event(
+        run_id,
+        EventType.PLAN_UPSERT,
+        {
+            "plan_id": "p1",
+            "units": [
+                {"id": "u1", "title": "milestone 1", "status": "done", "depends_on": []},
+                {"id": "u2", "title": "milestone 2", "status": "done", "depends_on": ["u1"]},
+            ],
+        },
+    )
+    state = project(run_id, storage.read_events(run_id))
+    print("after 2 done:", [(p.step_id, p.status.value) for p in state.plan])
+    storage2 = SQLiteStorage(db)
+    state2 = project(run_id, storage2.read_events(run_id))
+    remaining = [p for p in state2.plan if p.status.value != "completed"]
+    print("resume remaining:", [p.step_id for p in remaining])
+    assert [p.step_id for p in remaining] == ["u3", "u4", "u5"]
+    print("zero duplicate work for completed units across crash: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -315,6 +315,135 @@ def _degraded_lines(state: SemanticState) -> list[str]:
     ]
 
 
+def cmd_record_plan(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Record a structured plan upsert (issue #312). Mutates storage."""
+    from continuum.events import Event, EventType
+    from continuum.models import Origin
+    from continuum.state.semantic import project
+
+    plan_id = getattr(args, "plan_id", None) or getattr(args, "plan", None)
+    if not plan_id or not isinstance(plan_id, str) or not plan_id.strip():
+        print("error: --plan-id is required and must be non-empty", file=err)
+        return ExitCode.ERROR
+    raw_units: Any = None
+    if getattr(args, "file", None):
+        try:
+            text = Path(args.file).read_text(encoding="utf-8")
+            data = json.loads(text)
+            if isinstance(data, dict) and "units" in data:
+                raw_units = data["units"]
+                if not plan_id and isinstance(data.get("plan_id"), str):
+                    plan_id = data["plan_id"]
+            elif isinstance(data, list):
+                raw_units = data
+            else:
+                raw_units = data
+        except Exception as exc:
+            print(f"error: cannot read plan file: {exc}", file=err)
+            return ExitCode.ERROR
+    elif getattr(args, "units", None):
+        try:
+            raw_units = json.loads(args.units)
+        except Exception as exc:
+            print(f"error: --units is not valid JSON: {exc}", file=err)
+            return ExitCode.ERROR
+    else:
+        print("error: provide --file <path> or --units '<json>'", file=err)
+        return ExitCode.ERROR
+    if not isinstance(raw_units, list):
+        print("error: units must be a JSON array", file=err)
+        return ExitCode.ERROR
+    seen: set[str] = set()
+    sorted_units: list[dict[str, Any]] = []
+    for raw in raw_units:
+        if not isinstance(raw, dict):
+            print("error: each unit must be an object", file=err)
+            return ExitCode.ERROR
+        unit_id = raw.get("id")
+        if not isinstance(unit_id, str) or not unit_id.strip():
+            print("error: unit id must be non-empty", file=err)
+            return ExitCode.ERROR
+        if unit_id in seen:
+            print(f"error: duplicate unit id {unit_id!r}", file=err)
+            return ExitCode.ERROR
+        seen.add(unit_id)
+        title = raw.get("title")
+        if not isinstance(title, str):
+            print(f"error: unit {unit_id!r} title must be a string", file=err)
+            return ExitCode.ERROR
+        status = raw.get("status", "pending")
+        if status not in ("pending", "working", "done", "blocked"):
+            print(
+                f"error: unit {unit_id!r} status must be pending, working, done, or blocked",
+                file=err,
+            )
+            return ExitCode.ERROR
+        depends = raw.get("depends_on", [])
+        if not isinstance(depends, list):
+            print(f"error: unit {unit_id!r} depends_on must be a list", file=err)
+            return ExitCode.ERROR
+        for d in depends:
+            if not isinstance(d, str) or not d.strip():
+                print(
+                    f"error: unit {unit_id!r} depends_on entries must be non-empty strings",
+                    file=err,
+                )
+                return ExitCode.ERROR
+        sorted_units.append(
+            {
+                "id": unit_id,
+                "title": title,
+                "status": status,
+                "depends_on": [str(d) for d in depends],
+            }
+        )
+    sorted_units.sort(key=lambda u: u["id"])
+    try:
+        storage.get_run(args.run_id)
+    except Exception as exc:
+        print(f"error: {exc}", file=err)
+        return ExitCode.NOT_FOUND
+    payload = {"plan_id": plan_id, "units": sorted_units}
+    history = list(storage.read_events(args.run_id))
+    head = history[-1].sequence if history else 0
+    candidate = Event(
+        run_id=args.run_id,
+        sequence=head + 1,
+        type=EventType.PLAN_UPSERT,
+        payload=dict(payload),
+        source=Origin.HUMAN,
+    )
+    try:
+        project(args.run_id, [*history, candidate])
+    except Exception as exc:
+        print(f"error: plan would leave run unprojectable and was not recorded: {exc}", file=err)
+        return ExitCode.ERROR
+    event = storage.append_event(args.run_id, EventType.PLAN_UPSERT, payload, source=Origin.HUMAN)
+    state = project(args.run_id, storage.read_events(args.run_id))
+    _emit(
+        {
+            "run_id": args.run_id,
+            "plan_id": plan_id,
+            "units": len(sorted_units),
+            "sequence": event.sequence,
+            "plan": [
+                {
+                    "id": p.step_id,
+                    "title": p.description,
+                    "status": p.status.value,
+                    "depends_on": p.depends_on,
+                }
+                for p in state.plan
+            ],
+        },
+        f"Plan {plan_id!r} upserted {len(sorted_units)} unit(s) at seq {event.sequence} (plan now {len(state.plan)} units)",
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
+
+
 def cmd_inspect(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Show semantic state, optionally at a past version."""
     if args.version is not None:
@@ -335,6 +464,13 @@ def cmd_inspect(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
         f"evidence:    {len(state.evidence)}",
         f"pending:     {len(state.open_work())} task(s)",
     ]
+    if state.plan:
+        lines.append(f"plan:       {len(state.plan)} unit(s)")
+        for pp in state.plan:
+            deps = f" deps:{','.join(pp.depends_on)}" if pp.depends_on else ""
+            lines.append(f"  - {pp.step_id}: {pp.description} [{pp.status.value}]{deps}")
+    else:
+        lines.append("plan:       (none)")
     if state.external_dependencies:
         lines.append("dependencies:")
         lines += [
@@ -2306,6 +2442,15 @@ def build_parser() -> argparse.ArgumentParser:
     checkpoint = with_env(with_run(add("checkpoint", cmd_checkpoint, "Force a checkpoint.")))
     checkpoint.add_argument("--trigger", default="manual")
     checkpoint.add_argument("--reason", default="")
+
+    record_plan = with_run(
+        add("record-plan", cmd_record_plan, "Record a structured plan upsert. Mutates storage.")
+    )
+    record_plan.add_argument("--plan-id", dest="plan_id", required=True, help="plan identifier")
+    record_plan.add_argument(
+        "--file", dest="file", help="JSON file containing units array or {plan_id, units}"
+    )
+    record_plan.add_argument("--units", help="JSON array of units")
 
     observe = add("observe", cmd_observe, "Record one observed tool completion. Mutates storage.")
     observe.add_argument(

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -115,6 +115,12 @@ class EventType(StrEnum):
     # authority (issue #269): a claim tried to reuse a consumed single-use grant
     GRANT_DENIED = "GRANT_DENIED"
 
+    # structured attempt memory (issue #313): durable falsification lesson
+    ATTEMPT_LESSON = "ATTEMPT_LESSON"
+
+    # structured plan (issue #312): durable milestones for long-horizon recovery
+    PLAN_UPSERT = "PLAN_UPSERT"
+
 
 class AppendOnlyViolation(RuntimeError):
     """Raised when an operation would rewrite history."""

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -846,6 +846,84 @@ def build_server(
             }
         )
 
+    @server.tool(
+        name="continuum_record_plan",
+        description=(
+            "Record a structured plan milestone update. Call as you define or complete units "
+            "so the run can resume with exact remaining work. One call per unit status change. "
+            "Payload is {plan_id, units: [{id, title, status, depends_on}]} where status is "
+            "pending, working, done, or blocked. Creates the run if needed. Mutating."
+        ),
+        annotations=mutating,
+    )
+    @guard
+    def continuum_record_plan(
+        run_id: str,
+        plan_id: str,
+        units: list[dict[str, Any]],
+    ) -> str:
+        """Record a plan upsert (issue #312)."""
+        if not isinstance(plan_id, str) or not plan_id.strip():
+            raise ValueError("plan_id must be a non-empty string")
+        if not isinstance(units, list) or not units:
+            raise ValueError("units must be a non-empty list")
+        seen: set[str] = set()
+        sorted_units: list[dict[str, Any]] = []
+        for raw in units:
+            if not isinstance(raw, dict):
+                raise ValueError("each unit must be an object")
+            unit_id = raw.get("id")
+            if not isinstance(unit_id, str) or not unit_id.strip():
+                raise ValueError("unit id must be non-empty")
+            if unit_id in seen:
+                raise ValueError(f"duplicate unit id {unit_id!r}")
+            seen.add(unit_id)
+            title = raw.get("title")
+            if not isinstance(title, str):
+                raise ValueError(f"unit {unit_id!r} title must be a string")
+            status = raw.get("status", "pending")
+            if status not in ("pending", "working", "done", "blocked"):
+                raise ValueError(
+                    f"unit {unit_id!r} status must be pending, working, done, or blocked"
+                )
+            depends = raw.get("depends_on", [])
+            if not isinstance(depends, list):
+                raise ValueError(f"unit {unit_id!r} depends_on must be a list")
+            for d in depends:
+                if not isinstance(d, str) or not d.strip():
+                    raise ValueError(
+                        f"unit {unit_id!r} depends_on entries must be non-empty strings"
+                    )
+            sorted_units.append(
+                {
+                    "id": unit_id,
+                    "title": title,
+                    "status": status,
+                    "depends_on": [str(d) for d in depends],
+                }
+            )
+        sorted_units.sort(key=lambda u: u["id"])
+        ctx.ensure_run(run_id)
+        payload = {"plan_id": plan_id, "units": sorted_units}
+        state, event = _append_projectable(ctx, run_id, EventType.PLAN_UPSERT, payload)
+        return _json(
+            {
+                "run_id": run_id,
+                "plan_id": plan_id,
+                "units": len(sorted_units),
+                "sequence": event.sequence,
+                "plan": [
+                    {
+                        "id": p.step_id,
+                        "title": p.description,
+                        "status": p.status.value,
+                        "depends_on": p.depends_on,
+                    }
+                    for p in state.plan
+                ],
+            }
+        )
+
     # -- validation ------------------------------------------------------- #
 
     @server.tool(

--- a/src/continuum/state/diff.py
+++ b/src/continuum/state/diff.py
@@ -180,6 +180,14 @@ def diff_states(before: SemanticState, after: SemanticState) -> StateDiff:
         fields=("description", "status", "prerequisite"),
     )
     entries += _compare_collection(
+        before.plan,
+        after.plan,
+        component=Component.PLAN,
+        key=lambda p: p.step_id,
+        describe=lambda p: str(p.description),
+        fields=("description", "status", "depends_on"),
+    )
+    entries += _compare_collection(
         before.approvals,
         after.approvals,
         component=Component.APPROVAL,

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -432,6 +432,64 @@ class _Accumulator:
             if constraint_id not in self.unmatched_pin_retractions:
                 self.unmatched_pin_retractions.append(constraint_id)
 
+    def plan_upsert(self, event: Event) -> None:
+        payload = event.payload
+        plan_id = payload.get("plan_id")
+        if not isinstance(plan_id, str) or not plan_id.strip():
+            raise ProjectionError(f"event {event.event_id}: PLAN_UPSERT missing non-empty plan_id")
+        units = payload.get("units")
+        if not isinstance(units, list):
+            raise ProjectionError(f"event {event.event_id}: PLAN_UPSERT units must be a list")
+        seen: set[str] = set()
+        status_map = {
+            "pending": "pending",
+            "working": "in_progress",
+            "done": "completed",
+            "blocked": "blocked",
+        }
+        by_id: dict[str, Any] = {p.step_id: p for p in self.plan}
+        for raw in units:
+            if not isinstance(raw, dict):
+                raise ProjectionError(f"event {event.event_id}: PLAN_UPSERT unit must be an object")
+            unit_id = raw.get("id")
+            if not isinstance(unit_id, str) or not unit_id.strip():
+                raise ProjectionError(
+                    f"event {event.event_id}: PLAN_UPSERT unit id must be non-empty"
+                )
+            if unit_id in seen:
+                raise ProjectionError(
+                    f"event {event.event_id}: duplicate unit id {unit_id!r} in same PLAN_UPSERT"
+                )
+            seen.add(unit_id)
+            title = raw.get("title")
+            if not isinstance(title, str):
+                raise ProjectionError(
+                    f"event {event.event_id}: unit {unit_id!r} title must be a string"
+                )
+            raw_status = raw.get("status", "pending")
+            if not isinstance(raw_status, str) or raw_status not in status_map:
+                raise ProjectionError(
+                    f"event {event.event_id}: unit {unit_id!r} status must be one of {sorted(status_map)}"
+                )
+            status = status_map[raw_status]
+            depends = raw.get("depends_on", [])
+            if not isinstance(depends, list):
+                raise ProjectionError(
+                    f"event {event.event_id}: unit {unit_id!r} depends_on must be a list"
+                )
+            depends_list = [str(d) for d in depends]
+            from continuum.models import PlanStep, PlanStepStatus
+
+            step = PlanStep(
+                step_id=unit_id,
+                description=title,
+                status=PlanStepStatus(status),
+                depends_on=depends_list,
+                provenance=_provenance(event),
+            )
+            by_id[unit_id] = step
+        self.plan = sorted(by_id.values(), key=lambda p: p.step_id)
+
     # -- finish ----------------------------------------------------------- #
 
     def build(self) -> SemanticState:
@@ -532,6 +590,8 @@ def _dispatch(acc: _Accumulator, event: Event) -> bool:
             acc.constraint_pinned(event)
         case EventType.CONSTRAINT_RETRACTED:
             acc.constraint_retracted(event)
+        case EventType.PLAN_UPSERT:
+            acc.plan_upsert(event)
         case _:
             return False
     return True

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from typing import Any
 
 from continuum.environment.diff import EnvironmentDiff, ResourceChange, diff_environments
 from continuum.models import (
@@ -159,6 +160,7 @@ class StateValidator:
             state = self._propagate(state, broken, entries)
             self._check_goal(state, entries)
             self._check_progress(state, entries)
+            self._check_plan(state, entries)
             self._check_approvals(state, entries)
             self._check_model(state, expected_model, entries)
             self._check_evidence(state, entries)
@@ -413,6 +415,128 @@ class StateValidator:
                 detail=detail or f"{progress.completed} completed",
             )
         )
+
+    def _check_plan(self, state: SemanticState, entries: list[ComponentValidationEntry]) -> None:
+        if not state.plan:
+            return
+        seen: set[str] = set()
+        by_id: dict[str, Any] = {}
+        for step in state.plan:
+            if not step.step_id or not step.step_id.strip():
+                entries.append(
+                    ComponentValidationEntry(
+                        component=Component.PLAN,
+                        component_id=step.step_id,
+                        status=StateStatus.CONFLICTED,
+                        detail="plan unit id must be non-empty",
+                    )
+                )
+                continue
+            if step.step_id in seen:
+                entries.append(
+                    ComponentValidationEntry(
+                        component=Component.PLAN,
+                        component_id=step.step_id,
+                        status=StateStatus.CONFLICTED,
+                        detail=f"duplicate plan unit id {step.step_id!r}",
+                    )
+                )
+            seen.add(step.step_id)
+            by_id[step.step_id] = step
+        for step in state.plan:
+            for dep in step.depends_on:
+                if dep not in by_id:
+                    entries.append(
+                        ComponentValidationEntry(
+                            component=Component.PLAN,
+                            component_id=step.step_id,
+                            status=StateStatus.CONFLICTED,
+                            detail=f"depends_on {dep!r} not in plan",
+                        )
+                    )
+        visiting: set[str] = set()
+        visited: set[str] = set()
+        stack: list[str] = []
+        cycle: list[str] | None = None
+
+        def dfs(node: str) -> bool:
+            nonlocal cycle
+            if node in visited:
+                return False
+            if node in visiting:
+                idx = stack.index(node) if node in stack else 0
+                cycle = stack[idx:] + [node]
+                return True
+            if node not in by_id:
+                return False
+            visiting.add(node)
+            stack.append(node)
+            for dep in by_id[node].depends_on:
+                if dfs(dep):
+                    return True
+            stack.pop()
+            visiting.remove(node)
+            visited.add(node)
+            return False
+
+        for sid in list(by_id):
+            if sid not in visited and dfs(sid):
+                break
+        if cycle:
+            detail = f"cycle detected: {' -> '.join(cycle)}"
+            for sid in cycle:
+                entries.append(
+                    ComponentValidationEntry(
+                        component=Component.PLAN,
+                        component_id=sid,
+                        status=StateStatus.CONFLICTED,
+                        detail=detail,
+                    )
+                )
+        for step in state.plan:
+            if step.provenance.origin.self_certified:
+                entries.append(
+                    ComponentValidationEntry(
+                        component=Component.PLAN,
+                        component_id=step.step_id,
+                        status=StateStatus.REQUIRES_REVIEW,
+                        detail=f"plan unit {step.step_id!r} asserted by {step.provenance.origin.value}",
+                    )
+                )
+        stale_ids: set[str] = set()
+        for e in entries:
+            if (
+                e.component is Component.PLAN
+                and e.status
+                in (
+                    StateStatus.STALE,
+                    StateStatus.CONFLICTED,
+                    StateStatus.REQUIRES_REVIEW,
+                    StateStatus.INVALID,
+                )
+                and e.component_id
+            ):
+                stale_ids.add(e.component_id)
+        changed = True
+        while changed:
+            changed = False
+            for step in state.plan:
+                if step.step_id in stale_ids:
+                    continue
+                for dep in step.depends_on:
+                    if dep in stale_ids:
+                        if step.step_id not in stale_ids:
+                            stale_ids.add(step.step_id)
+                            entries.append(
+                                ComponentValidationEntry(
+                                    component=Component.PLAN,
+                                    component_id=step.step_id,
+                                    status=StateStatus.STALE,
+                                    detail=f"depends on stale plan unit {dep!r}",
+                                )
+                            )
+                            changed = True
+                        break
 
     @staticmethod
     def _check_approvals(state: SemanticState, entries: list[ComponentValidationEntry]) -> None:

--- a/tests/test_plan_upsert.py
+++ b/tests/test_plan_upsert.py
@@ -1,0 +1,224 @@
+"""Plan upsert (issue #312) - 7 tests plus property."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from continuum.events import EventType
+from continuum.interchange import export_semantic_state, import_semantic_state
+from continuum.models import Origin, Run, StateStatus
+from continuum.state.semantic import project
+from continuum.state.validator import StateValidator
+from continuum.storage import SQLiteStorage
+
+
+def _run(tmp_path: Path, run_id: str = "run_1") -> SQLiteStorage:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "g"})
+    return storage
+
+
+def test_latest_write_wins_for_same_plan_id_unit_id(tmp_path: Path) -> None:
+    storage = _run(tmp_path)
+    storage.append_event(
+        "run_1",
+        EventType.PLAN_UPSERT,
+        {
+            "plan_id": "p1",
+            "units": [{"id": "u1", "title": "first", "status": "pending", "depends_on": []}],
+        },
+    )
+    storage.append_event(
+        "run_1",
+        EventType.PLAN_UPSERT,
+        {
+            "plan_id": "p1",
+            "units": [{"id": "u1", "title": "updated", "status": "done", "depends_on": []}],
+        },
+    )
+    state = project("run_1", storage.read_events("run_1"))
+    assert len(state.plan) == 1
+    assert state.plan[0].step_id == "u1"
+    assert state.plan[0].description == "updated"
+    assert state.plan[0].status.value == "completed"
+    storage.close()
+
+
+def test_hash_chain_covers_plan_events(tmp_path: Path) -> None:
+    storage = _run(tmp_path)
+    storage.append_event(
+        "run_1",
+        EventType.PLAN_UPSERT,
+        {
+            "plan_id": "p1",
+            "units": [{"id": "u1", "title": "t", "status": "pending", "depends_on": []}],
+        },
+    )
+    report = storage.verify_events("run_1")
+    assert report.ok
+    events = list(storage.read_events("run_1"))
+    plan_event = next(e for e in events if e.type == EventType.PLAN_UPSERT)
+    tampered = plan_event.model_copy(
+        update={
+            "payload": {
+                "plan_id": "p1",
+                "units": [{"id": "u1", "title": "tampered", "status": "done", "depends_on": []}],
+            }
+        }
+    )
+    assert tampered.hash != tampered.digest()
+    storage.close()
+
+
+def test_project_with_no_plan_yields_empty(tmp_path: Path) -> None:
+    storage = _run(tmp_path)
+    state = project("run_1", storage.read_events("run_1"))
+    assert state.plan == []
+    storage.close()
+
+
+def test_validator_invalidates_stale_and_downstream_but_not_unrelated(tmp_path: Path) -> None:
+    storage2 = _run(tmp_path, "run_2")
+    storage2.append_event(
+        "run_2",
+        EventType.PLAN_UPSERT,
+        {
+            "plan_id": "p1",
+            "units": [
+                {"id": "u1", "title": "a", "status": "pending", "depends_on": ["missing"]},
+                {"id": "u2", "title": "b", "status": "pending", "depends_on": ["u1"]},
+                {"id": "u3", "title": "c", "status": "pending", "depends_on": ["u2"]},
+                {"id": "u4", "title": "d", "status": "pending", "depends_on": []},
+            ],
+        },
+    )
+    state2 = project("run_2", storage2.read_events("run_2"))
+    validator = StateValidator()
+    outcome = validator.validate(state2)
+    assert any(
+        e.component.value == "plan"
+        and e.component_id == "u1"
+        and e.status == StateStatus.CONFLICTED
+        for e in outcome.report.statuses
+    )
+    assert any(
+        e.component.value == "plan" and e.component_id == "u2" and e.status == StateStatus.STALE
+        for e in outcome.report.statuses
+    )
+    assert any(
+        e.component.value == "plan" and e.component_id == "u3" and e.status == StateStatus.STALE
+        for e in outcome.report.statuses
+    )
+    assert not any(
+        e.component.value == "plan"
+        and e.component_id == "u4"
+        and e.status in (StateStatus.STALE, StateStatus.CONFLICTED)
+        for e in outcome.report.statuses
+    )
+    storage2.close()
+
+
+def test_mcp_sets_external_agent_and_requires_review(tmp_path: Path) -> None:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_1", goal="g"))
+    storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"}, source=Origin.DETERMINISTIC)
+    storage.append_event(
+        "run_1",
+        EventType.PLAN_UPSERT,
+        {
+            "plan_id": "p1",
+            "units": [{"id": "u1", "title": "t", "status": "pending", "depends_on": []}],
+        },
+        source=Origin.EXTERNAL_AGENT,
+    )
+    state = project("run_1", storage.read_events("run_1"))
+    assert state.plan[0].provenance.origin == Origin.EXTERNAL_AGENT
+    validator = StateValidator()
+    outcome = validator.validate(state)
+    assert any(
+        e.component.value == "plan" and e.status == StateStatus.REQUIRES_REVIEW
+        for e in outcome.report.statuses
+    )
+    storage.close()
+
+
+def test_interchange_round_trip_preserves_plan(tmp_path: Path) -> None:
+    storage = _run(tmp_path)
+    storage.append_event(
+        "run_1",
+        EventType.PLAN_UPSERT,
+        {
+            "plan_id": "p1",
+            "units": [
+                {"id": "u1", "title": "t", "status": "done", "depends_on": []},
+                {"id": "u2", "title": "t2", "status": "pending", "depends_on": ["u1"]},
+            ],
+        },
+    )
+    state = project("run_1", storage.read_events("run_1"))
+    payload = export_semantic_state(state)
+    restored = import_semantic_state(payload)
+    assert len(restored.plan) == 2
+    assert restored.plan[0].step_id == "u1"
+    assert restored.plan[1].step_id == "u2"
+    assert restored.plan[0].status.value == "completed"
+    storage.close()
+
+
+def test_cli_round_trip(tmp_path: Path) -> None:
+    import io
+
+    from continuum.cli import main
+    from continuum.cli.exitcodes import ExitCode
+
+    db = str(tmp_path / "cli.db")
+    storage = SQLiteStorage(db)
+    storage.create_run(Run(run_id="run_1", goal="g"))
+    storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    storage.close()
+    plan_file = tmp_path / "plan.json"
+    plan_file.write_text(
+        json.dumps(
+            [
+                {"id": "u1", "title": "first", "status": "pending", "depends_on": []},
+                {"id": "u2", "title": "second", "status": "working", "depends_on": ["u1"]},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    out, err = io.StringIO(), io.StringIO()
+    code = main(
+        ["--db", db, "record-plan", "run_1", "--plan-id", "p1", "--file", str(plan_file)],
+        out=out,
+        err=err,
+    )
+    assert code == ExitCode.OK, err.getvalue()
+    out2, err2 = io.StringIO(), io.StringIO()
+    code2 = main(["--db", db, "--json", "inspect", "run_1"], out=out2, err=err2)
+    assert code2 == ExitCode.OK
+    data = json.loads(out2.getvalue())
+    assert "plan" in data
+    assert len(data["plan"]) == 2
+
+
+def test_property_random_ordering_deterministic(tmp_path: Path) -> None:
+    storage = _run(tmp_path, "run_a")
+    storage2 = _run(tmp_path, "run_b")
+    units_a = [
+        {"id": "u2", "title": "b", "status": "pending", "depends_on": []},
+        {"id": "u1", "title": "a", "status": "pending", "depends_on": []},
+    ]
+    units_b = [
+        {"id": "u1", "title": "a", "status": "pending", "depends_on": []},
+        {"id": "u2", "title": "b", "status": "pending", "depends_on": []},
+    ]
+    storage.append_event("run_a", EventType.PLAN_UPSERT, {"plan_id": "p1", "units": units_a})
+    storage2.append_event("run_b", EventType.PLAN_UPSERT, {"plan_id": "p1", "units": units_b})
+    state = project("run_a", storage.read_events("run_a"))
+    state2 = project("run_b", storage2.read_events("run_b"))
+    assert [p.step_id for p in state.plan] == ["u1", "u2"]
+    assert [p.step_id for p in state2.plan] == ["u1", "u2"]
+    storage.close()
+    storage2.close()


### PR DESCRIPTION
Refs #312

Add append-only PLAN_UPSERT event and project into SemanticState.plan so checkpoints carry verifiable milestone state. Latest write wins per plan_id and unit id, units sorted by id for deterministic hash. Validator checks unit id uniqueness, depends_on references, cycle detection (CONFLICTED), provenance (EXTERNAL_AGENT -> REQUIRES_REVIEW) and stale propagation downstream. MCP tool continuum_record_plan (mutating, allowlisted) and CLI record-plan with --plan-id and --file provide parity, resume includes state.plan. Diff, interchange and examples updated. Tests cover latest-wins, hash chain, empty project, validator, MCP, interchange, CLI and ordering.

Gate: pytest 8 passed, ruff check clean, ruff format --check clean, mypy --ignore-missing-imports 108 files (13 pre-existing untyped-decorator errors)

Branch: feat/state-plan-upsert-312 @ ba7b5a9dd00d8002c7ed54209c7ff3cb6e3b7d27