### PR TITLE
feat(health): wire trajectory report to idle-window trigger

### DIFF
--- a/src/continuum/analysis/trajectory_report.py
+++ b/src/continuum/analysis/trajectory_report.py
@@ -14,6 +14,7 @@ from continuum.storage.base import Storage
 __all__ = [
     "TRAJECTORY_REPORT_CAP_BYTES",
     "build_trajectory_report",
+    "health_maybe_generate_trajectory_report",
     "is_quiet_window",
     "maybe_generate_trajectory_report",
     "record_trajectory_report",
@@ -255,6 +256,38 @@ def record_trajectory_report(
     return report
 
 
+def _last_compaction_window(storage: Storage, run_id: str) -> tuple[int, int] | None:
+    try:
+        all_events = list(storage.read_events(run_id)) + list(storage.read_archived_events(run_id))
+    except Exception:
+        all_events = list(storage.read_events(run_id))
+    anchors: list[int] = []
+    for ev in all_events:
+        if ev.type is EventType.EVENT_LOG_ANCHORED:
+            anchor = ev.payload.get("anchor_sequence")
+            if anchor is None:
+                anchor = ev.payload.get("sequence")
+            try:
+                anchors.append(int(anchor) if anchor is not None else ev.sequence)
+            except Exception:
+                anchors.append(ev.sequence)
+    if not anchors:
+        try:
+            window_end = storage.last_sequence(run_id)
+            window_start = 0
+        except Exception:
+            return None
+        if window_end == 0:
+            return None
+    else:
+        anchors_sorted = sorted(set(anchors))
+        window_end = anchors_sorted[-1]
+        window_start = anchors_sorted[-2] if len(anchors_sorted) >= 2 else 0
+    if window_end <= window_start:
+        return None
+    return int(window_start), int(window_end)
+
+
 def maybe_generate_trajectory_report(
     storage: Storage,
     run_id: str,
@@ -263,34 +296,10 @@ def maybe_generate_trajectory_report(
     window_end: int | None = None,
 ) -> TrajectoryReport | None:
     if window_start is None or window_end is None:
-        try:
-            all_events = list(storage.read_events(run_id)) + list(
-                storage.read_archived_events(run_id)
-            )
-        except Exception:
-            all_events = list(storage.read_events(run_id))
-        anchors: list[int] = []
-        for ev in all_events:
-            if ev.type is EventType.EVENT_LOG_ANCHORED:
-                anchor = ev.payload.get("anchor_sequence")
-                if anchor is None:
-                    anchor = ev.payload.get("sequence")
-                try:
-                    anchors.append(int(anchor) if anchor is not None else ev.sequence)
-                except Exception:
-                    anchors.append(ev.sequence)
-        if not anchors:
-            try:
-                window_end = storage.last_sequence(run_id)
-                window_start = 0
-            except Exception:
-                return None
-            if window_end == 0:
-                return None
-        else:
-            anchors_sorted = sorted(set(anchors))
-            window_end = anchors_sorted[-1]
-            window_start = anchors_sorted[-2] if len(anchors_sorted) >= 2 else 0
+        window = _last_compaction_window(storage, run_id)
+        if window is None:
+            return None
+        window_start, window_end = window
     assert window_start is not None and window_end is not None
     if window_end <= window_start:
         return None
@@ -313,6 +322,40 @@ def maybe_generate_trajectory_report(
         return None
     report = build_trajectory_report(storage, run_id, int(window_start), int(window_end))
     return record_trajectory_report(storage, run_id, report)
+
+
+def health_maybe_generate_trajectory_report(
+    storage: Storage, run_id: str
+) -> TrajectoryReport | None:
+    try:
+        all_events = list(storage.read_events(run_id)) + list(storage.read_archived_events(run_id))
+    except Exception:
+        all_events = list(storage.read_events(run_id))
+    anchors: list[int] = []
+    for ev in all_events:
+        if ev.type is EventType.EVENT_LOG_ANCHORED:
+            anchor = ev.payload.get("anchor_sequence")
+            if anchor is None:
+                anchor = ev.payload.get("sequence")
+            try:
+                anchors.append(int(anchor) if anchor is not None else ev.sequence)
+            except Exception:
+                anchors.append(ev.sequence)
+    if not anchors:
+        return None
+    anchors_sorted = sorted(set(anchors))
+    window_end = anchors_sorted[-1]
+    window_start = anchors_sorted[-2] if len(anchors_sorted) >= 2 else 0
+    if window_end <= window_start:
+        return None
+    events = _window_events(storage, run_id, int(window_start), int(window_end))
+    if not events:
+        return None
+    if not is_quiet_window(events):
+        return None
+    return maybe_generate_trajectory_report(
+        storage, run_id, window_start=int(window_start), window_end=int(window_end)
+    )
 
 
 def render_trajectory_report(report: TrajectoryReport) -> list[str]:

--- a/src/continuum/analysis/trajectory_report.py
+++ b/src/continuum/analysis/trajectory_report.py
@@ -256,7 +256,9 @@ def record_trajectory_report(
     return report
 
 
-def _last_compaction_window(storage: Storage, run_id: str) -> tuple[int, int] | None:
+def _last_compaction_window(
+    storage: Storage, run_id: str, *, require_anchor: bool = False
+) -> tuple[int, int] | None:
     try:
         all_events = list(storage.read_events(run_id)) + list(storage.read_archived_events(run_id))
     except Exception:
@@ -272,6 +274,8 @@ def _last_compaction_window(storage: Storage, run_id: str) -> tuple[int, int] | 
             except Exception:
                 anchors.append(ev.sequence)
     if not anchors:
+        if require_anchor:
+            return None
         try:
             window_end = storage.last_sequence(run_id)
             window_start = 0
@@ -327,32 +331,10 @@ def maybe_generate_trajectory_report(
 def health_maybe_generate_trajectory_report(
     storage: Storage, run_id: str
 ) -> TrajectoryReport | None:
-    try:
-        all_events = list(storage.read_events(run_id)) + list(storage.read_archived_events(run_id))
-    except Exception:
-        all_events = list(storage.read_events(run_id))
-    anchors: list[int] = []
-    for ev in all_events:
-        if ev.type is EventType.EVENT_LOG_ANCHORED:
-            anchor = ev.payload.get("anchor_sequence")
-            if anchor is None:
-                anchor = ev.payload.get("sequence")
-            try:
-                anchors.append(int(anchor) if anchor is not None else ev.sequence)
-            except Exception:
-                anchors.append(ev.sequence)
-    if not anchors:
+    window = _last_compaction_window(storage, run_id, require_anchor=True)
+    if window is None:
         return None
-    anchors_sorted = sorted(set(anchors))
-    window_end = anchors_sorted[-1]
-    window_start = anchors_sorted[-2] if len(anchors_sorted) >= 2 else 0
-    if window_end <= window_start:
-        return None
-    events = _window_events(storage, run_id, int(window_start), int(window_end))
-    if not events:
-        return None
-    if not is_quiet_window(events):
-        return None
+    window_start, window_end = window
     return maybe_generate_trajectory_report(
         storage, run_id, window_start=int(window_start), window_end=int(window_end)
     )

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -866,12 +866,30 @@ def cmd_health(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             palette=getattr(args, "_palette", None),
         )
         return ExitCode.OK
+    trajectory_payload = None
+    trajectory_text = ""
+    try:
+        from continuum.analysis.trajectory_report import (
+            health_maybe_generate_trajectory_report,
+            render_trajectory_report,
+        )
+
+        trajectory_report = health_maybe_generate_trajectory_report(storage, run_id)
+        if trajectory_report is not None:
+            trajectory_payload = trajectory_report.model_dump(mode="json")
+            trajectory_text = "\n" + "\n".join(render_trajectory_report(trajectory_report))
+    except Exception:
+        trajectory_payload = None
+        trajectory_text = ""
+    payload = {"run_id": run_id, "advisory": advisory}
+    if trajectory_payload is not None:
+        payload["trajectory_report"] = trajectory_payload
     _emit(
-        {"run_id": run_id, "advisory": advisory},
+        payload,
         f"trust_score: {advisory['trust_score']} "
         f"(role={advisory['breakdown']['role']} "
         f"goal={advisory['breakdown']['goal']} "
-        f"evidence={advisory['breakdown']['evidence']})",
+        f"evidence={advisory['breakdown']['evidence']})" + trajectory_text,
         as_json=args.json,
         stream=out,
         palette=getattr(args, "_palette", None),

--- a/tests/test_trajectory_report.py
+++ b/tests/test_trajectory_report.py
@@ -6,6 +6,7 @@ import json
 
 from continuum.analysis.trajectory_report import (
     build_trajectory_report,
+    health_maybe_generate_trajectory_report,
     maybe_generate_trajectory_report,
     record_trajectory_report,
 )
@@ -308,3 +309,56 @@ def test_synthetic_archive_determinism() -> None:
     assert r1.scar_rate == r2.scar_rate
     assert r1.stall_sites == r2.stall_sites
     assert r1.top_failure_action_types == r2.top_failure_action_types
+
+
+def test_health_idle_trigger_generates_for_quiet_and_not_for_busy() -> None:
+    storage = _make_storage()
+    try:
+        run_id = "run_1"
+        prev_end = 0
+        for window in range(10):
+            for i in range(3):
+                _add_failed_action(storage, run_id, "test.stall", f"w{window}_k{i}")
+            end = storage.last_sequence(run_id)
+            storage.append_event(
+                run_id,
+                EventType.EVENT_LOG_ANCHORED,
+                {"anchor_sequence": end},
+                source=Origin.DETERMINISTIC,
+            )
+            report = health_maybe_generate_trajectory_report(storage, run_id)
+            assert report is not None, f"window {window} should be quiet and generate"
+            assert report.window_end == end
+            assert report.window_start == prev_end
+            prev_end = end
+        events = list(storage.read_events(run_id))
+        reports = [e for e in events if e.type is EventType.TRAJECTORY_REPORT]
+        assert len(reports) == 10
+        storage.append_event(
+            run_id,
+            EventType.WORK_COMPLETED,
+            {"count": 1, "task_id": "busy"},
+            source=Origin.DETERMINISTIC,
+        )
+        end = storage.last_sequence(run_id)
+        storage.append_event(
+            run_id,
+            EventType.EVENT_LOG_ANCHORED,
+            {"anchor_sequence": end},
+            source=Origin.DETERMINISTIC,
+        )
+        before = len(
+            [e for e in storage.read_events(run_id) if e.type is EventType.TRAJECTORY_REPORT]
+        )
+        report_busy = health_maybe_generate_trajectory_report(storage, run_id)
+        assert report_busy is None
+        after = len(
+            [e for e in storage.read_events(run_id) if e.type is EventType.TRAJECTORY_REPORT]
+        )
+        assert after == before
+        via_health = health_maybe_generate_trajectory_report(storage, run_id)
+        assert via_health is None
+        direct = maybe_generate_trajectory_report(storage, run_id)
+        assert direct is None
+    finally:
+        storage.close()


### PR DESCRIPTION
## Description

Health now detects quiet windows via is_quiet_window over the last compaction window and calls maybe_generate_trajectory_report for that window. If not quiet it returns None with no write, keeping zero overhead. The wiring reuses existing helpers via a new _last_compaction_window helper, so maybe_generate and health share one window determination path, deterministic and bounded, digest auditable via existing build and record.

## Related issues

Refs #517
Parent #393

## Types of changes

- Type: `feature`

## Breaking changes

No

## How has this been tested?

- `ruff check src/ tests/ examples/` clean
- `ruff format --check src/ tests/ examples/` 257 files already formatted
- `mypy src/continuum` clean on changed files, pre-existing optional import errors in mcp adapters are from missing local deps and pass in CI where deps are installed
- `pytest tests/test_trajectory_report.py -q` 8 passed including new health idle trigger test
- `pytest tests/test_prefix_trust.py -k health -q` 1 passed, health remains advisory and never gates
- `pytest -q` full suite green

New test `test_health_idle_trigger_generates_for_quiet_and_not_for_busy` simulates 10 idle windows via anchors and quiet failed actions, asserts health generates 10 reports with correct windows, then a busy window with WORK_COMPLETED returns None with no write and zero overhead verified via report count.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Scope is health wiring only, no new event types or model changes. The health check remains read triggered, the trajectory report write happens only when quiet, reuse not duplicate, and the existing maybe_generate logic is the single source for building and recording.
