### PR TITLE
docs(cli): fix diff example to include required versions

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -54,7 +54,7 @@ continuum --json <command>      # machine-readable output
 continuum resume run_42
 
 # What changed since the last checkpoint?
-continuum diff run_42
+continuum diff run_42 1 2
 
 # Prove the chain is untampered, then capture a signed attestation
 continuum verify run_42


### PR DESCRIPTION
## Description

The example in `docs/api/cli.md:57` showed `continuum diff run_42` but the command requires `<from_version> <to_version>`. Copying the example fails.

## Related issues

Fixes #453

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

- Read `docs/api/cli.md` and `src/continuum/cli/main.py` diff parser
- `continuum diff --help` shows two required positional args
