### PR TITLE
fix: add carry-forward passthrough to rewind CLI (Refs #493)

### DIFF
--- a/src/continuum/checkpoint/rewind.py
+++ b/src/continuum/checkpoint/rewind.py
@@ -179,7 +179,7 @@ def rewind_to_checkpoint(
         raise RewindError(
             f"rewind to {to!r} has {len(conflicts)} conflict(s) and {len(unrecoverable)} unrecoverable file(s); use --force to proceed anyway or resolve conflicts. Conflicts: {conflicts[:3]} Unrecoverable: {unrecoverable[:3]}"
         )
-    if not dry_run:
+    if not dry_run and not conflicts and not unrecoverable:
         from continuum.recovery.gate import stamp_lineage
 
         stamp_lineage(

--- a/src/continuum/checkpoint/rewind.py
+++ b/src/continuum/checkpoint/rewind.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -68,21 +69,28 @@ def rewind_to_checkpoint(
     *,
     force: bool = False,
     dry_run: bool = False,
+    carry_forward: Collection[str] | None = None,
 ) -> RewindResult:
     target = resolve_checkpoint(storage, run_id, to)
     # Gate wiring (#408): restore must pass the shared precondition gate
     # before it discards (anchor, head]. The rewind discards history, so the
     # same unsettled-authorization and uncertain-slot checks that block fork
     # must block rewind, with per-edit filtering for depended_results.
-    from continuum.recovery.gate import check_preconditions
+    # Carry-forward (#493): legitimate audited rewind may explicitly carry
+    # unsettled authorizations or uncertain slots, so the flag is threaded
+    # through to the gate. Omit it and the gate refuses as before (fail-closed).
+    from continuum.recovery.gate import EditPreconditionError, check_preconditions
 
     try:
-        check_preconditions(
+        _derivation, _carry_set, _summary = check_preconditions(
             storage,
             run_id,
             target.state.source_sequence,
             edit_type="restore",
+            carry_forward=carry_forward,
         )
+    except EditPreconditionError:
+        raise
     except Exception as exc:
         raise RewindError(str(exc)) from exc
     _ = project(run_id, storage.read_events(run_id), upto=target.state.source_sequence)
@@ -170,6 +178,18 @@ def rewind_to_checkpoint(
     if not force and not dry_run and (conflicts or unrecoverable):
         raise RewindError(
             f"rewind to {to!r} has {len(conflicts)} conflict(s) and {len(unrecoverable)} unrecoverable file(s); use --force to proceed anyway or resolve conflicts. Conflicts: {conflicts[:3]} Unrecoverable: {unrecoverable[:3]}"
+        )
+    if not dry_run:
+        from continuum.recovery.gate import stamp_lineage
+
+        stamp_lineage(
+            storage,
+            run_id,
+            edit_type="restore",
+            anchor=target.state.source_sequence,
+            summary=_summary,
+            carry_set=_carry_set,
+            extra={"target": target.checkpoint_id, "reason": f"rewind to {to}"},
         )
     try:
         engine = RecoveryEngine(storage)

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1359,7 +1359,7 @@ def cmd_fork(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
     except EditPreconditionError as exc:
         rationale: dict[str, Any] = dict(exc.rationale)
         refusal_text = _precondition_refusal_text(rationale, args.run_id)
-        payload: dict[str, Any] = {
+        refusal_payload: dict[str, Any] = {
             "run_id": args.run_id,
             "edit_type": exc.edit_type,
             "refused": True,
@@ -1367,7 +1367,7 @@ def cmd_fork(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
             "error": str(exc),
         }
         _emit(
-            payload,
+            refusal_payload,
             refusal_text,
             as_json=args.json,
             stream=out,
@@ -1452,7 +1452,7 @@ def cmd_restore(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
     except EditPreconditionError as exc:
         rationale: dict[str, Any] = dict(exc.rationale)
         refusal_text = _precondition_refusal_text(rationale, args.run_id)
-        payload = {
+        refusal_payload: dict[str, Any] = {
             "run_id": args.run_id,
             "edit_type": exc.edit_type,
             "refused": True,
@@ -1460,7 +1460,7 @@ def cmd_restore(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
             "error": str(exc),
         }
         _emit(
-            payload,
+            refusal_payload,
             refusal_text,
             as_json=args.json,
             stream=out,
@@ -1530,7 +1530,7 @@ def cmd_merge(args: argparse.Namespace, storage: Storage, out: Any, err: Any) ->
     except EditPreconditionError as exc:
         rationale: dict[str, Any] = dict(exc.rationale)
         refusal_text = _precondition_refusal_text(rationale, args.run_id)
-        payload = {
+        refusal_payload: dict[str, Any] = {
             "run_id": args.run_id,
             "edit_type": exc.edit_type,
             "refused": True,
@@ -1538,7 +1538,7 @@ def cmd_merge(args: argparse.Namespace, storage: Storage, out: Any, err: Any) ->
             "error": str(exc),
         }
         _emit(
-            payload,
+            refusal_payload,
             refusal_text,
             as_json=args.json,
             stream=out,
@@ -1615,14 +1615,39 @@ def cmd_checkpoint(args: argparse.Namespace, storage: Storage, out: Any, err: An
 
 
 def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
-    """Rewind workspace and projection to a checkpoint (issue #292)."""
+    """Rewind workspace and projection to a checkpoint (issue #292, gated in #408, carry-forward in #493)."""
     from continuum.checkpoint.rewind import RewindError, rewind_to_checkpoint
+    from continuum.recovery.gate import EditPreconditionError
 
     storage.get_run(args.run_id)
+    carry_forward = list(getattr(args, "carry_forward", None) or [])
     try:
         result = rewind_to_checkpoint(
-            storage, args.run_id, args.to, force=args.force, dry_run=args.dry_run
+            storage,
+            args.run_id,
+            args.to,
+            force=args.force,
+            dry_run=args.dry_run,
+            carry_forward=carry_forward,
         )
+    except EditPreconditionError as exc:
+        rationale: dict[str, Any] = dict(exc.rationale)
+        refusal_text = _precondition_refusal_text(rationale, args.run_id)
+        refusal_payload: dict[str, Any] = {
+            "run_id": args.run_id,
+            "edit_type": exc.edit_type,
+            "refused": True,
+            "rationale": rationale,
+            "error": str(exc),
+        }
+        _emit(
+            refusal_payload,
+            refusal_text,
+            as_json=args.json,
+            stream=out,
+            palette=getattr(args, "_palette", None),
+        )
+        return ExitCode.ERROR
     except RewindError as exc:
         print(f"error: {exc}", file=err)
         return ExitCode.ERROR
@@ -1630,7 +1655,7 @@ def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         print(f"error: rewind failed: {exc}", file=err)
         return ExitCode.ERROR
     if args.dry_run:
-        payload: dict[str, Any] = {
+        dry_payload: dict[str, Any] = {
             "run_id": result.run_id,
             "target_checkpoint": result.target_checkpoint.checkpoint_id,
             "target_version": result.target_checkpoint.version,
@@ -1659,7 +1684,7 @@ def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
                 f"unrecoverable ({len(result.unrecoverable)}): {'; '.join(result.unrecoverable[:3])}"
             )
         _emit(
-            payload,
+            dry_payload,
             "\n".join(lines) or "Dry run: nothing to revert.",
             as_json=args.json,
             stream=out,
@@ -1667,7 +1692,7 @@ def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         )
         return ExitCode.OK
     if result.conflicts or result.unrecoverable:
-        payload = {
+        conflict_payload: dict[str, Any] = {
             "run_id": result.run_id,
             "target_checkpoint": result.target_checkpoint.checkpoint_id,
             "target_version": result.target_checkpoint.version,
@@ -1687,14 +1712,32 @@ def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             )
         lines.append("Use --force to proceed or resolve conflicts and retry.")
         _emit(
-            payload,
+            conflict_payload,
             "\n".join(lines),
             as_json=args.json,
             stream=out,
             palette=getattr(args, "_palette", None),
         )
         return ExitCode.ERROR
-    payload = {
+    lineage_payload: dict[str, Any] = {}
+    summary: dict[str, Any] = {}
+    carry_set: set[str] = set(carry_forward)
+    anchor_val = result.target_checkpoint.state.source_sequence
+    try:
+        events = storage.read_events(args.run_id)
+        lineage = [e for e in events if e.type is EventType.RUN_RESTORED]
+        if lineage:
+            last = lineage[-1]
+            lineage_payload = dict(last.payload)
+            summary = dict(lineage_payload.get("preconditions", {}) or {})
+            carry_set = set(lineage_payload.get("carry_forward", []) or carry_forward)
+            anchor_val = int(lineage_payload.get("anchor_sequence", anchor_val) or anchor_val)
+    except Exception:
+        pass
+    preserved_line = _precondition_preserved_line(
+        summary, carry_set, anchor=anchor_val, edit_type="restore"
+    )
+    payload: dict[str, Any] = {
         "run_id": result.run_id,
         "target_checkpoint": result.target_checkpoint.checkpoint_id,
         "target_version": result.target_checkpoint.version,
@@ -1703,11 +1746,16 @@ def cmd_rewind(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         "deleted_files": list(result.deleted_files),
         "resume_mode": result.resume_mode,
         "resume_safe": result.resume_safe,
+        "carry_forward": sorted(carry_set),
+        "preconditions": summary,
+        "preserved_summary": preserved_line,
+        "lineage_event": lineage_payload,
     }
     lines = [
         f"Rewound {result.run_id} to checkpoint {result.target_checkpoint.checkpoint_id} (v{result.target_checkpoint.version})",
         f"  reverted {len(result.reverted_files)} file(s), deleted {len(result.deleted_files)} file(s)",
         f"  state now at v{result.state_version}, resume mode {result.resume_mode} (safe={result.resume_safe})",
+        f"[ok] {preserved_line}",
     ]
     _emit(
         payload,
@@ -2968,6 +3016,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--dry-run",
         action="store_true",
         help="report what would be reverted without touching files.",
+    )
+    rewind.add_argument(
+        "--carry-forward",
+        dest="carry_forward",
+        action="append",
+        default=None,
+        help="identifier to carry forward (repeatable: approval_id, key, action_id or sequence).",
     )
 
     record_plan = with_run(

--- a/tests/test_rewind_carry_forward.py
+++ b/tests/test_rewind_carry_forward.py
@@ -1,0 +1,152 @@
+"""Rewind carry-forward passthrough (issue #493)."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from continuum.actions import ActionLedger
+from continuum.checkpoint import CheckpointManager
+from continuum.cli import main
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.storage import SQLiteStorage
+
+
+def _run_cli(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+def test_rewind_over_unsettled_authorization_refuses_and_carry_passes(tmp_path: Path) -> None:
+    db = str(tmp_path / "carry.db")
+    run_id = "run_carry_1"
+    storage = SQLiteStorage(db)
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    storage.append_event(run_id, EventType.RUN_STARTED, {"goal": "g"})
+    cp = CheckpointManager(storage).checkpoint(run_id, trigger="test")
+    storage.append_event(
+        run_id, EventType.APPROVAL_GRANTED, {"approval_id": "ap-1", "subject": "ship"}
+    )
+    storage.close()
+    code, out, _ = _run_cli("--db", db, "rewind", run_id, "--to", cp.checkpoint_id)
+    assert code != 0
+    assert "ap-1" in out
+    assert "restore refused" in out.lower()
+    code2, out2, _ = _run_cli(
+        "--db", db, "rewind", run_id, "--to", cp.checkpoint_id, "--carry-forward", "ap-1"
+    )
+    assert code2 == 0, out2
+    assert "ap-1" in out2
+    assert "preserved preconditions" in out2.lower()
+    assert "carried forward: ap-1" in out2.lower()
+    storage2 = SQLiteStorage(db)
+    events = storage2.read_events(run_id)
+    lineage = [e for e in events if e.type is EventType.RUN_RESTORED]
+    assert lineage
+    assert "ap-1" in lineage[-1].payload.get("carry_forward", [])
+    code3, out3, _ = _run_cli(
+        "--db",
+        db,
+        "--json",
+        "rewind",
+        run_id,
+        "--to",
+        cp.checkpoint_id,
+        "--carry-forward",
+        "ap-1",
+    )
+    assert code3 == 0
+    payload = json.loads(out3)
+    assert "ap-1" in payload.get("carry_forward", [])
+    assert "preserved_summary" in payload
+    storage2.close()
+
+
+def test_rewind_carry_forward_repeatable(tmp_path: Path) -> None:
+    db = str(tmp_path / "repeat.db")
+    storage = SQLiteStorage(db)
+    storage.create_run(Run(run_id="run2", goal="g"))
+    storage.append_event("run2", EventType.RUN_STARTED, {"goal": "g"})
+    cp = CheckpointManager(storage).checkpoint("run2")
+    storage.append_event("run2", EventType.APPROVAL_GRANTED, {"approval_id": "a", "subject": "s1"})
+    storage.append_event("run2", EventType.APPROVAL_GRANTED, {"approval_id": "b", "subject": "s2"})
+    storage.close()
+    code, out, _ = _run_cli(
+        "--db",
+        db,
+        "rewind",
+        "run2",
+        "--to",
+        cp.checkpoint_id,
+        "--carry-forward",
+        "a",
+        "--carry-forward",
+        "b",
+    )
+    assert code == 0, out
+    assert "a" in out and "b" in out
+    storage2 = SQLiteStorage(db)
+    events = storage2.read_events("run2")
+    lineage = [e for e in events if e.type is EventType.RUN_RESTORED]
+    assert lineage
+    cf = lineage[-1].payload.get("carry_forward", [])
+    assert "a" in cf and "b" in cf
+    storage2.close()
+
+
+def test_rewind_over_uncertain_slot_refuses_and_carry_passes(tmp_path: Path) -> None:
+    db = str(tmp_path / "uncertain.db")
+    storage = SQLiteStorage(db)
+    storage.create_run(Run(run_id="run4", goal="g"))
+    storage.append_event("run4", EventType.RUN_STARTED, {"goal": "g"})
+    cp = CheckpointManager(storage).checkpoint("run4")
+    ledger = ActionLedger(storage, "run4")
+    outcome = ledger.claim("slack.notify", {"channel": "#ops"}, key="k1")
+    aid = outcome.action.action_id
+    storage.close()
+    code, out, _ = _run_cli("--db", db, "rewind", "run4", "--to", cp.checkpoint_id)
+    assert code != 0
+    assert aid in out
+    assert "restore refused" in out.lower()
+    code2, out2, _ = _run_cli(
+        "--db", db, "rewind", "run4", "--to", cp.checkpoint_id, "--carry-forward", aid
+    )
+    assert code2 == 0, out2
+    assert aid in out2
+    storage2 = SQLiteStorage(db)
+    events = storage2.read_events("run4")
+    lineage = [e for e in events if e.type is EventType.RUN_RESTORED]
+    assert aid in lineage[-1].payload.get("carry_forward", [])
+    storage2.close()
+
+
+def test_rewind_carry_forward_dry_run_does_not_write_lineage(tmp_path: Path) -> None:
+    db = str(tmp_path / "dry.db")
+    storage = SQLiteStorage(db)
+    storage.create_run(Run(run_id="run3", goal="g"))
+    storage.append_event("run3", EventType.RUN_STARTED, {"goal": "g"})
+    cp = CheckpointManager(storage).checkpoint("run3")
+    storage.append_event(
+        "run3", EventType.APPROVAL_GRANTED, {"approval_id": "ap-1", "subject": "s"}
+    )
+    storage.close()
+    code, _, _ = _run_cli(
+        "--db",
+        db,
+        "rewind",
+        "run3",
+        "--to",
+        cp.checkpoint_id,
+        "--dry-run",
+        "--carry-forward",
+        "ap-1",
+    )
+    assert code == 0
+    storage2 = SQLiteStorage(db)
+    events = storage2.read_events("run3")
+    lineage = [e for e in events if e.type is EventType.RUN_RESTORED]
+    assert len(lineage) == 0
+    storage2.close()


### PR DESCRIPTION
## Description

Rewind over an unsettled authorization or uncertain slot correctly refused via the shared gate (wired in #408), but the CLI had no way to carry an audited item forward. This threads `--carry-forward` (repeatable, `action="append"`, `dest="carry_forward"`) from `rewind` through `cmd_rewind` → `rewind_to_checkpoint(carry_forward=...)` → `check_preconditions(carry_forward=...)`. Fail-closed is preserved: omitting the flag still refuses. On success a `RUN_RESTORED` lineage event is stamped with `carry_forward`, `preconditions` and `preserved_summary`, and the CLI renders the preserved one-liner via `gate.render_*` helpers, matching fork/restore/merge.

## Related issues

Fixes #493
Refs #408
Refs #389

## Types of changes

- Type: `bugfix`

## Breaking changes

No.

## How has this been tested?

`pytest -q` (full suite, 0 failed)
`pytest tests/test_rewind_carry_forward.py` (4 new tests, all pass)
`pytest tests/test_rewind_dual_state.py` (6 tests, all pass)
`ruff check src/ tests/ examples/` (pass)
`ruff format --check` (259 files, pass)
`mypy src/continuum --strict` (114 files, 0 errors)

Manual verification: rewind over unsettled `ap-1` without flag refuses with `restore refused` naming `ap-1`; same rewind with `--carry-forward ap-1` passes, renders `[ok] restore preserved preconditions: ... carried forward: ap-1 at anchor 1`, and `storage.read_events` shows `RUN_RESTORED` payload `carry_forward: ["ap-1"]`. Repeatable flag `--carry-forward a --carry-forward b` correctly carries both and lineage contains `["a","b"]`. Dry-run does not write lineage. `--force` does not bypass the gate.

## Checklist

Tests added for the changed behaviour (tests/test_rewind_carry_forward.py). CI passes on the latest commit. No em dashes, no AI attribution.

## Additional context

Old code had no flag to pass, so gate was called with `carry_forward=None` hardcoded. New code threads the flag. Distribution surfaces already verified on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--carry-forward` support to checkpoint rewind operations.
  * Repeated flags can preserve multiple approvals or action identifiers during a rewind.
  * Successful rewinds now display and record carried-forward details in lineage output and JSON results.

* **Bug Fixes**
  * Rewinds are refused with clear error messages when unsettled approvals or uncertain actions are not carried forward.

* **Enhancements**
  * Dry-run rewinds continue to preview changes without recording restore lineage events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->