### PR TITLE
fix(cli): add ellipsis when goal truncated in runs and tree

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -285,7 +285,7 @@ def cmd_runs(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
     ]
     lines = [f"{'RUN':<24} {'STATUS':<12} {'EVENTS':>7}  GOAL"]
     lines += [
-        f"{r.run_id:<24} {r.status.value:<12} {storage.last_sequence(r.run_id):>7}  {r.goal[:44]}"
+        f"{r.run_id:<24} {r.status.value:<12} {storage.last_sequence(r.run_id):>7}  {(r.goal[:41] + '...' if len(r.goal) > 44 else r.goal)}"
         for r in runs
     ]
     _emit(
@@ -1149,7 +1149,7 @@ def cmd_tree(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
             mark = "ok " if d.safe else "!! "
             lines.append(
                 f"  {mark}{fork_mark}{child.run_id}  [{d.mode.value}, "
-                f"uncertain={len(d.uncertain_actions)}]  {child.goal[:44]}"
+                f"uncertain={len(d.uncertain_actions)}]  {(child.goal[:41] + '...' if len(child.goal) > 44 else child.goal)}"
             )
         except Exception as exc:
             lines.append(f"  !! {fork_mark}{child.run_id}  [assess error: {exc}]")


### PR DESCRIPTION
## Description

`continuum runs` and `tree` truncated goals to 44 characters with no ellipsis, so a 60 char goal looked complete.

## Related issues

Fixes #359

## Types of changes

- Type: `bugfix`

## Breaking changes

No. JSON output still has the full goal, only the human table now shows `...` when truncated.

## How has this been tested?

- `continuum runs` with a 79 char goal now prints `this is a very long goal that definitely ...`
- Short goals unchanged, no ellipsis
- `continuum runs --json` still has full goal
- `pytest tests/test_cli.py -k 'runs or tree' -q` 4 passed
- `ruff check` clean
