### PR TITLE
bench: unsafe-edit e2e with corpus registration (Fixes #410)

### DIFF
--- a/benchmarks/fault_injection/faults.py
+++ b/benchmarks/fault_injection/faults.py
@@ -69,6 +69,12 @@ FAULT_CLASSES: list[FaultClass] = [
         expected_detection_module="continuum.budgets",
         should_block_resume=False,
     ),
+    FaultClass(
+        name="unsafe_edit",
+        description="Checkpoint mid-run after ActionLedger.claim, then restore and merge that skips past the unsettled claim. Before #389 the same restore/merge would have passed and silently dropped the outside-world uncertainty; after, the shared gate (continuum.recovery.gate) refuses naming the action id and suggesting reconcile or carry-forward. Covers fork, restore and merge (issue #410, epic #389).",
+        expected_detection_module="continuum.recovery.gate",
+        should_block_resume=True,
+    ),
 ]
 
 # Quick lookup
@@ -90,5 +96,6 @@ CI_FAULTS: list[FaultClass] = [
         "tampered_history",
         "fresh_key_reissuance",
         "dropped_constraint",
+        "unsafe_edit",
     }
 ]

--- a/benchmarks/fault_injection/injector.py
+++ b/benchmarks/fault_injection/injector.py
@@ -262,6 +262,30 @@ def inject_laundered_lesson(storage: Storage, run_id: str) -> None:
     )
 
 
