### PR TITLE
fix(http): handle malformed Content-Length and chunked Transfer-Encoding in dashboard and gateway (#522)

### DIFF
--- a/src/continuum/dashboard/app.py
+++ b/src/continuum/dashboard/app.py
@@ -281,7 +281,29 @@ def make_dashboard_server(
             self._html(render_dashboard_html(storage))
 
         def do_POST(self) -> None:  # noqa: N802
-            length = int(self.headers.get("Content-Length") or 0)
+            te = self.headers.get("Transfer-Encoding", "").lower()
+            if "chunked" in te:
+                self._html(
+                    "<h1>400 Bad Request</h1><p>chunked transfer encoding is not supported</p>",
+                    code=400,
+                )
+                return
+
+            cl_header = self.headers.get("Content-Length")
+            if cl_header is not None:
+                try:
+                    length = int(cl_header)
+                    if length < 0:
+                        raise ValueError("Content-Length must be non-negative")
+                except ValueError as exc:
+                    self._html(
+                        f"<h1>400 Bad Request</h1><p>malformed Content-Length: {html.escape(str(exc))}</p>",
+                        code=400,
+                    )
+                    return
+            else:
+                length = 0
+
             if length > MAX_DASHBOARD_BODY:
                 drained = 0
                 while drained < length:

--- a/src/continuum/dashboard/app.py
+++ b/src/continuum/dashboard/app.py
@@ -285,21 +285,32 @@ def make_dashboard_server(
             self._html(render_dashboard_html(storage))
 
         def do_POST(self) -> None:  # noqa: N802
-            te = self.headers.get("Transfer-Encoding", "").lower()
-            if "chunked" in te:
+            transfer_encodings = self.headers.get_all("Transfer-Encoding", [])
+            if transfer_encodings:
+                self.close_connection = True
                 self._html(
-                    "<h1>400 Bad Request</h1><p>chunked transfer encoding is not supported</p>",
+                    "<h1>400 Bad Request</h1><p>transfer encoding is not supported</p>",
                     code=400,
                 )
                 return
 
-            cl_header = self.headers.get("Content-Length")
+            content_lengths = self.headers.get_all("Content-Length", [])
+            if len(content_lengths) > 1:
+                self.close_connection = True
+                self._html(
+                    "<h1>400 Bad Request</h1><p>multiple Content-Length headers are not supported</p>",
+                    code=400,
+                )
+                return
+
+            cl_header = content_lengths[0] if content_lengths else None
             if cl_header is not None:
                 try:
                     length = int(cl_header)
                     if length < 0:
                         raise ValueError("Content-Length must be non-negative")
                 except ValueError as exc:
+                    self.close_connection = True
                     self._html(
                         f"<h1>400 Bad Request</h1><p>malformed Content-Length: {html.escape(str(exc))}</p>",
                         code=400,

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -187,16 +187,11 @@ def match_route(
         for _v in body.values():
             if isinstance(_v, str) and _v in consumed_authorities:
                 ev = consumed_authorities[_v]
-                seq = (
-                    getattr(ev, "sequence", "?")
-                    if hasattr(ev, "sequence")
-                    else ev.get("sequence", "?")
-                )
-                payload = getattr(ev, "payload", {}) or {}
                 if hasattr(ev, "payload"):
                     seq = ev.sequence
-                    payload = ev.payload
+                    payload = ev.payload or {}
                 else:
+                    seq = ev.get("sequence", "?")
                     payload = ev.get("payload", {})
                 consumer = payload.get("consumer_run_id", "?")
                 return Decision(
@@ -268,13 +263,6 @@ def match_route(
                     )
         except Exception:
             action = None
-    else:
-        # action already from local, foreign stays None
-        pass
-    # If we already resolved action via foreign, we need to handle status below
-    # Reuse variable action; key already computed
-    # To avoid double lookup, we will have a flag
-
     if action is None or getattr(action, "action_type", None) != route.action_type:
         return Decision(
             False,

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -240,7 +240,23 @@ class GatewayServer:
                 decode (issue #323). Callers catch both and return, since the
                 response is already on the wire.
                 """
-                length = int(self.headers.get("Content-Length") or 0)
+                te = self.headers.get("Transfer-Encoding", "").lower()
+                if "chunked" in te:
+                    self._respond(400, {"error": "chunked transfer encoding is not supported"})
+                    raise _MalformedBody
+
+                cl_header = self.headers.get("Content-Length")
+                if cl_header is not None:
+                    try:
+                        length = int(cl_header)
+                        if length < 0:
+                            raise ValueError("Content-Length must be non-negative")
+                    except ValueError as exc:
+                        self._respond(400, {"error": f"malformed Content-Length header: {exc}"})
+                        raise _MalformedBody from exc
+                else:
+                    length = 0
+
                 if length > max_bytes:
                     # Drain (without buffering) so the client can finish
                     # writing and read our 413, instead of dying on a broken

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -259,7 +259,13 @@ def match_route(
             if getattr(storage, "supports_action_index", False):
                 foreign_action = storage.foreign_action(key, exclude_run=run_id)
                 if foreign_action is not None:
-                    action = foreign_action
+                    return Decision(
+                        False,
+                        f"side effect {route.action_type!r} key {rendered!r} "
+                        f"already has a claim in another run "
+                        f"({foreign_action.status.value}); reconcile it first",
+                        route=route,
+                    )
         except Exception:
             action = None
     else:

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -337,18 +337,28 @@ class GatewayServer:
                 decode (issue #323). Callers catch both and return, since the
                 response is already on the wire.
                 """
-                te = self.headers.get("Transfer-Encoding", "").lower()
-                if "chunked" in te:
-                    self._respond(400, {"error": "chunked transfer encoding is not supported"})
+                transfer_encodings = self.headers.get_all("Transfer-Encoding", [])
+                if transfer_encodings:
+                    self.close_connection = True
+                    self._respond(400, {"error": "transfer encoding is not supported"})
                     raise _MalformedBody
 
-                cl_header = self.headers.get("Content-Length")
+                content_lengths = self.headers.get_all("Content-Length", [])
+                if len(content_lengths) > 1:
+                    self.close_connection = True
+                    self._respond(
+                        400, {"error": "multiple Content-Length headers are not supported"}
+                    )
+                    raise _MalformedBody
+
+                cl_header = content_lengths[0] if content_lengths else None
                 if cl_header is not None:
                     try:
                         length = int(cl_header)
                         if length < 0:
                             raise ValueError("Content-Length must be non-negative")
                     except ValueError as exc:
+                        self.close_connection = True
                         self._respond(400, {"error": f"malformed Content-Length header: {exc}"})
                         raise _MalformedBody from exc
                 else:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -118,6 +118,34 @@ def test_dashboard_post_body_too_large_returns_413(tmp_path: Path) -> None:
         conn.close()
         assert resp.status == 200
         assert "goal and progress confirmed" in data
+
+        # Malformed Content-Length returns 400 without crashing (#522)
+        conn = http.client.HTTPConnection(addr, timeout=10)
+        conn.request(
+            "POST",
+            "/action/confirm",
+            body=b"x",
+            headers={"Content-Length": "abc"},
+        )
+        resp = conn.getresponse()
+        data = resp.read().decode(errors="ignore")
+        conn.close()
+        assert resp.status == 400
+        assert "400 Bad Request" in data
+
+        # Chunked Transfer-Encoding returns 400 (#522)
+        conn = http.client.HTTPConnection(addr, timeout=10)
+        conn.request(
+            "POST",
+            "/action/confirm",
+            body=b"1\r\nx\r\n0\r\n\r\n",
+            headers={"Transfer-Encoding": "chunked"},
+        )
+        resp = conn.getresponse()
+        data = resp.read().decode(errors="ignore")
+        conn.close()
+        assert resp.status == 400
+        assert "chunked transfer encoding is not supported" in data
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,5 +1,6 @@
 import http.client
 import os
+import socket
 import threading
 import urllib.parse
 from pathlib import Path
@@ -13,6 +14,13 @@ from continuum.dashboard.app import (
 from continuum.events import EventType
 from continuum.models import Run
 from continuum.storage import SQLiteStorage
+
+
+def recv_until_close(sock: socket.socket) -> bytes:
+    chunks = []
+    while chunk := sock.recv(4096):
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def test_dashboard_renders_runs() -> None:
@@ -222,7 +230,26 @@ def test_dashboard_post_body_too_large_returns_413(tmp_path: Path) -> None:
         data = resp.read().decode(errors="ignore")
         conn.close()
         assert resp.status == 400
-        assert "chunked transfer encoding is not supported" in data
+        assert "transfer encoding is not supported" in data
+        assert resp.getheader("Connection") == "close"
+
+        # Duplicate Content-Length is ambiguous framing and is refused (#522)
+        host, port = addr.split(":")
+        request = (
+            b"POST /action/confirm HTTP/1.1\r\n"
+            b"Host: 127.0.0.1\r\n"
+            b"Content-Length: 4\r\n"
+            b"Content-Length: 9\r\n"
+            b"\r\n"
+            b"token=x"
+        )
+        with socket.create_connection((host, int(port)), timeout=10) as sock:
+            sock.sendall(request)
+            response = recv_until_close(sock)
+
+        assert b"400 Bad Request" in response
+        assert b"Connection: close" in response
+        assert b"multiple Content-Length headers are not supported" in response
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import http.client
 import json
+import socket
 import threading
 from pathlib import Path
 
@@ -74,6 +75,13 @@ def post(addr: str, path: str, body: dict[str, object], host: str = "api.example
     data = json.loads(resp.read() or b"{}")
     conn.close()
     return resp.status, data
+
+
+def recv_until_close(sock: socket.socket) -> bytes:
+    chunks = []
+    while chunk := sock.recv(4096):
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def claim(db: str, key: str) -> str:
@@ -287,7 +295,11 @@ def test_malformed_content_length_returns_400(db: str, gateway: str) -> None:
         "POST",
         "/v1/invoices",
         body=b'{"id": "1"}',
-        headers={"Host": "api.example.com", "Content-Type": "application/json", "Content-Length": "invalid"},
+        headers={
+            "Host": "api.example.com",
+            "Content-Type": "application/json",
+            "Content-Length": "invalid",
+        },
     )
     resp = conn.getresponse()
     body = json.loads(resp.read())
@@ -302,11 +314,60 @@ def test_chunked_transfer_encoding_returns_400(db: str, gateway: str) -> None:
         "POST",
         "/v1/invoices",
         body=b'e\r\n{"id": "1"}\r\n0\r\n\r\n',
-        headers={"Host": "api.example.com", "Content-Type": "application/json", "Transfer-Encoding": "chunked"},
+        headers={
+            "Host": "api.example.com",
+            "Content-Type": "application/json",
+            "Transfer-Encoding": "chunked",
+        },
     )
     resp = conn.getresponse()
     body = json.loads(resp.read())
     conn.close()
     assert resp.status == 400
-    assert "chunked transfer encoding is not supported" in body["error"]
+    assert "transfer encoding is not supported" in body["error"]
+    assert resp.getheader("Connection") == "close"
 
+
+def test_duplicate_content_length_returns_400(db: str, gateway: str) -> None:
+    host, port = gateway.split(":")
+    request = (
+        b"POST /v1/invoices HTTP/1.1\r\n"
+        b"Host: api.example.com\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: 4\r\n"
+        b"Content-Length: 9\r\n"
+        b"\r\n"
+        b'{"id": "1"}'
+    )
+    with socket.create_connection((host, int(port)), timeout=10) as sock:
+        sock.sendall(request)
+        response = recv_until_close(sock)
+
+    assert b"400 Bad Request" in response
+    assert b"Connection: close" in response
+    assert b"multiple Content-Length headers are not supported" in response
+
+
+def test_transfer_encoding_closes_gateway_connection(db: str, gateway: str) -> None:
+    host, port = gateway.split(":")
+    request = (
+        b"POST /v1/invoices HTTP/1.1\r\n"
+        b"Host: api.example.com\r\n"
+        b"Transfer-Encoding: gzip\r\n"
+        b"Transfer-Encoding: chunked\r\n"
+        b"\r\n"
+        b"1\r\nx\r\n0\r\n\r\n"
+        b"POST /v1/invoices HTTP/1.1\r\n"
+        b"Host: api.example.com\r\n"
+        b"Content-Length: 0\r\n"
+        b"\r\n"
+    )
+    with socket.create_connection((host, int(port)), timeout=10) as sock:
+        sock.sendall(request)
+        response = recv_until_close(sock)
+
+    assert response.count(b"HTTP/1.1") == 1
+    assert b"400 Bad Request" in response
+    assert b"Connection: close" in response
+    assert b"transfer encoding is not supported" in response
+    assert b"501" not in response

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -279,3 +279,34 @@ def test_oversized_body_is_refused_with_413(db: str, gateway: str) -> None:
     conn.close()
     assert resp.status == 413
     assert "exceeds" in body["error"]
+
+
+def test_malformed_content_length_returns_400(db: str, gateway: str) -> None:
+    conn = http.client.HTTPConnection(gateway, timeout=10)
+    conn.request(
+        "POST",
+        "/v1/invoices",
+        body=b'{"id": "1"}',
+        headers={"Host": "api.example.com", "Content-Type": "application/json", "Content-Length": "invalid"},
+    )
+    resp = conn.getresponse()
+    body = json.loads(resp.read())
+    conn.close()
+    assert resp.status == 400
+    assert "malformed Content-Length" in body["error"]
+
+
+def test_chunked_transfer_encoding_returns_400(db: str, gateway: str) -> None:
+    conn = http.client.HTTPConnection(gateway, timeout=10)
+    conn.request(
+        "POST",
+        "/v1/invoices",
+        body=b'e\r\n{"id": "1"}\r\n0\r\n\r\n',
+        headers={"Host": "api.example.com", "Content-Type": "application/json", "Transfer-Encoding": "chunked"},
+    )
+    resp = conn.getresponse()
+    body = json.loads(resp.read())
+    conn.close()
+    assert resp.status == 400
+    assert "chunked transfer encoding is not supported" in body["error"]
+

--- a/tests/test_memory_forensic.py
+++ b/tests/test_memory_forensic.py
@@ -238,6 +238,40 @@ def test_gateway_tenant_deny_before_ledger(tmp_path) -> None:
         assert "tenant mismatch" in decision.reason
 
 
+def test_gateway_denies_foreign_memory_claim(tmp_path) -> None:
+    from continuum.gateway import Route
+
+    route = Route(
+        host="pgvector.internal",
+        methods=("POST",),
+        prefix="/upsert",
+        action_type="mem_write",
+        key_template="mem:{store_id}:{tenant}:{record_key}",
+    )
+    path = str(tmp_path / "gw.db")
+    with SQLiteStorage(path) as store:
+        for run_id in ("run_1", "run_2"):
+            store.create_run(Run(run_id=run_id, goal="g"))
+            store.append_event(run_id, EventType.RUN_STARTED, {"goal": "g"})
+
+        rendered = "mem:pgvector_main:acme:rec-42"
+        ActionLedger(store, "run_2").claim("mem_write", {}, key=rendered, scoped_to_run=False)
+        actions = fold_action_events(store.read_events("run_1"))
+
+        decision = match_route(
+            [route],
+            host="pgvector.internal",
+            method="POST",
+            body={"store_id": "pgvector_main", "tenant": "acme", "record_key": "rec-42"},
+            actions_by_key=actions,
+            run_id="run_1",
+            storage=store,
+        )
+
+    assert decision.allow is False
+    assert "already has a claim in another run" in decision.reason
+
+
 def test_memory_observation_unverified_escalates(tmp_path) -> None:
     path = str(tmp_path / "mem.db")
     with SQLiteStorage(path) as store:


### PR DESCRIPTION
Fixes #522

### Summary
Hardens HTTP body ingestion across both \src/continuum/dashboard/app.py\ and \src/continuum/gateway.py\ to gracefully handle malformed \Content-Length\ headers and reject unsupported chunked \Transfer-Encoding\ streams with HTTP 400 Bad Request instead of dropping connections.

### Changes
- In \src/continuum/dashboard/app.py\:
  - Checked for \Transfer-Encoding: chunked\ and answered with 400 Bad Request.
  - Safely parsed \Content-Length\ and verified non-negative integers; returns 400 on \ValueError\ without crashing.
- In \src/continuum/gateway.py\:
  - Added early check for \Transfer-Encoding: chunked\ in \_body\ and answered with 400 JSON error.
  - Validated \Content-Length\ integer values and answered 400 on malformed values.
- In \	ests/test_dashboard.py\ & \	ests/test_gateway.py\:
  - Added unit test cases covering malformed \Content-Length\ and chunked \Transfer-Encoding\ requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with malformed, negative, or duplicate `Content-Length` headers now receive a 400 Bad Request response.
  * Requests using transfer encoding are rejected safely with a 400 response, and affected connections are closed.
  * Gateway routing now prevents cross-tenant access and denies memory claims already associated with another run.
  * Run details now include archived events in the total shown in the event-count hint.

* **Tests**
  * Added coverage for invalid and ambiguous request framing, connection closure, and cross-run memory claim rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->