### PR TITLE
feat(recovery): structured attempt memory with falsification lessons (Fixes #313)

### DIFF
--- a/examples/attempt_lesson.py
+++ b/examples/attempt_lesson.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from continuum.events import EventType
 from continuum.models import Run
-from continuum.recovery.summary import build_attempt_lesson, record_attempt_lesson
+from continuum.recovery.summary import record_attempt_lesson
 from continuum.state.semantic import project
 from continuum.storage import SQLiteStorage
 
@@ -41,11 +41,13 @@ def _parent_resume(db_path: str, run_id: str) -> None:
     engine = RecoveryEngine(storage)
     decision = engine.assess(run_id)
     print(f"parent: decision mode={decision.mode}, uncertain={len(decision.uncertain_actions)}")
-    lesson = record_attempt_lesson(storage, run_id, decision, uncertain_actions=decision.uncertain_actions)
+    lesson = record_attempt_lesson(
+        storage, run_id, decision, uncertain_actions=decision.uncertain_actions
+    )
     print(f"parent: recorded lesson {lesson.attempt_id}: {lesson.falsified}")
     state = project(run_id, storage.read_events(run_id))
     assert state.attempt_lessons
-    assert any(l.attempt_id == lesson.attempt_id for l in state.attempt_lessons)
+    assert any(item.attempt_id == lesson.attempt_id for item in state.attempt_lessons)
     print(f"parent: project sees {len(state.attempt_lessons)} lesson(s)")
     from continuum.recovery.summary import render_attempt_lesson
 

--- a/examples/attempt_lesson.py
+++ b/examples/attempt_lesson.py
@@ -1,0 +1,73 @@
+"""Attempt lesson example: hard kill mid-action, resume sees lesson.
+
+Run this example directly: it will fork a subprocess that crashes with
+os._exit(137) mid-action, then the parent resumes and asserts the new session
+receives an AttemptLesson without reading the prior transcript.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.recovery.summary import build_attempt_lesson, record_attempt_lesson
+from continuum.state.semantic import project
+from continuum.storage import SQLiteStorage
+
+
+def _child_crash(db_path: str, run_id: str) -> None:
+    """Child process: claim an action then hard-kill before completion."""
+    from continuum.actions import ActionLedger
+
+    storage = SQLiteStorage(db_path)
+    storage.create_run(Run(run_id=run_id, goal="example goal: process mid-action crash"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "example goal"})
+    ledger = ActionLedger(storage, run_id)
+    outcome = ledger.claim("example.action", {"resource": "r1"}, key="k1")
+    print(f"child: claimed {outcome.action.action_id}, now hard-killing", flush=True)
+    os._exit(137)
+
+
+def _parent_resume(db_path: str, run_id: str) -> None:
+    """Parent: assess, repair, and verify lesson."""
+    from continuum.recovery.engine import RecoveryEngine
+
+    storage = SQLiteStorage(db_path)
+    engine = RecoveryEngine(storage)
+    decision = engine.assess(run_id)
+    print(f"parent: decision mode={decision.mode}, uncertain={len(decision.uncertain_actions)}")
+    lesson = record_attempt_lesson(storage, run_id, decision, uncertain_actions=decision.uncertain_actions)
+    print(f"parent: recorded lesson {lesson.attempt_id}: {lesson.falsified}")
+    state = project(run_id, storage.read_events(run_id))
+    assert state.attempt_lessons
+    assert any(l.attempt_id == lesson.attempt_id for l in state.attempt_lessons)
+    print(f"parent: project sees {len(state.attempt_lessons)} lesson(s)")
+    from continuum.recovery.summary import render_attempt_lesson
+
+    for line in render_attempt_lesson(state.attempt_lessons[0]):
+        print(f"  briefing: {line}")
+    print("example: PASS - resumed session sees lesson without transcript")
+    storage.close()
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = str(Path(tmp) / "example.db")
+        run_id = "run_lesson_example"
+        proc = subprocess.Popen([sys.executable, __file__, "--child", db_path, run_id])
+        proc.wait()
+        print(f"child exited with {proc.returncode} (expected 137 for hard kill)")
+        assert proc.returncode == 137
+        _parent_resume(db_path, run_id)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--child":
+        _child_crash(sys.argv[2], sys.argv[3])
+    else:
+        main()

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -471,6 +471,12 @@ def cmd_inspect(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
             lines.append(f"  - {pp.step_id}: {pp.description} [{pp.status.value}]{deps}")
     else:
         lines.append("plan:       (none)")
+    if state.attempt_lessons:
+        lines.append(f"lessons:   {len(state.attempt_lessons)}")
+        for lesson in state.attempt_lessons:
+            lines.append(f"  - {lesson.attempt_id}: {lesson.falsified[:80]}")
+            if lesson.next_avoid:
+                lines.append(f"    avoid: {lesson.next_avoid}")
     if state.external_dependencies:
         lines.append("dependencies:")
         lines += [
@@ -939,6 +945,9 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         "children": [c.__dict__ for c in child_statuses],
         "pinning_drift": drift_lines,
         "informed_retry": decision.informed_retry,
+        "attempt_lessons": [
+            lesson.model_dump(mode="json") for lesson in decision.state.attempt_lessons
+        ],
         "contract": decision.contract.model_dump(mode="json"),
         "repairs": [s.action_name for s in decision.plan.steps],
         "progress": {
@@ -972,6 +981,13 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
                 "plan": [step.model_dump() for step in decision.plan.steps],
             },
         )
+        # Structured attempt memory (issue #313): one lesson per repair, deterministic.
+        try:
+            from continuum.recovery.summary import record_attempt_lesson
+
+            record_attempt_lesson(storage, run_id, decision)
+        except Exception:
+            pass
         print(
             f"\nRepair plan recorded ({len(decision.plan.steps)} step(s)). "
             f"Rerun resume to confirm progress.",
@@ -1629,6 +1645,13 @@ def cmd_briefing(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
 
         lines.append("what previous attempts changed (engine-recorded):")
         lines += [f"  {line}" for line in render_informed_retry(decision.informed_retry)]
+    # Structured attempt memory (issue #313): after verified state before open questions.
+    if state.attempt_lessons:
+        from continuum.recovery.summary import render_attempt_lesson
+
+        lines.append("attempt lessons (system-derived):")
+        for lesson in state.attempt_lessons:
+            lines += [f"  {line}" for line in render_attempt_lesson(lesson)]
     if steps:
         lines.append("next steps:")
         lines += [f"  {i}. {t}" for i, t in enumerate(steps, 1)]
@@ -1642,6 +1665,7 @@ def cmd_briefing(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
             "safe": decision.safe,
             "context": context,
             "human_steps": steps,
+            "attempt_lessons": [lesson.model_dump(mode="json") for lesson in state.attempt_lessons],
             "hookSpecificOutput": {
                 "hookEventName": args.hook_event_name,
                 "additionalContext": context,

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -1089,6 +1089,9 @@ def build_server(
                 },
                 "tail_evidence": tail_evidence,
                 "informed_retry": decision.informed_retry,
+                "attempt_lessons": [
+                    lesson.model_dump(mode="json") for lesson in decision.state.attempt_lessons
+                ],
                 "contract": decision.contract.model_dump(mode="json"),
                 "contract_text": render_contract(decision.contract),
                 "report": decision.render(),

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -50,6 +50,7 @@ __all__ = [
     "ConstraintPinned",
     "ConstraintRetracted",
     "ConstraintPin",
+    "AttemptLesson",
     "ModelSpecificState",
     "ModelState",
     "Run",
@@ -493,6 +494,43 @@ class ConstraintPin(BaseModel):
         return value
 
 
+class AttemptLesson(BaseModel):
+    """Durable lesson from a failed attempt (issue #313).
+
+    System-derived from RecoveryDecision.rationale, RecoveryLedger and
+    ActionLedger, never from LLM. Bounded to 512 chars per field and 2KB
+    total so it survives as an artifact without becoming a transcript dump.
+    Origin.DETERMINISTIC, hash-chained via ATTEMPT_LESSON event.
+    """
+
+    model_config = Frozen
+
+    attempt_id: str = Field(min_length=1)
+    falsified: str = Field(default="")
+    env_delta: str = Field(default="")
+    scar_action_ids: list[str] = Field(default_factory=list)
+    next_avoid: str = Field(default="")
+    source_evidence: list[str] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=utcnow)
+
+    @field_validator("falsified", "env_delta", "next_avoid")
+    @classmethod
+    def _field_bounded(cls, value: str) -> str:
+        if len(value) > 512:
+            return value[:512]
+        return value
+
+    @field_validator("source_evidence")
+    @classmethod
+    def _evidence_bounded(cls, value: list[str]) -> list[str]:
+        return [str(v)[:512] for v in value]
+
+    @field_validator("scar_action_ids")
+    @classmethod
+    def _scar_bounded(cls, value: list[str]) -> list[str]:
+        return [str(v) for v in value]
+
+
 class ModelSpecificState(BaseModel):
     """An assumption tied to a specific model; switching models must revalidate."""
 
@@ -548,6 +586,8 @@ class SemanticState(BaseModel):
     is noted here so the operator can see a mismatch without the fold
     guessing whether the pin lived in an archived prefix or never existed.
     """
+    attempt_lessons: list[AttemptLesson] = Field(default_factory=list)
+    """Structured lessons from failed attempts (issue #313), sorted by created_at."""
     model: ModelState | None = None
     version: int = 0
     source_sequence: int = 0

--- a/src/continuum/recovery/fork.py
+++ b/src/continuum/recovery/fork.py
@@ -218,4 +218,58 @@ def approve_fork(
         payload,
         source=Origin.HUMAN,
     )
+    try:
+        from continuum.models import AttemptLesson
+        from continuum.recovery.summary import ATTEMPT_LESSON_FIELD_CAP
+        from continuum.security.hashing import stable_hash
+
+        def _trunc(text: str) -> str:
+            return text[:ATTEMPT_LESSON_FIELD_CAP] if len(text) > ATTEMPT_LESSON_FIELD_CAP else text
+
+        scar_ids = [str(item.get("action_id", "")) for item in summary.get("uncertain_slots", [])]
+        scar_ids = [sid for sid in scar_ids if sid][:16]
+        evidence: list[str] = []
+        for item in summary.get("unsettled_authorizations", []):
+            evidence.append(f"{item.get('approval_id', '')}: {item.get('subject', '')}".strip(": "))
+        for item in summary.get("depended_results", []):
+            evidence.append(f"{item.get('action_id', '')} ({item.get('key', '')})")
+        evidence = [_trunc(str(ev)) for ev in evidence if ev][:8]
+        attempt_id = stable_hash(
+            {"parent": parent_run_id, "child": child.run_id, "divergence": divergence}
+        )[:16]
+        lesson = AttemptLesson(
+            attempt_id=_trunc(attempt_id),
+            falsified=_trunc(reason.strip()),
+            env_delta="",
+            scar_action_ids=scar_ids,
+            next_avoid="",
+            source_evidence=evidence,
+            created_at=storage.get_run(parent_run_id).updated_at,
+        )
+        import json as _json
+
+        while len(_json.dumps(lesson.model_dump(mode="json"), sort_keys=True).encode()) > 2048:
+            if lesson.source_evidence:
+                lesson = lesson.model_copy(update={"source_evidence": lesson.source_evidence[:-1]})
+                continue
+            if lesson.falsified:
+                lesson = lesson.model_copy(
+                    update={"falsified": lesson.falsified[: max(len(lesson.falsified) // 2, 0)]}
+                )
+                continue
+            break
+        storage.append_event(
+            parent_run_id,
+            EventType.ATTEMPT_LESSON,
+            lesson.model_dump(mode="json"),
+            source=Origin.DETERMINISTIC,
+        )
+        storage.append_event(
+            child.run_id,
+            EventType.ATTEMPT_LESSON,
+            lesson.model_dump(mode="json"),
+            source=Origin.DETERMINISTIC,
+        )
+    except Exception:
+        pass
     return child

--- a/src/continuum/recovery/summary.py
+++ b/src/continuum/recovery/summary.py
@@ -45,13 +45,22 @@ if TYPE_CHECKING:
 
 __all__ = [
     "INFORMED_RETRY_CAP_BYTES",
+    "ATTEMPT_LESSON_FIELD_CAP",
+    "ATTEMPT_LESSON_TOTAL_CAP",
     "build_informed_retry",
     "render_informed_retry",
+    "build_attempt_lesson",
+    "render_attempt_lesson",
+    "record_attempt_lesson",
 ]
 
 #: Serialized blocks larger than this are shrunk deterministically rather
 #: than allowed to grow with run history (same spirit as the #235 cap).
 INFORMED_RETRY_CAP_BYTES = 4096
+
+#: Per-field cap for AttemptLesson (issue #313) - 512 chars per field, 2KB total.
+ATTEMPT_LESSON_FIELD_CAP = 512
+ATTEMPT_LESSON_TOTAL_CAP = 2048
 
 _MAX_STEPS = 8
 _MAX_SETTLED = 5
@@ -216,6 +225,164 @@ def _derived_label(block: dict[str, Any]) -> str | None:
     if origin.self_certified:
         return f"unverified (derived from {origin.value})"
     return f"derived from {origin.value}"
+
+
+def _truncate(text: str, cap: int = ATTEMPT_LESSON_FIELD_CAP) -> str:
+    if len(text) <= cap:
+        return text
+    return text[:cap]
+
+
+def _lesson_total_bytes(lesson: Any) -> int:
+    import json
+
+    return len(json.dumps(lesson.model_dump(mode="json"), sort_keys=True).encode())
+
+
+def build_attempt_lesson(
+    decision: Any,
+    *,
+    uncertain_actions: Any | None = None,
+    ledger_entries: Any | None = None,
+    now: Any | None = None,
+) -> Any:
+    from continuum.security.hashing import stable_hash
+
+    run_id = getattr(decision, "run_id", "unknown")
+    rationale = list(getattr(decision, "rationale", []) or [])
+    scars = (
+        uncertain_actions
+        if uncertain_actions is not None
+        else getattr(decision, "uncertain_actions", [])
+    )
+    scars = list(scars or [])
+    validation = getattr(decision, "validation", None)
+    report = getattr(validation, "report", None) if validation else None
+    statuses = list(getattr(report, "statuses", []) or []) if report else []
+    source_evidence = [
+        str(getattr(entry, "detail", "") or "")
+        for entry in statuses
+        if getattr(entry, "detail", "")
+    ]
+    source_evidence = [s for s in source_evidence if s]
+    falsified_raw = str(rationale[0]) if rationale else "attempt did not achieve its goal"
+    falsified = _truncate(falsified_raw.strip(), ATTEMPT_LESSON_FIELD_CAP)
+    env_delta = ""
+    for entry in statuses:
+        component = getattr(getattr(entry, "component", None), "value", "")
+        if component == "external_dependency":
+            env_delta = _truncate(str(getattr(entry, "detail", "") or ""), ATTEMPT_LESSON_FIELD_CAP)
+            break
+    if not env_delta:
+        for entry in statuses:
+            detail = str(getattr(entry, "detail", "") or "")
+            if detail:
+                env_delta = _truncate(detail, ATTEMPT_LESSON_FIELD_CAP)
+                break
+    scar_ids = [str(getattr(action, "action_id", "") or "") for action in scars]
+    scar_ids = [sid for sid in scar_ids if sid]
+    from continuum.recovery.summary import _avoid_rules
+
+    avoid_rules = _avoid_rules(statuses, scars)
+    next_avoid = _truncate(str(avoid_rules[0]) if avoid_rules else "", ATTEMPT_LESSON_FIELD_CAP)
+    source_evidence = [_truncate(str(s), ATTEMPT_LESSON_FIELD_CAP) for s in source_evidence[:8]]
+    ledger_len = len(list(ledger_entries or []))
+    attempt_id_raw = stable_hash(
+        {
+            "run_id": str(run_id),
+            "rationale": sorted(rationale),
+            "scars": sorted(scar_ids),
+            "ledger_len": ledger_len,
+        }
+    )
+    attempt_id = _truncate(attempt_id_raw[:16], ATTEMPT_LESSON_FIELD_CAP)
+    if not attempt_id:
+        attempt_id = "attempt_1"
+    created = (
+        now if now is not None else __import__("continuum.models", fromlist=["utcnow"]).utcnow()
+    )
+    lesson = __import__("continuum.models", fromlist=["AttemptLesson"]).AttemptLesson(
+        attempt_id=attempt_id,
+        falsified=falsified,
+        env_delta=env_delta,
+        scar_action_ids=scar_ids[:16],
+        next_avoid=next_avoid,
+        source_evidence=source_evidence,
+        created_at=created,
+    )
+    while _lesson_total_bytes(lesson) > 2048:
+        fields = ["falsified", "env_delta", "next_avoid"]
+        largest = max(fields, key=lambda name: len(getattr(lesson, name)))
+        current = getattr(lesson, largest)
+        if not current:
+            if lesson.source_evidence:
+                trimmed = list(lesson.source_evidence)
+                trimmed = (
+                    trimmed[:-1]
+                    if len(trimmed) > 1
+                    else [trimmed[0][: max(len(trimmed[0]) // 2, 0)]]
+                )
+                lesson = lesson.model_copy(update={"source_evidence": trimmed})
+                continue
+            break
+        truncated = current[: max(len(current) // 2, 0)]
+        lesson = lesson.model_copy(update={largest: truncated})
+        if _lesson_total_bytes(lesson) <= 2048:
+            break
+        if all(len(getattr(lesson, name)) == 0 for name in fields) and not lesson.source_evidence:
+            break
+    return lesson
+
+
+def render_attempt_lesson(lesson: Any) -> list[str]:
+    if isinstance(lesson, dict):
+        attempt_id = str(lesson.get("attempt_id", ""))
+        falsified = str(lesson.get("falsified", ""))
+        env_delta = str(lesson.get("env_delta", ""))
+        scars = list(lesson.get("scar_action_ids", []) or [])
+        next_avoid = str(lesson.get("next_avoid", ""))
+        evidence = list(lesson.get("source_evidence", []) or [])
+    else:
+        attempt_id = str(getattr(lesson, "attempt_id", ""))
+        falsified = str(getattr(lesson, "falsified", ""))
+        env_delta = str(getattr(lesson, "env_delta", ""))
+        scars = list(getattr(lesson, "scar_action_ids", []) or [])
+        next_avoid = str(getattr(lesson, "next_avoid", ""))
+        evidence = list(getattr(lesson, "source_evidence", []) or [])
+    lines = []
+    if attempt_id:
+        lines.append(f"attempt {attempt_id}: {falsified}" if falsified else f"attempt {attempt_id}")
+    elif falsified:
+        lines.append(f"falsified: {falsified}")
+    if env_delta:
+        lines.append(f"env delta: {env_delta}")
+    if scars:
+        lines.append(f"scar actions: {', '.join(scars[:5])}")
+    if next_avoid:
+        lines.append(f"next avoid: {next_avoid}")
+    for ev in evidence[:3]:
+        lines.append(f"evidence: {ev}")
+    return lines
+
+
+def record_attempt_lesson(
+    storage: Any,
+    run_id: str,
+    decision: Any,
+    *,
+    uncertain_actions: Any | None = None,
+    ledger_entries: Any | None = None,
+) -> Any:
+    lesson = build_attempt_lesson(
+        decision, uncertain_actions=uncertain_actions, ledger_entries=ledger_entries
+    )
+    storage.append_event(
+        run_id,
+        __import__("continuum.events", fromlist=["EventType"]).EventType.ATTEMPT_LESSON,
+        lesson.model_dump(mode="json"),
+        source=__import__("continuum.models", fromlist=["Origin"]).Origin.DETERMINISTIC,
+    )
+    return lesson
 
 
 def render_informed_retry(block: dict[str, Any]) -> list[str]:

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -413,6 +413,9 @@ def _decision_payload(decision: Any, *, goal: str) -> dict[str, Any]:
         },
         "tail_evidence": decision.tail_evidence,
         "informed_retry": getattr(decision, "informed_retry", None),
+        "attempt_lessons": [
+            lesson.model_dump(mode="json") for lesson in decision.state.attempt_lessons
+        ],
         "contract": decision.contract.model_dump(mode="json"),
         "contract_text": render_contract(decision.contract),
         "report": decision.render(),

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -32,6 +32,7 @@ from continuum.events import Event, EventType
 from continuum.models import (
     Approval,
     ApprovalStatus,
+    AttemptLesson,
     ConstraintPin,
     ConstraintPinned,
     ConstraintRetracted,
@@ -154,6 +155,9 @@ class _Accumulator:
         self.pins: dict[str, ConstraintPin] = dict(base.pins) if base else {}
         self.unmatched_pin_retractions: list[str] = (
             list(base.unmatched_pin_retractions) if base else []
+        )
+        self.attempt_lessons: list[AttemptLesson] = (
+            list(base.attempt_lessons) if base and base.attempt_lessons else []
         )
         self.model: ModelState | None = base.model if base else None
         self.created_at: datetime | None = base.created_at if base else None
@@ -432,6 +436,13 @@ class _Accumulator:
             if constraint_id not in self.unmatched_pin_retractions:
                 self.unmatched_pin_retractions.append(constraint_id)
 
+    def attempt_lesson(self, event: Event) -> None:
+        lesson = AttemptLesson.model_validate(event.payload)
+        if any(existing.attempt_id == lesson.attempt_id for existing in self.attempt_lessons):
+            return
+        self.attempt_lessons.append(lesson)
+        self.attempt_lessons.sort(key=lambda existing: existing.created_at)
+
     def plan_upsert(self, event: Event) -> None:
         payload = event.payload
         plan_id = payload.get("plan_id")
@@ -541,6 +552,7 @@ class _Accumulator:
             external_dependencies=self.dependencies,
             pins=dict(self.pins),
             unmatched_pin_retractions=list(self.unmatched_pin_retractions),
+            attempt_lessons=list(self.attempt_lessons),
             model=self.model,
             version=self.version,
             source_sequence=self.source_sequence,
@@ -590,6 +602,8 @@ def _dispatch(acc: _Accumulator, event: Event) -> bool:
             acc.constraint_pinned(event)
         case EventType.CONSTRAINT_RETRACTED:
             acc.constraint_retracted(event)
+        case EventType.ATTEMPT_LESSON:
+            acc.attempt_lesson(event)
         case EventType.PLAN_UPSERT:
             acc.plan_upsert(event)
         case _:

--- a/tests/test_attempt_lesson.py
+++ b/tests/test_attempt_lesson.py
@@ -1,0 +1,503 @@
+"""Structured attempt memory with falsification lessons (issue #313)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from continuum.events import EventType
+from continuum.interchange import export_semantic_state, import_semantic_state
+from continuum.models import AttemptLesson, Origin, Run
+from continuum.recovery.summary import build_attempt_lesson
+from continuum.state.semantic import project
+from continuum.storage import SQLiteStorage
+
+
+def _make_storage() -> SQLiteStorage:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_1", goal="g"))
+    storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    return storage
+
+
+def test_derivation_from_synthetic_repair_decision_yields_one_lesson() -> None:
+    """Falsified from rationale, scars from uncertain actions."""
+    from continuum.checkpoint.manager import RestoredRun
+    from continuum.models import (
+        Component,
+        ComponentValidationEntry,
+        RecoveryContract,
+        RecoverySafety,
+        StateStatus,
+        StateValidationResult,
+    )
+    from continuum.recovery.engine import RecoveryDecision
+    from continuum.recovery.planner import RepairPlan
+
+    storage = _make_storage()
+    try:
+        from continuum.actions import ActionLedger
+
+        ledger = ActionLedger(storage, "run_1")
+        ledger.claim("test.action", {"x": 1}, key="k1")
+        uncertain = ledger.pending()
+        assert len(uncertain) == 1
+
+        state = project("run_1", storage.read_events("run_1"))
+        report = StateValidationResult(
+            run_id="run_1",
+            statuses=[
+                ComponentValidationEntry(
+                    component=Component.EXTERNAL_DEPENDENCY,
+                    component_id="db",
+                    status=StateStatus.STALE,
+                    detail="db v1 -> v2",
+                ),
+            ],
+            safe_to_resume=False,
+            reason="db stale",
+        )
+        from continuum.environment.diff import EnvironmentDiff
+        from continuum.state.validator import ValidationOutcome
+
+        validation = ValidationOutcome(
+            state=state, report=report, environment_diff=EnvironmentDiff()
+        )
+        contract = RecoveryContract(
+            run_id="run_1",
+            checkpoint_version=0,
+            recovery_status=RecoverySafety.REQUIRES_REPAIR,
+            verified=[],
+            invalidated=[],
+            required_actions=[],
+        )
+        restored = RestoredRun(
+            run_id="run_1", state=state, checkpoint=None, pending_events=0, replayed=False
+        )
+        decision = RecoveryDecision(
+            run_id="run_1",
+            mode="repair_and_resume",  # type: ignore[arg-type]
+            contract=contract,
+            plan=RepairPlan(steps=[]),
+            validation=validation,
+            restored=restored,
+            uncertain_actions=tuple(uncertain),
+            rationale=("db v1 -> v2 is stale", "1 external side effect(s) have unknown outcomes"),
+        )
+        lesson = build_attempt_lesson(decision, uncertain_actions=uncertain)
+        assert lesson.falsified == "db v1 -> v2 is stale"
+        assert lesson.scar_action_ids == [uncertain[0].action_id]
+        assert "db v1 -> v2" in lesson.env_delta or "db" in lesson.env_delta
+        assert lesson.source_evidence
+        assert lesson.next_avoid
+        assert len(lesson.falsified) <= 512
+        assert lesson.attempt_id
+    finally:
+        storage.close()
+
+
+def test_lesson_is_hash_chained_and_verify_detects_tampering() -> None:
+    storage = _make_storage()
+    try:
+        from continuum.recovery.engine import RecoveryEngine
+        from continuum.recovery.summary import record_attempt_lesson
+
+        engine = RecoveryEngine(storage)
+        from continuum.environment import StaticProvider, capture
+
+        provider = StaticProvider(db="v2")
+        snap = capture("run_1", provider)
+        decision = engine.assess("run_1", current_environment=snap)
+        lesson = record_attempt_lesson(
+            storage, "run_1", decision, uncertain_actions=decision.uncertain_actions
+        )
+        assert lesson.falsified
+
+        report = storage.verify_events("run_1")
+        assert report.ok
+        assert report.trusted_through["run_1"] == storage.last_sequence("run_1")
+
+        events = list(storage.read_events("run_1"))
+        tampered = None
+        for ev in events:
+            if ev.type == EventType.ATTEMPT_LESSON:
+                tampered = ev
+                break
+        assert tampered is not None
+        bad = tampered.model_copy(
+            update={
+                "payload": {
+                    "falsified": "hacked",
+                    "attempt_id": "x",
+                    "created_at": tampered.payload.get("created_at", ""),
+                }
+            }
+        )
+        from continuum.events import AppendOnlyViolation, EventLog
+
+        log = EventLog()
+        try:
+            for e in events:
+                if e.event_id == tampered.event_id:
+                    log.extend([bad])
+                else:
+                    log.extend([e])
+            rep = log.verify("run_1")
+            assert not rep.ok
+            assert any(v.kind == "TAMPERED_CONTENT" for v in rep.violations)
+        except AppendOnlyViolation as exc:
+            assert "hash does not match content" in str(exc).lower()
+    finally:
+        storage.close()
+
+
+def test_project_with_no_lesson_events_yields_empty() -> None:
+    storage = _make_storage()
+    try:
+        state = project("run_1", storage.read_events("run_1"))
+        assert state.attempt_lessons == []
+        assert hasattr(state, "attempt_lessons")
+    finally:
+        storage.close()
+
+
+def test_interchange_round_trip_preserves_lessons() -> None:
+    storage = _make_storage()
+    try:
+        from continuum.checkpoint.manager import RestoredRun
+        from continuum.environment.diff import EnvironmentDiff
+        from continuum.models import (
+            Component,
+            ComponentValidationEntry,
+            RecoveryContract,
+            RecoverySafety,
+            StateStatus,
+            StateValidationResult,
+        )
+        from continuum.recovery.engine import RecoveryDecision
+        from continuum.recovery.planner import RepairPlan
+        from continuum.recovery.summary import record_attempt_lesson
+        from continuum.state.validator import ValidationOutcome
+
+        state_before = project("run_1", storage.read_events("run_1"))
+        report = StateValidationResult(
+            run_id="run_1",
+            statuses=[
+                ComponentValidationEntry(
+                    component=Component.GOAL, status=StateStatus.STALE, detail="goal stale"
+                )
+            ],
+            safe_to_resume=False,
+            reason="goal stale",
+        )
+        validation = ValidationOutcome(
+            state=state_before, report=report, environment_diff=EnvironmentDiff()
+        )
+        contract = RecoveryContract(
+            run_id="run_1",
+            checkpoint_version=0,
+            recovery_status=RecoverySafety.REQUIRES_REPAIR,
+            verified=[],
+            invalidated=[],
+            required_actions=[],
+        )
+        restored = RestoredRun(
+            run_id="run_1", state=state_before, checkpoint=None, pending_events=0, replayed=False
+        )
+        decision = RecoveryDecision(
+            run_id="run_1",
+            mode="repair_and_resume",  # type: ignore[arg-type]
+            contract=contract,
+            plan=RepairPlan(steps=[]),
+            validation=validation,
+            restored=restored,
+            uncertain_actions=(),
+            rationale=("goal stale",),
+        )
+        lesson = record_attempt_lesson(storage, "run_1", decision)
+        state_after = project("run_1", storage.read_events("run_1"))
+        assert len(state_after.attempt_lessons) == 1
+        payload = export_semantic_state(state_after)
+        imported = import_semantic_state(payload)
+        assert imported.attempt_lessons == state_after.attempt_lessons
+        assert imported.attempt_lessons[0].falsified == lesson.falsified
+    finally:
+        storage.close()
+
+
+def test_lesson_survives_compaction() -> None:
+    storage = SQLiteStorage(":memory:")
+    try:
+        storage.create_run(Run(run_id="run_1", goal="g"))
+        storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        from continuum.checkpoint.manager import CheckpointManager
+
+        manager = CheckpointManager(storage)
+        manager.checkpoint("run_1")
+        from continuum.checkpoint.manager import RestoredRun
+        from continuum.environment.diff import EnvironmentDiff
+        from continuum.models import (
+            Component,
+            ComponentValidationEntry,
+            RecoveryContract,
+            RecoverySafety,
+            StateStatus,
+            StateValidationResult,
+        )
+        from continuum.recovery.engine import RecoveryDecision
+        from continuum.recovery.planner import RepairPlan
+        from continuum.recovery.summary import record_attempt_lesson
+        from continuum.state.validator import ValidationOutcome
+
+        state = project("run_1", storage.read_events("run_1"))
+        report = StateValidationResult(
+            run_id="run_1",
+            statuses=[
+                ComponentValidationEntry(
+                    component=Component.EXTERNAL_DEPENDENCY,
+                    status=StateStatus.STALE,
+                    detail="dep stale",
+                )
+            ],
+            safe_to_resume=False,
+            reason="dep stale",
+        )
+        validation = ValidationOutcome(
+            state=state, report=report, environment_diff=EnvironmentDiff()
+        )
+        contract = RecoveryContract(
+            run_id="run_1",
+            checkpoint_version=0,
+            recovery_status=RecoverySafety.REQUIRES_REPAIR,
+            verified=[],
+            invalidated=[],
+            required_actions=[],
+        )
+        restored = RestoredRun(
+            run_id="run_1", state=state, checkpoint=None, pending_events=0, replayed=False
+        )
+        decision = RecoveryDecision(
+            run_id="run_1",
+            mode="repair_and_resume",  # type: ignore[arg-type]
+            contract=contract,
+            plan=RepairPlan(steps=[]),
+            validation=validation,
+            restored=restored,
+            uncertain_actions=(),
+            rationale=("dep stale",),
+        )
+        lesson = record_attempt_lesson(storage, "run_1", decision)
+        assert storage.supports_compaction
+        report2 = storage.compact_run("run_1")
+        assert report2["archived"] >= 0
+        all_events = list(storage.read_archived_events("run_1")) + list(
+            storage.read_events("run_1")
+        )
+        state2 = project("run_1", all_events)
+        assert any(
+            lesson.attempt_id == lesson_item.attempt_id for lesson_item in state2.attempt_lessons
+        )
+        restored2 = manager.restore("run_1")
+        assert any(
+            lesson.attempt_id == lesson_item.attempt_id
+            for lesson_item in restored2.state.attempt_lessons
+        )
+    finally:
+        storage.close()
+
+
+def test_lesson_size_bounded() -> None:
+    from continuum.checkpoint.manager import RestoredRun
+    from continuum.environment.diff import EnvironmentDiff
+    from continuum.models import (
+        Component,
+        ComponentValidationEntry,
+        RecoveryContract,
+        RecoverySafety,
+        StateStatus,
+        StateValidationResult,
+    )
+    from continuum.recovery.engine import RecoveryDecision
+    from continuum.recovery.planner import RepairPlan
+    from continuum.recovery.summary import build_attempt_lesson
+    from continuum.state.validator import ValidationOutcome
+
+    storage = _make_storage()
+    try:
+        state = project("run_1", storage.read_events("run_1"))
+        oversize = "x" * 1000
+        report = StateValidationResult(
+            run_id="run_1",
+            statuses=[
+                ComponentValidationEntry(
+                    component=Component.GOAL, status=StateStatus.STALE, detail=oversize
+                )
+            ],
+            safe_to_resume=False,
+            reason=oversize,
+        )
+        validation = ValidationOutcome(
+            state=state, report=report, environment_diff=EnvironmentDiff()
+        )
+        contract = RecoveryContract(
+            run_id="run_1",
+            checkpoint_version=0,
+            recovery_status=RecoverySafety.REQUIRES_REPAIR,
+            verified=[],
+            invalidated=[],
+            required_actions=[],
+        )
+        restored = RestoredRun(
+            run_id="run_1", state=state, checkpoint=None, pending_events=0, replayed=False
+        )
+        decision = RecoveryDecision(
+            run_id="run_1",
+            mode="repair_and_resume",  # type: ignore[arg-type]
+            contract=contract,
+            plan=RepairPlan(steps=[]),
+            validation=validation,
+            restored=restored,
+            uncertain_actions=(),
+            rationale=(oversize, oversize),
+        )
+        lesson = build_attempt_lesson(decision)
+        assert len(lesson.falsified) <= 512
+        assert len(lesson.env_delta) <= 512
+        assert len(lesson.next_avoid) <= 512
+        for ev in lesson.source_evidence:
+            assert len(ev) <= 512
+        total = len(json.dumps(lesson.model_dump(mode="json"), sort_keys=True).encode())
+        assert total <= 2048
+    finally:
+        storage.close()
+
+
+def test_briefing_includes_lessons_and_excludes_raw_tail(tmp_path=None) -> None:
+    from continuum.state.semantic import project
+
+    storage = SQLiteStorage(":memory:")
+    try:
+        storage.create_run(Run(run_id="run_1", goal="g"))
+        storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        from continuum.checkpoint.manager import RestoredRun
+        from continuum.environment.diff import EnvironmentDiff
+        from continuum.models import (
+            Component,
+            ComponentValidationEntry,
+            RecoveryContract,
+            RecoverySafety,
+            StateStatus,
+            StateValidationResult,
+        )
+        from continuum.recovery.engine import RecoveryDecision
+        from continuum.recovery.planner import RepairPlan
+        from continuum.recovery.summary import record_attempt_lesson
+        from continuum.state.validator import ValidationOutcome
+
+        state = project("run_1", storage.read_events("run_1"))
+        report = StateValidationResult(
+            run_id="run_1",
+            statuses=[
+                ComponentValidationEntry(
+                    component=Component.GOAL, status=StateStatus.STALE, detail="goal stale"
+                )
+            ],
+            safe_to_resume=False,
+            reason="goal stale",
+        )
+        validation = ValidationOutcome(
+            state=state, report=report, environment_diff=EnvironmentDiff()
+        )
+        contract = RecoveryContract(
+            run_id="run_1",
+            checkpoint_version=0,
+            recovery_status=RecoverySafety.REQUIRES_REPAIR,
+            verified=[],
+            invalidated=[],
+            required_actions=[],
+        )
+        restored = RestoredRun(
+            run_id="run_1", state=state, checkpoint=None, pending_events=0, replayed=False
+        )
+        decision = RecoveryDecision(
+            run_id="run_1",
+            mode="repair_and_resume",  # type: ignore[arg-type]
+            contract=contract,
+            plan=RepairPlan(steps=[]),
+            validation=validation,
+            restored=restored,
+            uncertain_actions=(),
+            rationale=("goal stale",),
+        )
+        lesson = record_attempt_lesson(storage, "run_1", decision)
+        storage.append_event(
+            "run_1",
+            EventType.EVIDENCE_ADDED,
+            {
+                "evidence_id": "tail_1",
+                "summary": "Traceback: raw error tail that should be excluded",
+                "status": "valid",
+            },
+        )
+        state2 = project("run_1", storage.read_events("run_1"))
+        assert any(
+            lesson_item.attempt_id == lesson.attempt_id for lesson_item in state2.attempt_lessons
+        )
+        from continuum.recovery.engine import RecoveryEngine
+
+        decision2 = RecoveryEngine(storage).assess("run_1")
+        assert decision2.state.attempt_lessons
+        from continuum.recovery.summary import render_attempt_lesson
+
+        lines = render_attempt_lesson(decision2.state.attempt_lessons[0])
+        assert any("falsified" in line or lesson.falsified[:20] in line for line in lines)
+        for line in lines:
+            assert "Traceback" not in line
+    finally:
+        storage.close()
+
+
+def test_property_ordering_deterministic_by_created_at() -> None:
+
+    storage = SQLiteStorage(":memory:")
+    try:
+        storage.create_run(Run(run_id="run_1", goal="g"))
+        storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        base_time = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        lessons = [
+            AttemptLesson(
+                attempt_id="a2", falsified="second", created_at=base_time + timedelta(seconds=10)
+            ),
+            AttemptLesson(attempt_id="a1", falsified="first", created_at=base_time),
+            AttemptLesson(
+                attempt_id="a3", falsified="third", created_at=base_time + timedelta(seconds=20)
+            ),
+        ]
+        for lesson in lessons:
+            storage.append_event(
+                "run_1",
+                EventType.ATTEMPT_LESSON,
+                lesson.model_dump(mode="json"),
+                source=Origin.DETERMINISTIC,
+            )
+        state = project("run_1", storage.read_events("run_1"))
+        ids = [lesson.attempt_id for lesson in state.attempt_lessons]
+        assert ids == ["a1", "a2", "a3"]
+        state2 = project("run_1", storage.read_events("run_1"))
+        assert [lesson_item.attempt_id for lesson_item in state2.attempt_lessons] == ids
+        dup = AttemptLesson(
+            attempt_id="a1", falsified="duplicate", created_at=base_time + timedelta(seconds=30)
+        )
+        storage.append_event(
+            "run_1",
+            EventType.ATTEMPT_LESSON,
+            dup.model_dump(mode="json"),
+            source=Origin.DETERMINISTIC,
+        )
+        state3 = project("run_1", storage.read_events("run_1"))
+        a1 = next(
+            lesson_item for lesson_item in state3.attempt_lessons if lesson_item.attempt_id == "a1"
+        )
+        assert a1.falsified == "first"
+    finally:
+        storage.close()

--- a/tests/test_fork.py
+++ b/tests/test_fork.py
@@ -167,8 +167,9 @@ def test_fork_child_is_independently_resumable(db: str) -> None:
         child = approve_fork(store, "run_1", reason="new terms")
         # The child's own log is startable with no help from this test.
         events = store.read_events(child.run_id)
-        assert [e.type for e in events] == [EventType.RUN_STARTED]
+        assert events[0].type == EventType.RUN_STARTED
         assert events[0].source is Origin.HUMAN
+        assert all(e.type in (EventType.RUN_STARTED, EventType.ATTEMPT_LESSON) for e in events)
 
     code, out, _ = run("--db", db, "resume", child.run_id)
     # Resume reaches its own verdict about the CHILD, independent of the parent.


### PR DESCRIPTION
## Description

Add AttemptLesson as durable artifact carried on fork and repair so a fresh session resumes with what was falsified, not the raw error tail. Cherry-picked from local feat/recovery-attempt-memory-313 at b0b799d (correct 883 insertions) onto current origin/main (182e9dc). This supersedes PR #487 which is CONFLICTING because remote feat/recovery-attempt-memory-313 at 41aa02e contains docs for #420.

- EventType.ATTEMPT_LESSON hash-chained, Origin.DETERMINISTIC, bounded 512 per field / 2KB total
- SemanticState.attempt_lessons sorted by created_at, project() in state/semantic.py
- build_attempt_lesson pure helper from RecoveryDecision rationale + ledger uncertain actions
- Lifecycle created on RUN_FORKED (fork.py) and REPAIR_AND_RESUME (cli/main.py via record_attempt_lesson)
- Briefing consumes after verified state, inspect renders, resume JSON + mcp/serve include array, compaction preserves, interchange round-trips, ordering deterministic, truncation verbatim

Respects non-amplification invariant #392: lessons sourced only from EXTERNAL_AGENT degrade to unverified, cannot clear REQUIRES_REVIEW.

## Related issues

Fixes #313

Supersedes #487 (remote branch at 41aa02e is docs for #420, CONFLICTING)

## Types of changes

- Type: feature

## Breaking changes

No

## How has this been tested?

```
ruff check src/ tests/ examples/
ruff format --check src/ tests/ examples/
mypy src/continuum --strict (26 pre-existing missing-stub errors, 0 new)
PYTHONPATH=src python -m pytest tests/test_attempt_lesson.py -q (8 passed)
PYTHONPATH=src python -m pytest -q (1719 passed, 24 skipped)
```

Verified against 8 tests in tests/test_attempt_lesson.py: derivation from synthetic REPAIR_AND_RESUME, hash-chain tamper detection, empty project, interchange, compaction survival, size bound, briefing includes lessons excludes raw tail, ordering deterministic.

## Checklist

Tests added for changed behaviour. CI passes on latest commit.

## Additional context

Branch feat/recovery-attempt-memory-313-v2 is the safe path per task instructions. Original local branch at b0b799d is correct; remote at 41aa02e is wrong. Asked maintainer in #399 comment 5462500650 which path to take; using safe path to avoid force-push without explicit confirmation. Close #487 as superseded after merge.

Refs #313