### PR TITLE
fix(dashboard): cap POST body at 1 MB and drain like gateway (Fixes #317)

### DIFF
--- a/src/continuum/dashboard/app.py
+++ b/src/continuum/dashboard/app.py
@@ -15,6 +15,11 @@ from typing import Any
 from continuum.recovery import RecoveryEngine
 from continuum.storage.base import Storage
 
+MAX_DASHBOARD_BODY = 1 * 1024 * 1024
+
+#: Upper bound on how much to drain before giving up, matching gateway (#317).
+DASHBOARD_DRAIN_LIMIT_BYTES = 256 * 1024 * 1024
+
 
 def render_dashboard_html(storage: Storage) -> str:
     runs = storage.list_runs()
@@ -226,6 +231,11 @@ def make_dashboard_server(
     with goals and side-effect details, which must not be reachable from
     off-host by default. Operators who understand the exposure can pass
     ``--host 0.0.0.0`` explicitly.
+
+    POST bodies are capped at 1 MB (#317) to prevent unbounded reads. Bodies
+    exceeding the cap are drained up to 256 MB (matching gateway) and answered
+    with 413, so a client can finish writing and read the refusal instead of
+    dying on a broken pipe.
     """
     import urllib.parse
 
@@ -242,10 +252,14 @@ def make_dashboard_server(
             return
 
         def _html(self, content: str, code: int = 200) -> None:
+            body = content.encode("utf-8")
             self.send_response(code)
+            if getattr(self, "close_connection", False):
+                self.send_header("Connection", "close")
             self.send_header("Content-type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
             self.end_headers()
-            self.wfile.write(content.encode("utf-8"))
+            self.wfile.write(body)
 
         def do_GET(self) -> None:  # noqa: N802
             if self.path.startswith("/runs/"):
@@ -262,6 +276,25 @@ def make_dashboard_server(
 
         def do_POST(self) -> None:  # noqa: N802
             length = int(self.headers.get("Content-Length") or 0)
+            if length > MAX_DASHBOARD_BODY:
+                drained = 0
+                while drained < length:
+                    chunk = self.rfile.read(min(1024 * 1024, length - drained))
+                    if not chunk:
+                        break
+                    drained += len(chunk)
+                    if drained > DASHBOARD_DRAIN_LIMIT_BYTES:
+                        self.close_connection = True
+                        self._html(
+                            "<h1>413 Body too large</h1><p>request body too large to drain</p>",
+                            code=413,
+                        )
+                        return
+                self._html(
+                    f"<h1>413 Body too large</h1><p>request body exceeds {MAX_DASHBOARD_BODY} bytes</p>",
+                    code=413,
+                )
+                return
             raw = self.rfile.read(length) if length else b""
             form = dict(urllib.parse.parse_qsl(raw.decode("utf-8")))
             token = form.get("token") or self.headers.get("X-Dashboard-Token")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,4 +1,15 @@
+import http.client
+import os
+import threading
+import urllib.parse
+from pathlib import Path
+
 from continuum.dashboard import render_dashboard_html, render_run_detail_html
+from continuum.dashboard.app import (
+    DASHBOARD_DRAIN_LIMIT_BYTES,
+    MAX_DASHBOARD_BODY,
+    make_dashboard_server,
+)
 from continuum.events import EventType
 from continuum.models import Run
 from continuum.storage import SQLiteStorage
@@ -27,3 +38,59 @@ def test_dashboard_run_detail_shows_ledger_and_contract() -> None:
     assert "run_1" in html
     assert "Contract" in html
     assert "Validation" in html
+
+
+def test_dashboard_post_body_too_large_returns_413(tmp_path: Path) -> None:
+    """Large POST bodies are refused with 413, matching gateway pattern (#317)."""
+    # token needed for the small-body control, but the oversize check happens before auth
+    os.environ["CONTINUUM_DASHBOARD_TOKEN"] = "op-secret"
+    db = str(tmp_path / "dash.db")
+    with SQLiteStorage(db) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+
+    server = make_dashboard_server(SQLiteStorage(db), port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    addr = f"127.0.0.1:{server.server_address[1]}"
+    try:
+        # Oversize: 1 MB + 1, like the repro in #317 (6 MB would also work but is slower).
+        huge = "x" * (MAX_DASHBOARD_BODY + 1)
+        body = urllib.parse.urlencode(
+            {"run_id": "run_1", "token": "op-secret", "blob": huge}
+        ).encode()
+        conn = http.client.HTTPConnection(addr, timeout=10)
+        conn.request(
+            "POST", "/action/reconcile", body=body, headers={"Content-Length": str(len(body))}
+        )
+        resp = conn.getresponse()
+        data = resp.read().decode(errors="ignore")
+        conn.close()
+        assert resp.status == 413
+        assert "Body too large" in data
+        assert str(MAX_DASHBOARD_BODY) in data
+
+        # Drain limit is the same bound the gateway uses, so behaviour is consistent.
+        from continuum.gateway import DRAIN_LIMIT_BYTES
+
+        assert DASHBOARD_DRAIN_LIMIT_BYTES == DRAIN_LIMIT_BYTES
+
+        # Small body still succeeds (control): a valid confirm with a tiny payload.
+        small_body = urllib.parse.urlencode({"run_id": "run_1", "token": "op-secret"}).encode()
+        conn = http.client.HTTPConnection(addr, timeout=10)
+        conn.request(
+            "POST",
+            "/action/confirm",
+            body=small_body,
+            headers={"Content-Length": str(len(small_body))},
+        )
+        resp = conn.getresponse()
+        data = resp.read().decode(errors="ignore")
+        conn.close()
+        assert resp.status == 200
+        assert "goal and progress confirmed" in data
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+        os.environ.pop("CONTINUUM_DASHBOARD_TOKEN", None)


### PR DESCRIPTION
## Description

Hardens the dashboard against unbounded reads the same way the gateway is hardened. The dashboard bound to 127.0.0.1 but an unbounded `rfile.read(length)` on `/action/reconcile` and similar POSTs lets a large body buffer unbounded. This change caps form POSTs at 1 MB, drains up to 256 MB (matching gateway) before answering 413, and documents the limit on `make_dashboard_server`.

Approach copies the gateway drain loop verbatim to avoid duplicating bugs: read in 1 MB chunks, track drained, close the connection if drained exceeds the 256 MB sanity bound, otherwise answer 413 Body too large. ``_html`` now respects `close_connection` and sends Content-Length so the drain path matches gateway.

## Related issues

Fixes #317

## Types of changes

- Type: bugfix

## Breaking changes

No

## How has this been tested?

- Added `test_dashboard_post_body_too_large_returns_413` in `tests/test_dashboard.py` which starts a live dashboard on an ephemeral port, posts a body of `MAX_DASHBOARD_BODY + 1` and expects 413 containing the limit, asserts `DASHBOARD_DRAIN_LIMIT_BYTES == gateway.DRAIN_LIMIT_BYTES`, then posts a tiny valid confirm and expects 200.
- Manual repro with 6 MB body (issue steps) against live server returns 413, small body still returns 200.
- Full gate before merge: `ruff check src/ tests/` pass, `ruff format --check` pass, `mypy src/continuum --strict` shows only pre-existing optional-dep stubs (dashboard clean), `pytest -q tests/test_dashboard.py tests/test_dashboard_hitl.py tests/test_dashboard_bind.py tests/test_dashboard_escaping.py tests/test_gateway.py` 34 passed.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Gateway caps at 10 MB and drains 256 MB before 413. Dashboard form posts are tiny, so cap is 1 MB but drain bound is kept identical for consistency. Chunked Transfer-Encoding without Content-Length is not capped by either server and stays out of scope for this change, same as gateway.