### PR TITLE
fix: merge gate checks source preconditions Refs #494

### DIFF
--- a/src/continuum/recovery/gate.py
+++ b/src/continuum/recovery/gate.py
@@ -55,6 +55,7 @@ __all__ = [
     "ForkPreconditionError",
     "EditType",
     "check_preconditions",
+    "check_merge_preconditions",
     "enforce",
     "render_preserved_summary",
     "render_refusal_text",
@@ -276,6 +277,303 @@ def _filtered_depended_for_edit(
         if item.key in survivors or item.action_id in survivors
     )
     return restored_set | derived_surviving
+
+
+def _derive_single(
+    storage: Storage,
+    run_id: str,
+    anchor: int,
+    *,
+    candidate: int | None = None,
+    edit_type: EditType = "fork",
+) -> Any:
+    """Derive a single-run DerivationResult with per-edit filtering applied."""
+    from continuum.recovery.preconditions import DerivationResult, EditPoint, derive
+
+    head = candidate if candidate is not None else storage.last_sequence(run_id)
+    if anchor > head:
+        head = anchor
+    point = EditPoint(
+        run_id=run_id,
+        anchor_sequence=anchor,
+        candidate_sequence=head,
+    )
+    raw_derivation = derive(storage, point)
+    filtered_depended = _filtered_depended_for_edit(
+        raw_derivation, storage, run_id, anchor, edit_type
+    )
+    return DerivationResult(
+        unsettled_authorizations=raw_derivation.unsettled_authorizations,
+        depended_results=filtered_depended,
+        uncertain_slots=raw_derivation.uncertain_slots,
+    )
+
+
+def _all_strings_up_to(storage: Storage, run_id: str, head: int) -> frozenset[str]:
+    """All string payload values in ``[1, head]`` for cross-run checks."""
+    strings: set[str] = set()
+    from heapq import merge
+
+    stream = merge(
+        storage.read_archived_events(run_id),
+        storage.read_events(run_id),
+        key=lambda e: e.sequence,
+    )
+    for event in stream:
+        if event.sequence > head:
+            break
+        strings.update(_payload_strings_local(event.payload))
+    return frozenset(strings)
+
+
+def _collect_completions(storage: Storage, run_id: str, anchor: int, head: int) -> dict[str, Any]:
+    """Completed actions inside ``(anchor, head]`` keyed by ledger key."""
+    from heapq import merge
+
+    from continuum.events import EventType
+    from continuum.models import Action, ActionStatus
+
+    completions: dict[str, Any] = {}
+    stream = merge(
+        storage.read_archived_events(run_id),
+        storage.read_events(run_id),
+        key=lambda e: e.sequence,
+    )
+    for event in stream:
+        if event.sequence <= anchor:
+            continue
+        if event.sequence > head:
+            break
+        if event.type not in (
+            EventType.ACTION_RECORDED,
+            EventType.ACTION_RECONCILED,
+            EventType.ACTION_COMPENSATED,
+        ):
+            continue
+        raw_key = event.payload.get("key")
+        if not raw_key:
+            continue
+        try:
+            action = Action.model_validate(event.payload["action"])
+        except Exception:
+            continue
+        if action.status is not ActionStatus.COMPLETED:
+            continue
+        from continuum.recovery.preconditions import DependedResult
+
+        completions[str(raw_key)] = DependedResult(
+            key=str(raw_key),
+            action_id=action.action_id,
+            action_type=action.action_type,
+            sequence=event.sequence,
+        )
+    return completions
+
+
+def _cross_depended_for_merge(
+    storage: Storage,
+    target_run_id: str,
+    target_anchor: int,
+    target_head: int,
+    source_run_id: str,
+    source_anchor: int,
+    source_head: int,
+) -> frozenset[Any]:
+    """Completions on one side referenced by the other side's log."""
+    cross: set[Any] = set()
+    completions_source = _collect_completions(storage, source_run_id, source_anchor, source_head)
+    if completions_source:
+        target_strings = _all_strings_up_to(storage, target_run_id, target_head)
+        for key, item in completions_source.items():
+            if key in target_strings or item.action_id in target_strings:
+                cross.add(item)
+    completions_target = _collect_completions(storage, target_run_id, target_anchor, target_head)
+    if completions_target:
+        source_strings = _all_strings_up_to(storage, source_run_id, source_head)
+        for key, item in completions_target.items():
+            if key in source_strings or item.action_id in source_strings:
+                cross.add(item)
+    return frozenset(cross)
+
+
+def check_merge_preconditions(
+    storage: Storage,
+    target_run_id: str,
+    target_anchor: int,
+    *,
+    source_run_id: str | None = None,
+    source_anchor: int | None = None,
+    carry_forward: Collection[str] | None = None,
+) -> tuple[Any, set[str], dict[str, Any], dict[str, Any], dict[str, Any] | None]:
+    """Derive and enforce preconditions for both sides of a merge.
+
+    Target span is ``(target_anchor, target_head]`` where ``target_head`` is
+    ``last_sequence(target_run_id)``. Source span is
+    ``(source_anchor, source_head]`` where ``source_anchor`` is the explicit
+    ancestor or, when None, ``storage.latest_version(source_run_id).source_sequence``
+    (fallback 0). If ``source_run_id`` is None only the target side is checked
+    for backward compatibility.
+
+    Returns ``(union_derivation, carry_set, union_summary, target_summary, source_summary)``
+    where the union blocks if either side has unaccounted items. Raises
+    :class:`EditPreconditionError` with rationale naming both sides' sequences.
+    """
+    from continuum.recovery.preconditions import DerivationResult
+
+    target_head = storage.last_sequence(target_run_id)
+    if target_anchor > target_head:
+        target_head = target_anchor
+    target_derivation = _derive_single(
+        storage, target_run_id, target_anchor, candidate=target_head, edit_type="merge"
+    )
+    target_summary = summary_payload(target_derivation)
+
+    if source_run_id is None:
+        carry_set = {str(x) for x in (carry_forward or ())}
+        unaccounted = _unaccounted_sets(target_derivation, carry_set)
+        if (
+            unaccounted.unsettled_authorizations
+            or unaccounted.depended_results
+            or unaccounted.uncertain_slots
+        ):
+            check_preconditions(
+                storage,
+                target_run_id,
+                target_anchor,
+                candidate=target_head,
+                edit_type="merge",
+                carry_forward=carry_forward,
+            )
+            raise AssertionError("check_preconditions should have raised")
+        return target_derivation, carry_set, target_summary, target_summary, None
+
+    storage.get_run(source_run_id)
+    if source_anchor is None:
+        latest = storage.latest_version(source_run_id)
+        source_anchor_val = latest.source_sequence if latest is not None else 0
+    else:
+        source_anchor_val = int(source_anchor)
+    source_head = storage.last_sequence(source_run_id)
+    if source_anchor_val > source_head:
+        source_head = source_anchor_val
+    source_derivation = _derive_single(
+        storage, source_run_id, source_anchor_val, candidate=source_head, edit_type="merge"
+    )
+    source_summary = summary_payload(source_derivation)
+
+    cross = _cross_depended_for_merge(
+        storage,
+        target_run_id,
+        target_anchor,
+        target_head,
+        source_run_id,
+        source_anchor_val,
+        source_head,
+    )
+
+    union_depended = frozenset(
+        set(target_derivation.depended_results)
+        | set(source_derivation.depended_results)
+        | set(cross)
+    )
+    union = DerivationResult(
+        unsettled_authorizations=frozenset(
+            set(target_derivation.unsettled_authorizations)
+            | set(source_derivation.unsettled_authorizations)
+        ),
+        depended_results=union_depended,
+        uncertain_slots=frozenset(
+            set(target_derivation.uncertain_slots) | set(source_derivation.uncertain_slots)
+        ),
+    )
+    carry_set = {str(x) for x in (carry_forward or ())}
+    unaccounted = _unaccounted_sets(union, carry_set)
+
+    if (
+        unaccounted.unsettled_authorizations
+        or unaccounted.depended_results
+        or unaccounted.uncertain_slots
+    ):
+        parts: list[str] = []
+        rationale: dict[str, Any] = {
+            "edit_type": "merge",
+            "anchor_sequence": target_anchor,
+            "candidate_sequence": target_head,
+            "divergence_sequence": target_anchor,
+            "target_anchor_sequence": target_anchor,
+            "target_candidate_sequence": target_head,
+            "source_run_id": source_run_id,
+            "source_anchor_sequence": source_anchor_val,
+            "source_candidate_sequence": source_head,
+            "unsettled_authorizations": [
+                {
+                    "approval_id": item.approval_id,
+                    "sequence": item.sequence,
+                    "subject": item.subject,
+                }
+                for item in sorted(unaccounted.unsettled_authorizations, key=lambda x: x.sequence)
+            ],
+            "depended_results": [
+                {
+                    "key": item.key,
+                    "action_id": item.action_id,
+                    "action_type": item.action_type,
+                    "sequence": item.sequence,
+                }
+                for item in sorted(unaccounted.depended_results, key=lambda x: x.sequence)
+            ],
+            "uncertain_slots": [
+                {
+                    "key": item.key,
+                    "action_id": item.action_id,
+                    "action_type": item.action_type,
+                    "status": item.status,
+                    "sequence": item.sequence,
+                }
+                for item in sorted(unaccounted.uncertain_slots, key=lambda x: x.sequence)
+            ],
+            "carry_forward": sorted(carry_set),
+            "target_preconditions": target_summary,
+            "source_preconditions": source_summary,
+        }
+        if unaccounted.unsettled_authorizations:
+            ids = ", ".join(
+                f"{item.approval_id} at sequence {item.sequence}"
+                for item in sorted(unaccounted.unsettled_authorizations, key=lambda x: x.sequence)
+            )
+            parts.append(
+                f"{len(unaccounted.unsettled_authorizations)} unsettled authorization(s): {ids}"
+            )
+        if unaccounted.depended_results:
+            ids = ", ".join(
+                f"{item.action_id} (key {item.key}) at sequence {item.sequence}"
+                for item in sorted(unaccounted.depended_results, key=lambda x: x.sequence)
+            )
+            parts.append(
+                f"{len(unaccounted.depended_results)} depended result(s) would be stranded: {ids}"
+            )
+        if unaccounted.uncertain_slots:
+            ids = ", ".join(
+                f"{item.action_id} (key {item.key}, status {item.status}) at sequence {item.sequence}"
+                for item in sorted(unaccounted.uncertain_slots, key=lambda x: x.sequence)
+            )
+            parts.append(f"{len(unaccounted.uncertain_slots)} uncertain slot(s) still open: {ids}")
+        message = (
+            "merge refused: preconditions in target (anchor "
+            f"{target_anchor}, head {target_head}] and source (anchor "
+            f"{source_anchor_val}, head {source_head}] are unaccounted for: "
+            + "; ".join(parts)
+            + ". Pass carry_forward with the identifiers you intend to carry, or reconcile first."
+        )
+        raise EditPreconditionError(
+            message,
+            edit_type="merge",
+            derivation=union,
+            unaccounted=unaccounted,
+            rationale=rationale,
+        )
+    union_summary = summary_payload(union)
+    return union, carry_set, union_summary, target_summary, source_summary
 
 
 def check_preconditions(

--- a/src/continuum/recovery/merge.py
+++ b/src/continuum/recovery/merge.py
@@ -16,7 +16,11 @@ from typing import Any
 
 from continuum.events import EventType
 from continuum.models import Origin, Run
-from continuum.recovery.gate import EditPreconditionError, check_preconditions
+from continuum.recovery.gate import (
+    EditPreconditionError,
+    check_merge_preconditions,
+    check_preconditions,
+)
 from continuum.storage.base import Storage
 
 __all__ = [
@@ -39,15 +43,39 @@ def merge_to_anchor(
     *,
     reason: str,
     carry_forward: Collection[str] | None = None,
+    source_run_id: str | None = None,
+    source_anchor: int | None = None,
+    source_anchor_sequence: int | None = None,
 ) -> tuple[Any, set[str], dict[str, Any]]:
-    """Check preconditions for merging into ``run_id`` at ``anchor``."""
-    return check_preconditions(
+    """Check preconditions for merging into ``run_id`` at ``anchor``.
+
+    When ``source_run_id`` is given both sides are derived: target
+    ``(anchor, target_head]`` and source
+    ``(source_anchor, source_head]`` where ``source_anchor`` is the explicit
+    ancestor or ``storage.latest_version(source_run_id).source_sequence`` when
+    absent. Merge refuses if either side has unaccounted preconditions (union).
+    ``carry_forward`` may name items from either side (key, action_id or
+    sequence). Per-edit filtering keeps fork semantics for depended_results.
+    """
+    if source_anchor is None and source_anchor_sequence is not None:
+        source_anchor = int(source_anchor_sequence)
+    if source_run_id is None:
+        return check_preconditions(
+            storage,
+            run_id,
+            anchor,
+            edit_type="merge",
+            carry_forward=carry_forward,
+        )
+    union, carry_set, union_summary, _t, _s = check_merge_preconditions(
         storage,
-        run_id,
-        anchor,
-        edit_type="merge",
+        target_run_id=run_id,
+        target_anchor=anchor,
+        source_run_id=source_run_id,
+        source_anchor=source_anchor,
         carry_forward=carry_forward,
     )
+    return union, carry_set, union_summary
 
 
 def approve_merge(
@@ -56,10 +84,24 @@ def approve_merge(
     *,
     source_run_id: str | None = None,
     anchor_sequence: int | None = None,
+    source_anchor_sequence: int | None = None,
     reason: str,
     carry_forward: Collection[str] | None = None,
 ) -> Run:
-    """Approve a merge into ``run_id`` at ``anchor_sequence``."""
+    """Approve a merge into ``run_id`` at ``anchor_sequence``.
+
+    Both sides are derived when ``source_run_id`` is given: target
+    ``(anchor, target_head]`` and source
+    ``(source_anchor, source_head]`` where ``source_anchor`` is the common
+    ancestor or, when absent, ``storage.latest_version(source_run_id).source_sequence``.
+    If ``source_run_id`` is None only the target side is checked (backward
+    compat). Merge refuses if either side has unaccounted unsettled
+    authorizations, depended results or uncertain slots (union); ``carry_forward``
+    may name items from either side (key, action_id or sequence). Depended
+    filtering keeps fork semantics (full set) and cross-run references are
+    considered stranded as well. Rationale names both sides' sequences and the
+    lineage event stamps both sides' summaries.
+    """
     run = storage.get_run(run_id)
     if not reason or not reason.strip():
         raise ValueError("a merge needs a stated reason; the reason is the audit")
@@ -72,24 +114,71 @@ def approve_merge(
     else:
         anchor = int(anchor_sequence)
 
-    derivation, carry_set, summary = check_preconditions(
+    if source_run_id is None:
+        derivation, carry_set, summary = check_preconditions(
+            storage,
+            run_id,
+            anchor,
+            edit_type="merge",
+            carry_forward=carry_forward,
+        )
+        payload: dict[str, Any] = {
+            "reason": reason.strip(),
+            "anchor_sequence": anchor,
+            "divergence_sequence": anchor,
+            "candidate_sequence": storage.last_sequence(run_id),
+            "source_run_id": source_run_id,
+            "preconditions": summary,
+            "precondition_summary": summary,
+            "derivation": summary,
+            "derivation_summary": summary,
+            "carry_forward": sorted(carry_set),
+            "edit_type": "merge",
+        }
+        storage.append_event(
+            run_id,
+            EventType.RUN_MERGED,
+            payload,
+            source=Origin.HUMAN,
+        )
+        return run
+
+    source_anchor: int | None = None
+    if source_anchor_sequence is not None:
+        source_anchor = int(source_anchor_sequence)
+    derivation, carry_set, summary, target_summary, source_summary = check_merge_preconditions(
         storage,
-        run_id,
-        anchor,
-        edit_type="merge",
+        target_run_id=run_id,
+        target_anchor=anchor,
+        source_run_id=source_run_id,
+        source_anchor=source_anchor,
         carry_forward=carry_forward,
     )
-
-    payload: dict[str, Any] = {
+    target_head = storage.last_sequence(run_id)
+    source_head = storage.last_sequence(source_run_id)
+    if source_anchor is None:
+        latest_src = storage.latest_version(source_run_id)
+        resolved_source_anchor = latest_src.source_sequence if latest_src else 0
+    else:
+        resolved_source_anchor = source_anchor
+    payload = {
         "reason": reason.strip(),
         "anchor_sequence": anchor,
         "divergence_sequence": anchor,
-        "candidate_sequence": storage.last_sequence(run_id),
+        "candidate_sequence": target_head,
+        "target_anchor_sequence": anchor,
+        "target_candidate_sequence": target_head,
         "source_run_id": source_run_id,
+        "source_anchor_sequence": resolved_source_anchor,
+        "source_candidate_sequence": source_head,
         "preconditions": summary,
         "precondition_summary": summary,
         "derivation": summary,
         "derivation_summary": summary,
+        "target_preconditions": target_summary,
+        "source_preconditions": source_summary,
+        "target_summary": target_summary,
+        "source_summary": source_summary,
         "carry_forward": sorted(carry_set),
         "edit_type": "merge",
     }

--- a/tests/test_merge_gate_source_494.py
+++ b/tests/test_merge_gate_source_494.py
@@ -1,0 +1,382 @@
+"""Source-aware merge gate (#494, #389).
+
+Merge must derive both sides: target (anchor, target_head] and source
+(source_anchor, source_head] where source_anchor is common ancestor or
+source latest checkpoint if absent. Merge refuses if either side has
+unaccounted preconditions (union) and carry_forward may name items from
+either side. Per-edit filtering keeps fork semantics for depended_results.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.actions.idempotency import idempotency_key
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.recovery.gate import EditPreconditionError, check_merge_preconditions
+from continuum.recovery.merge import approve_merge, merge_to_anchor
+from continuum.storage import SQLiteStorage
+
+
+def _make_run(storage: SQLiteStorage, run_id: str) -> None:
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "g"})
+
+
+def test_source_completed_target_dependent_blocks_and_names_source_sequence() -> None:
+    storage = SQLiteStorage(":memory:")
+    try:
+        _make_run(storage, "target")
+        _make_run(storage, "source")
+        # Source side: completed result
+        ledger_src = ActionLedger(storage, "source")
+        outcome = ledger_src.claim("github.create_issue", {"title": "t"}, key="k1")
+        ledger_src.complete(outcome.key, external_id="42")
+        expected_key = idempotency_key(
+            "github.create_issue", {"title": "t"}, scope="source", key="k1"
+        )
+        src_seq = storage.last_sequence("source")
+        # Target side: surviving dependent referencing source key
+        storage.append_event(
+            "target",
+            EventType.WORK_ADDED,
+            {"task_id": "w1", "prerequisite": [expected_key]},
+        )
+        # Merge must refuse, error names source sequence and both anchors
+        with pytest.raises(EditPreconditionError) as exc:
+            approve_merge(
+                storage,
+                "target",
+                source_run_id="source",
+                anchor_sequence=0,
+                reason="cross",
+            )
+        err = exc.value
+        # Old code would have passed (target-only derivation empty), new code blocks
+        assert hasattr(err, "rationale")
+        rationale = err.rationale  # type: ignore[attr-defined]
+        assert str(src_seq) in str(err) or str(src_seq) in str(rationale)
+        assert any(d["sequence"] == src_seq for d in rationale["depended_results"])
+        # Rationale must name both sides
+        assert "target_anchor_sequence" in rationale
+        assert "source_anchor_sequence" in rationale
+        assert "target_candidate_sequence" in rationale
+        assert "source_candidate_sequence" in rationale
+        assert rationale["source_run_id"] == "source"
+        assert "target (anchor" in str(err) and "source (anchor" in str(err)
+    finally:
+        storage.close()
+
+
+def test_source_depended_with_carry_forward_passes_and_lineage_stamps() -> None:
+    storage = SQLiteStorage(":memory:")
+    try:
+        _make_run(storage, "target")
+        _make_run(storage, "source")
+        ledger_src = ActionLedger(storage, "source")
+        outcome = ledger_src.claim("github.create_issue", {"title": "t"}, key="k1")
+        ledger_src.complete(outcome.key, external_id="42")
+        expected_key = idempotency_key(
+            "github.create_issue", {"title": "t"}, scope="source", key="k1"
+        )
+        storage.append_event(
+            "target",
+            EventType.WORK_ADDED,
+            {"task_id": "w1", "prerequisite": [expected_key]},
+        )
+        # With carry_forward containing source key, merge passes
+        merged = approve_merge(
+            storage,
+            "target",
+            source_run_id="source",
+            anchor_sequence=0,
+            reason="carry source",
+            carry_forward=[expected_key],
+        )
+        assert merged.run_id == "target"
+        events = storage.read_events("target")
+        lineage = [e for e in events if e.type is EventType.RUN_MERGED][-1]
+        assert expected_key in lineage.payload["carry_forward"]
+        # Lineage stamps both sides' summaries
+        assert "target_preconditions" in lineage.payload
+        assert "source_preconditions" in lineage.payload
+        assert "target_summary" in lineage.payload
+        assert "source_summary" in lineage.payload
+        # Union summary still records the carried depended result for audit,
+        # but the check passed because it was accounted via carry_forward
+        assert len(lineage.payload["preconditions"]["depended_results"]) == 1
+        assert lineage.payload["preconditions"]["depended_results"][0]["key"] == expected_key
+        assert lineage.payload["source_preconditions"] is not None
+        assert lineage.payload["target_preconditions"] is not None
+        assert lineage.payload["source_anchor_sequence"] is not None
+        assert lineage.payload["target_anchor_sequence"] is not None
+    finally:
+        storage.close()
+
+
+def test_clean_merge_of_two_branches_passes_and_stamps_both_summaries() -> None:
+    storage = SQLiteStorage(":memory:")
+    try:
+        _make_run(storage, "target")
+        _make_run(storage, "source")
+        # No outstanding items on either side
+        merged = approve_merge(storage, "target", source_run_id="source", reason="clean")
+        assert merged is not None
+        events = storage.read_events("target")
+        lineage = [e for e in events if e.type is EventType.RUN_MERGED][-1]
+        # Both sides summaries present and empty
+        assert lineage.payload["source_preconditions"]["unsettled_authorizations"] == []
+        assert lineage.payload["source_preconditions"]["depended_results"] == []
+        assert lineage.payload["source_preconditions"]["uncertain_slots"] == []
+        assert lineage.payload["target_preconditions"]["unsettled_authorizations"] == []
+        assert lineage.payload["target_preconditions"]["depended_results"] == []
+        assert lineage.payload["target_preconditions"]["uncertain_slots"] == []
+        assert lineage.payload["preconditions"]["unsettled_authorizations"] == []
+        assert lineage.payload["preconditions"]["depended_results"] == []
+        assert lineage.payload["preconditions"]["uncertain_slots"] == []
+        assert lineage.payload["source_run_id"] == "source"
+        # Also check merge_to_anchor stamps similarly when source given
+        storage2 = SQLiteStorage(":memory:")
+        try:
+            _make_run(storage2, "t2")
+            _make_run(storage2, "s2")
+            derivation, carry_set, summary = merge_to_anchor(
+                storage2, "t2", 0, reason="clean2", source_run_id="s2"
+            )
+            assert summary["unsettled_authorizations"] == []
+            assert summary["depended_results"] == []
+        finally:
+            storage2.close()
+    finally:
+        storage.close()
+
+
+def test_source_run_id_none_only_target_checked_backward_compat() -> None:
+    storage = SQLiteStorage(":memory:")
+    try:
+        _make_run(storage, "target")
+        # Target has uncertain slot, no source
+        ledger = ActionLedger(storage, "target")
+        outcome = ledger.claim("slack.notify", {"channel": "#ops"}, key="k1")
+        seq = storage.last_sequence("target")
+        with pytest.raises(EditPreconditionError) as exc:
+            approve_merge(storage, "target", reason="target only", anchor_sequence=0)
+        assert str(seq) in str(exc.value)
+        # Carry by target action_id unblocks
+        merged = approve_merge(
+            storage,
+            "target",
+            reason="carry target",
+            anchor_sequence=0,
+            carry_forward=[outcome.action.action_id],
+        )
+        assert merged is not None
+        # Same via check_merge_preconditions with source None
+        storage2 = SQLiteStorage(":memory:")
+        try:
+            _make_run(storage2, "t2")
+            ledger2 = ActionLedger(storage2, "t2")
+            out2 = ledger2.claim("slack.notify", {"channel": "#ops"}, key="k1")
+            with pytest.raises(EditPreconditionError):
+                check_merge_preconditions(
+                    storage2, target_run_id="t2", target_anchor=0, source_run_id=None
+                )
+            # Should pass with carry
+            _, _, _, _, _ = check_merge_preconditions(
+                storage2,
+                target_run_id="t2",
+                target_anchor=0,
+                source_run_id=None,
+                carry_forward=[out2.action.action_id],
+            )
+        finally:
+            storage2.close()
+    finally:
+        storage.close()
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["unsettled_authorization", "depended_result", "uncertain_slot"],
+)
+def test_source_side_each_kind_blocks_and_carry_by_key_action_sequence(kind: str) -> None:
+    storage = SQLiteStorage(":memory:")
+    try:
+        _make_run(storage, "target")
+        _make_run(storage, "source")
+        if kind == "unsettled_authorization":
+            storage.append_event(
+                "source",
+                EventType.APPROVAL_GRANTED,
+                {"approval_id": "ap-1", "subject": "ship"},
+            )
+            seq = storage.last_sequence("source")
+            with pytest.raises(EditPreconditionError) as exc:
+                approve_merge(storage, "target", source_run_id="source", reason="block")
+            assert str(seq) in str(exc.value)
+            assert "ap-1" in str(exc.value)
+            # carry by approval_id
+            approve_merge(
+                storage,
+                "target",
+                source_run_id="source",
+                reason="carry ap",
+                carry_forward=["ap-1"],
+            )
+            # Must also work by sequence string
+            storage2 = SQLiteStorage(":memory:")
+            try:
+                _make_run(storage2, "t2")
+                _make_run(storage2, "s2")
+                storage2.append_event(
+                    "s2",
+                    EventType.APPROVAL_GRANTED,
+                    {"approval_id": "ap-2", "subject": "ship"},
+                )
+                seq2 = storage2.last_sequence("s2")
+                with pytest.raises(EditPreconditionError):
+                    approve_merge(storage2, "t2", source_run_id="s2", reason="block2")
+                approve_merge(
+                    storage2,
+                    "t2",
+                    source_run_id="s2",
+                    reason="carry seq",
+                    carry_forward=[str(seq2)],
+                )
+            finally:
+                storage2.close()
+        elif kind == "depended_result":
+            ledger = ActionLedger(storage, "source")
+            out = ledger.claim("github.create_issue", {"title": "t"}, key="k1")
+            ledger.complete(out.key, external_id="42")
+            storage.append_event(
+                "source",
+                EventType.WORK_ADDED,
+                {"task_id": "w1", "prerequisite": [out.key]},
+            )
+            with pytest.raises(EditPreconditionError) as exc:
+                approve_merge(storage, "target", source_run_id="source", reason="block")
+            assert "depended" in str(exc.value).lower()
+            # carry by key, action_id, sequence each unblock (per-run scope)
+            for carry_kind in ["key", "action_id", "sequence"]:
+                storage2 = SQLiteStorage(":memory:")
+                try:
+                    _make_run(storage2, "t2")
+                    _make_run(storage2, "s2")
+                    ledger2 = ActionLedger(storage2, "s2")
+                    out2 = ledger2.claim("github.create_issue", {"title": "t"}, key="k1")
+                    ledger2.complete(out2.key, external_id="42")
+                    storage2.append_event(
+                        "s2",
+                        EventType.WORK_ADDED,
+                        {"task_id": "w1", "prerequisite": [out2.key]},
+                    )
+                    if carry_kind == "key":
+                        carry_val = out2.key
+                    elif carry_kind == "action_id":
+                        carry_val = out2.action.action_id
+                    else:
+                        carry_val = str(storage2.last_sequence("s2") - 1)
+                    approve_merge(
+                        storage2,
+                        "t2",
+                        source_run_id="s2",
+                        reason="carry",
+                        carry_forward=[carry_val],
+                    )
+                finally:
+                    storage2.close()
+            # Clean carry test already done
+        else:  # uncertain_slot
+            ledger = ActionLedger(storage, "source")
+            out = ledger.claim("slack.notify", {"channel": "#ops"}, key="k1")
+            seq = storage.last_sequence("source")
+            with pytest.raises(EditPreconditionError) as exc:
+                approve_merge(storage, "target", source_run_id="source", reason="block")
+            assert str(seq) in str(exc.value)
+            # carry by key, action_id, sequence
+            for carry in [out.key, out.action.action_id, str(seq)]:
+                storage2 = SQLiteStorage(":memory:")
+                try:
+                    _make_run(storage2, "t2")
+                    _make_run(storage2, "s2")
+                    ledger2 = ActionLedger(storage2, "s2")
+                    out2 = ledger2.claim("slack.notify", {"channel": "#ops"}, key="k1")
+                    seq2 = storage2.last_sequence("s2")
+                    carry_val = carry
+                    if carry == out.key:
+                        carry_val = out2.key
+                    elif carry == out.action.action_id:
+                        carry_val = out2.action.action_id
+                    else:
+                        carry_val = str(seq2)
+                    with pytest.raises(EditPreconditionError):
+                        approve_merge(storage2, "t2", source_run_id="s2", reason="block2")
+                    approve_merge(
+                        storage2,
+                        "t2",
+                        source_run_id="s2",
+                        reason="carry",
+                        carry_forward=[carry_val],
+                    )
+                finally:
+                    storage2.close()
+    finally:
+        storage.close()
+
+
+def test_merge_to_anchor_with_source_union() -> None:
+    storage = SQLiteStorage(":memory:")
+    try:
+        _make_run(storage, "target")
+        _make_run(storage, "source")
+        ledger = ActionLedger(storage, "source")
+        out = ledger.claim("slack.notify", {"channel": "#ops"}, key="k1")
+        with pytest.raises(EditPreconditionError):
+            merge_to_anchor(storage, "target", 0, reason="block", source_run_id="source")
+        # carry by source key passes
+        _, _, summary = merge_to_anchor(
+            storage, "target", 0, reason="carry", source_run_id="source", carry_forward=[out.key]
+        )
+        assert summary is not None
+    finally:
+        storage.close()
+
+
+def test_old_code_would_have_passed_incorrectly_new_blocks() -> None:
+    """Demonstrate bug: target-only check passes, source-aware check blocks."""
+    storage = SQLiteStorage(":memory:")
+    try:
+        _make_run(storage, "target")
+        _make_run(storage, "source")
+        ledger_src = ActionLedger(storage, "source")
+        outcome = ledger_src.claim("github.create_issue", {"title": "t"}, key="k1")
+        ledger_src.complete(outcome.key, external_id="42")
+        expected_key = idempotency_key(
+            "github.create_issue", {"title": "t"}, scope="source", key="k1"
+        )
+        storage.append_event(
+            "target",
+            EventType.WORK_ADDED,
+            {"task_id": "w1", "prerequisite": [expected_key]},
+        )
+        # Old code: only target side, no depended on target alone, would pass
+        from continuum.recovery.gate import check_preconditions
+
+        # Target-only derivation should NOT block (old behavior)
+        check_preconditions(storage, "target", 0, edit_type="merge")  # should not raise
+        # New code with source must block
+        with pytest.raises(EditPreconditionError) as exc:
+            approve_merge(
+                storage,
+                "target",
+                source_run_id="source",
+                anchor_sequence=0,
+                reason="new should block",
+            )
+        assert "depended" in str(exc.value).lower()
+        assert str(storage.last_sequence("source")) in str(exc.value)
+    finally:
+        storage.close()


### PR DESCRIPTION
## Description

Merge previously checked only the target side span (anchor, target_head]. This change extends the gate to derive both sides: target (anchor, target_head] and source (source_anchor, source_head] where source_anchor is the common ancestor or source latest checkpoint (storage.latest_version(source_run_id).source_sequence) when no explicit ancestor is given. If source_run_id is None, only target is checked for backward compatibility.

- Union of unsettled_authorizations, depended_results (with cross-run reference detection) and uncertain_slots blocks the merge if either side is unaccounted.
- carry_forward may name key, action_id or sequence from either side (via union).
- Per-edit filtering keeps fork semantics for depended_results (merge does not apply restore's surviving-prefix filter).
- Rationale names both sides' sequences (target_anchor_sequence, target_candidate_sequence, source_anchor_sequence, source_candidate_sequence) and message mentions both spans.
- Lineage event stamps both sides' summaries (target_preconditions, source_preconditions, target_summary, source_summary) plus union preconditions.

Files: src/continuum/recovery/gate.py (union helper check_merge_preconditions, cross-run depended detection), src/continuum/recovery/merge.py (approve_merge and merge_to_anchor extended to derive both sides), tests/test_merge_gate_source_494.py

## Related issues

Fixes #494
Refs #389

## Types of changes

- Type: bugfix

## Breaking changes

No. Previously passing merges with outstanding source preconditions now correctly refuse.

## How has this been tested?

- New parametrised suite tests/test_merge_gate_source_494.py covers:
  - Source completed result + target surviving dependent blocks and names source sequence
  - Same with carry_forward containing source key passes and lineage stamps both summaries
  - Clean merge of two branches passes and lineage stamps both sides empty
  - source_run_id=None only target checked
  - Per-kind blocks (unsettled, depended, uncertain) and carry by key/action_id/sequence for both sides
  - Old code would pass (target-only check) new code blocks demonstration
- Existing suite still green:
  - pytest -q -k "not serve_http"  (exit 0)
  - pytest tests/test_restore_merge_gate.py (14 passed)
  - ruff check src/ tests/ examples/ (All checks passed)
  - ruff format src/continuum/recovery/gate.py src/continuum/recovery/merge.py tests/test_merge_gate_source_494.py (formatted)
  - mypy src/continuum/recovery/gate.py src/continuum/recovery/merge.py --strict (no new errors)

## Checklist

Tests added for changed behaviour. Documentation not needed. CI passes. Security: fail-closed, no new auth handling.

## Additional context

Cross-run depended detection scans both logs for key/action_id references, so a completion on source referenced by target's WORK_ADDED is considered stranded even though the two events live on different runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added source-aware merge validation that checks both target and source branches before merging.
  - Merges now identify and report unresolved prerequisites from either side.
  - Added support for carrying forward approved items from either branch.
  - Merge records now include anchor, candidate, and prerequisite summaries for both sides.

- **Bug Fixes**
  - Prevented merges from proceeding when the source branch contains unresolved requirements.

- **Backward Compatibility**
  - Existing single-branch merge behavior remains unchanged when no source branch is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->