### PR TITLE
fix(tests): close file-backed storage before unlink on Windows

### DIFF
--- a/tests/test_trajectory_report.py
+++ b/tests/test_trajectory_report.py
@@ -268,19 +268,22 @@ def test_digest_auditable_and_briefing_consumption() -> None:
 
         tmp = tempfile.mktemp(suffix=".sqlite")
         file_storage = SQLiteStorage(tmp)
-        file_storage.create_run(Run(run_id=run_id, goal="g"))
-        for ev in all_events:
-            file_storage.append_event(run_id, ev.type, ev.payload, source=ev.source)
-        verify2 = file_storage.verify_events(run_id)
-        assert verify2.ok
-        out = io.StringIO()
-        err = io.StringIO()
-        code = cli_main(["--db", tmp, "briefing", "--run-id", run_id], out=out, err=err)
-        assert code == 0
-        text = out.getvalue()
-        assert "trajectory reports" in text.lower() or "trajectory report" in text.lower()
-        assert report.report_id in text or str(report.window_end) in text
-        pathlib.Path(tmp).unlink(missing_ok=True)
+        try:
+            file_storage.create_run(Run(run_id=run_id, goal="g"))
+            for ev in all_events:
+                file_storage.append_event(run_id, ev.type, ev.payload, source=ev.source)
+            verify2 = file_storage.verify_events(run_id)
+            assert verify2.ok
+            out = io.StringIO()
+            err = io.StringIO()
+            code = cli_main(["--db", tmp, "briefing", "--run-id", run_id], out=out, err=err)
+            assert code == 0
+            text = out.getvalue()
+            assert "trajectory reports" in text.lower() or "trajectory report" in text.lower()
+            assert report.report_id in text or str(report.window_end) in text
+        finally:
+            file_storage.close()
+            pathlib.Path(tmp).unlink(missing_ok=True)
     finally:
         storage.close()
 


### PR DESCRIPTION
## Description

test_digest_auditable_and_briefing_consumption created a file-backed SQLiteStorage at a temp path and called unlink without closing the connection. On Windows unlink fails with WinError 32 when the file is still open. Unix allows it, so the failure only shows in the Windows CI jobs.

Wrapping the file storage use in try/finally and closing before unlink fixes it.

## Related issues

Fixes Windows CI failure on main, unblocks #507

## Types of changes

- Type: `bugfix`

## Breaking changes

No

## How has this been tested?

- `pytest tests/test_trajectory_report.py::test_digest_auditable_and_briefing_consumption -q` passed locally
- `ruff check` clean
