### PR TITLE
docs: mention .continuum/ in CONTRIBUTING Setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ source .venv/bin/activate        # macOS / Linux
 pip install -e ".[dev]"
 ```
 
+Local CONTINUUM data lives in `.continuum/` (budgets, local `*.db` files). It is already listed in `.gitignore`, so do not commit it. If you cloned before this was added, run `echo ".continuum/" >> .gitignore`.
+
 ---
 
 ## Running the Tests


### PR DESCRIPTION
## Summary
- Add a short Setup note in CONTRIBUTING.md explaining that `.continuum/` holds local budgets/db files and is gitignored.
- Include the one-line fix for older forks missing the entry.

Fixes #539

## Test plan
- [x] Docs-only change; no code paths affected
- [x] Verified paragraph placement after install step in Setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup guidance for handling local `.continuum/` data.
  * Clarified that older clones should add `.continuum/` to `.gitignore`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->