### PR TITLE
test(mcp): fix slim full mode count to 12 after plan upsert (Fixes #470)

### DIFF
--- a/tests/test_mcp_instant_resume.py
+++ b/tests/test_mcp_instant_resume.py
@@ -180,7 +180,7 @@ def test_slim_subset_lists_exactly_read_only_trio(monkeypatch) -> None:
     server2, _ = build_server(storage=SQLiteStorage(":memory:"))
     names2 = {tool.name for tool in server2._tool_manager._tools.values()}
     assert "continuum_record_progress" in names2
-    assert len(names2) == 11
+    assert len(names2) == 12
 
 
 def test_default_flows_unchanged_when_features_unused(tmp_path: Path) -> None:


### PR DESCRIPTION
Follow-up to #471, missed one file.

## Description

tests/test_mcp_instant_resume.py::test_slim_subset_lists_exactly_read_only_trio still asserted len==11, but server has 12 after #312.

Fix to 12.

## Related issues

Fixes #470

## Types of changes

- Type: tests

## Breaking changes

No

## How has this been tested?

pytest -q  # now 1661 passed, 24 skipped, 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations to reflect the expanded MCP tool set, which now includes 12 tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->