### PR TITLE
refactor(hooks): one list of installed kinds, kind read off the command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ All notable changes to this project are documented here. The format follows
   ledger work. A genuinely empty body still becomes an empty mapping, so a route
   whose template needs no fields stays callable with no body.
 
+- **One list of installed hook kinds, and the kind is read off the command
+  (#484).** `hooks install` duplicated the `SessionStart` briefing hook on
+  every run because the installer recognised an existing entry as its own only
+  when the command ended in `observe` or `gate`, while `hooks remove` already
+  knew about `briefing`: the two lists were written out separately, so the kind
+  added in 7c6248d reached one and missed the other. #526 fixed the
+  duplication by extending the installer's list. The kinds are now a single
+  `_INSTALLED_KINDS` read by both the installer and the remover, so a future
+  kind cannot be added to one and forgotten in the other, and the kind is
+  derived from the command being installed rather than checked as a set: an
+  install of one kind can no longer repoint an entry of another that happens
+  to share the event and matcher, which would drop a hook the caller never
+  named. A command this module did not build carries no kind and is appended,
+  as before. A settings file that already holds duplicates is cleaned by
+  `hooks remove` followed by `hooks install`.
+
 ## [0.1.0] - 2026-08-27
 
 ### Added

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -57,6 +57,15 @@ __all__ = [
 #: matcher expression so the installed settings stay a single entry.
 DEFAULT_MATCHER = "Write|Edit|MultiEdit|NotebookEdit"
 
+#: Every hook kind this module installs, which is also the final word of each
+#: installed command. One list, read by both the installer and the remover: they
+#: used to carry the set separately, and when the briefing hook was added
+#: (7c6248d) only the remover's copy was updated, so the installer appended a
+#: duplicate SessionStart group on every re-run instead of reporting it present
+#: or repointing a moved one (issue #484, duplication fixed in #526). Keeping the
+#: kinds here is what stops that drift recurring.
+_INSTALLED_KINDS = ("observe", "gate", "briefing")
+
 #: Keys of ``tool_input`` that hold the primary file path, in priority order.
 _PATH_KEYS = ("file_path", "notebook_path")
 
@@ -227,6 +236,25 @@ def _is_observe_hook(hook: Mapping[str, Any]) -> bool:
     return _is_continuum_hook(hook, "observe")
 
 
+def _installed_kind(command: str) -> str | None:
+    """Which of :data:`_INSTALLED_KINDS` ``command`` ends in, or ``None``.
+
+    The kind a command carries is what makes an existing entry the same hook
+    rather than a different one, so it is read from the command being installed
+    instead of being listed at the call site: a new kind then cannot reach the
+    installer without the installer knowing about it. ``None`` for anything else,
+    which leaves :func:`_install_hook` appending, exactly as it does today for a
+    command this module did not build.
+    """
+    try:
+        tokens = _split_command(command)
+    except ValueError:
+        return None
+    if tokens and tokens[-1] in _INSTALLED_KINDS:
+        return tokens[-1]
+    return None
+
+
 def install_client_hook(
     settings_path: Path,
     command: str,
@@ -268,10 +296,16 @@ def _install_hook(
     """Add a continuum hook entry to a client settings file.
 
     Existing settings are preserved; only the matching list under ``hooks``
-    gains (or updates) our single entry. Returns ``"installed"`` when the
-    entry was added, ``"updated"`` when an existing entry pointed somewhere
-    else (a moved virtualenv, say) and was repointed, ``"present"`` when
-    nothing needed to change.
+    gains (or updates) our single entry of the kind ``command`` names.
+    Returns ``"installed"`` when the entry was added, ``"updated"`` when an
+    existing entry of the same kind pointed somewhere else (a moved
+    virtualenv, say) and was repointed, ``"present"`` when nothing needed to
+    change.
+
+    An entry counts as ours only when its kind matches the one being installed,
+    so an observe install cannot repoint a briefing or gate hook that happens to
+    share the event and matcher: repointing across kinds would silently drop a
+    hook the caller never asked about.
 
     A settings file that exists but is unreadable raises rather than being
     overwritten: a file someone edited by hand is a statement of intent, and
@@ -299,6 +333,7 @@ def _install_hook(
 
     status = "installed"
     entry_found = False
+    kind = _installed_kind(command)
     for group in hook_list:
         if not isinstance(group, dict) or group.get("matcher") != matcher:
             continue
@@ -306,9 +341,7 @@ def _install_hook(
         if not isinstance(entries, list):
             continue
         for hook in entries:
-            ours = isinstance(hook, dict) and any(
-                _is_continuum_hook(hook, k) for k in ("observe", "gate", "briefing")
-            )
+            ours = kind is not None and isinstance(hook, dict) and _is_continuum_hook(hook, kind)
             if ours:
                 entry_found = True
                 if hook.get("command") != command:
@@ -334,10 +367,10 @@ def remove_claude_code_hook(settings_path: Path) -> bool:
     """Remove every continuum hook this module installed. True when anything
     was removed.
 
-    Only entries this module's shape recognises are touched (observe and gate,
-    any matcher): a hand-written entry pointing elsewhere survives untouched,
-    as does every other key in the file. A group holding unrelated hooks keeps
-    them.
+    Only entries this module's shape recognises are touched
+    (:data:`_INSTALLED_KINDS`, any matcher): a hand-written entry pointing
+    elsewhere survives untouched, as does every other key in the file. A group
+    holding unrelated hooks keeps them.
     """
     if not settings_path.exists():
         return False
@@ -373,8 +406,7 @@ def remove_claude_code_hook(settings_path: Path) -> bool:
                 h
                 for h in group["hooks"]
                 if not (
-                    isinstance(h, dict)
-                    and any(_is_continuum_hook(h, k) for k in ("observe", "gate", "briefing"))
+                    isinstance(h, dict) and any(_is_continuum_hook(h, k) for k in _INSTALLED_KINDS)
                 )
             ]
             if len(kept_hooks) != len(group["hooks"]):

--- a/tests/test_client_installers.py
+++ b/tests/test_client_installers.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 
 from continuum.cli import ExitCode, main
-from continuum.clienthooks import CLIENT_PROFILES
+from continuum.clienthooks import CLIENT_PROFILES, install_client_hook
 
 
 def run(*argv: str) -> tuple[int, str, str]:
@@ -248,3 +248,31 @@ def test_briefing_repoint_reuses_group(tmp_path: Path) -> None:
         )
         == "present"
     )
+
+
+def _installed_commands(settings: Path, event_name: str) -> list[str]:
+    """Every command wired under ``event_name``, in file order, duplicates included."""
+    groups = json.loads(settings.read_text())["hooks"][event_name]
+    return [h["command"] for g in groups if isinstance(g.get("hooks"), list) for h in g["hooks"]]
+
+
+def test_an_install_of_one_kind_does_not_repoint_another(tmp_path: Path) -> None:
+    """Only an entry of the same kind counts as the one being installed (#484).
+
+    The kinds used to be checked as a set, so any continuum entry sharing the
+    event and matcher matched: installing observe where a briefing was already
+    wired repointed the briefing and reported "updated", silently dropping a
+    hook the caller never named. Reading the kind off the command keeps the two
+    entries apart.
+    """
+    settings = tmp_path / "settings.json"
+    briefing = "/venv/bin/continuum briefing"
+    observe = "/venv/bin/continuum observe"
+    assert (
+        install_client_hook(settings, briefing, event_name="SessionStart", matcher="")
+        == "installed"
+    )
+    assert (
+        install_client_hook(settings, observe, event_name="SessionStart", matcher="") == "installed"
+    )
+    assert _installed_commands(settings, "SessionStart") == [briefing, observe]

--- a/tests/test_client_installers.py
+++ b/tests/test_client_installers.py
@@ -276,3 +276,20 @@ def test_an_install_of_one_kind_does_not_repoint_another(tmp_path: Path) -> None
         install_client_hook(settings, observe, event_name="SessionStart", matcher="") == "installed"
     )
     assert _installed_commands(settings, "SessionStart") == [briefing, observe]
+
+
+def test_a_command_of_no_known_kind_is_appended_never_matched(tmp_path: Path) -> None:
+    """The kind is read off the command, so an unknown one matches nothing (issue #484).
+
+    Deriving the kind is what stops an install of one kind repointing another, and
+    the flip side has to hold too: a command this module did not build -- including
+    one whose quoting cannot be parsed at all -- carries no kind, so it is appended
+    rather than mistaken for ours, and unparseable quoting does not raise.
+    """
+    settings = tmp_path / "settings.json"
+    unknown = "/venv/bin/continuum inspect"
+    malformed = '"C:\\no\\closing\\quote continuum briefing'
+    for command in (unknown, malformed, unknown):
+        status = install_client_hook(settings, command, event_name="SessionStart", matcher="")
+        assert status == "installed"
+    assert _installed_commands(settings, "SessionStart") == [unknown, malformed, unknown]


### PR DESCRIPTION
## Description

Follow-up to #484 / #526, opened at @Cyrax321's request on #485: the duplication
bug is already fixed on `main` by #526, so this carries only the hygiene half of
#485, rebased onto current `main` with the CHANGELOG and test conflicts resolved.

#526 fixed the duplication by extending the installer's kind list in place:

```python
ours = isinstance(hook, dict) and any(
    _is_continuum_hook(hook, k) for k in ("observe", "gate", "briefing")
)
```

That is correct today, and this PR does not change what it fixes. Two things
about the shape remain, both of which #484's root-cause section calls out:

- The kinds are still written out twice — once here, once in
  `remove_claude_code_hook`. That duplication is exactly what caused #484:
  7c6248d added `briefing` to the remover's tuple and not the installer's. A
  fourth kind can still be added to one and forgotten in the other.
- Matching is a set membership test, so *any* continuum entry sharing the event
  and matcher counts as the one being installed. Installing `observe` where a
  `briefing` is already wired under the same event and matcher repoints the
  briefing and reports `updated`, dropping a hook the caller never named.

The change:

- `_INSTALLED_KINDS = ("observe", "gate", "briefing")` is read by both the
  installer and `remove_claude_code_hook`, so the two cannot drift again.
- `_installed_kind(command)` reads the kind off the command being installed, so
  a new kind cannot reach the installer without the installer knowing about it.
  A command this module did not build — including one whose quoting cannot be
  parsed — yields `None` and is appended, exactly as before.
- Matching is kind-for-kind, so an install of one kind cannot repoint another.

The installed settings shape and the `installed` / `updated` / `present`
statuses are unchanged, as is the removal contract. The CHANGELOG entry for
\#484 was not added by #526, so it is added here and describes both halves.

## Related issues

Refs #484. Follow-up to #526. Supersedes #485 (closed as a duplicate of #526);
this is the hygiene remainder requested there, not a second fix for the bug.

## Types of changes

- Type: `refactor` (behaviour change limited to cross-kind repointing, covered
  by a new test)

## Breaking changes

No. One behaviour differs from `main`: an install no longer repoints an existing
entry of a *different* kind at the same event and matcher — it appends its own
entry instead. No profile in `CLIENT_PROFILES` installs two kinds under one
event and matcher, so no supported configuration reaches that path; a
hand-written settings file that did was silently losing a hook.

## How has this been tested?

Environment: Windows 11 (26200), Python 3.13.7, project venv at `.venv`,
rebased onto `upstream/main` @ `b62029c`.

Commands run, all from a clean tree:

```
pytest -q --no-cov                        # full suite green, exit 0 (skips only, no failures)
pytest tests/test_client_installers.py -q --no-cov   # 24 passed
ruff check src/ tests/                    # All checks passed!
ruff format --check src/ tests/           # 246 files already formatted
mypy src/continuum                        # Success: no issues found in 114 source files
```

New-test-fails-without-the-fix check, run in a second worktree pinned to
`upstream/main` @ `b62029c` with only this branch's test file copied in:

```
FAILED tests/test_client_installers.py::test_an_install_of_one_kind_does_not_repoint_another
E       AssertionError: assert 'updated' == 'installed'
```

The other 23 tests in that file pass at the baseline, which is the point: #526
already fixed the duplication, so the two tests it added and the two equivalents
#485 proposed cover the same ground. I dropped #485's duplicates rather than
re-adding them, and kept the two tests that pin what this PR changes:

- `test_an_install_of_one_kind_does_not_repoint_another` — the cross-kind
  regression above; fails on `main`.
- `test_a_command_of_no_known_kind_is_appended_never_matched` — the `None` arms
  of `_installed_kind`, including a command whose quoting cannot be parsed
  (added originally because Codecov flagged those arms as unhit).

## Checklist

Tests added or updated for the changed behaviour — yes, the two above.
Documentation updated where the change affects user-facing behaviour — yes,
`CHANGELOG.md` under `[Unreleased] / Fixed`, appended after the existing entries
so the ordering is preserved (the conflict from the #485 review is resolved this
way). Security-relevant changes state known limitations explicitly — not
security-relevant. Existing duplicates in a user's settings file are still not
collapsed by an install; `hooks remove` followed by `hooks install` cleans them,
which the CHANGELOG entry says.

## Additional context

If the maintainers would rather have the centralisation as a tracked issue
before a PR, say so and I will open one and relink this; #485's closing comment
asked for a follow-up, and this is it in PR form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeated hook installations creating duplicate `SessionStart` briefing hooks.
  * Prevented different hook types from overwriting or being mistaken for one another.
  * Ensured unknown or malformed hooks remain safely preserved during installation.
  * Improved cleanup of duplicate hook entries when removing and reinstalling hooks.

* **Tests**
  * Added coverage for installing multiple hook types and handling unrecognized commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->