### PR TITLE
docs(cli): show the --db default and a --json example that runs

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -5,8 +5,9 @@ codes are a safety contract: only a verified-safe run exits `0`, so
 `continuum resume "$RUN" && ./start-agent.sh` cannot launch onto stale state.
 
 ```bash
-continuum --db continuum.db <command> [args]
-continuum --json <command>      # machine-readable output
+continuum <command> [args]                    # storage defaults to ./continuum.db
+continuum --db <url-or-path> <command>        # storage URL or path (default: continuum.db)
+continuum --json <command>                    # machine-readable output
 ```
 
 ## Commands
@@ -60,9 +61,17 @@ continuum diff run_42 1 2
 continuum verify run_42
 continuum attest run_42 --key signer.pem --out run_42.attest.json
 continuum attest-verify run_42 --attest run_42.attest.json
+
+# Same data, machine-readable: --json goes before the command, not after it
+continuum --json runs | jq '.runs[] | {run_id, status}'
+continuum --json resume run_42 | jq '{safe, mode}'
 ```
 
-Most commands accept `--db` (storage path or URL) and `--json` (machine-readable output, also available as `continuum <command> --help` for each subcommand). Colour is
+`--db` (storage URL or path, default `continuum.db`) and `--json`
+(machine-readable output) are global flags, so they go before the command:
+`continuum --json runs`, not `continuum runs --json`, which is rejected as an
+unrecognised argument. Most commands emit JSON with it, and
+`continuum <command> --help` lists that command's own flags. Colour is
 TTY-aware and respects `NO_COLOR`; piped output is byte-identical to uncoloured
 output.
 


### PR DESCRIPTION
## Description

Two docs-only fixes in `docs/api/cli.md`, both one-liners in the issues but one
of them turned out to document a command that does not work.

**#510, the `--db` default.** The header read `continuum --db continuum.db
<command> [args]`, which shows the value without saying it is the default, so
`--db` reads as required. It now mirrors the `--help` text and shows the form
that omits the flag:

```bash
continuum <command> [args]                    # storage defaults to ./continuum.db
continuum --db <url-or-path> <command>        # storage URL or path (default: continuum.db)
continuum --json <command>                    # machine-readable output
```

`continuum --help` prints `--db DB storage URL or path (default: continuum.db).`
and `src/continuum/cli/main.py:88` sets `_DEFAULT_DB = "continuum.db"`, so the
header now matches both. The CLI reads no environment variable for this (only
the MCP server and `serve` consult `CONTINUUM_DB`), so the doc does not claim
one.

**#508, the missing `--json` example.** The Examples block had no `--json`
invocation. The issue suggests `continuum runs --json | jq .`; that form does
not work, and the note under the block said something close to it:

> Most commands accept `--db` (storage path or URL) and `--json`
> (machine-readable output, also available as `continuum <command> --help` for
> each subcommand).

`--json` is a global flag, parsed before the subcommand. Verified against the
built CLI:

```console
$ continuum runs --json
usage: continuum [-h] [--version] [--db DB] [--json] [--color | --no-color] COMMAND ...
continuum: error: unrecognized arguments: --json

$ continuum --json runs
{
  "runs": []
}
```

So the example uses the working order, and the note now says which order is
which instead of implying the flag belongs to each subcommand:

```bash
# Same data, machine-readable: --json goes before the command, not after it
continuum --json runs | jq '.runs[] | {run_id, status}'
continuum --json resume run_42 | jq '{safe, mode}'
```

The note keeps "most commands emit JSON with it" rather than "every command",
because that is what the CLI does: `runs`, `inspect`, `history`, `events`,
`resume`, `budget`, `tree`, `actions`, `verify`, `validate`, `show-contract` and
`replay` emit JSON, while `status` and `health` print their human text either
way. Whether those two should also honour it is a separate question and not
touched here.

## Related issues

Fixes #510
Fixes #508

## Types of changes

- Type: `docs`

## Breaking changes

No. Documentation only; no source, test or CI file is touched.

## How has this been tested?

Environment: Windows 11 (26200), Python 3.13.7, project venv at `.venv`, branch
based on `upstream/main` @ `4133de0`.

Every command in the diff was run against a real database before it was written
down:

```bash
cd "$(mktemp -d)"
continuum init
continuum start run_42 --goal demo
continuum --json runs        # object with runs[].run_id and runs[].status
continuum --json resume run_42   # object with safe=true, mode="resume"
continuum runs --json        # error: unrecognized arguments: --json  (as quoted above)
```

The `jq` filters were chosen against those payloads: `runs` returns
`{"runs": [{"created_at", "events", "goal", "run_id", "status"}]}` and `resume`
returns keys including `safe` and `mode` but no `status`, which is why the
example does not filter on `.status`. `jq` itself is not installed on this
machine, so the filters were written against the verified field names rather
than executed; both are plain object construction.

Markdown side: the enabled `markdownlint-cli2` rules are `MD031`, `MD040` and
`MD047`. Both fenced blocks keep their `bash` language and blank lines on either
side, and the file still ends in a single newline. No em dashes added.

No `CHANGELOG.md` entry: this is docs-only, matching the recent docs PRs in this
area (#498, #490, #491, all `docs/api/cli.md` with no changelog change). It also
keeps the diff to one file, so nothing here can conflict with the changelog
entries in flight.

## Checklist

Tests added or updated for the changed behaviour — not applicable, no behaviour
change; the documented commands were executed instead, output quoted above.
Documentation updated where the change affects user-facing behaviour — this is
the documentation change. CI passes on the latest commit — will confirm on the
run for this PR. Security-relevant changes state known limitations explicitly —
not security-relevant.

## Additional context

While checking the neighbouring good-first-issues I found two that look already
resolved on `main`, so no PR here: #509 (the README pip-fallback note's inline
code is balanced and renders correctly at `4133de0`) and #331 (the Codex flag
check already strips comments in `_codex_feature_flag_hint`, covered by
`test_codex_install_hints_when_feature_flag_commented_out`). I have commented on
both with the evidence rather than opening changes that do nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI usage synopsis to show global flags before commands.
  * Documented the default database location and supported `--db` and `--json` options.
  * Clarified that command-specific help is available with `continuum <command> --help`.
  * Added guidance that placing `--json` after a command is not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->