### PR TITLE
docs: add Windows PowerShell try-it launcher (try-it.ps1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Zero-setup paths (no clone, no install, nothing published anywhere):
 | Watch crash recovery happen end to end | `docker run --rm ghcr.io/cyrax321/continuum` |
 | Use the CLI through Docker | `docker run --rm ghcr.io/cyrax321/continuum continuum --help` |
 | Run the CLI without cloning | `uvx --from git+https://github.com/Cyrax321/CONTINUUM.git continuum --help` |
-| Windows PowerShell (from a clone) | `powershell -ExecutionPolicy Bypass -File try-it.ps1` — or `try-it.ps1 cli --help` |
+| Windows PowerShell (from a clone) | `powershell -ExecutionPolicy Bypass -File .\try-it.ps1` or `powershell -ExecutionPolicy Bypass -File .\try-it.ps1 cli --help` |
 | Full dev environment in the browser | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Cyrax321/CONTINUUM?quickstart=1) |
 
 The Docker image is published to GHCR by CI on every push to `main` and every release tag (`.github/workflows/docker-publish.yml`). The Codespace is defined in `.devcontainer/`.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Zero-setup paths (no clone, no install, nothing published anywhere):
 | Watch crash recovery happen end to end | `docker run --rm ghcr.io/cyrax321/continuum` |
 | Use the CLI through Docker | `docker run --rm ghcr.io/cyrax321/continuum continuum --help` |
 | Run the CLI without cloning | `uvx --from git+https://github.com/Cyrax321/CONTINUUM.git continuum --help` |
+| Windows PowerShell (from a clone) | `powershell -ExecutionPolicy Bypass -File try-it.ps1` — or `try-it.ps1 cli --help` |
 | Full dev environment in the browser | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Cyrax321/CONTINUUM?quickstart=1) |
 
 The Docker image is published to GHCR by CI on every push to `main` and every release tag (`.github/workflows/docker-publish.yml`). The Codespace is defined in `.devcontainer/`.

--- a/references/install.md
+++ b/references/install.md
@@ -93,6 +93,9 @@ continuum-mcp --help             # needs [mcp] or [dev]
 
 # One-command demo (process kill, hash-chain verify)
 ./try-it.sh demo                 # same as: python examples/crash_recovery_agent.py
+# Windows PowerShell (from repo root):
+# powershell -ExecutionPolicy Bypass -File try-it.ps1
+# powershell -ExecutionPolicy Bypass -File try-it.ps1 cli --help
 
 # Full test suite (~1,300 tests; exact skips vary by environment)
 pytest -q                        # or: ./try-it.sh test

--- a/references/install.md
+++ b/references/install.md
@@ -94,8 +94,8 @@ continuum-mcp --help             # needs [mcp] or [dev]
 # One-command demo (process kill, hash-chain verify)
 ./try-it.sh demo                 # same as: python examples/crash_recovery_agent.py
 # Windows PowerShell (from repo root):
-# powershell -ExecutionPolicy Bypass -File try-it.ps1
-# powershell -ExecutionPolicy Bypass -File try-it.ps1 cli --help
+# powershell -ExecutionPolicy Bypass -File .\try-it.ps1
+# powershell -ExecutionPolicy Bypass -File .\try-it.ps1 cli --help
 
 # Full test suite (~1,300 tests; exact skips vary by environment)
 pytest -q                        # or: ./try-it.sh test

--- a/try-it.ps1
+++ b/try-it.ps1
@@ -1,5 +1,5 @@
 # CONTINUUM - one-command demo for Windows PowerShell.
-# Run:  powershell -ExecutionPolicy Bypass -File try-it.ps1
+# Run:  powershell -ExecutionPolicy Bypass -File .\try-it.ps1
 # Modes match try-it.sh: demo (default), test, cli ..., shell
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
@@ -19,27 +19,39 @@ $python = if (Test-Path (Join-Path $venvScripts "python.exe")) {
     "python"
 }
 
+function Exit-IfNativeFailed {
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
 $mode = if ($args.Count -gt 0) { $args[0] } else { "demo" }
 
 switch ($mode) {
     "demo" {
         & $python (Join-Path $Root "examples\crash_recovery_agent.py")
+        Exit-IfNativeFailed
     }
     "test" {
         & $python -m pytest
+        Exit-IfNativeFailed
     }
     "cli" {
         $cliArgs = @()
         if ($args.Count -gt 1) {
             $cliArgs = $args[1..($args.Count - 1)]
         }
-        & continuum @cliArgs
+        & $python -m continuum.cli @cliArgs
+        Exit-IfNativeFailed
     }
     "shell" {
         Write-Host "PATH and PYTHONPATH set. Try: continuum --help"
+        $shell = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
+        & $shell -NoExit
+        Exit-IfNativeFailed
     }
     default {
-        Write-Host "usage: try-it.ps1 [demo|test|cli ...|shell]"
+        Write-Host "usage: .\try-it.ps1 [demo|test|cli ...|shell]"
         exit 1
     }
 }

--- a/try-it.ps1
+++ b/try-it.ps1
@@ -1,0 +1,45 @@
+# CONTINUUM - one-command demo for Windows PowerShell.
+# Run:  powershell -ExecutionPolicy Bypass -File try-it.ps1
+# Modes match try-it.sh: demo (default), test, cli ..., shell
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Root = $PSScriptRoot
+Set-Location $Root
+
+$venvScripts = Join-Path $Root ".venv\Scripts"
+if (Test-Path $venvScripts) {
+    $env:PATH = "$venvScripts;$env:PATH"
+}
+$env:PYTHONPATH = Join-Path $Root "src"
+
+$python = if (Test-Path (Join-Path $venvScripts "python.exe")) {
+    Join-Path $venvScripts "python.exe"
+} else {
+    "python"
+}
+
+$mode = if ($args.Count -gt 0) { $args[0] } else { "demo" }
+
+switch ($mode) {
+    "demo" {
+        & $python (Join-Path $Root "examples\crash_recovery_agent.py")
+    }
+    "test" {
+        & $python -m pytest
+    }
+    "cli" {
+        $cliArgs = @()
+        if ($args.Count -gt 1) {
+            $cliArgs = $args[1..($args.Count - 1)]
+        }
+        & continuum @cliArgs
+    }
+    "shell" {
+        Write-Host "PATH and PYTHONPATH set. Try: continuum --help"
+    }
+    default {
+        Write-Host "usage: try-it.ps1 [demo|test|cli ...|shell]"
+        exit 1
+    }
+}


### PR DESCRIPTION
## Summary
- Add `try-it.ps1` as a PowerShell equivalent of `try-it.sh` (demo/test/cli/shell modes).
- Document the Windows path in README Quick Start and `references/install.md`.

## Test plan
- [x] `powershell -ExecutionPolicy Bypass -File try-it.ps1 shell` sets PATH/PYTHONPATH and prints help hint
- [ ] `try-it.ps1 cli --help` with dev venv installed (maintainer can verify on Windows 11)


Fixes #541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the Windows PowerShell script to run the CLI through the selected Python interpreter.
  * Added support for launching interactive PowerShell sessions without closing them automatically.
  * Improved error handling so command failures return the correct exit status.

* **Documentation**
  * Updated Quick Start and installation guidance with explicit `.\try-it.ps1` commands and PowerShell equivalents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->