### PR TITLE
fix(cli): honour tree --limit instead of accepting and ignoring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ All notable changes to this project are documented here. The format follows
   as before. A settings file that already holds duplicates is cleaned by
   `hooks remove` followed by `hooks install`.
 
+- **`continuum tree --limit` truncates the child list instead of being ignored
+  (#321).** The flag was registered with `help=argparse.SUPPRESS` and never
+  read, so `--limit 5` was accepted and printed every child anyway: an operator
+  with a wide family got the full wall of output and no error saying why. The
+  flag now shows the newest `n` children and reports what it hid
+  (`... 3 of 40 children hidden by --limit 5`), because a truncated tree that
+  says nothing is indistinguishable from a small family. `--json` gained
+  `children_total` and `children_hidden` alongside the truncated `children`
+  list; output without `--limit` is unchanged. The truncation is display-only:
+  `children_of` still returns every child, so the family safety roll-up behind
+  `resume` cannot lose an uncertain child that scrolled off the printed list.
+  A limit below `1` is refused with exit code 1 rather than clamped, since
+  `--limit 0` would render a family with children as childless.
+
 ## [0.1.0] - 2026-08-27
 
 ### Added

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -27,7 +27,7 @@ continuum --json <command>                    # machine-readable output
 | `confirm <run_id>` | Confirm a human-approved recovery step. |
 | `complete <run_id>` | Close a run as done. Mutates storage. |
 | `budget <run_id>` | Retry-budget usage per action type. |
-| `tree <run_id>` | Show a parent run and its children. |
+| `tree <run_id> [--limit <n>]` | Show a parent run and its children. `--limit` shows only the newest `n` children. |
 | `fork <run_id> --reason <text>` | Approve a divergent continuation as a child run. Mutates storage. |
 | `compact <run_id>` | Archive the pre-anchor log prefix. Mutates storage. |
 | `checkpoint <run_id>` | Force a state checkpoint. |
@@ -65,7 +65,18 @@ continuum attest-verify run_42 --attest run_42.attest.json
 # Same data, machine-readable: --json goes before the command, not after it
 continuum --json runs | jq '.runs[] | {run_id, status}'
 continuum --json resume run_42 | jq '{safe, mode}'
+
+# Just the newest few children of a wide family
+continuum tree run_42 --limit 5
 ```
+
+`tree --limit <n>` truncates the printed child list to the newest `n` children
+and says how many it hid, so a short tree is never mistaken for a small family.
+The truncation is display-only: the family safety roll-up behind `resume` still
+reads every child, so hiding one cannot turn a blocked family into a safe one.
+With `--json`, `children_total` and `children_hidden` report the full count
+alongside the truncated `children` list. A `--limit` below `1` is refused rather
+than clamped (issue #321).
 
 `--db` (storage URL or path, default `continuum.db`) and `--json`
 (machine-readable output) are global flags, so they go before the command:

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1191,8 +1191,23 @@ def cmd_budget(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
 
 
 def cmd_tree(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
-    """Show a parent run and its children with recovery states (issue #243)."""
+    """Show a parent run and its children with recovery states (issue #243).
+
+    ``--limit`` truncates the child list for display only (issue #321). The
+    family safety roll-up behind ``resume`` reads every child regardless, so a
+    truncated tree can never make a blocked family look resumable; the count of
+    what was hidden is printed and carried in the JSON so a reader can tell the
+    difference between "no more children" and "not shown".
+    """
     from continuum.recovery.family import children_of
+
+    limit = getattr(args, "limit", None)
+    if limit is not None and limit < 1:
+        # Refuse rather than clamp: --limit 0 would print a childless-looking
+        # tree for a family that has children, which is the one reading this
+        # command must never produce.
+        print(f"--limit must be 1 or more (got {limit})", file=err)
+        return ExitCode.ERROR
 
     parent_id = args.run_id
     storage.get_run(parent_id)
@@ -1208,9 +1223,11 @@ def cmd_tree(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
         lines.append(f"{parent_id}  [assess error: {exc}]")
 
     children = children_of(storage, parent_id)
+    shown = children if limit is None else children[:limit]
+    hidden = len(children) - len(shown)
     if not children:
         lines.append("  (no children)")
-    for child in children:
+    for child in shown:
         fork_mark = "[fork] " if str(child.metadata.get("fork", "")) == "true" else ""
         try:
             d = engine.assess(child.run_id)
@@ -1221,15 +1238,22 @@ def cmd_tree(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
             )
         except Exception as exc:
             lines.append(f"  !! {fork_mark}{child.run_id}  [assess error: {exc}]")
+    if hidden:
+        lines.append(
+            f"  ... {hidden} of {len(children)} children hidden by --limit {limit}; "
+            "run without it to see the whole family"
+        )
     a2a = [
-        (c.run_id, c.metadata.get("a2a_task_id")) for c in children if c.metadata.get("a2a_task_id")
+        (c.run_id, c.metadata.get("a2a_task_id")) for c in shown if c.metadata.get("a2a_task_id")
     ]
     for rid, task in a2a:
         lines.append(f"  a2a: {rid} -> {task}")
     _emit(
         {
             "parent": args.run_id,
-            "children": [{"run_id": c.run_id, "status": c.status.value} for c in children],
+            "children": [{"run_id": c.run_id, "status": c.status.value} for c in shown],
+            "children_total": len(children),
+            "children_hidden": hidden,
         },
         "\n".join(lines),
         as_json=args.json,
@@ -2948,7 +2972,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     tree_parser = with_run(add("tree", cmd_tree, "Show a parent run and its children."))
-    tree_parser.add_argument("--limit", type=int, default=None, help=argparse.SUPPRESS)
+    tree_parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="show at most this many children, newest first (default: all).",
+    )
 
     fork_cmd = with_run(
         add("fork", cmd_fork, "Approve a divergent continuation as a child run. Mutates storage.")

--- a/tests/test_family.py
+++ b/tests/test_family.py
@@ -68,6 +68,93 @@ def test_tree_lists_children(db: str) -> None:
     assert "boss" in out and "kid_ok" in out
 
 
+def _family(db: str, count: int = 3) -> None:
+    run("--db", db, "start", "boss", "--goal", "supervise")
+    for i in range(count):
+        run("--db", db, "start", f"kid{i}", "--goal", f"work {i}", "--parent", "boss")
+
+
+def test_tree_limit_truncates_and_says_how_much_it_hid(db: str) -> None:
+    """`--limit` used to be accepted and ignored (issue #321).
+
+    Truncating silently is the failure mode that matters here: a reader cannot
+    tell a two-child family from the first two children of a ten-child one, so
+    the hidden count is printed with the flag that caused it.
+    """
+    _family(db, 3)
+    code, out, err = run("--db", db, "tree", "boss", "--limit", "2")
+    assert code == ExitCode.OK, err
+    shown = [line for line in out.splitlines() if "kid" in line and "hidden" not in line]
+    assert len(shown) == 2
+    assert "1 of 3 children hidden by --limit 2" in out
+
+
+def test_tree_without_limit_shows_every_child_and_hides_nothing(db: str) -> None:
+    _family(db, 3)
+    code, out, err = run("--db", db, "--json", "tree", "boss")
+    assert code == ExitCode.OK, err
+    payload = json.loads(out)
+    assert len(payload["children"]) == 3
+    assert payload["children_total"] == 3
+    assert payload["children_hidden"] == 0
+    assert "hidden by --limit" not in out
+
+
+def test_tree_limit_reports_the_full_total_in_json(db: str) -> None:
+    """A truncated `children` list stays honest about the family size, so a
+    script reading the JSON can notice it is not looking at everything."""
+    _family(db, 3)
+    code, out, err = run("--db", db, "--json", "tree", "boss", "--limit", "1")
+    assert code == ExitCode.OK, err
+    payload = json.loads(out)
+    assert len(payload["children"]) == 1
+    assert payload["children_total"] == 3
+    assert payload["children_hidden"] == 2
+
+
+@pytest.mark.parametrize("bad", ("0", "-1"))
+def test_tree_refuses_a_limit_below_one(db: str, bad: str) -> None:
+    """`--limit 0` would render a family with children as childless, which is
+    the one output this command must never produce; refuse instead of clamp."""
+    _family(db, 2)
+    code, out, err = run("--db", db, "tree", "boss", "--limit", bad)
+    assert code == ExitCode.ERROR
+    assert "--limit must be 1 or more" in err
+    assert "kid" not in out
+
+
+def test_tree_limit_cannot_hide_a_child_from_family_safety(db: str) -> None:
+    """Display-only truncation, deliberately not the change the issue proposed:
+    limiting `children_of` would also truncate the input to the family roll-up,
+    so an uncertain child could scroll off the list and leave `resume` calling a
+    blocked family safe. The tree may omit it; the safety decision may not."""
+    run("--db", db, "start", "boss", "--goal", "supervise")
+    run("--db", db, "start", "kid_uncertain", "--goal", "risky", "--parent", "boss")
+    run("--db", db, "start", "kid_late", "--goal", "later", "--parent", "boss")
+    ActionLedger(SQLiteStorage(db), "kid_uncertain").claim("send_invoice", {}, key="invoice:I-9")
+
+    code, out, err = run("--db", db, "--json", "tree", "boss", "--limit", "1")
+    assert code == ExitCode.OK, err
+    listed = {c["run_id"] for c in json.loads(out)["children"]}
+    assert len(listed) == 1
+
+    code, out, _ = run("--db", db, "--json", "resume", "boss")
+    payload = json.loads(out)
+    assert payload["mode"] == "request_human"
+    assert any("kid_uncertain" in r for r in payload.get("family_rationale", []))
+
+
+def test_tree_limit_is_documented_not_suppressed(capsys: pytest.CaptureFixture[str]) -> None:
+    """The flag existed but `--help` hid it, which is what made it look absent
+    rather than broken (issue #321)."""
+    with pytest.raises(SystemExit) as exit_info:
+        main(["tree", "--help"])
+    assert exit_info.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "--limit" in help_text
+    assert "children" in help_text
+
+
 def test_uncertain_child_blocks_the_parent_resume(db: str) -> None:
     """The acceptance core: parent alone would RESUME; an uncertain child
     forces request_human. Settling the child unblocks the family."""


### PR DESCRIPTION
## Description

`continuum tree` registered `--limit` with `help=argparse.SUPPRESS` and then
never read it, so the flag was accepted, hidden from `--help`, and printed every
child anyway. `continuum tree boss --limit 1` on `main` exits 0 and lists all
three children.

`cmd_tree` now truncates the printed child list to the newest `n` children and
says how many it hid:

```text
boss  [resume, safe=True]  supervise
  ok kid2  [resume, uncertain=0]  work 2
  ... 2 of 3 children hidden by --limit 1; run without it to see the whole family
```

The hidden count is the part that matters. A truncated tree that says nothing is
indistinguishable from a small family, which is exactly the wrong impression for
a command whose job is showing you what a supervisor is responsible for. With
`--json`, `children_total` and `children_hidden` carry the same fact for
scripts, added alongside the existing `children` list so nothing that reads the
payload today breaks. Output without `--limit` is unchanged.

A limit below `1` is refused with exit code 1 rather than clamped: `--limit 0`
would render a family that has children as childless, which is the one output
this command must never produce.

**One deliberate deviation from the issue.** The issue suggests wiring the limit
into `children_of`. I did not, because `roll_up_children` calls `children_of` to
decide whether a family blocks `resume` — truncating there would let an
uncertain child fall off the end of a safety decision and report a blocked
family as safe. The truncation is display-only, and there is a test that pins
this: an uncertain child hidden from the tree by `--limit 1` still forces
`resume` into `request_human`.

## Related issues

Fixes #321

## Types of changes

- Type: `bugfix`

## Breaking changes

No. Behaviour is unchanged without `--limit`; the JSON payload gains two keys
and loses none.

## How has this been tested?

Windows 11, Python 3.11.13 (project `.venv`), from the repo root:

```bash
python -m pytest tests/test_family.py -q          # 14 passed
python -m pytest -q -p no:randomly                # full suite green, exit 0
python -m ruff check src tests                    # All checks passed!
python -m ruff format --check src tests           # 246 files already formatted
python -m mypy src/continuum                      # no issues in 114 source files
npx markdownlint-cli2 CHANGELOG.md docs/api/cli.md # 0 issues
```

Seven new tests in `tests/test_family.py` cover truncation and its report, the
unlimited path hiding nothing, the JSON totals, `--limit 0` and `--limit -1`
being refused, family safety surviving truncation, and `--limit` appearing in
`tree --help`.

All seven were checked against the baseline before the fix: `upstream/main`
(`e129f91`) in a separate `git worktree` with `PYTHONPATH` pointed at it (
`continuum.__file__` confirmed to resolve into the worktree), where all seven
fail. The `--help` one fails with `assert '--limit' in 'usage: continuum tree
[-h] run_id ...'`, which is the suppressed-flag symptom itself.

Also exercised by hand end to end (`init`, `start` a parent and three children,
then `tree --limit 1`, `tree`, `--json tree --limit 2`, `tree --limit 0`) to
confirm the ordering claim in the help text: `list_runs` orders
`created_at DESC, run_id DESC`, so the children shown are genuinely the newest.

## Checklist

Tests added for the changed behaviour and verified to fail at the baseline
commit. `docs/api/cli.md` documents the flag, its display-only scope, the JSON
keys, and the sub-1 refusal; `CHANGELOG.md` has an entry under
`[Unreleased] / Fixed`. Lint, format, types and the full suite pass locally. No
security-relevant surface is touched; the one safety-adjacent question (whether
truncation can weaken the family roll-up) is answered by
`test_tree_limit_cannot_hide_a_child_from_family_safety`.

## Additional context

Branched from `upstream/main` at `e129f91`, so this merges cleanly and does not
touch the regions changed by the recently merged #536 or #542.

The alternative in the issue was removing the flag instead of wiring it. Wiring
it is the better trade here: the flag is already in released argv and a wide
fork tree is genuinely hard to read, so the capability is worth having as long
as the truncation announces itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
