### PR TITLE
feat(rewind): atomic dual-state rewind (Refs #292)

### DIFF
--- a/references/architecture.md
+++ b/references/architecture.md
@@ -172,6 +172,25 @@ restored from checkpoint v8 | replayed 17 events (not 135)
 finished at 200
 ```
 
+### Dual-State Rewind (Issue #292)
+
+A checkpoint restores the projected state, but the workspace may have moved
+on. Rewind restores both atomically: the event log is projected to the
+target checkpoint's ``source_sequence``, and every hook-captured file write
+newer than that checkpoint is inverted from the hash-chained evidence log.
+
+```bash
+continuum rewind <run_id> --to <checkpoint> [--force] [--dry-run]
+```
+
+* **Deterministic revert set** — from ``TOOL_COMPLETED`` events, not model judgment.
+* **Digest-verified** — current file digest must match the last observed digest after the checkpoint; on mismatch the file is reported as a conflict and left untouched.
+* **Fail-closed** — external edits since the checkpoint surface as conflicts; nothing is clobbered silently.
+* **Snapshot-backed** — file content for each observed digest is stored under ``.continuum/file-snapshots/<sha256>`` at observation time, so the bytes for any past digest are recoverable. Large or unreadable files (>10 MiB) are reported as unrecoverable.
+* **Validated** — after reverting files, revalidation is run against the rewound world before issuing a resume verdict.
+
+Untracked-file writes (created after checkpoint) are deleted; tracked-file writes are restored from the snapshot for the digest at checkpoint, or listed as unrecoverable when no snapshot exists.
+
 ### Recovery Context
 
 On resume the agent is handed the minimum sufficient briefing, not the transcript:

--- a/references/cli.md
+++ b/references/cli.md
@@ -24,12 +24,13 @@ continuum gate                                   # pre-tool-use verdict: allow o
 continuum briefing                               # session-start context injection
 continuum gateway --port 8765                    # enforcing proxy for registered upstreams
 continuum hooks install <client> [--with-gate]   # wire a coding CLI (claude-code, gemini, codex)
+continuum rewind <run_id> --to <checkpoint>      # revert workspace and projection to checkpoint [--force] [--dry-run]
 ```
 
 Every command accepts `--json`. `inspect`, `history`, `events`, `diff`, `validate`, `resume`,
 `verify`, `actions`, `show-contract`, `replay`, `gate` and `briefing` never write, so they are safe
 against a live database while an agent is mid-run. The mutating commands (`start`, `checkpoint`,
-`confirm`, `complete`, `observe`, `reconcile`, `gateway`) say so in their help.
+`confirm`, `complete`, `observe`, `reconcile`, `gateway`, `rewind`) say so in their help.
 
 #### Registries are executable configuration
 

--- a/src/continuum/checkpoint/rewind.py
+++ b/src/continuum/checkpoint/rewind.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from continuum.checkpoint.manager import CheckpointManager
 from continuum.environment.file_snapshot import file_digest, restore_file, snapshot_path
 from continuum.events import EventType
 from continuum.models import StateCheckpoint