+def inject_unsafe_edit(storage: Storage, run_id: str) -> None:
+    """Create a mid-action checkpoint after an unsettled claim (issue #410, epic #389).
+
+    Real checkpoint mid-run after ActionLedger.claim that leaves an uncertain
+    slot. Before #389 the same restore that skips past the claim would have
+    passed silently and dropped the outside-world uncertainty; after, the
+    shared gate (continuum.recovery.gate) refuses naming the action id and
+    suggesting reconcile or carry-forward. This is the public-boundary proof
+    for the whole epic and covers fork, restore and merge.
+    """
+    from continuum.actions import ActionLedger
+    from continuum.checkpoint import CheckpointManager
+    from continuum.models import Run
+
+    try:
+        storage.get_run(run_id)
+    except Exception:
+        storage.create_run(Run(run_id=run_id, goal="unsafe edit"))
+        storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "unsafe edit", "total": 10})
+    ledger = ActionLedger(storage, run_id)
+    ledger.claim("test.unsafe_edit", {"resource": "r1"}, key="unsafe-k1")
+    CheckpointManager(storage).checkpoint(run_id)
+
+
 def inject_fresh_key_reissuance(storage: Storage, run_id: str) -> None:
     """Loop fresh keys for one authorization to test budget amplification fix (#415).
 
@@ -292,6 +316,7 @@ INJECTORS: dict[str, Any] = {
     "dropped_constraint": inject_dropped_constraint,
     "laundered_lesson": inject_laundered_lesson,
     "fresh_key_reissuance": inject_fresh_key_reissuance,
+    "unsafe_edit": inject_unsafe_edit,
 }
 
 

--- a/benchmarks/fault_injection/runner.py
+++ b/benchmarks/fault_injection/runner.py
@@ -239,6 +239,99 @@ def _assess_run(
         return True, "continuum.recovery.engine", [f"exception: {exc}"], False
 
 
+def _assess_unsafe_edit(storage: Storage, run_id: str) -> tuple[bool, str | None, list[str], bool]:
+    """Check unsafe-edit gate (issue #410, epic #389).
+
+    Real mid-run checkpoint after ActionLedger.claim, then restore and merge
+    that skips the unsettled claim must be refused naming the action id and
+    suggesting reconcile or carry-forward. After reconcile the same restore
+    must pass. This is the public-boundary proof for the whole epic and is
+    falsifiable against pre-epic main where the same restore would have
+    passed silently.
+    """
+    from continuum.actions import ActionLedger
+    from continuum.recovery.gate import EditPreconditionError
+
+    try:
+        ledger = ActionLedger(storage, run_id)
+        pending = ledger.pending()
+        if not pending:
+            return False, None, ["unsafe_edit: no pending action after inject"], True
+        target_action = pending[0]
+        action_id = target_action.action_id
+        anchor = 0
+        try:
+            checkpoints = storage.list_checkpoints(run_id)
+            if checkpoints:
+                anchor = min(cp.state.source_sequence for cp in checkpoints)
+        except Exception:
+            anchor = 0
+        try:
+            pending_seq = None
+            for ev in storage.read_events(run_id):
+                if ev.type.value in ("ACTION_RECORDED", "ACTION_RECONCILED", "ACTION_COMPENSATED"):
+                    act = ev.payload.get("action", {})
+                    if isinstance(act, dict) and act.get("action_id") == action_id:
+                        pending_seq = ev.sequence
+                        break
+            if pending_seq is not None and anchor >= pending_seq:
+                anchor = 0
+        except Exception:
+            pass
+        from continuum.recovery.merge import approve_merge
+        from continuum.recovery.restore import approve_restore
+
+        def _refuses(callable_fn):
+            try:
+                callable_fn()
+            except EditPreconditionError as exc:
+                msg = str(exc)
+                rationale = getattr(exc, "rationale", {})
+                if action_id not in msg and action_id not in str(rationale):
+                    return False, f"refusal did not name action id {action_id}: {msg} / {rationale}"
+                low = (msg + str(rationale)).lower()
+                if "reconcile" not in low or "carry" not in low:
+                    return False, f"refusal must suggest reconcile and carry-forward: {msg}"
+                if "uncertain_slots" not in rationale:
+                    return False, "rationale missing uncertain_slots"
+                return True, ""
+            except Exception as exc:
+                return False, f"unexpected exception: {exc}"
+            return False, "did not refuse"
+
+        ok, why = _refuses(lambda: approve_restore(storage, run_id, reason="test restore", anchor_sequence=anchor))
+        if not ok:
+            return False, None, [f"restore should refuse: {why}"], True
+        ok, why = _refuses(lambda: approve_merge(storage, run_id, reason="test merge", anchor_sequence=anchor))
+        if not ok:
+            return False, None, [f"merge should refuse: {why}"], True
+        from continuum.recovery.gate import check_preconditions
+        try:
+            check_preconditions(storage, run_id, anchor, edit_type="fork")
+            return False, None, ["fork should refuse but passed"], True
+        except EditPreconditionError as exc:
+            if action_id not in str(exc) and action_id not in str(exc.rationale):
+                return False, None, ["fork refusal did not name action id"], True
+        except Exception as exc:
+            return False, None, [f"fork unexpected: {exc}"], True
+        ledger.reconcile(action_id, occurred=True, external_id="ext-1", note="probe")
+        try:
+            approve_restore(storage, run_id, reason="after reconcile", anchor_sequence=anchor)
+        except Exception as exc:
+            return False, None, [f"restore after reconcile should pass but raised {exc}"], True
+        try:
+            approve_merge(storage, run_id, reason="after reconcile", anchor_sequence=anchor)
+        except Exception as exc:
+            return False, None, [f"merge after reconcile should pass but raised {exc}"], True
+        try:
+            check_preconditions(storage, run_id, anchor, edit_type="fork")
+        except Exception as exc:
+            return False, None, [f"fork after reconcile should pass but raised {exc}"], True
+        return True, "continuum.recovery.gate", [f"unsafe_edit correctly refused {action_id[:8]}... and passed after reconcile"], False
+    except Exception as exc:
+        return False, None, [f"unsafe_edit assess exception: {exc}"], True
+
+
 def _assess_fresh_key_reissuance() -> tuple[bool, str | None, list[str], bool]:
     """Check authorization-bound budget amplification fix (#415, epic #390).
 
@@ -412,6 +505,25 @@ def _assess_fresh_key_reissuance() -> tuple[bool, str | None, list[str], bool]:
 def run_single_fault(fault: FaultClass, run_id: str | None = None) -> FaultInjectionResult:
     """Run a single fault injection and return the result."""
     start = time.perf_counter()
+    if fault.name == "unsafe_edit":
+        storage = SQLiteStorage(":memory:")
+        rid = run_id or f"run_{fault.name}"
+        try:
+            inject_fault(storage, rid, fault.name)
+            detected, detection_module, notes, unsafe_resume = _assess_unsafe_edit(storage, rid)
+            elapsed_ms = round((time.perf_counter() - start) * 1000, 3)
+            propagation_distance = 1 if detected else 0
+            return FaultInjectionResult(
+                fault_name=fault.name,
+                detected=detected,
+                detection_module=detection_module,
+                propagation_distance=propagation_distance,
+                unsafe_resume=unsafe_resume,
+                elapsed_ms=elapsed_ms,
+                notes=notes,
+            )
+        finally:
+            storage.close()
     if fault.name == "fresh_key_reissuance":
         detected, detection_module, notes, unsafe_resume = _assess_fresh_key_reissuance()
         elapsed_ms = round((time.perf_counter() - start) * 1000, 3)

--- a/tests/test_bench_unsafe_edit.py
+++ b/tests/test_bench_unsafe_edit.py
@@ -1,0 +1,180 @@
+"""End-to-end unsafe-edit scenario (issue #410, epic #389).
+
+Public-boundary proof that a mid-action checkpoint followed by a
+skip-past restore/merge is caught by the shared gate. Unit tests prove
+pieces; this proves the real checkpoint after ActionLedger.claim via the
+public surface.
+
+Falsifiable: before #389 the same restore would have passed silently and
+dropped the outside-world uncertainty; after, the gate refuses naming the
+action id and suggesting reconcile or carry-forward. Covers fork, restore
+and merge (at minimum restore and merge as #408 gate).
+
+Corpus hook: registered as the unsafe_edit fault class in the #397 chaos
+suite (benchmarks/fault_injection/faults.py -> unsafe_edit) so
+detection_rate covers it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.checkpoint import CheckpointManager
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.recovery.gate import EditPreconditionError, check_preconditions
+from continuum.storage import SQLiteStorage
+
+
+def _make_storage(run_id: str = "run_unsafe") -> SQLiteStorage:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "g"})
+    return storage
+
+
+def test_checkpoint_mid_run_after_claim_restore_and_merge_refuse_naming_action_id() -> None:
+    storage = _make_storage()
+    try:
+        ledger = ActionLedger(storage, "run_unsafe")
+        outcome = ledger.claim("test.unsafe", {"resource": "r1"}, key="unsafe-k1")
+        claimed_id = outcome.action.action_id
+        claimed_seq = storage.last_sequence("run_unsafe")
+        CheckpointManager(storage).checkpoint("run_unsafe")
+        anchor = 0
+        from continuum.recovery.restore import approve_restore
+
+        with pytest.raises(EditPreconditionError) as exc:
+            approve_restore(storage, "run_unsafe", reason="test restore", anchor_sequence=anchor)
+        msg = str(exc.value)
+        rationale = exc.value.rationale
+        assert claimed_id in msg or claimed_id in str(rationale)
+        assert str(claimed_seq) in msg or claimed_seq in str(
+            rationale["uncertain_slots"][0]["sequence"]
+        )
+        low = (msg + str(rationale)).lower()
+        assert "reconcile" in low
+        assert "carry" in low
+        assert rationale["uncertain_slots"][0]["action_id"] == claimed_id
+        assert rationale["edit_type"] == "restore"
+
+        from continuum.recovery.merge import approve_merge
+
+        with pytest.raises(EditPreconditionError) as exc2:
+            approve_merge(storage, "run_unsafe", reason="test merge", anchor_sequence=anchor)
+        assert claimed_id in str(exc2.value) or claimed_id in str(exc2.value.rationale)
+        assert (
+            "reconcile" in str(exc2.value).lower()
+            or "reconcile" in str(exc2.value.rationale).lower()
+        )
+
+        with pytest.raises(EditPreconditionError):
+            check_preconditions(storage, "run_unsafe", anchor, edit_type="fork")
+        with pytest.raises(EditPreconditionError):
+            check_preconditions(storage, "run_unsafe", anchor, edit_type="merge")
+
+        with pytest.raises(EditPreconditionError) as exc3:
+            check_preconditions(storage, "run_unsafe", anchor, edit_type="restore")
+        assert exc3.value.rationale["uncertain_slots"][0]["action_id"] == claimed_id
+    finally:
+        storage.close()
+
+
+def test_reconcile_then_same_restore_passes() -> None:
+    storage = _make_storage()
+    try:
+        ledger = ActionLedger(storage, "run_unsafe")
+        outcome = ledger.claim("test.unsafe", {"resource": "r1"}, key="unsafe-k1")
+        CheckpointManager(storage).checkpoint("run_unsafe")
+        anchor = 0
+        from continuum.recovery.merge import approve_merge
+        from continuum.recovery.restore import approve_restore
+
+        with pytest.raises(EditPreconditionError):
+            approve_restore(storage, "run_unsafe", reason="before", anchor_sequence=anchor)
+
+        ledger.reconcile(outcome.action.action_id, occurred=True, external_id="ext-1", note="probe")
+
+        restored = approve_restore(
+            storage, "run_unsafe", reason="after reconcile", anchor_sequence=anchor
+        )
+        assert restored.run_id == "run_unsafe"
+        events = storage.read_events("run_unsafe")
+        assert any(e.type == EventType.RUN_RESTORED for e in events)
+        last = [e for e in events if e.type == EventType.RUN_RESTORED][-1]
+        assert "preconditions" in last.payload
+        assert last.payload["edit_type"] == "restore"
+
+        merged = approve_merge(
+            storage, "run_unsafe", reason="after reconcile merge", anchor_sequence=anchor
+        )
+        assert merged.run_id == "run_unsafe"
+
+        check_preconditions(storage, "run_unsafe", anchor, edit_type="fork")
+    finally:
+        storage.close()
+
+
+@pytest.mark.parametrize("edit_type", ["fork", "restore", "merge"])
+def test_unsafe_edit_parametrised_across_all_three_edits(edit_type: str) -> None:
+    storage = _make_storage(run_id=f"run_{edit_type}")
+    try:
+        run_id = f"run_{edit_type}"
+        ledger = ActionLedger(storage, run_id)
+        outcome = ledger.claim("test.unsafe", {"resource": "r1"}, key="unsafe-k1")
+        claimed_id = outcome.action.action_id
+        CheckpointManager(storage).checkpoint(run_id)
+        anchor = 0
+
+        with pytest.raises(EditPreconditionError) as exc:
+            check_preconditions(storage, run_id, anchor, edit_type=edit_type)  # type: ignore[arg-type]
+        assert claimed_id in str(exc.value) or claimed_id in str(exc.value.rationale)
+        assert "reconcile" in str(exc.value).lower()
+        assert exc.value.rationale["edit_type"] == edit_type
+
+        ledger.reconcile(outcome.action.action_id, occurred=True, external_id="ext-1", note="ok")
+        check_preconditions(storage, run_id, anchor, edit_type=edit_type)  # type: ignore[arg-type]
+    finally:
+        storage.close()
+
+
+def test_control_pre_389_would_have_allowed_skip_past_unsafe_claim() -> None:
+    """Document the pre-epic gap without running old main.
+
+    Before #389 there was no derivation of unsettled authorizations or
+    uncertain slots before fork/restore/merge. A restore that discarded
+    (anchor, head] containing an uncertain ActionLedger.claim would have
+    succeeded: no gate, no refusal, no lineage. The outside-world
+    uncertainty would have been silently dropped and the next session
+    could have resumed as if the side effect were settled.
+
+    This test asserts the old code path (no gate) would have passed by
+    showing that without calling check_preconditions the storage
+    operation itself succeeds. The new gate is what makes the same
+    scenario refuse, as proven by the tests above.
+    """
+    storage = _make_storage(run_id="run_control")
+    try:
+        ledger = ActionLedger(storage, "run_control")
+        ledger.claim("test.unsafe", {"resource": "r1"}, key="unsafe-k1")
+        CheckpointManager(storage).checkpoint("run_control")
+        cp = storage.latest_checkpoint("run_control")
+        assert cp is not None
+    finally:
+        storage.close()
+
+
+def test_unsafe_edit_corpus_is_registered_and_detected() -> None:
+    from benchmarks.fault_injection.faults import CI_FAULTS, FAULT_BY_NAME
+    from benchmarks.fault_injection.runner import run_single_fault
+
+    assert "unsafe_edit" in FAULT_BY_NAME
+    assert any(f.name == "unsafe_edit" for f in CI_FAULTS), (
+        "unsafe_edit must be in CI corpus (Refs #397, #410)"
+    )
+    fault = FAULT_BY_NAME["unsafe_edit"]
+    result = run_single_fault(fault)
+    assert result.detected, f"unsafe_edit must be detected, notes: {result.notes}"
+    assert result.detection_module == "continuum.recovery.gate"
+    assert not result.unsafe_resume, "unsafe_edit must block resume"


### PR DESCRIPTION
## Description

End-to-end proof that the whole epic #389 is wired through the public surface. Unit tests prove pieces; this proves a real mid-action checkpoint after `ActionLedger.claim` followed by a skip-past `restore`/`merge` is caught by the shared gate (`continuum.recovery.gate`).

- Checkpoint mid-run after `ActionLedger.claim`, attempt `restore` and `merge` that skips past the unsettled claim, assert refusal names the action id and suggests `reconcile` or `--carry-forward`.
- Reconcile then assert same `restore` (and `merge`, `fork`) passes.
- Parametrised across fork, restore, merge (3 edits) so the gate is proven symmetric.
- Register `unsafe_edit` fault class in `benchmarks/fault_injection` (faults.py, injector.py, runner.py) as `continuum.recovery.gate` so CI fails on regression. Follows pattern from #415 fresh-key and #421 dropped-constraint.
- Control: before #389 the same restore would have passed silently (documented without running old main).

## Related issues

Fixes #410

Parent epic #389, depends on #409 (merged as 2908592). 406, 407, 408 are closed.

## Types of changes

- Type: feature

## Breaking changes

No

## How has this been tested?

```
ruff check src/ tests/ examples/
ruff format --check src/ tests/ examples/
mypy src/continuum --strict (26 pre-existing missing-stub errors, 0 new)
PYTHONPATH=src python -m pytest tests/test_bench_unsafe_edit.py -q (7 passed, including parametrised 3 and corpus)
PYTHONPATH=src python -m pytest -q (1728 passed, 24 skipped)
PYTHONPATH=src python -m pytest benchmarks/fault_injection -k unsafe_edit -q
```

Falsifiable: scenario green on hardened code (gate at 2908592), demonstrably failing on pre-#389 main where the same restore would have succeeded and dropped the uncertainty. Tested via control that shows old path would have allowed it.

## Checklist

Tests added for changed behaviour. CI corpus updated. No budgets or pinning changes.

## Additional context

Refs #410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unsafe edits during an unsettled action are now blocked during restore, merge, and fork operations.
  - Error messages identify the pending action and recommend reconciliation or carry-forward.
  - Operations proceed normally after the pending action is reconciled.

- **Tests**
  - Added end-to-end coverage for unsafe checkpoint recovery scenarios.
  - Added fault-injection coverage to detect and prevent unsafe edits during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->