### PR TITLE
fix(dashboard): count archived events in pagination hint (Refs #520)

### DIFF
--- a/src/continuum/dashboard/app.py
+++ b/src/continuum/dashboard/app.py
@@ -152,7 +152,11 @@ def render_run_detail_html(storage: Storage, run_id: str) -> str:
         advisory_html = ""
         pins_html = ""
     events = storage.read_events(run_id)
-    total = len(events)
+    try:
+        archived = storage.read_archived_events(run_id)
+    except Exception:
+        archived = []
+    total = len(events) + len(archived)
     hint = (
         f"<p>Showing last 20 of {total} events, see continuum events {html.escape(run_id)} for full log.</p>"
         if total > 20

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -69,6 +69,83 @@ def test_dashboard_no_pagination_hint_for_exactly_twenty() -> None:
     assert "Showing last 20 of" not in html
 
 
+def test_dashboard_pagination_hint_includes_archived_after_compaction() -> None:
+    """After compaction the hint must count archived events (Refs #520).
+
+    Before the fix total = len(live) so a run with 20 live but 80 archived
+    showed no hint even though the full log is 100. The fix counts both.
+    """
+    import html as html_lib
+
+    # Use html-sensitive run_id to verify escaping in the hint.
+    run_id = "run<1>&test"
+    storage = SQLiteStorage(":memory:")
+    storage.create_run_started(Run(run_id=run_id, goal="g"))
+    # 98 total before compact: 1 RUN_STARTED + 97 TOOL_CALLED
+    for i in range(97):
+        storage.append_event(run_id, EventType.TOOL_CALLED, {"i": i})
+    assert len(storage.read_events(run_id)) == 98
+    assert len(storage.read_archived_events(run_id)) == 0
+    # Compact so 80 archived, 20 live (18 tail + 2 anchor/checkpoint), 100 total.
+    storage.compact_run(run_id, through_sequence=80)
+    live = len(storage.read_events(run_id))
+    archived = len(storage.read_archived_events(run_id))
+    assert archived == 80
+    assert live == 20
+    assert live + archived == 100
+    html = render_run_detail_html(storage, run_id)
+    # Hint must show combined total, not just live (20 would be no hint).
+    assert "Showing last 20 of 100 events" in html
+    # HTML-escaped: run_id in hint is escaped, raw <>& must not appear.
+    assert html_lib.escape(run_id) in html
+    assert f"continuum events {html_lib.escape(run_id)} for full log" in html
+    # Old logic would have computed total = live = 20 and shown no hint.
+    assert live == 20
+
+
+def test_dashboard_no_hint_for_fifteen_events_no_compact() -> None:
+    """15 events with no anchor must not show the hint (Refs #520)."""
+    storage = SQLiteStorage(":memory:")
+    storage.create_run_started(Run(run_id="run_15", goal="g"))
+    for i in range(14):
+        storage.append_event("run_15", EventType.TOOL_CALLED, {"i": i})
+    assert len(storage.read_events("run_15")) == 15
+    assert len(storage.read_archived_events("run_15")) == 0
+    html = render_run_detail_html(storage, "run_15")
+    assert "Showing last 20 of" not in html
+
+
+def test_dashboard_no_hint_for_twenty_exact_no_compact() -> None:
+    """Exactly 20 combined events must not show the hint (Refs #520)."""
+    storage = SQLiteStorage(":memory:")
+    storage.create_run_started(Run(run_id="run_20", goal="g"))
+    for i in range(19):
+        storage.append_event("run_20", EventType.TOOL_CALLED, {"i": i})
+    assert len(storage.read_events("run_20")) == 20
+    html = render_run_detail_html(storage, "run_20")
+    assert "Showing last 20 of" not in html
+
+
+def test_dashboard_hint_for_twenty_one_with_one_archived() -> None:
+    """21 combined (20 live + 1 archived) must show hint for 21 (Refs #520)."""
+    run_id = "run_21"
+    storage = SQLiteStorage(":memory:")
+    storage.create_run_started(Run(run_id=run_id, goal="g"))
+    for i in range(18):
+        storage.append_event(run_id, EventType.TOOL_CALLED, {"i": i})
+    assert len(storage.read_events(run_id)) == 19
+    # Compact 1 archived, leaving 20 live (18 tail + 2 system) + 1 archived = 21 total.
+    storage.compact_run(run_id, through_sequence=1)
+    live = len(storage.read_events(run_id))
+    archived = len(storage.read_archived_events(run_id))
+    assert archived == 1
+    assert live == 20
+    assert live + archived == 21
+    html = render_run_detail_html(storage, run_id)
+    assert "Showing last 20 of 21 events" in html
+    assert f"continuum events {run_id} for full log" in html
+
+
 def test_dashboard_post_body_too_large_returns_413(tmp_path: Path) -> None:
     """Large POST bodies are refused with 413, matching gateway pattern (#317)."""
     # token needed for the small-body control, but the oversize check happens before auth


### PR DESCRIPTION
## Description

Dashboard pagination hint `Showing last 20 of {total} events` previously computed total from live events only (`len(storage.read_events(run_id))`). After `continuum compact`, events before the anchor move to `events_archive` and `read_events` returns only the tail, so a run with 300 events compacted to 20 live + 280 archived reported total 20 and showed no hint even though the full log is 300.

This change counts both live and archived events: `total = len(storage.read_events(run_id)) + len(storage.read_archived_events(run_id))` with a try/except fallback to [] for engines without an archive. The hint text and escaping stay exactly as in #324 and are shown only when combined total > 20. No new endpoint or JS, one presentation line change.

## Related issues

Fixes #520

Follow-up to #324 which added the hint, split from closed #399 Phase 4 dashboard work. Duplicate search for pagination/archived/compaction/dashboard found nothing.

## Types of changes

- Type: bugfix

## Breaking changes

No

## How has this been tested?

Before fix: compacted run with 20 live + 80 archived showed no hint (live=20 not >20). After fix: same run shows `Showing last 20 of 100 events` with html-escaped run_id.

Added tests in tests/test_dashboard.py:

- Create run, append 100 events, compact so 20 live + 80 archived, assert html contains `Showing last 20 of 100 events` with escaped run_id
- Run with 15 events (no compact) -> no hint
- Run with 20 exactly -> no hint
- Run with 21 (20 live + 1 archived) -> hint shows 21

Showed before fix hint missing after compact, after fix hint correct via repro script.

Full gate in worktree at 51fbcb9 with /opt/miniconda3/bin/python 3.13:

- pytest: 1773 passed, 24 skipped
- ruff check src/ tests/ examples/: All checks passed
- ruff format --check src/ tests/ examples/: 258 files already formatted
- mypy src/continuum --strict: Success, 114 files, exit 0 (conda python with dev deps)

Distribution surfaces already verified on main.

## Checklist

Tests added for the changed behaviour. CI passes on latest commit.

## Additional context

Minimal one-line HTML addition shape from #324 preserved. Archived helper is the existing `storage.read_archived_events` (issue #239), engine without archive returns [] so no extra handling needed. Verified live tail slicing (`events[-20:]`) still shows last 20 live rows; total now reflects full log.