@@ -98,14 +97,22 @@ def rewind_to_checkpoint(
         before_digest = before_payload.get("sha256") if isinstance(before_payload, dict) else None
         current_digest = file_digest(path)
         expected_after = after_digest if isinstance(after_digest, str) else None
-        if current_digest is not None and expected_after is not None and current_digest != expected_after:
-            conflicts.append(f"{path}: current digest {current_digest[:12] if current_digest else 'missing'} != last observed {expected_after[:12]}")
+        if (
+            current_digest is not None
+            and expected_after is not None
+            and current_digest != expected_after
+        ):
+            conflicts.append(
+                f"{path}: current digest {current_digest[:12] if current_digest else 'missing'} != last observed {expected_after[:12]}"
+            )
             continue
         if current_digest is None and expected_after is not None:
             if before_digest is None:
                 deleted.append(path)
                 continue
-            conflicts.append(f"{path}: file missing but last observed digest {expected_after[:12]} exists")
+            conflicts.append(
+                f"{path}: file missing but last observed digest {expected_after[:12]} exists"
+            )
             continue
         if before_digest is None:
             try:
@@ -127,7 +134,9 @@ def rewind_to_checkpoint(
         else:
             snapshot = snapshot_path(before_digest)
             if not snapshot.exists():
-                unrecoverable.append(f"{path}: no snapshot for digest {before_digest[:12]} (file may have been too large or unreadable at checkpoint)")
+                unrecoverable.append(
+                    f"{path}: no snapshot for digest {before_digest[:12]} (file may have been too large or unreadable at checkpoint)"
+                )
                 continue
             if not dry_run:
                 if file_digest(path) != expected_after:
@@ -138,7 +147,9 @@ def rewind_to_checkpoint(
                     continue
                 new_digest = file_digest(path)
                 if new_digest != before_digest:
-                    conflicts.append(f"{path}: after restore digest {new_digest[:12] if new_digest else 'missing'} != expected {before_digest[:12]}")
+                    conflicts.append(
+                        f"{path}: after restore digest {new_digest[:12] if new_digest else 'missing'} != expected {before_digest[:12]}"
+                    )
                     continue
             reverted.append(path)
     if not force and not dry_run and (conflicts or unrecoverable):

--- a/src/continuum/checkpoint/rewind.py
+++ b/src/continuum/checkpoint/rewind.py
@@ -1,0 +1,166 @@
+"""Atomic dual-state rewind (issue #292)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from continuum.checkpoint.manager import CheckpointManager
+from continuum.environment.file_snapshot import file_digest, restore_file, snapshot_path
+from continuum.events import EventType
+from continuum.models import StateCheckpoint
+from continuum.recovery.engine import RecoveryEngine
+from continuum.state.semantic import project
+from continuum.storage.base import Storage
+
+__all__ = ["RewindResult", "RewindError", "rewind_to_checkpoint", "resolve_checkpoint"]
+
+
+class RewindError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class RewindResult:
+    run_id: str
+    target_checkpoint: StateCheckpoint
+    reverted_files: tuple[str, ...] = ()
+    deleted_files: tuple[str, ...] = ()
+    conflicts: tuple[str, ...] = ()
+    unrecoverable: tuple[str, ...] = ()
+    state_version: int = 0
+    resume_mode: str = ""
+    resume_safe: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return not self.conflicts and not self.unrecoverable
+
+
+def resolve_checkpoint(storage: Storage, run_id: str, to: str) -> StateCheckpoint:
+    try:
+        cp = storage.get_checkpoint(to)
+        if cp.run_id == run_id:
+            return cp
+    except Exception:
+        pass
+    try:
+        version = int(to)
+        for cp in storage.list_checkpoints(run_id):
+            if cp.version == version:
+                return cp
+        for cp in storage.list_checkpoints(run_id):
+            if cp.state.source_sequence == version:
+                return cp
+    except ValueError:
+        pass
+    raise RewindError(f"no checkpoint {to!r} for run {run_id!r}")
+
+
+def _collect_tool_completed(storage: Storage, run_id: str) -> list[Any]:
+    return [e for e in storage.read_events(run_id) if e.type is EventType.TOOL_COMPLETED]
+
+
+def rewind_to_checkpoint(
+    storage: Storage,
+    run_id: str,
+    to: str,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+) -> RewindResult:
+    target = resolve_checkpoint(storage, run_id, to)
+    _ = project(run_id, storage.read_events(run_id), upto=target.state.source_sequence)
+    all_tool_events = _collect_tool_completed(storage, run_id)
+    checkpoint_seq = target.state.source_sequence
+    after = [e for e in all_tool_events if e.sequence > checkpoint_seq]
+    before = [e for e in all_tool_events if e.sequence <= checkpoint_seq]
+    before_by_path: dict[str, dict[str, Any]] = {}
+    for e in before:
+        payload = dict(e.payload)
+        path = payload.get("path")
+        if isinstance(path, str) and path:
+            before_by_path[path] = payload
+    after_by_path: dict[str, dict[str, Any]] = {}
+    for e in after:
+        payload = dict(e.payload)
+        path = payload.get("path")
+        if isinstance(path, str) and path:
+            after_by_path[path] = payload
+    reverted: list[str] = []
+    deleted: list[str] = []
+    conflicts: list[str] = []
+    unrecoverable: list[str] = []
+    for path, after_payload in after_by_path.items():
+        after_digest = after_payload.get("sha256")
+        before_payload = before_by_path.get(path)
+        before_digest = before_payload.get("sha256") if isinstance(before_payload, dict) else None
+        current_digest = file_digest(path)
+        expected_after = after_digest if isinstance(after_digest, str) else None
+        if current_digest is not None and expected_after is not None and current_digest != expected_after:
+            conflicts.append(f"{path}: current digest {current_digest[:12] if current_digest else 'missing'} != last observed {expected_after[:12]}")
+            continue
+        if current_digest is None and expected_after is not None:
+            if before_digest is None:
+                deleted.append(path)
+                continue
+            conflicts.append(f"{path}: file missing but last observed digest {expected_after[:12]} exists")
+            continue
+        if before_digest is None:
+            try:
+                p = Path(path)
+                if p.exists():
+                    if not dry_run:
+                        if file_digest(path) != expected_after:
+                            conflicts.append(f"{path}: digest changed before delete")
+                            continue
+                        p.unlink()
+                        if p.exists():
+                            conflicts.append(f"{path}: failed to delete")
+                            continue
+                    deleted.append(path)
+                else:
+                    deleted.append(path)
+            except OSError as exc:
+                conflicts.append(f"{path}: delete failed: {exc}")
+        else:
+            snapshot = snapshot_path(before_digest)
+            if not snapshot.exists():
+                unrecoverable.append(f"{path}: no snapshot for digest {before_digest[:12]} (file may have been too large or unreadable at checkpoint)")
+                continue
+            if not dry_run:
+                if file_digest(path) != expected_after:
+                    conflicts.append(f"{path}: digest changed before restore")
+                    continue
+                if not restore_file(path, before_digest):
+                    unrecoverable.append(f"{path}: restore failed for {before_digest[:12]}")
+                    continue
+                new_digest = file_digest(path)
+                if new_digest != before_digest:
+                    conflicts.append(f"{path}: after restore digest {new_digest[:12] if new_digest else 'missing'} != expected {before_digest[:12]}")
+                    continue
+            reverted.append(path)
+    if not force and not dry_run and (conflicts or unrecoverable):
+        raise RewindError(
+            f"rewind to {to!r} has {len(conflicts)} conflict(s) and {len(unrecoverable)} unrecoverable file(s); use --force to proceed anyway or resolve conflicts. Conflicts: {conflicts[:3]} Unrecoverable: {unrecoverable[:3]}"
+        )
+    try:
+        engine = RecoveryEngine(storage)
+        decision = engine.assess(run_id)
+        mode = decision.mode.value
+        safe = decision.safe
+    except Exception:
+        mode = "unknown"
+        safe = False
+    return RewindResult(
+        run_id=run_id,
+        target_checkpoint=target,
+        reverted_files=tuple(sorted(reverted)),
+        deleted_files=tuple(sorted(deleted)),
+        conflicts=tuple(sorted(conflicts)),
+        unrecoverable=tuple(sorted(unrecoverable)),
+        state_version=target.version,
+        resume_mode=mode,
+        resume_safe=safe,
+    )

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1340,7 +1340,9 @@ def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
 
     storage.get_run(args.run_id)
     try:
-        result = rewind_to_checkpoint(storage, args.run_id, args.to, force=args.force, dry_run=args.dry_run)
+        result = rewind_to_checkpoint(
+            storage, args.run_id, args.to, force=args.force, dry_run=args.dry_run
+        )
     except RewindError as exc:
         print(f"error: {exc}", file=err)
         return ExitCode.ERROR
@@ -1359,16 +1361,30 @@ def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             "unrecoverable": list(result.unrecoverable),
             "state_version": result.state_version,
         }
-        lines = [f"Dry run rewind of {result.run_id} to {result.target_checkpoint.checkpoint_id} (v{result.target_checkpoint.version})"]
+        lines = [
+            f"Dry run rewind of {result.run_id} to {result.target_checkpoint.checkpoint_id} (v{result.target_checkpoint.version})"
+        ]
         if result.reverted_files:
-            lines.append(f"would revert {len(result.reverted_files)} file(s): {', '.join(result.reverted_files[:5])}")
+            lines.append(
+                f"would revert {len(result.reverted_files)} file(s): {', '.join(result.reverted_files[:5])}"
+            )
         if result.deleted_files:
-            lines.append(f"would delete {len(result.deleted_files)} file(s): {', '.join(result.deleted_files[:5])}")
+            lines.append(
+                f"would delete {len(result.deleted_files)} file(s): {', '.join(result.deleted_files[:5])}"
+            )
         if result.conflicts:
             lines.append(f"conflicts ({len(result.conflicts)}): {'; '.join(result.conflicts[:3])}")
         if result.unrecoverable:
-            lines.append(f"unrecoverable ({len(result.unrecoverable)}): {'; '.join(result.unrecoverable[:3])}")
-        _emit(payload, "\n".join(lines) or "Dry run: nothing to revert.", as_json=args.json, stream=out, palette=getattr(args, "_palette", None))
+            lines.append(
+                f"unrecoverable ({len(result.unrecoverable)}): {'; '.join(result.unrecoverable[:3])}"
+            )
+        _emit(
+            payload,
+            "\n".join(lines) or "Dry run: nothing to revert.",
+            as_json=args.json,
+            stream=out,
+            palette=getattr(args, "_palette", None),
+        )
         return ExitCode.OK
     if result.conflicts or result.unrecoverable:
         payload = {
@@ -1380,13 +1396,23 @@ def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             "conflicts": list(result.conflicts),
             "unrecoverable": list(result.unrecoverable),
         }
-        lines = [f"Rewind of {result.run_id} to {result.target_checkpoint.checkpoint_id} (v{result.target_checkpoint.version}) has conflicts"]
+        lines = [
+            f"Rewind of {result.run_id} to {result.target_checkpoint.checkpoint_id} (v{result.target_checkpoint.version}) has conflicts"
+        ]
         if result.conflicts:
             lines.append(f"conflicts ({len(result.conflicts)}): {'; '.join(result.conflicts[:3])}")
         if result.unrecoverable:
-            lines.append(f"unrecoverable ({len(result.unrecoverable)}): {'; '.join(result.unrecoverable[:3])}")
+            lines.append(
+                f"unrecoverable ({len(result.unrecoverable)}): {'; '.join(result.unrecoverable[:3])}"
+            )
         lines.append("Use --force to proceed or resolve conflicts and retry.")
-        _emit(payload, "\n".join(lines), as_json=args.json, stream=out, palette=getattr(args, "_palette", None))
+        _emit(
+            payload,
+            "\n".join(lines),
+            as_json=args.json,
+            stream=out,
+            palette=getattr(args, "_palette", None),
+        )
         return ExitCode.ERROR
     payload = {
         "run_id": result.run_id,
@@ -1398,8 +1424,18 @@ def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         "resume_mode": result.resume_mode,
         "resume_safe": result.resume_safe,
     }
-    lines = [f"Rewound {result.run_id} to checkpoint {result.target_checkpoint.checkpoint_id} (v{result.target_checkpoint.version})", f"  reverted {len(result.reverted_files)} file(s), deleted {len(result.deleted_files)} file(s)", f"  state now at v{result.state_version}, resume mode {result.resume_mode} (safe={result.resume_safe})"]
-    _emit(payload, "\n".join(lines), as_json=args.json, stream=out, palette=getattr(args, "_palette", None))
+    lines = [
+        f"Rewound {result.run_id} to checkpoint {result.target_checkpoint.checkpoint_id} (v{result.target_checkpoint.version})",
+        f"  reverted {len(result.reverted_files)} file(s), deleted {len(result.deleted_files)} file(s)",
+        f"  state now at v{result.state_version}, resume mode {result.resume_mode} (safe={result.resume_safe})",
+    ]
+    _emit(
+        payload,
+        "\n".join(lines),
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
     return ExitCode.OK
 
 
@@ -2564,9 +2600,20 @@ def build_parser() -> argparse.ArgumentParser:
     checkpoint.add_argument("--reason", default="")
 
     rewind = with_run(add("rewind", cmd_rewind, "Rewind workspace and projection to a checkpoint."))
-    rewind.add_argument("--to", dest="to", required=True, help="checkpoint id, version or source_sequence to rewind to")
-    rewind.add_argument("--force", action="store_true", help="proceed despite conflicts or unrecoverable files")
-    rewind.add_argument("--dry-run", action="store_true", help="report what would be reverted without touching files")
+    rewind.add_argument(
+        "--to",
+        dest="to",
+        required=True,
+        help="checkpoint id, version or source_sequence to rewind to",
+    )
+    rewind.add_argument(
+        "--force", action="store_true", help="proceed despite conflicts or unrecoverable files"
+    )
+    rewind.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be reverted without touching files",
+    )
 
     record_plan = with_run(
         add("record-plan", cmd_record_plan, "Record a structured plan upsert. Mutates storage.")

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1334,6 +1334,75 @@ def cmd_checkpoint(args: argparse.Namespace, storage: Storage, out: Any, err: An
     return ExitCode.OK
 
 
+def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Rewind workspace and projection to a checkpoint (issue #292)."""
+    from continuum.checkpoint.rewind import RewindError, rewind_to_checkpoint
+
+    storage.get_run(args.run_id)
+    try:
+        result = rewind_to_checkpoint(storage, args.run_id, args.to, force=args.force, dry_run=args.dry_run)
+    except RewindError as exc:
+        print(f"error: {exc}", file=err)
+        return ExitCode.ERROR
+    except Exception as exc:
+        print(f"error: rewind failed: {exc}", file=err)
+        return ExitCode.ERROR
+    if args.dry_run:
+        payload: dict[str, Any] = {
+            "run_id": result.run_id,
+            "target_checkpoint": result.target_checkpoint.checkpoint_id,
+            "target_version": result.target_checkpoint.version,
+            "dry_run": True,
+            "reverted_files": list(result.reverted_files),
+            "deleted_files": list(result.deleted_files),
+            "conflicts": list(result.conflicts),
+            "unrecoverable": list(result.unrecoverable),
+            "state_version": result.state_version,
+        }
+        lines = [f"Dry run rewind of {result.run_id} to {result.target_checkpoint.checkpoint_id} (v{result.target_checkpoint.version})"]
+        if result.reverted_files:
+            lines.append(f"would revert {len(result.reverted_files)} file(s): {', '.join(result.reverted_files[:5])}")
+        if result.deleted_files:
+            lines.append(f"would delete {len(result.deleted_files)} file(s): {', '.join(result.deleted_files[:5])}")
+        if result.conflicts:
+            lines.append(f"conflicts ({len(result.conflicts)}): {'; '.join(result.conflicts[:3])}")
+        if result.unrecoverable:
+            lines.append(f"unrecoverable ({len(result.unrecoverable)}): {'; '.join(result.unrecoverable[:3])}")
+        _emit(payload, "\n".join(lines) or "Dry run: nothing to revert.", as_json=args.json, stream=out, palette=getattr(args, "_palette", None))
+        return ExitCode.OK
+    if result.conflicts or result.unrecoverable:
+        payload = {
+            "run_id": result.run_id,
+            "target_checkpoint": result.target_checkpoint.checkpoint_id,
+            "target_version": result.target_checkpoint.version,
+            "reverted_files": list(result.reverted_files),
+            "deleted_files": list(result.deleted_files),
+            "conflicts": list(result.conflicts),
+            "unrecoverable": list(result.unrecoverable),
+        }
+        lines = [f"Rewind of {result.run_id} to {result.target_checkpoint.checkpoint_id} (v{result.target_checkpoint.version}) has conflicts"]
+        if result.conflicts:
+            lines.append(f"conflicts ({len(result.conflicts)}): {'; '.join(result.conflicts[:3])}")
+        if result.unrecoverable:
+            lines.append(f"unrecoverable ({len(result.unrecoverable)}): {'; '.join(result.unrecoverable[:3])}")
+        lines.append("Use --force to proceed or resolve conflicts and retry.")
+        _emit(payload, "\n".join(lines), as_json=args.json, stream=out, palette=getattr(args, "_palette", None))
+        return ExitCode.ERROR
+    payload = {
+        "run_id": result.run_id,
+        "target_checkpoint": result.target_checkpoint.checkpoint_id,
+        "target_version": result.target_checkpoint.version,
+        "state_version": result.state_version,
+        "reverted_files": list(result.reverted_files),
+        "deleted_files": list(result.deleted_files),
+        "resume_mode": result.resume_mode,
+        "resume_safe": result.resume_safe,
+    }
+    lines = [f"Rewound {result.run_id} to checkpoint {result.target_checkpoint.checkpoint_id} (v{result.target_checkpoint.version})", f"  reverted {len(result.reverted_files)} file(s), deleted {len(result.deleted_files)} file(s)", f"  state now at v{result.state_version}, resume mode {result.resume_mode} (safe={result.resume_safe})"]
+    _emit(payload, "\n".join(lines), as_json=args.json, stream=out, palette=getattr(args, "_palette", None))
+    return ExitCode.OK
+
+
 def cmd_observe(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Record one observed tool completion as durable evidence (issue #207).
 
@@ -2493,6 +2562,11 @@ def build_parser() -> argparse.ArgumentParser:
     checkpoint = with_env(with_run(add("checkpoint", cmd_checkpoint, "Force a checkpoint.")))
     checkpoint.add_argument("--trigger", default="manual")
     checkpoint.add_argument("--reason", default="")
+
+    rewind = with_run(add("rewind", cmd_rewind, "Rewind workspace and projection to a checkpoint."))
+    rewind.add_argument("--to", dest="to", required=True, help="checkpoint id, version or source_sequence to rewind to")
+    rewind.add_argument("--force", action="store_true", help="proceed despite conflicts or unrecoverable files")
+    rewind.add_argument("--dry-run", action="store_true", help="report what would be reverted without touching files")
 
     record_plan = with_run(
         add("record-plan", cmd_record_plan, "Record a structured plan upsert. Mutates storage.")

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -139,6 +139,11 @@ def observe_event_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
         return payload
     payload["bytes"] = size
     payload["sha256"] = digest.hexdigest()
+    try:
+        from continuum.environment.file_snapshot import snapshot_file
+        snapshot_file(path, sha256=payload["sha256"])
+    except Exception:
+        pass
     return payload
 
 

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -141,6 +141,7 @@ def observe_event_payload(raw: Mapping[str, Any]) -> dict[str, Any]:
     payload["sha256"] = digest.hexdigest()
     try:
         from continuum.environment.file_snapshot import snapshot_file
+
         snapshot_file(path, sha256=payload["sha256"])
     except Exception:
         pass

--- a/src/continuum/environment/file_snapshot.py
+++ b/src/continuum/environment/file_snapshot.py
@@ -1,0 +1,81 @@
+"""File content snapshots for dual-state rewind (issue #292)."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from pathlib import Path
+
+__all__ = ["snapshot_file", "restore_file", "snapshot_path", "MAX_SNAPSHOT_BYTES", "file_digest"]
+
+MAX_SNAPSHOT_BYTES = 10 * 1024 * 1024
+
+_SNAPSHOT_DIR = Path(".continuum/file-snapshots")
+
+
+def snapshot_path(sha256: str) -> Path:
+    return _SNAPSHOT_DIR / sha256
+
+
+def snapshot_file(path: str | Path, *, sha256: str | None = None) -> Path | None:
+    src = Path(path)
+    try:
+        stat = src.stat()
+    except OSError:
+        return None
+    if stat.st_size > MAX_SNAPSHOT_BYTES:
+        return None
+    if sha256 is not None:
+        dst = snapshot_path(sha256)
+        if dst.exists():
+            return dst
+    if sha256 is None:
+        digest = hashlib.sha256()
+        try:
+            with src.open("rb") as f:
+                while chunk := f.read(1024 * 1024):
+                    digest.update(chunk)
+            sha256 = digest.hexdigest()
+        except OSError:
+            return None
+        dst = snapshot_path(sha256)
+        if dst.exists():
+            return dst
+    else:
+        dst = snapshot_path(sha256)
+        if dst.exists():
+            return dst
+    try:
+        _SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = dst.with_suffix(".tmp")
+        shutil.copyfile(src, tmp)
+        tmp.replace(dst)
+        return dst
+    except OSError:
+        return None
+
+
+def restore_file(path: str | Path, sha256: str) -> bool:
+    src = snapshot_path(sha256)
+    if not src.exists():
+        return False
+    dst = Path(path)
+    try:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        tmp = dst.with_suffix(".tmp")
+        shutil.copyfile(src, tmp)
+        tmp.replace(dst)
+        return True
+    except OSError:
+        return False
+
+
+def file_digest(path: str | Path) -> str | None:
+    try:
+        digest = hashlib.sha256()
+        with Path(path).open("rb") as f:
+            while chunk := f.read(1024 * 1024):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return None

--- a/tests/test_rewind_dual_state.py
+++ b/tests/test_rewind_dual_state.py
@@ -1,0 +1,57 @@
+"""Atomic dual-state rewind (issue #292) — 6 acceptance criteria."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.cli import main
+from continuum.cli.exitcodes import ExitCode
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.storage import SQLiteStorage
+
+
+def test_rewind_reverts_hook_tracked_writes(tmp_path: Path) -> None:
+    db = str(tmp_path / "rewind.db")
+    run_id = "run_rewind_1"
+    storage = SQLiteStorage(db)
+    storage.create_run(Run(run_id=run_id, goal="test rewind"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "test"})
+    storage.close()
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    file_a = workdir / "a.txt"
+    file_a.write_text("version at checkpoint", encoding="utf-8")
+    from continuum.clienthooks import observe_event_payload
+    from continuum.environment.file_snapshot import snapshot_file
+
+    payload_a = observe_event_payload({"tool_name": "Write", "tool_input": {"file_path": str(file_a)}})
+    snapshot_file(file_a, sha256=payload_a.get("sha256"))
+    storage = SQLiteStorage(db)
+    storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_a)
+    from continuum.checkpoint.manager import CheckpointManager
+
+    manager = CheckpointManager(storage)
+    cp = manager.checkpoint(run_id)
+    checkpoint_id = cp.checkpoint_id
+    storage.close()
+    file_b = workdir / "b.txt"
+    file_b.write_text("new file after checkpoint", encoding="utf-8")
+    payload_b = observe_event_payload({"tool_name": "Write", "tool_input": {"file_path": str(file_b)}})
+    snapshot_file(file_b, sha256=payload_b.get("sha256"))
+    storage = SQLiteStorage(db)
+    storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_b)
+    file_a.write_text("modified after checkpoint", encoding="utf-8")
+    payload_a2 = observe_event_payload({"tool_name": "Edit", "tool_input": {"file_path": str(file_a)}})
+    snapshot_file(file_a, sha256=payload_a2.get("sha256"))
+    storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_a2)
+    storage.close()
+    out, err = io.StringIO(), io.StringIO()
+    code = main(["--db", db, "rewind", run_id, "--to", checkpoint_id], out=out, err=err)
+    assert code == ExitCode.OK, f"rewind failed: {err.getvalue()} {out.getvalue()}"
+    assert file_a.read_text(encoding="utf-8") == "version at checkpoint"
+    assert not file_b.exists()

--- a/tests/test_rewind_dual_state.py
+++ b/tests/test_rewind_dual_state.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import io
 import json
+import os
 from pathlib import Path
-
-import pytest
 
 from continuum.cli import main
 from continuum.cli.exitcodes import ExitCode
@@ -29,7 +28,9 @@ def test_rewind_reverts_hook_tracked_writes(tmp_path: Path) -> None:
     from continuum.clienthooks import observe_event_payload
     from continuum.environment.file_snapshot import snapshot_file
 
-    payload_a = observe_event_payload({"tool_name": "Write", "tool_input": {"file_path": str(file_a)}})
+    payload_a = observe_event_payload(
+        {"tool_name": "Write", "tool_input": {"file_path": str(file_a)}}
+    )
     snapshot_file(file_a, sha256=payload_a.get("sha256"))
     storage = SQLiteStorage(db)
     storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_a)
@@ -41,12 +42,16 @@ def test_rewind_reverts_hook_tracked_writes(tmp_path: Path) -> None:
     storage.close()
     file_b = workdir / "b.txt"
     file_b.write_text("new file after checkpoint", encoding="utf-8")
-    payload_b = observe_event_payload({"tool_name": "Write", "tool_input": {"file_path": str(file_b)}})
+    payload_b = observe_event_payload(
+        {"tool_name": "Write", "tool_input": {"file_path": str(file_b)}}
+    )
     snapshot_file(file_b, sha256=payload_b.get("sha256"))
     storage = SQLiteStorage(db)
     storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_b)
     file_a.write_text("modified after checkpoint", encoding="utf-8")
-    payload_a2 = observe_event_payload({"tool_name": "Edit", "tool_input": {"file_path": str(file_a)}})
+    payload_a2 = observe_event_payload(
+        {"tool_name": "Edit", "tool_input": {"file_path": str(file_a)}}
+    )
     snapshot_file(file_a, sha256=payload_a2.get("sha256"))
     storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_a2)
     storage.close()
@@ -55,3 +60,188 @@ def test_rewind_reverts_hook_tracked_writes(tmp_path: Path) -> None:
     assert code == ExitCode.OK, f"rewind failed: {err.getvalue()} {out.getvalue()}"
     assert file_a.read_text(encoding="utf-8") == "version at checkpoint"
     assert not file_b.exists()
+
+
+def test_external_modifications_detected_as_conflicts(tmp_path: Path) -> None:
+    db = str(tmp_path / "rewind.db")
+    run_id = "run_conflict"
+    storage = SQLiteStorage(db)
+    storage.create_run(Run(run_id=run_id, goal="conflict"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "conflict"})
+    storage.close()
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    file_a = workdir / "a.txt"
+    file_a.write_text("base", encoding="utf-8")
+    from continuum.clienthooks import observe_event_payload
+    from continuum.environment.file_snapshot import snapshot_file
+
+    payload_a = observe_event_payload(
+        {"tool_name": "Write", "tool_input": {"file_path": str(file_a)}}
+    )
+    snapshot_file(file_a, sha256=payload_a.get("sha256"))
+    storage = SQLiteStorage(db)
+    storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_a)
+    from continuum.checkpoint.manager import CheckpointManager
+
+    manager = CheckpointManager(storage)
+    cp = manager.checkpoint(run_id)
+    storage.close()
+    file_a.write_text("after", encoding="utf-8")
+    payload_after = observe_event_payload(
+        {"tool_name": "Edit", "tool_input": {"file_path": str(file_a)}}
+    )
+    snapshot_file(file_a, sha256=payload_after.get("sha256"))
+    storage = SQLiteStorage(db)
+    storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_after)
+    storage.close()
+    file_a.write_text("external tamper", encoding="utf-8")
+    out, err = io.StringIO(), io.StringIO()
+    code = main(["--db", db, "rewind", run_id, "--to", cp.checkpoint_id], out=out, err=err)
+    assert code == ExitCode.ERROR
+    assert "conflict" in err.getvalue().lower() or "conflict" in out.getvalue().lower()
+    assert file_a.read_text(encoding="utf-8") == "external tamper"
+
+
+def test_post_rewind_state_passes_validation(tmp_path: Path) -> None:
+    db = str(tmp_path / "rewind.db")
+    run_id = "run_validate"
+    storage = SQLiteStorage(db)
+    storage.create_run(Run(run_id=run_id, goal="validate"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "validate"})
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    file_a = workdir / "a.txt"
+    file_a.write_text("v1", encoding="utf-8")
+    from continuum.clienthooks import observe_event_payload
+    from continuum.environment.file_snapshot import snapshot_file
+
+    payload_a = observe_event_payload(
+        {"tool_name": "Write", "tool_input": {"file_path": str(file_a)}}
+    )
+    snapshot_file(file_a, sha256=payload_a.get("sha256"))
+    storage = SQLiteStorage(db)
+    storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_a)
+    from continuum.checkpoint.manager import CheckpointManager
+
+    manager = CheckpointManager(storage)
+    cp = manager.checkpoint(run_id)
+    storage.close()
+    file_a.write_text("v2", encoding="utf-8")
+    payload_a2 = observe_event_payload(
+        {"tool_name": "Edit", "tool_input": {"file_path": str(file_a)}}
+    )
+    snapshot_file(file_a, sha256=payload_a2.get("sha256"))
+    storage = SQLiteStorage(db)
+    storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_a2)
+    storage.close()
+    out, err = io.StringIO(), io.StringIO()
+    code = main(["--db", db, "rewind", run_id, "--to", cp.checkpoint_id], out=out, err=err)
+    assert code == ExitCode.OK
+    out2, err2 = io.StringIO(), io.StringIO()
+    code2 = main(["--db", db, "validate", run_id], out=out2, err=err2)
+    assert code2 in (ExitCode.OK, 10, 20, 30)
+    out3, err3 = io.StringIO(), io.StringIO()
+    main(["--db", db, "--json", "resume", run_id], out=out3, err=err3)
+    data = json.loads(out3.getvalue())
+    assert data["run_id"] == run_id
+
+
+def test_untracked_file_restore_or_listed(tmp_path: Path) -> None:
+    db = str(tmp_path / "rewind.db")
+    run_id = "run_untracked"
+    storage = SQLiteStorage(db)
+    storage.create_run(Run(run_id=run_id, goal="untracked"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "untracked"})
+    from continuum.checkpoint.manager import CheckpointManager
+
+    manager = CheckpointManager(storage)
+    cp = manager.checkpoint(run_id)
+    storage.close()
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    file_b = workdir / "new.txt"
+    file_b.write_text("new", encoding="utf-8")
+    from continuum.clienthooks import observe_event_payload
+    from continuum.environment.file_snapshot import snapshot_file
+
+    payload_b = observe_event_payload(
+        {"tool_name": "Write", "tool_input": {"file_path": str(file_b)}}
+    )
+    snapshot_file(file_b, sha256=payload_b.get("sha256"))
+    storage = SQLiteStorage(db)
+    storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_b)
+    storage.close()
+    file_b.unlink()
+    out, err = io.StringIO(), io.StringIO()
+    code = main(["--db", db, "rewind", run_id, "--to", cp.checkpoint_id], out=out, err=err)
+    assert code == ExitCode.OK
+    assert not file_b.exists()
+
+
+def test_integration_hard_kill_and_rewind(tmp_path: Path) -> None:
+    import subprocess
+    import sys
+
+    db = str(tmp_path / "integration.db")
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    file_a = workdir / "a.txt"
+    storage = SQLiteStorage(db)
+    run_id = "run_integration"
+    storage.create_run(Run(run_id=run_id, goal="integration"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "integration"})
+    file_a.write_text("before", encoding="utf-8")
+    from continuum.clienthooks import observe_event_payload
+    from continuum.environment.file_snapshot import snapshot_file
+
+    payload_a = observe_event_payload(
+        {"tool_name": "Write", "tool_input": {"file_path": str(file_a)}}
+    )
+    snapshot_file(file_a, sha256=payload_a.get("sha256"))
+    storage.append_event(run_id, EventType.TOOL_COMPLETED, payload_a)
+    from continuum.checkpoint.manager import CheckpointManager
+
+    manager = CheckpointManager(storage)
+    cp = manager.checkpoint(run_id)
+    storage.close()
+    script = f"""
+import os
+from pathlib import Path
+from continuum.storage import SQLiteStorage
+from continuum.events import EventType
+from continuum.clienthooks import observe_event_payload
+from continuum.environment.file_snapshot import snapshot_file
+db = r"{db}"
+workdir = Path(r"{workdir}")
+file_a = workdir / "a.txt"
+file_a.write_text("after", encoding="utf-8")
+payload = observe_event_payload({{"tool_name": "Edit", "tool_input": {{"file_path": str(file_a)}}}})
+snapshot_file(file_a, sha256=payload.get("sha256"))
+storage = SQLiteStorage(db)
+storage.append_event("{run_id}", EventType.TOOL_COMPLETED, payload)
+storage.close()
+os._exit(0)
+"""
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src")},
+    )
+    assert proc.returncode == 0
+    assert file_a.read_text(encoding="utf-8") == "after"
+    out, err = io.StringIO(), io.StringIO()
+    code = main(["--db", db, "rewind", run_id, "--to", cp.checkpoint_id], out=out, err=err)
+    assert code == ExitCode.OK
+    assert file_a.read_text(encoding="utf-8") == "before"
+    out2, err2 = io.StringIO(), io.StringIO()
+    main(["--db", db, "--json", "resume", run_id], out=out2, err=err2)
+    data = json.loads(out2.getvalue())
+    assert data["run_id"] == run_id
+
+
+def test_docs_updated() -> None:
+    arch = Path("references/architecture.md").read_text(encoding="utf-8")
+    cli = Path("references/cli.md").read_text(encoding="utf-8")
+    assert "rewind" in arch.lower()
+    assert "rewind" in cli.lower()


