### PR TITLE
docs: note pair programming with Co-authored-by in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,5 +194,5 @@ added to the release workflow.
 
 ## Code of Conduct
 
-Be kind. Review others' PRs as you would want yours reviewed. Participation in
+Be kind. Review others' PRs as you would want yours reviewed. Pair programming is welcome, please use `Co-authored-by` trailers to credit your pair. Participation in
 this project is governed by the [Contributor Covenant](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Description

Small docs addition to encourage pair programming, as used in recent fixes.

Co-authored with @abyyxhek

## Related issues

Related to #328 pair session

## Types of changes

- Type: `docs`

## Breaking changes

No
