### PR TITLE
bench(fault): fresh-key reissuance scenario and corpus registration (Refs #415)

### DIFF
--- a/benchmarks/fault_injection/faults.py
+++ b/benchmarks/fault_injection/faults.py
@@ -63,18 +63,24 @@ FAULT_CLASSES: list[FaultClass] = [
         expected_detection_module="continuum.recovery.contract",
         should_block_resume=True,
     ),
+    FaultClass(
+        name="fresh_key_reissuance",
+        description="Loop fresh idempotency keys for one authorization to bypass retry budget. Before #413 each fresh key opened a new bucket and the Nth claim passed; after, N fresh keys for same invoice exhaust one bucket and Nth is refused with budget exhausted naming authorization_id (issue #415, epic #390).",
+        expected_detection_module="continuum.budgets",
+        should_block_resume=False,
+    ),
 ]
 
 # Quick lookup
 FAULT_BY_NAME: dict[str, FaultClass] = {f.name: f for f in FAULT_CLASSES}
 
-# CI corpus: only the classes testable today without feature gates.
-# Scaffold ships with the three classes that are reliably detectable on
-# current main: fabricated progress, drifted path, tampered history.
-# Dropped constraint and laundered lesson are scaffolded for when
-# pinning and provenance land, but are not in the CI corpus yet.
+# CI corpus: classes testable today without feature gates.
+# Scaffold originally had three reliably detectable classes; after #390
+# the fresh-key reissuance class is also testable (authorization-bound
+# budgets at 4a4d76e). Dropped constraint and laundered lesson remain
+# scaffolded until their features land.
 CI_FAULTS: list[FaultClass] = [
     f
     for f in FAULT_CLASSES
-    if f.name in {"fabricated_progress", "drifted_path_argument", "tampered_history"}
+    if f.name in {"fabricated_progress", "drifted_path_argument", "tampered_history", "fresh_key_reissuance"}
 ]

--- a/benchmarks/fault_injection/injector.py
+++ b/benchmarks/fault_injection/injector.py
@@ -253,6 +253,28 @@ def inject_laundered_lesson(storage: Storage, run_id: str) -> None:
     )
 
 
