### PR TITLE
fix(gate): strip surrounding whitespace from derived key values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ All notable changes to this project are documented here. The format follows
 
 - Make `continuum complete` idempotent for runs that are already completed (#356).
 
+- **Derived keys ignore surrounding whitespace in argument values (#361).**
+  `render_key` substituted values verbatim, so a tool argument of `" 123 "` and
+  one of `"123"` produced two different ledger keys for one resource. LLM output
+  routinely carries a trailing space or newline, and with two keys the second
+  call found no record of itself: the gate answered with claim instructions
+  rather than the already-completed refusal, so the same side effect could fire
+  twice. String values are now stripped before substitution in both `gate` and
+  the enforcing `gateway`, which share one `normalize_key_value` rule so the
+  hook and the proxy cannot derive different keys for the same operation.
+  Non-string values are untouched, keeping templates that carry a format spec
+  such as `{amount:.2f}` working. Keys are unchanged for values without
+  surrounding whitespace; a run whose in-flight claim was recorded under a
+  padded key will not match the stripped key derived after upgrading.
+
 ## [0.1.0] - 2026-08-27
 
 ### Added

--- a/src/continuum/gate.py
+++ b/src/continuum/gate.py
@@ -41,6 +41,7 @@ __all__ = [
     "DEFAULT_GATE_CONFIG_PATH",
     "Decision",
     "load_gate_config",
+    "normalize_key_value",
     "render_key",
     "decide",
 ]
@@ -97,13 +98,34 @@ def load_gate_config(path: Path) -> dict[str, dict[str, Any]] | None:
     return tools
 
 
+def normalize_key_value(value: Any) -> Any:
+    """Surrounding whitespace stripped from a string value, others untouched.
+
+    Two calls that name the same resource must derive the same key, and an
+    LLM-authored argument routinely arrives as ``" 123 "`` or ``"123\\n"``. Left
+    alone, ``invoice: 123 `` and ``invoice:123`` are different ledger keys, so
+    the second call finds no live claim of its own and the dedup verdict the
+    gate exists to deliver never fires -- the same side effect can happen twice.
+
+    Only ``str`` is touched. A template may carry a format spec (``{amount:.2f}``),
+    and stringifying the value first would make that spec raise on the way to a
+    key, turning a working configuration into a hard error.
+
+    Public because the enforcing gateway derives keys from HTTP bodies the same
+    way (issue #361): one rule in one place, since two copies of an identity
+    rule drift into two different identities.
+    """
+    return value.strip() if isinstance(value, str) else value
+
+
 def render_key(template: str, tool_input: Mapping[str, Any]) -> str:
     """Substitute ``{field}`` placeholders from the call's arguments.
 
     Only top-level argument fields are supported in v1. A placeholder with no
     matching argument raises: a template the current call cannot satisfy is a
     configuration problem worth surfacing, not something to paper over with a
-    weaker identity.
+    weaker identity. String values are stripped of surrounding whitespace
+    (:func:`normalize_key_value`); the template itself is used verbatim.
     """
     import string
 
@@ -114,7 +136,7 @@ def render_key(template: str, tool_input: Mapping[str, Any]) -> str:
             f"key template {template!r} needs argument(s) {missing} "
             f"but the call supplied {sorted(tool_input)!r}"
         )
-    values = {f: tool_input[f] for f in fields}
+    values = {f: normalize_key_value(tool_input[f]) for f in fields}
     return template.format(**values)
 
 

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from typing import Any
 
 from continuum.events import EventType
+from continuum.gate import normalize_key_value
 from continuum.models import Origin
 
 __all__ = [
@@ -121,13 +122,20 @@ def load_gateway_config(path: Path) -> list[Route]:
 
 
 def render_key(template: str, body: dict[str, Any]) -> str:
+    """Substitute ``{field}`` placeholders from the request body.
+
+    Values are normalised exactly as ``gate`` normalises tool arguments
+    (:func:`continuum.gate.normalize_key_value`): the proxy and the hook must
+    derive the same key for the same operation, or a call claimed through one
+    seam looks unclaimed at the other.
+    """
     import string
 
     fields = [f for _, f, _, _ in string.Formatter().parse(template) if f]
     missing = [f for f in fields if f not in body]
     if missing:
         raise GatewayConfigError(f"key template {template!r} needs body field(s) {missing}")
-    return template.format(**{f: body[f] for f in fields})
+    return template.format(**{f: normalize_key_value(body[f]) for f in fields})
 
 
 def match_route(

--- a/tests/test_cli_gate.py
+++ b/tests/test_cli_gate.py
@@ -67,6 +67,30 @@ def test_render_key_refuses_a_template_the_call_cannot_satisfy() -> None:
         render_key("invoice:{invoice_id}", {"customer": "acme"})
 
 
+@pytest.mark.parametrize("padded", (" 123 ", "123\n", "\n123", "\t123 \r\n"))
+def test_render_key_strips_surrounding_whitespace_from_values(padded: str) -> None:
+    """Whitespace in an argument must not fork the key (issue #361).
+
+    Key templates are configuration, but the values substituted into them come
+    from the model, and an LLM routinely emits a trailing space or newline. Left
+    in, ``invoice: 123 `` and ``invoice:123`` are two ledger keys for one
+    invoice, which is the one thing the derived key exists to prevent.
+    """
+    assert render_key("invoice:{id}", {"id": padded}) == render_key("invoice:{id}", {"id": "123"})
+
+
+def test_render_key_leaves_non_strings_to_the_templates_format_spec() -> None:
+    """Only strings are stripped; a numeric value keeps its type (issue #361).
+
+    Stringifying every value before formatting would be simpler, and would break
+    any template carrying a format spec: ``{amount:.2f}`` against ``"1.5"``
+    raises rather than rendering, so a working configuration would start failing
+    closed on every gated call.
+    """
+    assert render_key("amount:{amount:.2f}", {"amount": 1.5}) == "amount:1.50"
+    assert render_key("invoice:{id}", {"id": 7}) == "invoice:7"
+
+
 def test_load_gate_config_returns_none_when_absent(tmp_path: Path) -> None:
     assert load_gate_config(tmp_path / "missing.json") is None
 
@@ -132,6 +156,22 @@ def test_a_completed_call_is_denied_even_though_a_record_exists(db: str) -> None
     effect the ledger knows already happened, claim or no claim."""
     _seed(db, "send_invoice", "invoice:acme:7", ActionStatus.COMPLETED)
     decision = _decide(db, {"customer": "acme", "invoice_id": 7})
+    assert decision.allow is False
+    assert "already completed" in decision.reason
+
+
+def test_a_padded_retry_hits_the_dedup_verdict_of_the_clean_claim(db: str) -> None:
+    """The harm whitespace stripping prevents, end to end (issue #361).
+
+    The record is for ``invoice:acme:7``. A retry whose arguments carry stray
+    whitespace means the same invoice, so it has to land on the same key and be
+    refused as already completed. Before the fix it derived
+    ``invoice: acme :7``, found no record of itself, and was allowed through --
+    a second send of one invoice, which is precisely what the ledger key exists
+    to make impossible.
+    """
+    _seed(db, "send_invoice", "invoice:acme:7", ActionStatus.COMPLETED)
+    decision = _decide(db, {"customer": " acme ", "invoice_id": "7\n"})
     assert decision.allow is False
     assert "already completed" in decision.reason
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -138,6 +138,25 @@ def test_completed_effect_blocks_the_duplicate(db: str, gateway: str) -> None:
     assert "already completed" in body["reason"]
 
 
+def test_a_padded_body_field_still_hits_the_duplicate_verdict(db: str, gateway: str) -> None:
+    """The proxy has to derive the same key `gate` does (issue #361).
+
+    The effect on ``invoice:I-4`` is already completed and the retry body says
+    ``" I-4\\n"``, which names the same invoice. Before the fix the gateway
+    rendered ``invoice: I-4\\n``, found no record of itself, and answered with
+    claim instructions instead of the already-completed refusal -- so a client
+    following those instructions would have sent the invoice a second time.
+    """
+    key = claim(db, "invoice:I-4")
+    with SQLiteStorage(db) as store:
+        from continuum.actions.ledger import ActionLedger as AL
+
+        AL(store, "run_1").complete(key, external_id="sent")
+    status, body = post(gateway, "/v1/invoices", {"id": " I-4\n"})
+    assert status == 403
+    assert "already completed" in body["reason"]
+
+
 def test_unknown_host_is_refused_fail_closed(db: str, gateway: str) -> None:
     key = claim(db, "invoice:I-9")
     del key


### PR DESCRIPTION
## Description

`render_key` substituted argument values verbatim:

```python
values = {f: tool_input[f] for f in fields}
return template.format(**values)
```

So `" 123 "` and `"123"` produced two different ledger keys for one resource:

```
>>> render_key("invoice:{id}", {"id": " 123 "})
'invoice: 123 '
>>> render_key("invoice:{id}", {"id": "123"})
'invoice:123'
```

Templates are configuration, but the values substituted into them come from the model, and LLM output routinely carries a trailing space or newline. With two keys the second call finds no record of itself, so the gate answers with *claim instructions* rather than the already-completed refusal — a client following those instructions sends the invoice a second time. That is precisely what a derived key exists to prevent.

The fix strips string values before substitution. Two deliberate details:

- **Only strings are touched.** The obvious `str(value).strip()` would break any template carrying a format spec: `{amount:.2f}` against `"1.5"` raises `Unknown format code 'f' for object of type 'str'`, so a working configuration would start failing closed on every gated call. Non-string values pass through and the template's spec still applies.
- **One rule, shared.** `gate.render_key` and `gateway.render_key` both derive keys, and the issue notes the gateway has the same defect. Rather than two copies of the strip, `normalize_key_value` is now public in `continuum.gate` and imported by `continuum.gateway`. Two copies of an identity rule drift into two different identities, and the hook and the proxy deriving different keys for one operation is the failure that matters here.

## Related issues

Fixes #361

## Types of changes

- Type: `bugfix`

## Breaking changes

No for configuration and API. Worth one line of operator awareness, though: keys are unchanged for every value that has no surrounding whitespace, but a run whose in-flight claim was recorded under a *padded* key will not match the stripped key derived after upgrading. That window is the buggy case itself, and it is stated in the CHANGELOG entry rather than left for someone to discover.

## How has this been tested?

Environment: Windows 11 (26200), Python 3.11.15 (venv at `.venv`), pytest 9.1.1, ruff 0.16.3, mypy strict.

Reproduction, before and after:

```
python -c "from continuum.gate import render_key; print(repr(render_key('invoice:{id}', {'id': ' 123 '})), repr(render_key('invoice:{id}', {'id': '123'})))"
```

Before: `'invoice: 123 ' 'invoice:123'` — two keys. After: `'invoice:123' 'invoice:123'`. Same for `continuum.gateway.render_key`, and `render_key('amt:{amount:.2f}', {'amount': 1.5})` stays `'amt:1.50'` throughout.

The new tests fail on `upstream/main` and pass with this patch. Stashing only the two source files and rerunning gives 6 failures — the four padding shapes, the gate dedup case, and the gateway dedup case:

```
FAILED tests/test_cli_gate.py::test_render_key_strips_surrounding_whitespace_from_values[ 123 ]
FAILED tests/test_cli_gate.py::test_render_key_strips_surrounding_whitespace_from_values[123\n]
FAILED tests/test_cli_gate.py::test_render_key_strips_surrounding_whitespace_from_values[\n123]
FAILED tests/test_cli_gate.py::test_render_key_strips_surrounding_whitespace_from_values[\t123 \r\n]
FAILED tests/test_cli_gate.py::test_a_padded_retry_hits_the_dedup_verdict_of_the_clean_claim
FAILED tests/test_gateway.py::test_a_padded_body_field_still_hits_the_duplicate_verdict
```

The gateway failure is the informative one — the padded duplicate was answered with `key 'invoice: I-4\n' has no ledger claim. Call continuum_intercept_action(...)` instead of the completed refusal.

Commands run:

```
pytest tests/test_cli_gate.py tests/test_gateway.py --no-cov -q -p no:randomly   # 39 passed
pytest --tb=short -q --cov=continuum --cov-report=term-missing                   # exit 0, full suite green, 86% total
ruff check src/ tests/ examples/                                                 # All checks passed!
ruff format --check src/ tests/ examples/                                        # 243 files already formatted
mypy src/continuum                                                               # Success: no issues found in 110 source files
```

## Checklist

Tests added or updated for the changed behaviour — yes: `test_render_key_strips_surrounding_whitespace_from_values` (parametrized over four padding shapes), `test_render_key_leaves_non_strings_to_the_templates_format_spec`, `test_a_padded_retry_hits_the_dedup_verdict_of_the_clean_claim`, and `test_a_padded_body_field_still_hits_the_duplicate_verdict` for the gateway seam. Documentation updated where the change affects user-facing behaviour — yes: `CHANGELOG.md` under `[Unreleased] / Fixed`, including the in-flight-claim note. CI passes on the latest commit — full suite, lint, format and mypy pass locally; awaiting CI. Security-relevant changes state known limitations explicitly — this is a dedup-correctness fix; the scope is stripping only, not internal whitespace collapsing or case folding, since those change identity in ways an operator has not asked for.

## Additional context

Scope held deliberately narrow. Stripping is safe because surrounding whitespace never distinguishes two real resources; collapsing internal runs of whitespace or folding case would, so neither is included. The issue's acceptance criteria are met by stripping alone.

The gateway test asserts the already-completed refusal rather than a successful forward, because forwarding in tests hits an unreachable `api.example.com` and returns 502 by design (see `test_claimed_request_is_forwarded_settled_and_recorded`). Asserting on the verdict keeps the test independent of DNS while still proving the key matched.
