### PR TITLE
docs(mcp): document continuum_record_plan and audit the tool table (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,17 @@ All notable changes to this project are documented here. The format follows
   A limit below `1` is refused with exit code 1 rather than clamped, since
   `--limit 0` would render a family with children as childless.
 
+- **The MCP reference documents all twelve tools (#271).** `docs/api/mcp.md`
+  carried eleven rows and summarised them as "three read-only, eight
+  mutating", but `tools/list` has served twelve tools since
+  `continuum_record_plan` was added: a client author reading the reference had
+  no way to learn the plan tool exists. The table gains a
+  `continuum_record_plan` row and the totals now match the server. Every other
+  row's `read`/`mutate` kind was audited against the `read_only_hint` the
+  server declares and needed no change. `tests/test_mcp_docs.py` now checks the
+  table against `tools/list`, so a tool registered without a row fails the
+  suite instead of shipping undocumented.
+
 ## [0.1.0] - 2026-08-27
 
 ### Added

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -31,7 +31,7 @@ may resume. The integration points, in order of most to least common, are:
 - [Checkpoints](checkpoints.md) - CheckpointManager, RestoredRun
 - [Recovery](recovery.md) - RecoveryEngine, RecoveryDecision
 - [Validation](validation.md) - StateValidator, validate_state, ValidationOutcome
-- [MCP server](mcp.md) - continuum-mcp, the eleven tools, build_server
+- [MCP server](mcp.md) - continuum-mcp, the twelve tools, build_server
 - [Security](security.md) - attestation and caller authentication
 - [CLI](cli.md) - the `continuum` command reference
 

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -53,6 +53,7 @@ tools are gated by the allowlist (see Security).
 | `continuum_record_progress` | mutate | Record goal progress (completed/total). |
 | `continuum_checkpoint` | mutate | Force a state checkpoint. |
 | `continuum_record_summary` | mutate | Record where reasoning stands (plan stack, decisions, open questions, working set) so a fresh session inherits the plan instead of guessing. Capped at 4096 serialized characters; informational only, never moves mode or safety. |
+| `continuum_record_plan` | mutate | Record a structured plan milestone, one call per unit status change, so a resumed session knows the exact remaining work. Units carry `id`, `title`, `status` (`pending`, `working`, `done`, `blocked`) and optional `depends_on`. |
 | `continuum_intercept_action` | mutate | Claim a side effect; returns whether to proceed. |
 | `continuum_complete_action` | mutate | Record a side effect succeeded. |
 | `continuum_fail_action` | mutate | Record a side effect did not happen. |
@@ -62,7 +63,7 @@ tools are gated by the allowlist (see Security).
 | `continuum_resume` | read | Assess and describe how the run may resume. Omit `run_id` to target the most recently active (interrupted) run. Returns the run's `goal` so a resumed session knows what to continue. |
 | `continuum_list_actions` | read | List recorded side effects and their outcomes. |
 
-Eleven tools: three read-only, eight mutating.
+Twelve tools: three read-only, nine mutating.
 
 Read-only responses `continuum_resume` and `continuum_validate` include a
 `constraint_pins` block: per-pin status (`present`, `absent`, `unverifiable`), grace deadline, and flagged set derived from reconstruction accounting (hash-tagged markers in the recovery context, issue #419). The CLI renders flagged pins prominently with TTY-aware colour while piped output stays byte-identical modulo colour codes. No gating changes live here; strict escalation remains in the accounting layer.

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -53,7 +53,7 @@ tools are gated by the allowlist (see Security).
 | `continuum_record_progress` | mutate | Record goal progress (completed/total). |
 | `continuum_checkpoint` | mutate | Force a state checkpoint. |
 | `continuum_record_summary` | mutate | Record where reasoning stands (plan stack, decisions, open questions, working set) so a fresh session inherits the plan instead of guessing. Capped at 4096 serialized characters; informational only, never moves mode or safety. |
-| `continuum_record_plan` | mutate | Record a structured plan milestone, one call per unit status change, so a resumed session knows the exact remaining work. Units carry `id`, `title`, `status` (`pending`, `working`, `done`, `blocked`) and optional `depends_on`. |
+| `continuum_record_plan` | mutate | Upsert plan units by `id` so a resumed session knows the exact remaining work; one call carries a single unit or the whole plan, and units absent from it keep their recorded status. Units carry `id`, `title`, `status` (`pending`, `working`, `done`, `blocked`) and optional `depends_on`. |
 | `continuum_intercept_action` | mutate | Claim a side effect; returns whether to proceed. |
 | `continuum_complete_action` | mutate | Record a side effect succeeded. |
 | `continuum_fail_action` | mutate | Record a side effect did not happen. |

--- a/tests/test_mcp_docs.py
+++ b/tests/test_mcp_docs.py
@@ -60,10 +60,13 @@ async def test_the_table_lists_every_served_tool_with_its_kind(server: Any) -> N
     """A row per tool, and the Kind column reads off the declared annotation.
 
     Failing here means the table and ``tools/list`` disagree; the sentence of
-    totals directly under the table is part of the same edit.
+    totals directly under the table is part of the same edit. Duplicate rows
+    are rejected before the comparison, or a second row for one tool would
+    silently decide its kind.
     """
-    documented = dict(ROW.findall(MCP_DOC.read_text(encoding="utf-8")))
-    assert documented == kinds(await server.list_tools())
+    rows = ROW.findall(MCP_DOC.read_text(encoding="utf-8"))
+    assert len(rows) == len({name for name, _ in rows}), "a tool is documented twice"
+    assert dict(rows) == kinds(await server.list_tools())
 
 
 def test_the_page_carries_no_em_dashes() -> None:

--- a/tests/test_mcp_docs.py
+++ b/tests/test_mcp_docs.py
@@ -1,0 +1,71 @@
+"""The documented MCP surface must match the one the server actually serves.
+
+``docs/api/mcp.md`` is what a client author reads before writing any code
+against this server, so a tool registered without a row there is a tool nobody
+knows to call. ``continuum_record_plan`` shipped that way and the table stayed
+at eleven rows (issue #271), which is why the audit is a test rather than a
+periodic reread: the drift is silent, and ``tools/list`` is the only authority
+on it.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from continuum.mcp.server import build_server
+from continuum.storage import SQLiteStorage
+
+#: The API reference page whose tool table mirrors ``tools/list``.
+MCP_DOC = Path(__file__).resolve().parents[1] / "docs" / "api" / "mcp.md"
+
+#: One documented tool: name and kind. The purpose column is prose and is left
+#: to a human reviewer, as is the sentence of totals under the table; the two
+#: columns that can silently contradict the server are not.
+ROW = re.compile(r"^\| `(continuum_\w+)` \| (mutate|read) \|", re.MULTILINE)
+
+#: The character house style bans, by code point so this file carries none.
+EM_DASH = chr(0x2014)
+
+
+@pytest.fixture
+def store() -> Iterator[SQLiteStorage]:
+    storage = SQLiteStorage(":memory:")
+    yield storage
+    storage.close()
+
+
+@pytest.fixture
+def server(store: SQLiteStorage) -> Any:
+    # No policy: listing the tools is read-only, and the deny-by-default
+    # allowlist is what test_mcp_authz.py covers.
+    srv, _ = build_server(storage=store)
+    return srv
+
+
+def kinds(tools: list[Any]) -> dict[str, str]:
+    """Map each served tool to the kind the table spells in its Kind column."""
+    return {
+        tool.name: "read" if tool.annotations and tool.annotations.read_only_hint else "mutate"
+        for tool in tools
+    }
+
+
+@pytest.mark.asyncio
+async def test_the_table_lists_every_served_tool_with_its_kind(server: Any) -> None:
+    """A row per tool, and the Kind column reads off the declared annotation.
+
+    Failing here means the table and ``tools/list`` disagree; the sentence of
+    totals directly under the table is part of the same edit.
+    """
+    documented = dict(ROW.findall(MCP_DOC.read_text(encoding="utf-8")))
+    assert documented == kinds(await server.list_tools())
+
+
+def test_the_page_carries_no_em_dashes() -> None:
+    """House style forbids them (issue #266) and one had reached the table."""
+    assert EM_DASH not in MCP_DOC.read_text(encoding="utf-8")


### PR DESCRIPTION
## Description

`docs/api/mcp.md` listed eleven tools and summarised them as "three read-only,
eight mutating", but the server has served twelve since `continuum_record_plan`
was added in ba7b5a9. The plan tool was undocumented: a client author reading
the reference had no way to learn it exists.

This adds the missing `continuum_record_plan` row, corrects the totals under the
table to twelve tools (three read-only, nine mutating), and adds
`tests/test_mcp_docs.py` so the audit is mechanical from now on: it compares the
documented rows against `await server.list_tools()` rather than a hardcoded
list, so a tool registered without a row fails the suite instead of shipping
undocumented.

Audit results for the rest of the issue:

- Every documented `read`/`mutate` kind matches the `read_only_hint` the server
  declares. No row needed correcting.
- The em dash reported in the `continuum_record_summary` row is already gone
  from `main` (removed in 62b1634). The test pins that too, so it cannot come
  back.
- The stale "eleven tools" claim also appears in `README.md` (lines 187, 239),
  `references/architecture-data.md`, `references/auto-resume-integration.md`,
  `references/mcp.md`, `references/testing.md`, and
  `docs/research/token_floor.md`. Those are outside the file this issue names,
  and `docs/research/token_floor.md` reads as a measurement taken at the time,
  so I left them alone rather than widening a docs PR. Happy to open a follow-up
  issue or extend this PR if you would prefer them fixed here.

Verified against the live server rather than by reading the source:

```
$ python -c "..."   # build_server + await server.list_tools()
mutate continuum_record_progress
mutate continuum_checkpoint
mutate continuum_record_summary
mutate continuum_record_plan
read   continuum_validate
read   continuum_resume
mutate continuum_confirm
mutate continuum_intercept_action
mutate continuum_complete_action
mutate continuum_fail_action
mutate continuum_reconcile_action
read   continuum_list_actions
total: 12
```

## Related issues

Fixes #271

## Types of changes

- Type: `docs`

## Breaking changes

No.

## How has this been tested?

Environment: Windows 11, Python 3.11.15, `pip install -e ".[dev]"`.

The new tests fail on the documentation as it stands on `main` (docs stashed,
test file kept):

```
$ pytest tests/test_mcp_docs.py --no-cov --tb=line
E   AssertionError: assert {'continuum_r...'mutate', ...} == {'continuum_r...'mutate', ...}
      Right contains 1 more item:
      {'continuum_record_plan': 'mutate'}
2 failed, 1 passed in 2.44s
```

(The third test there was the totals check, folded into the row test before
commit; the em dash test passed on `main`, as expected.)

With the documentation fix applied:

```
$ pytest tests/test_mcp_docs.py tests/test_mcp_slim.py tests/test_mcp_authz.py --no-cov
74 passed in 4.40s

$ pytest --no-cov
1788 passed, 37 skipped in 256.81s (0:04:16)

$ ruff check src/ tests/ examples/
All checks passed!

$ ruff format --check src/ tests/ examples/
261 files already formatted

$ mypy src/continuum
Success: no issues found in 114 source files
```

`markdownlint-cli2` was not run: CI globs only `CONTRIBUTING.md`, `README.md`,
`SECURITY.md`, and `CODE_OF_CONDUCT.md`, none of which this PR touches.

## Checklist

Tests added (`tests/test_mcp_docs.py`) for the drift this fixes. Documentation
updated (`docs/api/mcp.md`, plus the one-line index entry in
`docs/api/README.md` that names the same count). `CHANGELOG.md` updated under
`[Unreleased]` / `Fixed`. No security-relevant behaviour changes: the
read-only/mutating split and the allowlist are untouched, only their
documentation.

## Additional context

The test derives the expected surface from the server, so it cannot go stale on
its own; the one thing left to a human is the purpose column and the sentence of
totals, which the row test's failure lands next to. `tests/test_mcp_slim.py`
already asserts the tool count is 12, so the two checks agree by construction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated MCP API documentation to list all twelve available tools.
  - Documented the `continuum_record_plan` tool and corrected read-only and mutating totals.
  - Updated the API module overview to reflect the expanded tool count.

- **Tests**
  - Added validation that documentation matches the tools exposed by the server.
  - Added a style check to prevent em dashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->