### PR TITLE
fix(dashboard): add pagination hint to recent events table (Refs #324)

### DIFF
--- a/src/continuum/dashboard/app.py
+++ b/src/continuum/dashboard/app.py
@@ -147,11 +147,17 @@ def render_run_detail_html(storage: Storage, run_id: str) -> str:
         advisory_html = ""
         pins_html = ""
     events = storage.read_events(run_id)
+    total = len(events)
+    hint = (
+        f"<p>Showing last 20 of {total} events, see continuum events {html.escape(run_id)} for full log.</p>"
+        if total > 20
+        else ""
+    )
     events_rows = "".join(
         f"<tr><td>{e.sequence}</td><td>{html.escape(e.type.value)}</td><td>{html.escape(str(e.payload))}</td></tr>"
         for e in events[-20:]
     )
-    events_html = f'<table border="1" cellpadding="4"><tr><th>Seq</th><th>Type</th><th>Payload</th></tr>{events_rows}</table>'
+    events_html = f'{hint}<table border="1" cellpadding="4"><tr><th>Seq</th><th>Type</th><th>Payload</th></tr>{events_rows}</table>'
 
     # Human-in-the-loop surface (issue #242): buttons only when there is
     # something a person can actually settle.

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -27,3 +27,32 @@ def test_dashboard_run_detail_shows_ledger_and_contract() -> None:
     assert "run_1" in html
     assert "Contract" in html
     assert "Validation" in html
+
+
+def test_dashboard_pagination_hint_shows_for_many_events() -> None:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_1", goal="g"))
+    for i in range(30):
+        storage.append_event("run_1", EventType.TOOL_CALLED, {"i": i})
+    html = render_run_detail_html(storage, "run_1")
+    assert "Showing last 20 of 30 events" in html
+    assert "continuum events run_1" in html
+    assert "for full log" in html
+
+
+def test_dashboard_no_pagination_hint_for_few_events() -> None:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_1", goal="g"))
+    for i in range(5):
+        storage.append_event("run_1", EventType.TOOL_CALLED, {"i": i})
+    html = render_run_detail_html(storage, "run_1")
+    assert "Showing last 20 of" not in html
+
+
+def test_dashboard_no_pagination_hint_for_exactly_twenty() -> None:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_1", goal="g"))
+    for i in range(20):
+        storage.append_event("run_1", EventType.TOOL_CALLED, {"i": i})
+    html = render_run_detail_html(storage, "run_1")
+    assert "Showing last 20 of" not in html


### PR DESCRIPTION
## Description

Add one line pagination hint above the recent events table in `render_run_detail_html`. When `len(events) > 20` the page now shows `<p>Showing last 20 of {total} events, see continuum events {run_id} for full log.</p>` directly above the table. When 20 or fewer events, no caption is shown. The hint uses `html.escape(run_id)` to prevent XSS and does not add a new endpoint.

## Related issues

Fixes #324

## Types of changes

- Type: bugfix

## Breaking changes

No

## How has this been tested?

```
ruff check src/continuum/dashboard/app.py
ruff format --check src/continuum/dashboard/app.py
python -m mypy --strict src/continuum/dashboard/app.py
pytest -q tests/test_dashboard.py tests/test_dashboard_hitl.py tests/test_dashboard_escaping.py tests/test_dashboard_bind.py
```
All passed. Manual verification with 0, 5, 20, 21, 30, 284 events confirms hint appears only when >20 and total is correct, XSS escaped, and only last 20 rows are shown.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

One line HTML addition, no new endpoint. Checked open and closed issues for duplicates, #319 is verify violations truncation hint and is distinct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hint on run-detail pages when more than 20 events are available.
  * The hint explains that only the latest 20 events are shown and provides a CLI command to view the complete event log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->