### PR TITLE
test(mcp): include continuum_record_plan in tool count (Fixes #470)

### DIFF
--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -70,6 +70,11 @@ MUTATING_CALLS: dict[str, dict[str, Any]] = {
         "run_id": "run_1",
         "plan_stack": ["step"],
     },
+    "continuum_record_plan": {
+        "run_id": "run_1",
+        "plan_id": "plan-1",
+        "units": [{"id": "u1", "title": "t", "status": "pending"}],
+    },
 }
 MUTATING = list(MUTATING_CALLS)
 READ_ONLY = ["continuum_validate", "continuum_resume", "continuum_list_actions"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -124,6 +124,7 @@ async def test_every_tool_is_registered(server_ctx: tuple[Any, Any]) -> None:
         "continuum_list_actions",
         "continuum_confirm",
         "continuum_record_summary",
+        "continuum_record_plan",
     }
 
 

--- a/tests/test_mcp_slim.py
+++ b/tests/test_mcp_slim.py
@@ -17,4 +17,4 @@ def test_full_mode_exposes_all_tools(monkeypatch) -> None:
     names = {tool.name for tool in server._tool_manager._tools.values()}
     assert "continuum_record_progress" in names
     assert "continuum_checkpoint" in names
-    assert len(names) == 11
+    assert len(names) == 12


### PR DESCRIPTION
## Description

After #312 (PLAN_UPSERT) merged to main via #467 and #465, src/continuum/mcp/server.py has 12 tools (adds continuum_record_plan) but tests still expect 11.

Fix 4 tests:
- tests/test_mcp_server.py::test_every_tool_is_registered expects 12
- tests/test_mcp_slim.py::test_full_mode_exposes_all_tools expects 12
- tests/test_mcp_authz.py::MUTATING_CALLS includes continuum_record_plan

## Related issues

Fixes #470, Refs #312, #386

## Types of changes

- Type: tests

## Breaking changes

No

## How has this been tested?

```
ruff check src/ tests/ examples/  # All checks passed
ruff format --check  # 236 files already formatted
pytest -q  # 1661 passed, 24 skipped
```

## Checklist

Tests updated for the changed behaviour. CI passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded authorization coverage to include plan-recording operations.
  * Updated MCP registration checks to verify the plan-recording tool is available.
  * Adjusted full-mode tool availability expectations to reflect the additional tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->