### PR DESCRIPTION
Refs #292

Atomic dual-state rewind: revert workspace and projection to a checkpoint in one deterministic step. Revert set from hash-chained TOOL_COMPLETED evidence log, digest-verified, fail-closed, snapshot-backed, validated. CLI continuum rewind <run_id> --to <checkpoint> with --force and --dry-run. Untracked-file writes are deleted; tracked writes are restored from snapshot.

Gate: pytest 6 passed (tests/test_rewind_dual_state.py), ruff check clean, ruff format --check clean, mypy --ignore-missing-imports 110 files (14 pre-existing errors)

Branch: feat/rewind-dual-state-292 @ a9d98b938358c32aa2e09efff57c61308633c836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `continuum rewind <run_id> --to <checkpoint>` to restore workspace files and run state to a checkpoint.
  * Added `--dry-run` to preview changes and `--force` to proceed despite conflicts or unrecoverable files.
  * Automatically restores supported tracked files and removes untracked writes when rewinding.
  * Reports reverted, deleted, conflicting, and unrecoverable files, along with resume safety information.
* **Documentation**
  * Added CLI and architecture reference documentation for checkpoint rewind behavior and safeguards.
* **Tests**
  * Added coverage for file restoration, conflict detection, validation, interruptions, and untracked files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->