### PR TITLE
test: add regression test for render_key with whitespace-only value (#512)

### DIFF
--- a/tests/test_cli_gate.py
+++ b/tests/test_cli_gate.py
@@ -79,6 +79,25 @@ def test_render_key_strips_surrounding_whitespace_from_values(padded: str) -> No
     assert render_key("invoice:{id}", {"id": padded}) == render_key("invoice:{id}", {"id": "123"})
 
 
+def test_render_key_handles_whitespace_only_value() -> None:
+    """A whitespace-only value normalizes to an empty string (issue #512).
+
+    When an LLM supplies whitespace-only for an argument, normalize_key_value
+    strips it to empty. The template still renders and decide handles the
+    resulting key gracefully without error.
+    """
+    assert render_key("invoice:{id}", {"id": "   "}) == "invoice:"
+    decision = decide(
+        {"send_invoice": {"key_template": "invoice:{id}"}},
+        "send_invoice",
+        {"id": "   "},
+        run_id="run_1",
+        actions_by_key={},
+    )
+    assert decision.allow is False
+    assert "invoice:" in decision.reason
+
+
 def test_render_key_leaves_non_strings_to_the_templates_format_spec() -> None:
     """Only strings are stripped; a numeric value keeps its type (issue #361).
 


### PR DESCRIPTION
Closes #512.

### Summary
Adds a regression test in \	ests/test_cli_gate.py\ asserting that \ender_key('invoice:{id}', {'id': '   '}) == 'invoice:'\ and that \decide\ handles the resulting key gracefully without error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for whitespace-only template values.
  * Verified normalization to an empty value, correct `invoice:` rendering, and denial of unclaimed actions with the derived key included in the reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->