### PR TITLE
fix: avoid duplicate briefing hook on install

### DIFF
--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -265,15 +265,13 @@ def _install_hook(
     event_name: str,
     matcher: str,
 ) -> str:
-    """Add a continuum hook entry to a Claude Code settings file.
+    """Add a continuum hook entry to a client settings file.
 
-    ``kind`` selects which hook this is ("observe" or "gate"); it must equal
-    the final word of ``command``. Existing settings are preserved; only the
-    matching list under ``hooks`` gains (or updates) our single entry.
-    Returns ``"installed"`` when the entry was added, ``"updated"`` when an
-    existing entry of the same kind pointed somewhere else (a moved
-    virtualenv, say) and was repointed, ``"present"`` when nothing needed to
-    change.
+    Existing settings are preserved; only the matching list under ``hooks``
+    gains (or updates) our single entry. Returns ``"installed"`` when the
+    entry was added, ``"updated"`` when an existing entry pointed somewhere
+    else (a moved virtualenv, say) and was repointed, ``"present"`` when
+    nothing needed to change.
 
     A settings file that exists but is unreadable raises rather than being
     overwritten: a file someone edited by hand is a statement of intent, and
@@ -308,8 +306,8 @@ def _install_hook(
         if not isinstance(entries, list):
             continue
         for hook in entries:
-            ours = isinstance(hook, dict) and (
-                _is_continuum_hook(hook, "observe") or _is_continuum_hook(hook, "gate")
+            ours = isinstance(hook, dict) and any(
+                _is_continuum_hook(hook, k) for k in ("observe", "gate", "briefing")
             )
             if ours:
                 entry_found = True

--- a/tests/test_client_installers.py
+++ b/tests/test_client_installers.py
@@ -57,8 +57,9 @@ def test_install_is_idempotent_per_client(tmp_path: Path, client: str) -> None:
         code, _, err = run("--json", "hooks", "install", client, "--settings", str(settings))
         assert code == ExitCode.OK, err
     data = json.loads(settings.read_text())
-    event = CLIENT_PROFILES[client]["post_event"]
-    assert len(data["hooks"][event]) == 1
+    profile = CLIENT_PROFILES[client]
+    assert len(data["hooks"][profile["post_event"]]) == 1
+    assert len(data["hooks"][profile["start_event"]]) == 1
 
 
 def test_gemini_gate_uses_before_tool(tmp_path: Path) -> None:
@@ -196,3 +197,54 @@ def test_briefing_is_wired_on_session_start(tmp_path: Path, client: str) -> None
         and any(h.get("command", "").split()[-1] == "briefing" for h in g["hooks"])
     ]
     assert len(ours) == 1
+
+
+@pytest.mark.parametrize("client", ("claude-code", "gemini", "codex"))
+def test_three_installs_leave_one_start_group(tmp_path: Path, client: str) -> None:
+    """Repro for #484: briefing was duplicated on every install. Three runs
+    must leave exactly one SessionStart group and the third reports present."""
+    profile = CLIENT_PROFILES[client]
+    settings = tmp_path / "settings.json"
+    last_payload: dict[str, object] | None = None
+    for _ in range(3):
+        code, out, err = run("--json", "hooks", "install", client, "--settings", str(settings))
+        assert code == ExitCode.OK, err
+        last_payload = json.loads(out)  # type: ignore[assignment]
+    assert last_payload is not None
+    data = json.loads(settings.read_text())
+    assert len(data["hooks"][profile["post_event"]]) == 1
+    assert len(data["hooks"][profile["start_event"]]) == 1
+    statuses = {str(h["kind"]): str(h["status"]) for h in last_payload["hooks"]}  # type: ignore[union-attr]
+    assert statuses["briefing"] == "present"
+    assert statuses["observe"] == "present"
+
+
+def test_briefing_repoint_reuses_group(tmp_path: Path) -> None:
+    """Repro for #484 repointing path: a moved venv must repoint briefing
+    rather than duplicate it; old command gone, count stays 1, present after."""
+    from continuum.clienthooks import install_client_hook
+
+    s = tmp_path / "settings.json"
+    assert (
+        install_client_hook(
+            s, "/old/venv/bin/continuum briefing", event_name="SessionStart", matcher=""
+        )
+        == "installed"
+    )
+    assert (
+        install_client_hook(
+            s, "/new/venv/bin/continuum briefing", event_name="SessionStart", matcher=""
+        )
+        == "updated"
+    )
+    data = json.loads(s.read_text())
+    groups = data["hooks"]["SessionStart"]
+    assert len(groups) == 1
+    assert groups[0]["hooks"][0]["command"] == "/new/venv/bin/continuum briefing"
+    assert "/old/venv" not in json.dumps(data)
+    assert (
+        install_client_hook(
+            s, "/new/venv/bin/continuum briefing", event_name="SessionStart", matcher=""
+        )
+        == "present"
+    )


### PR DESCRIPTION
## Description

Fixes duplicate SessionStart briefing hook on every `continuum hooks install`.

Root cause was `_install_hook` recognising only `observe` and `gate` via
`_is_continuum_hook`, so a `... continuum briefing` command never matched
`entry_found`, and the tail unconditionally appended a fresh
SessionStart group. `remove_claude_code_hook` already handled all three
kinds, so the lists drifted when briefing was added in 7c6248d.

Change `ours` in `_install_hook` to `any(_is_continuum_hook(hook, k) for k in ("observe", "gate", "briefing"))`
so installer and remover agree. Update the stale docstring that still
described a non-existent `kind` parameter to match the actual
`(settings_path, command, *, event_name, matcher)` signature. No change to
the remover.

## Related issues

Fixes #484

## Types of changes

- Type: bugfix

## Breaking changes

No

## How has this been tested?

Re-ran issue reproductions on fixed code, raw output:

```
=== Reproduction 1 ===
Run 1: observe PostToolUse installed, briefing SessionStart installed
Run 2: observe PostToolUse present, briefing SessionStart present
Run 3: observe PostToolUse present, briefing SessionStart present
PostToolUse groups: 1, SessionStart groups: 1

=== Reproduction 2 ===
observe old -> installed, new -> updated (1 group)
briefing old -> installed, new -> updated (1 group, old gone), third -> present
```

Added regression tests in `tests/test_client_installers.py`:
- `test_install_is_idempotent_per_client` now asserts both `post_event` and `start_event` are 1 (previously only post_event, so bug passed)
- `test_three_installs_leave_one_start_group` 3 installs leave exactly 1 SessionStart group, third reports present
- `test_briefing_repoint_reuses_group` repoint briefing reuses group, old command gone, count stays 1

Shown to FAIL on old code (7 failed, 15 passed) and PASS on new (22 passed).

Gate:
- `pytest -q` 1769 passed, 24 skipped
- `ruff check src/ tests/ examples/` All checks passed
- `ruff format --check src/ tests/ examples/` 258 files already formatted
- `mypy src/continuum/clienthooks.py --strict --follow-imports=skip` Success

## Checklist

Tests added, docs not needed, CI green for changed files, no new security surface.

## Additional context

Files touched: `src/continuum/clienthooks.py` only (plus tests). Remover unchanged. Matches remover's kind list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook installation recognition for briefing hooks.
  * Existing briefing commands are now correctly updated when their environment path changes.
  * Repeated installations no longer create duplicate or outdated hooks.

* **Tests**
  * Added coverage for profile-specific post-event and session-start hook installation.
  * Verified idempotent installation across multiple clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->