### PR TITLE
fix(hooks): recognise the briefing kind so install stays idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ All notable changes to this project are documented here. The format follows
 
 - Make `continuum complete` idempotent for runs that are already completed (#356).
 
+- **`hooks install` no longer duplicates the SessionStart briefing hook (#484).**
+  The installer recognised an existing entry as its own only when the command
+  ended in `observe` or `gate`, so the briefing hook added alongside them was
+  appended afresh on every run: three `continuum hooks install` invocations left
+  three identical `SessionStart` groups, each reported as `installed`, and the
+  client ran `continuum briefing` once per copy on every session start. A moved
+  virtualenv was duplicated rather than repointed too, leaving the stale command
+  firing. The recognised kinds are now one list read by both the installer and
+  `hooks remove` (which already knew about `briefing`), and the kind is taken
+  from the command being installed, so an install of one kind cannot repoint
+  another. A settings file that already holds duplicates is cleaned by
+  `hooks remove` followed by `hooks install`.
+
 ## [0.1.0] - 2026-08-27
 
 ### Added

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -57,6 +57,15 @@ __all__ = [
 #: matcher expression so the installed settings stay a single entry.
 DEFAULT_MATCHER = "Write|Edit|MultiEdit|NotebookEdit"
 
+#: Every hook kind this module installs, which is also the final word of each
+#: installed command. One list, read by both the installer and the remover: they
+#: used to carry the set separately, and when the briefing hook was added
+#: (7c6248d) only the remover's copy was updated. The installer therefore stopped
+#: recognising a briefing entry as its own, so every re-run appended a duplicate
+#: SessionStart group instead of reporting it present or repointing a moved one
+#: (issue #484).
+_INSTALLED_KINDS = ("observe", "gate", "briefing")
+
 #: Keys of ``tool_input`` that hold the primary file path, in priority order.
 _PATH_KEYS = ("file_path", "notebook_path")
 
@@ -221,6 +230,25 @@ def _is_observe_hook(hook: Mapping[str, Any]) -> bool:
     return _is_continuum_hook(hook, "observe")
 
 
+def _installed_kind(command: str) -> str | None:
+    """Which of :data:`_INSTALLED_KINDS` ``command`` ends in, or ``None``.
+
+    The kind a command carries is what makes an existing entry the same hook
+    rather than a different one, so it is read from the command being installed
+    instead of being listed at the call site: a new kind then cannot reach the
+    installer without the installer knowing about it. ``None`` for anything else,
+    which leaves :func:`_install_hook` appending, exactly as it does today for a
+    command this module did not build.
+    """
+    try:
+        tokens = _split_command(command)
+    except ValueError:
+        return None
+    if tokens and tokens[-1] in _INSTALLED_KINDS:
+        return tokens[-1]
+    return None
+
+
 def install_client_hook(
     settings_path: Path,
     command: str,
@@ -261,13 +289,17 @@ def _install_hook(
 ) -> str:
     """Add a continuum hook entry to a Claude Code settings file.
 
-    ``kind`` selects which hook this is ("observe" or "gate"); it must equal
-    the final word of ``command``. Existing settings are preserved; only the
-    matching list under ``hooks`` gains (or updates) our single entry.
+    Existing settings are preserved; only the matching list under ``hooks``
+    gains (or updates) our single entry of the kind ``command`` names.
     Returns ``"installed"`` when the entry was added, ``"updated"`` when an
     existing entry of the same kind pointed somewhere else (a moved
     virtualenv, say) and was repointed, ``"present"`` when nothing needed to
     change.
+
+    An entry counts as ours only when its kind matches the one being installed,
+    so an observe install cannot repoint a briefing or gate hook that happens to
+    share the event and matcher: repointing across kinds would silently drop a
+    hook the caller never asked about.
 
     A settings file that exists but is unreadable raises rather than being
     overwritten: a file someone edited by hand is a statement of intent, and
@@ -295,6 +327,7 @@ def _install_hook(
 
     status = "installed"
     entry_found = False
+    kind = _installed_kind(command)
     for group in hook_list:
         if not isinstance(group, dict) or group.get("matcher") != matcher:
             continue
@@ -302,9 +335,7 @@ def _install_hook(
         if not isinstance(entries, list):
             continue
         for hook in entries:
-            ours = isinstance(hook, dict) and (
-                _is_continuum_hook(hook, "observe") or _is_continuum_hook(hook, "gate")
-            )
+            ours = kind is not None and isinstance(hook, dict) and _is_continuum_hook(hook, kind)
             if ours:
                 entry_found = True
                 if hook.get("command") != command:
@@ -330,10 +361,10 @@ def remove_claude_code_hook(settings_path: Path) -> bool:
     """Remove every continuum hook this module installed. True when anything
     was removed.
 
-    Only entries this module's shape recognises are touched (observe and gate,
-    any matcher): a hand-written entry pointing elsewhere survives untouched,
-    as does every other key in the file. A group holding unrelated hooks keeps
-    them.
+    Only entries this module's shape recognises are touched
+    (:data:`_INSTALLED_KINDS`, any matcher): a hand-written entry pointing
+    elsewhere survives untouched, as does every other key in the file. A group
+    holding unrelated hooks keeps them.
     """
     if not settings_path.exists():
         return False
@@ -369,8 +400,7 @@ def remove_claude_code_hook(settings_path: Path) -> bool:
                 h
                 for h in group["hooks"]
                 if not (
-                    isinstance(h, dict)
-                    and any(_is_continuum_hook(h, k) for k in ("observe", "gate", "briefing"))
+                    isinstance(h, dict) and any(_is_continuum_hook(h, k) for k in _INSTALLED_KINDS)
                 )
             ]
             if len(kept_hooks) != len(group["hooks"]):

--- a/tests/test_client_installers.py
+++ b/tests/test_client_installers.py
@@ -229,3 +229,25 @@ def test_a_moved_briefing_command_is_repointed_not_duplicated(tmp_path: Path) ->
     assert install_client_hook(settings, old, event_name="SessionStart", matcher="") == "installed"
     assert install_client_hook(settings, new, event_name="SessionStart", matcher="") == "updated"
     assert _briefing_commands(settings, "SessionStart") == [new]
+
+
+def test_a_command_of_no_known_kind_is_appended_never_matched(tmp_path: Path) -> None:
+    """The kind is read off the command, so an unknown one matches nothing (issue #484).
+
+    Deriving the kind is what stops an install of one kind repointing another, and
+    the flip side has to hold too: a command this module did not build -- including
+    one whose quoting cannot be parsed at all -- carries no kind, so it is appended
+    rather than mistaken for ours, and unparseable quoting does not raise.
+    """
+    settings = tmp_path / "settings.json"
+    unknown = "/venv/bin/continuum inspect"
+    malformed = '"C:\\no\\closing\\quote continuum briefing'
+    for command in (unknown, malformed, unknown):
+        status = install_client_hook(settings, command, event_name="SessionStart", matcher="")
+        assert status == "installed"
+    commands = [
+        hook["command"]
+        for group in json.loads(settings.read_text())["hooks"]["SessionStart"]
+        for hook in group["hooks"]
+    ]
+    assert commands == [unknown, malformed, unknown]

--- a/tests/test_client_installers.py
+++ b/tests/test_client_installers.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 
 from continuum.cli import ExitCode, main
-from continuum.clienthooks import CLIENT_PROFILES
+from continuum.clienthooks import CLIENT_PROFILES, install_client_hook
 
 
 def run(*argv: str) -> tuple[int, str, str]:
@@ -178,3 +178,54 @@ def test_briefing_is_wired_on_session_start(tmp_path: Path, client: str) -> None
         and any(h.get("command", "").split()[-1] == "briefing" for h in g["hooks"])
     ]
     assert len(ours) == 1
+
+
+def _briefing_commands(settings: Path, event_name: str) -> list[str]:
+    """Every briefing command wired under ``event_name``, duplicates included."""
+    groups = json.loads(settings.read_text())["hooks"][event_name]
+    return [
+        h["command"]
+        for g in groups
+        if isinstance(g.get("hooks"), list)
+        for h in g["hooks"]
+        if h.get("command", "").split()[-1] == "briefing"
+    ]
+
+
+@pytest.mark.parametrize("client", ("claude-code", "gemini", "codex"))
+def test_reinstalling_does_not_duplicate_the_briefing_hook(tmp_path: Path, client: str) -> None:
+    """The SessionStart entry has to settle like the tool-event one (issue #484).
+
+    ``_install_hook`` recognised only the observe and gate kinds, so a briefing
+    command matched nothing already present and was appended afresh every run:
+    three installs left three byte-identical SessionStart groups, each reported
+    as "installed", and the client ran the briefing once per copy on every
+    session start. Idempotency was pinned only on the post-tool event, where a
+    duplicate cannot arise, so the whole accumulation went unnoticed.
+    """
+    profile = CLIENT_PROFILES[client]
+    settings = tmp_path / "settings.json"
+    statuses = []
+    for _ in range(3):
+        code, out, err = run("--json", "hooks", "install", client, "--settings", str(settings))
+        assert code == ExitCode.OK, err
+        statuses.append(
+            next(h["status"] for h in json.loads(out)["hooks"] if h["kind"] == "briefing")
+        )
+    assert statuses == ["installed", "present", "present"]
+    assert len(_briefing_commands(settings, profile["start_event"])) == 1
+
+
+def test_a_moved_briefing_command_is_repointed_not_duplicated(tmp_path: Path) -> None:
+    """A relocated virtualenv must not leave a stale briefing firing (issue #484).
+
+    The observe hook reports "updated" and keeps one entry; briefing reported
+    "installed" and kept both, so the old interpreter path went on running
+    alongside the new one until someone hand-edited the settings file.
+    """
+    settings = tmp_path / "settings.json"
+    old = "/old/venv/bin/continuum briefing"
+    new = "/new/venv/bin/continuum briefing"
+    assert install_client_hook(settings, old, event_name="SessionStart", matcher="") == "installed"
+    assert install_client_hook(settings, new, event_name="SessionStart", matcher="") == "updated"
+    assert _briefing_commands(settings, "SessionStart") == [new]


### PR DESCRIPTION
## Description

`continuum hooks install` was not idempotent for the `SessionStart` briefing hook: every re-run appended another copy instead of reporting it present.

`_install_hook` decides whether an entry already in the settings file is one of ours, and it asked only two questions:

```python
ours = isinstance(hook, dict) and (
    _is_continuum_hook(hook, "observe") or _is_continuum_hook(hook, "gate")
)
```

`_is_continuum_hook` matches on the command's final token, so a `... continuum briefing` command matched neither arm. `entry_found` stayed `False` and the function fell through to the append branch. The briefing hook was added in 7c6248d (#227), which updated the *remover's* kind tuple to `("observe", "gate", "briefing")` and left the installer's recogniser alone — the same drift left `_install_hook`'s docstring still describing a `kind` parameter that no longer exists.

Consequences, both reproduced below:

- Three `continuum hooks install` runs leave three byte-identical `SessionStart` groups, each reported as `installed`, so the client runs `continuum briefing` once per copy at every session start. All three profiled clients use `start_event: "SessionStart"`, so this affects `claude-code`, `gemini` and `codex` alike. The resume context that #213/#227 exist to inject exactly once is injected N times, and each copy opens storage.
- A moved virtualenv is duplicated rather than repointed: the observe hook reports `updated` and keeps one entry, while briefing reports `installed` and keeps both, so the stale interpreter path goes on firing alongside the new one.

The fix keeps the recognised kinds in one place and derives the kind from the command being installed:

- `_INSTALLED_KINDS = ("observe", "gate", "briefing")` is now read by both the installer and `remove_claude_code_hook`, so a future kind cannot be added to one and forgotten in the other.
- `_installed_kind(command)` reads the kind off the command instead of taking it from the call site, so a new kind cannot reach the installer without the installer knowing about it. A command this module did not build yields `None` and still appends, exactly as before.
- Matching is now kind-for-kind, so an observe install cannot repoint a briefing or gate hook that happens to share the event and matcher. Repointing across kinds would silently drop a hook the caller never asked about.

Scope note: this prevents new duplicates and repoints a moved command. It does not collapse duplicates already accumulated in a user's settings file — that would mean restructuring existing group lists, which is beyond a fix for the non-idempotency itself. Existing duplicates are cleaned by `continuum hooks remove <client>` followed by `continuum hooks install <client>`; this is documented in the issue and the CHANGELOG entry.

## Related issues

Fixes #484

## Types of changes

- Type: `bugfix`

## Breaking changes

No. Installed settings shape, statuses (`installed` / `updated` / `present`) and the removal contract are unchanged; only which existing entries count as ours changes, and only in the direction of recognising one more kind that this module itself installs.

## How has this been tested?

Environment: Windows 11 (26200), Python 3.13.7, pytest 9.1.1, ruff 0.16.3, mypy strict, project venv at `.venv`.

Before/after reproduction, verbatim (`--json` is a global flag, so it precedes the subcommand):

```
for i in 1 2 3; do python -m continuum.cli --json hooks install claude-code --settings ./settings.json; done
python -c "import json;d=json.load(open('settings.json'));print(len(d['hooks']['SessionStart']))"
```

Before: briefing status `installed`, `installed`, `installed`; 3 `SessionStart` groups.
After: briefing status `installed`, `present`, `present`; 1 `SessionStart` group.

Moved-virtualenv case (`install_client_hook` with `/old/venv/bin/continuum briefing` then `/new/venv/bin/continuum briefing`):

Before: `installed` → `installed`, 2 entries, stale `/old/...` retained.
After: `installed` → `updated`, 1 entry pointing at `/new/...`.

The two new tests fail on `upstream/main` and pass with this patch (4 failed / 17 passed before, all green after — the first is parametrized over three clients).

Commands run:

```
pytest tests/test_client_installers.py tests/test_cli_observe.py --no-cov     # 36 passed
pytest --tb=short -q --cov=continuum --cov-report=term-missing                # exit 0, full suite green, 87% total
ruff check src/ tests/ examples/                                              # All checks passed!
ruff format --check src/ tests/ examples/                                     # 240 files already formatted
mypy src/continuum                                                            # Success: no issues found in 108 source files
```

Baseline on `upstream/main` @ `a7705d8` was green before any change, so no failure here is pre-existing.

## Checklist

Tests added or updated for the changed behaviour — yes: `test_reinstalling_does_not_duplicate_the_briefing_hook` (parametrized over all three clients), `test_a_moved_briefing_command_is_repointed_not_duplicated`, and `test_a_command_of_no_known_kind_is_appended_never_matched` (the fallback arms of `_installed_kind`, added after Codecov flagged them as unhit). Documentation updated where the change affects user-facing behaviour — yes: `CHANGELOG.md` under `[Unreleased] / Fixed`, including the remediation for settings files that already hold duplicates. CI passes on the latest commit — all Test jobs (ubuntu/macos/windows × 3.11–3.13), Postgres backend, Lint & Type-check, Markdown lint and `codecov/patch` are green on `5da897b`. Security-relevant changes state known limitations explicitly — not security-relevant; the scope limitation is stated above.

## Additional context

Why the existing tests missed it: `test_install_is_idempotent_per_client` asserts only on `data["hooks"][profile["post_event"]]`, where a duplicate cannot arise, and `test_briefing_is_wired_on_session_start` installs once, so its `assert len(ours) == 1` holds trivially. The new test asserts on the `start_event` list across three consecutive installs and checks the reported status for each, so a regression shows up as both a wrong status and a duplicated entry.

Nearest existing work is open issue #449 (PreCompact wiring, Codex Bash-only matcher). Different scope; it confirms `SessionStart` → `briefing` is intended behaviour rather than proposing to change it.
