### PR TITLE
fix(cli): clarify observe output when tool_name missing

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1490,7 +1490,7 @@ def cmd_observe(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
             "event_id": event.event_id,
             **payload,
         },
-        f"Observed {payload.get('tool')} -> {run_id} (seq {event.sequence})",
+        f"Observed {payload.get('tool') if payload.get('tool') != 'unknown' else '(no tool name)'} -> {run_id} (seq {event.sequence})",
         as_json=args.json,
         stream=out,
         palette=getattr(args, "_palette", None),


### PR DESCRIPTION
## Description

`continuum observe` printed `Observed unknown` when the payload had no `tool_name`, which looks like a real tool named unknown.

## Related issues

Fixes #362

## Types of changes

- Type: `bugfix`

## Breaking changes

No. Event payload still stores `tool: unknown`, only the human message changes to `Observed (no tool name) -> run`.

## How has this been tested?

- `echo '{}' | continuum observe --run-id r1` now prints `Observed (no tool name) -> r1`
- Valid `tool_name` still prints `Observed Write -> r1`
- `pytest tests/test_cli_observe.py -k 'not test_installed_command_actually_records' --no-cov -q` 14 passed
- `ruff check` clean
