### PR TITLE
docs(cli): show --total flag in benchmark table

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -40,7 +40,7 @@ continuum --json <command>      # machine-readable output
 | `actions <run_id>` | List recorded side effects and flag uncertain outcomes. |
 | `show-contract <run_id>` | Print the recovery contract for the run. |
 | `replay <run_id>` | Replay events and verify the stored state version. |
-| `benchmark` | Run the CONTINUUM-Bench harness. |
+| `benchmark [--total <n>]` | Run the CONTINUUM-Bench harness (default: 200 documents per run). |
 | `attest-keygen` | Generate an Ed25519 signer key pair (PEM files). |
 | `attest <run_id>` | Sign a run's event chain into an attestation document. |
 | `attest-verify <run_id> --attest <file>` | Verify a signed attestation against the live chain. |


### PR DESCRIPTION
## Description

The command table in `docs/api/cli.md` omitted the `--total` flag added to the `benchmark` command. A newcomer reading the table does not see the option.

## Related issues

Fixes #456

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

- Read `docs/api/cli.md:43` and `src/continuum/cli/main.py:2765` (`--total` flag on benchmark)
- `continuum benchmark --help` shows `--total`
- Docs build not broken

## Checklist

Documentation updated where the change affects user-facing behaviour.
