### PR TITLE
fix(gateway): answer malformed JSON with 400 instead of an empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,14 @@ All notable changes to this project are documented here. The format follows
 - **The gateway answers malformed JSON with 400 instead of hiding it (#323).**
   `_body` caught `JSONDecodeError` and returned an empty mapping, so a request
   whose body never parsed was carried on to key derivation and refused with
-  `key template 'invoice:{id}' needs body field(s) ['id']` — sending the operator
-  to look for a field they did send, in a body the gateway never read. Broken
-  JSON now returns `400 {"error": "invalid JSON in request body: ..."}` before
-  any routing or ledger work. A genuinely empty body still becomes an empty
-  mapping, so a route whose template needs no fields stays callable with no body.
+  `key template 'invoice:{id}' needs body field(s) ['id']`. That sent the
+  operator to look for a field they did send, in a body the gateway never read.
+  A body that is not valid UTF-8 was worse: `json.loads` decodes before it
+  parses, so `UnicodeDecodeError` escaped the handler and the connection closed
+  with no response at all. Both now return
+  `400 {"error": "invalid JSON in request body: ..."}` before any routing or
+  ledger work. A genuinely empty body still becomes an empty mapping, so a route
+  whose template needs no fields stays callable with no body.
 
 ## [0.1.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ All notable changes to this project are documented here. The format follows
   surrounding whitespace; a run whose in-flight claim was recorded under a
   padded key will not match the stripped key derived after upgrading.
 
+- **The gateway answers malformed JSON with 400 instead of hiding it (#323).**
+  `_body` caught `JSONDecodeError` and returned an empty mapping, so a request
+  whose body never parsed was carried on to key derivation and refused with
+  `key template 'invoice:{id}' needs body field(s) ['id']` — sending the operator
+  to look for a field they did send, in a body the gateway never read. Broken
+  JSON now returns `400 {"error": "invalid JSON in request body: ..."}` before
+  any routing or ledger work. A genuinely empty body still becomes an empty
+  mapping, so a route whose template needs no fields stays callable with no body.
+
 ## [0.1.0] - 2026-08-27
 
 ### Added

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -226,6 +226,20 @@ class GatewayServer:
                 pass
 
             def _body(self, max_bytes: int = MAX_BODY_BYTES) -> dict[str, Any]:
+                """Read the request body as a mapping, or answer and raise.
+
+                Returns an empty mapping for a body that is absent, and for one
+                that parses to valid JSON of some other shape: neither can bind
+                a key template field, and the missing-field refusal downstream
+                names that correctly.
+
+                A body that cannot be read at all does not come back. This
+                writes the refusal itself and raises, 413 with
+                :class:`_BodyTooLarge` when it is longer than ``max_bytes``, 400
+                with :class:`_MalformedBody` when it is not JSON this proxy can
+                decode (issue #323). Callers catch both and return, since the
+                response is already on the wire.
+                """
                 length = int(self.headers.get("Content-Length") or 0)
                 if length > max_bytes:
                     # Drain (without buffering) so the client can finish

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -60,7 +60,7 @@ class _BodyTooLarge(Exception):
 
 
 class _MalformedBody(Exception):
-    """Internal signal: the request body was not parseable JSON (issue #323)."""
+    """Internal signal: the request body could not be read as JSON (issue #323)."""
 
 
 #: Requests larger than this are refused with 413 before the body is read.
@@ -257,11 +257,18 @@ class GatewayServer:
                     return {}
                 try:
                     parsed = json.loads(raw)
-                except json.JSONDecodeError as exc:
+                except (json.JSONDecodeError, UnicodeDecodeError) as exc:
                     # Answering with an empty mapping instead would send the
                     # request on to be refused for a missing template field,
                     # naming the wrong problem: the body was never read as the
                     # caller wrote it. Say so, in the status code too (#323).
+                    #
+                    # UnicodeDecodeError is the other half of "cannot be read":
+                    # json.loads decodes bytes before parsing them, so a body
+                    # that is not valid UTF-8 raises from the decode rather than
+                    # the parse. Left uncaught it escapes the handler entirely
+                    # and the connection closes with no response at all, which
+                    # is the same misreport as the missing field, only quieter.
                     self._respond(400, {"error": f"invalid JSON in request body: {exc}"})
                     raise _MalformedBody from exc
                 return parsed if isinstance(parsed, dict) else {}

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -59,6 +59,10 @@ class _BodyTooLarge(Exception):
     """Internal signal: the request body exceeded the configured cap."""
 
 
+class _MalformedBody(Exception):
+    """Internal signal: the request body was not parseable JSON (issue #323)."""
+
+
 #: Requests larger than this are refused with 413 before the body is read.
 #: A proxy that reads unbounded bodies into memory is a denial-of-service
 #: surface against the very agent it protects.
@@ -246,11 +250,21 @@ class GatewayServer:
                     )
                     raise _BodyTooLarge
                 raw = self.rfile.read(length) if length else b""
-                try:
-                    parsed = json.loads(raw) if raw else {}
-                    return parsed if isinstance(parsed, dict) else {}
-                except json.JSONDecodeError:
+                if not raw:
+                    # A genuinely empty body stays an empty mapping: a route
+                    # whose template needs no fields is legitimately callable
+                    # with no body at all.
                     return {}
+                try:
+                    parsed = json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    # Answering with an empty mapping instead would send the
+                    # request on to be refused for a missing template field,
+                    # naming the wrong problem: the body was never read as the
+                    # caller wrote it. Say so, in the status code too (#323).
+                    self._respond(400, {"error": f"invalid JSON in request body: {exc}"})
+                    raise _MalformedBody from exc
+                return parsed if isinstance(parsed, dict) else {}
 
             def _respond(self, code: int, payload: dict[str, Any]) -> None:
                 body = json.dumps(payload).encode()
@@ -266,7 +280,7 @@ class GatewayServer:
                 host = self.headers.get("Host", "")
                 try:
                     body = self._body()
-                except _BodyTooLarge:
+                except (_BodyTooLarge, _MalformedBody):
                     return
 
                 # Resolve the run lazily so hooks can precede any explicit start.

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -298,6 +298,12 @@ class GatewayServer:
                 self.wfile.write(body)
 
             def _handle(self, method: str) -> None:
+                """Route one request through the gate and answer it.
+
+                The bare ``return`` on a body failure is not a swallowed error:
+                :meth:`_body` has already written the 413 or the 400, and going
+                on would put a second response on the same connection.
+                """
                 host = self.headers.get("Host", "")
                 try:
                     body = self._body()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -182,6 +182,49 @@ def test_body_missing_template_field_denies_with_config_error(db: str, gateway: 
     assert "key template" in body["reason"]
 
 
+def _post_raw(addr: str, path: str, raw: str, host: str = "api.example.com"):
+    """POST a body verbatim, bypassing the JSON encoding of :func:`post`."""
+    conn = http.client.HTTPConnection(addr, timeout=10)
+    conn.request(
+        "POST",
+        path,
+        body=raw.encode(),
+        headers={"Host": host, "Content-Type": "application/json"},
+    )
+    resp = conn.getresponse()
+    data = json.loads(resp.read() or b"{}")
+    conn.close()
+    return resp.status, data
+
+
+def test_malformed_json_is_refused_with_400(db: str, gateway: str) -> None:
+    """Broken JSON must name itself, not masquerade as a missing field (#323).
+
+    ``_body`` swallowed ``JSONDecodeError`` and returned an empty mapping, so a
+    request whose body never parsed was carried on to the key derivation and
+    refused with ``key template 'invoice:{id}' needs body field(s) ['id']``.
+    The operator then goes looking for a field they did send, in a body the
+    gateway never read.
+    """
+    claim(db, "invoice:seed")
+    status, body = _post_raw(gateway, "/v1/invoices", '{"id": "I-5"')
+    assert status == 400
+    assert "invalid JSON" in body["error"]
+
+
+def test_an_empty_body_is_still_an_empty_mapping(db: str, gateway: str) -> None:
+    """Only broken JSON becomes a 400; absent is not the same as malformed.
+
+    A route whose template needs no fields is legitimately callable with no body,
+    so the empty case has to keep reaching the decision table rather than being
+    swept up by the new refusal.
+    """
+    claim(db, "invoice:seed")
+    status, body = _post_raw(gateway, "/v1/invoices", "")
+    assert status == 403
+    assert "key template" in body["reason"]
+
+
 # --- CLI ---------------------------------------------------------------------- #
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -182,13 +182,17 @@ def test_body_missing_template_field_denies_with_config_error(db: str, gateway: 
     assert "key template" in body["reason"]
 
 
-def _post_raw(addr: str, path: str, raw: str, host: str = "api.example.com"):
-    """POST a body verbatim, bypassing the JSON encoding of :func:`post`."""
+def _post_raw(addr: str, path: str, raw: str | bytes, host: str = "api.example.com"):
+    """POST a body verbatim, bypassing the JSON encoding of :func:`post`.
+
+    Accepts ``bytes`` as well as ``str`` so a test can send a body that is not
+    valid UTF-8, which no encoding of a ``str`` can produce.
+    """
     conn = http.client.HTTPConnection(addr, timeout=10)
     conn.request(
         "POST",
         path,
-        body=raw.encode(),
+        body=raw.encode() if isinstance(raw, str) else raw,
         headers={"Host": host, "Content-Type": "application/json"},
     )
     resp = conn.getresponse()
@@ -208,6 +212,21 @@ def test_malformed_json_is_refused_with_400(db: str, gateway: str) -> None:
     """
     claim(db, "invoice:seed")
     status, body = _post_raw(gateway, "/v1/invoices", '{"id": "I-5"')
+    assert status == 400
+    assert "invalid JSON" in body["error"]
+
+
+def test_a_body_that_is_not_utf8_is_refused_with_400(db: str, gateway: str) -> None:
+    """The decode half of "cannot be read" answers the same way (#323).
+
+    ``json.loads`` decodes bytes before it parses them, so a body that is not
+    valid UTF-8 raises ``UnicodeDecodeError`` rather than ``JSONDecodeError``.
+    Uncaught, that escapes the handler and the connection closes with no
+    response at all, so the caller cannot tell a rejected body from a crashed
+    proxy.
+    """
+    claim(db, "invoice:seed")
+    status, body = _post_raw(gateway, "/v1/invoices", b'{"id": "\xff\xfe I-5"}')
     assert status == 400
     assert "invalid JSON" in body["error"]
 


### PR DESCRIPTION
## Description

`GatewayServer.Handler._body` caught `json.JSONDecodeError` and returned `{}`, so a
request whose body never parsed was indistinguishable from a request that carried no
body at all. Key derivation then ran against that empty mapping and the call was
refused with:

```text
gateway configuration error: key template 'invoice:{id}' needs body field(s) ['id']
```

An operator who did send `id`, in a body with one character wrong, is sent to look for
a field that is already there. The status code said 403, which claims the gate decided
something. Nothing had been decided, because the body the decision rests on was never
read.

A body that is not valid UTF-8 failed worse. `json.loads` decodes bytes before it
parses them, so those raise `UnicodeDecodeError` from the decode rather than
`JSONDecodeError` from the parse. That escaped `_body`, `do_POST` and
`handle_one_request` alike, so `socketserver` logged a traceback and closed the
connection with no response written. A rejected body and a crashed proxy were
indistinguishable, and a client that retries on a dropped connection would retry a body
that can never be read.

Both now get one answer, emitted from `_body` before any routing, lookup or ledger work:

```text
400 {"error": "invalid JSON in request body: Expecting ',' delimiter: line 1 column 13 (char 12)"}
```

The decoder's own message is carried through, so the position of the fault and which of
the two failures it was travel with the refusal. The approach follows the issue's step
2: a `_MalformedBody` sentinel, raised after the 400 is written and caught in `do_POST`
alongside the existing `_BodyTooLarge`, so the handler returns without putting a second
response on the same connection.

Two cases are deliberately left as they were:

- **An absent body stays an empty mapping.** A route whose key template needs no fields
  is legitimately callable with no body, so `if not raw: return {}` still reaches the
  decision table. This is now explicit rather than incidental to the `try` block.
- **Valid JSON that is not an object** (an array, or a bare string) also still becomes
  an empty mapping. That is a shape the template cannot bind, not a body that cannot be
  read, and the existing missing-field refusal names it correctly.

## Related issues

Fixes #323

## Types of changes

- Type: `bugfix`

## Breaking changes

No. A caller that previously sent malformed JSON received a 403 refusal naming a missing
template field, and now receives a 400 naming the JSON fault. Both are refusals and
neither performed the side effect, so no request that used to succeed changes outcome.
A caller that sent a body which was not valid UTF-8 previously received nothing at all,
so a 400 there is strictly more than before. A client matching on the 403 status, or on
the missing-field string, to detect its own bad body would need to look at 400 instead.

## How has this been tested?

Rebased onto current `main` (`2908592`) before running these, on Windows 11 with Python
3.13 in the project `.venv`, confirmed importing from this checkout
(`continuum.__file__` is `src/continuum/__init__.py` here):

```bash
python -m pytest tests/test_gateway.py -q                          # 13 passed
python -m pytest -q                                                # full suite passed
ruff check src/ tests/                                             # All checks passed
ruff format --check src/continuum/gateway.py tests/test_gateway.py # 2 files already formatted
mypy src/continuum                                                 # no issues in 113 files
```

Three tests were added to `tests/test_gateway.py`, and each fails on the previous code
path:

- `test_malformed_json_is_refused_with_400` posts `{"id": "I-5"` verbatim and asserts
  `400` with `invalid JSON` in the body. Previously this returned 403 with the
  missing-field reason.
- `test_a_body_that_is_not_utf8_is_refused_with_400` posts `{"id": "\xff\xfe I-5"}` and
  asserts the same 400. On the previous code path this fails with
  `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 8` raised
  through `_body`, and no response written. Verified by reverting just the
  `UnicodeDecodeError` arm and rerunning the test.
- `test_an_empty_body_is_still_an_empty_mapping` posts an empty body to the same route
  and asserts the unchanged `403` missing-field refusal. This is the guard that the new
  400 did not widen to swallow the empty case.

All three go through a `_post_raw` helper, since the existing `post` helper JSON-encodes
its argument and so cannot express an unparseable body. `_post_raw` accepts `bytes` as
well as `str`, because no encoding of a `str` can produce a body that is not valid UTF-8.

## Checklist

Tests added for the changed behaviour (three, each failing on the previous code path).
Documentation updated: the `CHANGELOG.md` `[Unreleased]` / `Fixed` entry states the new
status code, the message shape, the UTF-8 case, and that the empty-body path is
unchanged. No other user-facing docs describe the gateway's malformed-body handling. CI
passes on the latest commit. Security-relevant limitation stated explicitly: the 400
body interpolates the exception message, which reports the fault's line, column and
character offset and the token expected there. It does not echo the body's contents, so
a malformed body carrying a secret does not have that secret reflected back. The offsets
do disclose the length and rough structure of what the client itself sent, to the client
that sent it. The existing 413 and the gate's refusal reasons already answer at this
level of detail.

## Additional context

The empty-body test is the reason the `try` block was restructured rather than just
having its `except` arm changed. With `parsed = json.loads(raw) if raw else {}` inside
the `try`, the empty case and the malformed case share one exit, and there is no way to
give one a 400 without giving it to the other. Hoisting `if not raw` above the `try`
separates them, which is what the issue's step 4 asks for.

`_MalformedBody` writes its response inside `_body` rather than returning a value for
`do_POST` to interpret, matching how `_BodyTooLarge` already handles the 413. Keeping the
two the same shape means `do_POST` has one rule for both (the response is already sent,
return) instead of one sentinel meaning "already answered" and another meaning "answer
this for me".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed JSON request bodies now receive a clear HTTP 400 error instead of an incorrect missing-field response.
  - Non-UTF-8 request bodies now return HTTP 400 rather than closing the connection without a response.
  - Empty request bodies continue to behave as empty mappings.
  - Oversized request bodies continue to return HTTP 413.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->