### PR TITLE
fix(cli): include archived events in continuum events

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -651,7 +651,12 @@ def cmd_history(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
 
 def cmd_events(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     storage.get_run(args.run_id)  # raises RunNotFound for a run that was never created
-    events = storage.read_events(args.run_id, after_sequence=args.after, upto=args.upto)
+    # Full log: archived prefix plus live tail, matching the dashboard hint (issue #532).
+    events = [
+        event
+        for event in storage.read_all_events(args.run_id)
+        if event.sequence > args.after and (args.upto is None or event.sequence <= args.upto)
+    ]
     payload = [
         {
             "sequence": e.sequence,


### PR DESCRIPTION
## Description

`continuum events <run>` still called `read_events`, so after `continuum compact` it printed only the live tail. The dashboard hint already counts archived plus live and points at this command for the full log.

The command now reads `read_all_events` and applies `--after` / `--upto` over that combined stream.

## Related issues

Fixes #532

## Types of changes

- Type: `bugfix`

## Breaking changes

No. `continuum events` without compaction is unchanged. After compaction it prints the archived prefix as well as the live tail, which matches the dashboard hint.

## How has this been tested?

```
python3.11 -m venv .venv
.venv/bin/pip install -e . pytest
.venv/bin/python -m pytest tests/test_cli.py::test_events_includes_archived_prefix_after_compaction tests/test_cli.py::test_events_can_be_windowed --tb=short -q
.venv/bin/ruff check src/continuum/cli/main.py tests/test_cli.py
.venv/bin/ruff format --check src/continuum/cli/main.py tests/test_cli.py
```

Two tests passed. The new test fails if `cmd_events` is switched back to `read_events` (20 live rows instead of archived plus live). Windowed `--after` / `--upto` still works. ruff check and ruff format --check passed on the touched files. Full suite and mypy were not run.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

CHANGELOG Unreleased records the CLI behaviour. No security change.

## Additional context

Chose combining archived plus live over rewriting the dashboard hint, because the hint already promises a full log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event listing to include both archived and recent events.
  * Ensured `--after` and `--upto` filters apply consistently across the complete event history.
  * Preserved existing event output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->