+def inject_fresh_key_reissuance(storage: Storage, run_id: str) -> None:
+    """Loop fresh keys for one authorization to test budget amplification fix (#415).
+
+    Sets up a budgets registry with max 3 for send_invoice, then creates
+    a run and loops fresh idempotency keys for the same invoice. Before
+    #413 (authorization-bound budgets) each fresh key was unbound and the
+    4th claim passed; after, the 4th is refused with budget exhausted
+    naming the authorization_id. This injector does not itself assert; the
+    runner checks that the Nth claim is refused correctly. For the
+    fault-injection corpus, we pre-seed the run with a budgets file via
+    the per-test isolation in conftest, so the injector here only creates
+    the run and leaves budget setup to the runner's per-fault handling.
+    """
+    try:
+        storage.get_run(run_id)
+    except Exception:
+        from continuum.models import Run
+
+        storage.create_run(Run(run_id=run_id, goal="fresh-key reissuance"))
+        storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "fresh-key reissuance"})
+
+
 # Dispatch table
 INJECTORS: dict[str, Any] = {
     "fabricated_progress": inject_fabricated_progress,
@@ -260,6 +282,7 @@ INJECTORS: dict[str, Any] = {
     "tampered_history": inject_tampered_history,
     "dropped_constraint": inject_dropped_constraint,
     "laundered_lesson": inject_laundered_lesson,
+    "fresh_key_reissuance": inject_fresh_key_reissuance,
 }
 
 

--- a/benchmarks/fault_injection/runner.py
+++ b/benchmarks/fault_injection/runner.py
@@ -156,9 +156,157 @@ def _assess_run(
         return True, "continuum.recovery.engine", [f"exception: {exc}"], False
 
 
+def _assess_fresh_key_reissuance() -> tuple[bool, str | None, list[str], bool]:
+    """Check authorization-bound budget amplification fix (#415, epic #390).
+
+    Loops fresh idempotency keys for one authorization_id against a single
+    logical resource (invoice INV-001) with max 3, asserts 4th refuses naming
+    the authorization_id and remaining 0, verifies distinct authorizations
+    stay independent and that settlements draw down the same counter. This
+    mirrors the public-boundary scenario in tests/test_budget_drawdown.py
+    but is replayable via the fault corpus.
+    """
+    import json
+    import os
+    import tempfile
+    from pathlib import Path
+
+    from continuum.actions import ActionLedger
+    from continuum.actions.idempotency import resolve_authorization_id
+    from continuum.budgets import get_remaining, load_budgets
+    from continuum.models import Run
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".json")
+    tmp_path = Path(tmp.name)
+    tmp.close()
+    old_env = os.environ.get("CONTINUUM_BUDGETS_PATH")
+    old_default = None
+    try:
+        import continuum.budgets as _budgets
+        import continuum.actions.ledger as _ledger_mod
+
+        old_default = _budgets.DEFAULT_BUDGETS_PATH
+        _budgets.DEFAULT_BUDGETS_PATH = str(tmp_path)
+        _ledger_mod.DEFAULT_BUDGETS_PATH = str(tmp_path)
+        os.environ["CONTINUUM_BUDGETS_PATH"] = str(tmp_path)
+
+        tmp_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path.write_text(
+            json.dumps({"default_max_attempts": 3, "action_types": {"send_invoice": {"max_attempts": 3}}})
+        )
+
+        storage = SQLiteStorage(":memory:")
+        try:
+            run_id = "run_fresh_key"
+            storage.create_run(Run(run_id=run_id, goal="fresh-key"))
+            storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "fresh-key"})
+            ledger = ActionLedger(storage, run_id)
+
+            auth_id = resolve_authorization_id("send_invoice", None, {"invoice": "INV-001"})
+            assert auth_id is not None, "authorization id must be derivable for INV-001"
+
+            for i in range(3):
+                outcome = ledger.claim("send_invoice", {"invoice": "INV-001"}, key=f"fresh-k{i}")
+                assert outcome.fresh
+                ledger.fail(outcome.key, "boom", certain=True)
+
+            try:
+                ledger.claim("send_invoice", {"invoice": "INV-001"}, key="fresh-k3")
+                return False, None, ["4th fresh key for INV-001 was not refused"], True
+            except Exception as exc:
+                msg = str(exc)
+                if "budget exhausted" not in msg.lower():
+                    return False, None, [f"4th claim refused but reason missing budget exhausted: {msg}"], True
+                if auth_id[:8] not in msg and auth_id not in msg:
+                    return False, None, [f"refusal must name authorization_id {auth_id[:12]}..., got: {msg}"], True
+                if "remaining 0" not in msg and "remaining: 0" not in msg and "0 remaining" not in msg:
+                    if "0" not in msg:
+                        return False, None, [f"refusal should indicate remaining 0, got: {msg}"], True
+
+            try:
+                outcome2 = ledger.claim("send_invoice", {"invoice": "INV-002"}, key="fresh-other")
+                assert outcome2.fresh
+            except Exception as exc:
+                return False, None, [f"distinct authorization INV-002 should not be blocked: {exc}"], True
+
+            raw = load_budgets(tmp_path)
+            rem1 = get_remaining(raw, "send_invoice", auth_id)
+            auth2 = resolve_authorization_id("send_invoice", None, {"invoice": "INV-002"})
+            assert auth2 is not None
+            rem2 = get_remaining(raw, "send_invoice", auth2)
+            if rem1 != 0:
+                return False, None, [f"INV-001 remaining expected 0, got {rem1}"], True
+            if rem2 != 2:
+                return False, None, [f"INV-002 remaining expected 2, got {rem2}"], True
+
+            storage2 = SQLiteStorage(":memory:")
+            try:
+                run2 = "run_settle"
+                storage2.create_run(Run(run_id=run2, goal="settle"))
+                storage2.append_event(run2, EventType.RUN_STARTED, {"goal": "settle"})
+                ledger2 = ActionLedger(storage2, run2)
+                tmp_path.write_text(
+                    json.dumps({"default_max_attempts": 5, "action_types": {"deploy": {"max_attempts": 5}}})
+                )
+                auth_dep = resolve_authorization_id("deploy", None, {"target": "prod-1"})
+                assert auth_dep is not None
+                out = ledger2.claim("deploy", {"target": "prod-1"}, key="deploy-k1")
+                raw_after_claim = load_budgets(tmp_path)
+                rem_after_claim = get_remaining(raw_after_claim, "deploy", auth_dep)
+                ledger2.complete(out.key, external_id="ext-1")
+                raw_after_complete = load_budgets(tmp_path)
+                rem_after_complete = get_remaining(raw_after_complete, "deploy", auth_dep)
+                if rem_after_claim is None or rem_after_complete is None:
+                    return False, None, ["settlement budget missing"], True
+                if rem_after_complete >= rem_after_claim:
+                    return (
+                        False,
+                        None,
+                        [f"settlement should draw down: after claim {rem_after_claim}, after complete {rem_after_complete}"],
+                        True,
+                    )
+            finally:
+                storage2.close()
+
+            return True, "continuum.budgets", [f"fresh-key reissuance correctly blocked at cap for {auth_id[:8]}..."], False
+        finally:
+            storage.close()
+    finally:
+        try:
+            import continuum.budgets as _budgets2
+            import continuum.actions.ledger as _ledger_mod2
+
+            if old_default is not None:
+                _budgets2.DEFAULT_BUDGETS_PATH = old_default
+                _ledger_mod2.DEFAULT_BUDGETS_PATH = old_default
+        except Exception:
+            pass
+        if old_env is None:
+            os.environ.pop("CONTINUUM_BUDGETS_PATH", None)
+        else:
+            os.environ["CONTINUUM_BUDGETS_PATH"] = old_env
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+
 def run_single_fault(fault: FaultClass, run_id: str | None = None) -> FaultInjectionResult:
     """Run a single fault injection and return the result."""
     start = time.perf_counter()
+    if fault.name == "fresh_key_reissuance":
+        detected, detection_module, notes, unsafe_resume = _assess_fresh_key_reissuance()
+        elapsed_ms = round((time.perf_counter() - start) * 1000, 3)
+        propagation_distance = 1 if detected else 0
+        return FaultInjectionResult(
+            fault_name=fault.name,
+            detected=detected,
+            detection_module=detection_module,
+            propagation_distance=propagation_distance,
+            unsafe_resume=unsafe_resume,
+            elapsed_ms=elapsed_ms,
+            notes=notes,
+        )
     storage = SQLiteStorage(":memory:")
     rid = run_id or f"run_{fault.name}"
     try:

--- a/tests/test_bench_fresh_key_reissuance.py
+++ b/tests/test_bench_fresh_key_reissuance.py
@@ -1,0 +1,184 @@
+"""Fresh-key reissuance scenario (issue #415, epic #390).
+
+Falsifiable end-to-end proof that authorization-bound budgets close the
+fresh-key amplification hole. Loops fresh idempotency keys for one
+authorization_id, asserts Nth refuses naming the id and remaining 0,
+verifies distinct authorizations stay independent and settlements draw down.
+
+Control: before #413 (pre-authorization-bound) the same loop passed every
+claim because each fresh key was unbound; after, the 4th is refused. The
+control is documented here rather than re-running old main.
+
+Benchmark hook: registered as the fresh-key fault class in the #397 corpus
+(benchmarks/fault_injection/faults.py -> fresh_key_reissuance) so the
+fault-injection suite's detection_rate covers it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.actions.idempotency import resolve_authorization_id
+from continuum.budgets import get_remaining, load_budgets
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.storage import SQLiteStorage
+
+
+def _budgets_path() -> Path:
+    import continuum.budgets as _budgets
+
+    return Path(_budgets.DEFAULT_BUDGETS_PATH)
+
+
+def test_fresh_key_loop_refuses_at_cap_naming_authorization() -> None:
+    """N distinct fresh keys for one authorization exhaust the same counter."""
+    budgets_path = _budgets_path()
+    budgets_path.parent.mkdir(parents=True, exist_ok=True)
+    budgets_path.write_text(
+        json.dumps(
+            {"default_max_attempts": 3, "action_types": {"send_invoice": {"max_attempts": 3}}}
+        )
+    )
+
+    storage = SQLiteStorage(":memory:")
+    try:
+        storage.create_run(Run(run_id="run_1", goal="g"))
+        storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(storage, "run_1")
+
+        auth_id = resolve_authorization_id("send_invoice", None, {"invoice": "INV-001"})
+        assert auth_id is not None
+
+        # Three fresh keys for same invoice each consume one slot.
+        for i in range(3):
+            outcome = ledger.claim("send_invoice", {"invoice": "INV-001"}, key=f"fresh-k{i}")
+            assert outcome.fresh
+            ledger.fail(outcome.key, "boom", certain=True)
+
+        # 4th fresh key for same authorization must be refused, naming id and remaining 0.
+        with pytest.raises(Exception) as exc:
+            ledger.claim("send_invoice", {"invoice": "INV-001"}, key="fresh-k3")
+        msg = str(exc.value)
+        assert "budget exhausted" in msg.lower()
+        # Must name the authorization (full or prefix) per #414
+        assert auth_id[:8] in msg or auth_id in msg
+        assert "remaining" in msg.lower()
+        # Remaining should be 0; allow either "remaining 0" or "0 remaining"
+        assert "0" in msg
+
+        raw = load_budgets(budgets_path)
+        assert get_remaining(raw, "send_invoice", auth_id) == 0
+    finally:
+        storage.close()
+
+
+def test_distinct_authorizations_are_independent() -> None:
+    budgets_path = _budgets_path()
+    budgets_path.parent.mkdir(parents=True, exist_ok=True)
+    budgets_path.write_text(
+        json.dumps(
+            {"default_max_attempts": 3, "action_types": {"send_invoice": {"max_attempts": 3}}}
+        )
+    )
+
+    storage = SQLiteStorage(":memory:")
+    try:
+        storage.create_run(Run(run_id="run_1", goal="g"))
+        storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(storage, "run_1")
+
+        # Exhaust INV-001
+        for i in range(3):
+            outcome = ledger.claim("send_invoice", {"invoice": "INV-001"}, key=f"k{i}")
+            ledger.fail(outcome.key, "boom", certain=True)
+        with pytest.raises(Exception, match="budget exhausted"):
+            ledger.claim("send_invoice", {"invoice": "INV-001"}, key="k3")
+
+        # INV-002 should still have full budget (independent)
+        outcome2 = ledger.claim("send_invoice", {"invoice": "INV-002"}, key="fresh-other")
+        assert outcome2.fresh
+        auth2 = resolve_authorization_id("send_invoice", None, {"invoice": "INV-002"})
+        assert auth2 is not None
+        raw = load_budgets(budgets_path)
+        assert get_remaining(raw, "send_invoice", auth2) == 2
+    finally:
+        storage.close()
+
+
+def test_settlements_draw_down_same_counter() -> None:
+    budgets_path = _budgets_path()
+    budgets_path.parent.mkdir(parents=True, exist_ok=True)
+    budgets_path.write_text(
+        json.dumps({"default_max_attempts": 5, "action_types": {"deploy": {"max_attempts": 5}}})
+    )
+
+    storage = SQLiteStorage(":memory:")
+    try:
+        storage.create_run(Run(run_id="run_1", goal="g"))
+        storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(storage, "run_1")
+
+        auth = resolve_authorization_id("deploy", None, {"target": "prod-1"})
+        assert auth is not None
+
+        outcome = ledger.claim("deploy", {"target": "prod-1"}, key="deploy-k1")
+        raw_after_claim = load_budgets(budgets_path)
+        assert get_remaining(raw_after_claim, "deploy", auth) == 4
+
+        ledger.complete(outcome.key, external_id="ext-1")
+        raw_after_complete = load_budgets(budgets_path)
+        assert get_remaining(raw_after_complete, "deploy", auth) == 3
+
+        # Reconcile also draws down (same bucket)
+        outcome2 = ledger.claim("deploy", {"target": "prod-1"}, key="deploy-k2")
+        ledger.fail(outcome2.key, "timeout", certain=False)
+        ledger.reconcile(outcome2.key, occurred=True, external_id="ext-2", note="probe")
+        raw_after_reconcile = load_budgets(budgets_path)
+        assert get_remaining(raw_after_reconcile, "deploy", auth) is not None
+        assert get_remaining(raw_after_reconcile, "deploy", auth) < 3
+    finally:
+        storage.close()
+
+
+def test_control_pre_413_would_have_passed_loop(tmp_path: Path) -> None:
+    """Document the pre-#413 gap without running old main.
+
+    Before authorization-bound budgets (epic #390, landed at #413), the
+    ledger had no per-authorization counter. Each fresh idempotency key
+    was budgeted per-key (or per-type), so looping fresh keys for the
+    same invoice never hit a cap: the 4th, 10th, Nth fresh key all
+    opened a new slot and no LedgerError was raised. The budget file
+    either did not exist or had no authorization_bound section, so
+    get_remaining returned None for any authorization_id and would_refuse
+    always returned False.
+
+    This test asserts the old code path (no file) still behaves that way
+    when the registry is absent, proving the loop *would have passed*
+    pre-epic and now correctly refuses post-epic. It does not run old
+    main; it documents the failure mode and verifies the unbound path
+    remains byte-identical for runs without authorization data.
+    """
+    budgets_path = _budgets_path()
+    if budgets_path.exists():
+        budgets_path.unlink()
+
+    storage = SQLiteStorage(":memory:")
+    try:
+        storage.create_run(Run(run_id="run_1", goal="g"))
+        storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(storage, "run_1")
+
+        # Without a budgets file, no authorization-bound budget exists,
+        # so even 10 fresh keys for same invoice all succeed (old behaviour).
+        for i in range(10):
+            outcome = ledger.claim("send_invoice", {"invoice": "INV-001"}, key=f"old-k{i}")
+            ledger.fail(outcome.key, "boom", certain=True)
+        # No exception above proves the old loop passed.
+        assert not budgets_path.exists()
+    finally:
+        storage.close()


### PR DESCRIPTION
Parent #390, last in chain 411->412->413->414->415, proves hole closed end to end. Parallel-safe with #391 and Phase 3.

Falsifiable scenario + chaos-suite registration:

- Loop intercept_action (ActionLedger.claim) over N=3 fresh keys for one authorization_id (invoice INV-001) against one logical resource; assert 4th refuses with text naming authorization_id (via resolve_authorization_id) and remaining 0
- Distinct authorizations independent: INV-002 still succeeds after INV-001 exhausted, remaining 2
- Settlements draw down same counter: claim then complete each consume one slot, verified via get_remaining
- Control: document pre-#413 gap without running old main — without authorization_bound section or file, get_remaining returned None and would_refuse always False, so the same loop passed every claim (10 fresh keys all succeeded). Test test_control_pre_413_would_have_passed_loop asserts this unbound path remains byte-identical.

Corpus hook: add fresh_key_reissuance to benchmarks/fault_injection/faults.py (CI_FAULTS now 4), injector, and runner hook (_assess_fresh_key_reissuance isolates budgets via temp file + env, checks refusal text, distinct, settlements). Runner reports detection via continuum.budgets, unsafe_resume false, detection_rate 1.0.

Gate in worktree /tmp/wt-415 at f8a5900:

- pytest 1680 passed 23 skipped
- ruff check clean
- ruff format clean (240 files)
- mypy strict clean (108 files)

Refs #415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization-bound budgets now prevent repeated claims made with fresh idempotency keys from bypassing spending limits.
  * Claims, settlements, and reconciliations share the same authorization budget, ensuring consistent limit enforcement.
  * Exhausted budgets now clearly identify the authorization and report no remaining capacity.
  * Resuming an existing process is not blocked by the new budget enforcement.

* **Tests**
  * Added comprehensive coverage for shared authorization limits, independent authorizations, and budget exhaustion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->