### PR TITLE
feat: add caused_by payload for provenance graph

### DIFF
--- a/docs/UPGRADE_SPEC.md
+++ b/docs/UPGRADE_SPEC.md
@@ -123,6 +123,7 @@ Grouped from `gh issue list --state open` and label counts (`good first issue` 3
 **Research novelty, not yet implemented:**
 
 * #288 Claim-level provenance graph with staleness propagation (`enhancement` `research` `state`)
+  - #551 caused_by payload on DECISION_CREATED and ACTION_RECORDED, validation against log ids, hash-covered, max 32, 1-128 chars, defaults to [] (Refs #551)
 * #289 Authority lifecycle: consumed-credential tracking and resurrection prevention (`enhancement` `mcp` `security`, complements 239 grant work in 287)
 * #292 Atomic dual-state rewind, context plus environment revert in one command (`enhancement` `research`)
 * #293 Public recovery-correctness benchmark, fault-injection grading for any framework (`enhancement` `benchmark` `research`)

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -68,6 +68,9 @@ class EventType(StrEnum):
     TOOL_FAILED = "TOOL_FAILED"
 
     # semantic state
+    # DECISION_CREATED payload may include caused_by: list[str] (1-128 chars each, max 32,
+    # default []). Unknown ids raise ValueError. Field is hash-covered and old events
+    # without it load as [].
     DECISION_CREATED = "DECISION_CREATED"
     DECISION_INVALIDATED = "DECISION_INVALIDATED"
     EVIDENCE_ADDED = "EVIDENCE_ADDED"
@@ -110,6 +113,8 @@ class EventType(StrEnum):
     BRANCH_RESOLVED = "BRANCH_RESOLVED"
 
     # action ledger
+    # ACTION_RECORDED payload may include caused_by: list[str] (1-128 chars each, max 32,
+    # default []). Unknown ids raise ValueError. Hash-covered, old events load as [].
     ACTION_RECORDED = "ACTION_RECORDED"
     ACTION_RECONCILED = "ACTION_RECONCILED"
     ACTION_COMPENSATED = "ACTION_COMPENSATED"
@@ -267,6 +272,18 @@ class EventLog:
     ) -> Event:
         """Append an event and return the sealed (hashed) record."""
         chain = self._by_run.setdefault(run_id, [])
+        if type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED) and payload is not None:
+            caused_by = payload.get("caused_by") if isinstance(payload, Mapping) else None
+            if caused_by is not None:
+                if not isinstance(caused_by, list):
+                    raise ValueError("caused_by must be a list")
+                if len(caused_by) > 32:
+                    raise ValueError("caused_by must contain at most 32 ids")
+                for cid in caused_by:
+                    if not isinstance(cid, str) or not 1 <= len(cid) <= 128:
+                        raise ValueError("caused_by entries must be 1-128 chars")
+                    if not any(e.event_id == cid for e in chain):
+                        raise ValueError(f"unknown caused_by id {cid!r}")
         head = chain[-1] if chain else None
         event = Event(
             event_id=event_id or make_id("event"),

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -727,6 +727,60 @@ class Action(BaseModel):
     completed_at: datetime | None = None
 
 
+class ActionRecordPayload(BaseModel):
+    """Payload for ACTION_RECORDED (issue #551).
+
+    ``caused_by`` records the event ids that caused this action, completing
+    the causal chain. Same caps as DecisionPayload: optional, max 32 ids
+    of 1-128 chars, default [], unknown ids raise ValueError.
+    """
+
+    model_config = Frozen
+
+    action_id: str = Field(default_factory=lambda: make_id("action"))
+    action_type: str
+    arguments: Mapping[str, Any] = Field(default_factory=dict)
+    caused_by: list[str] = Field(default_factory=list)
+
+    @field_validator("caused_by")
+    @classmethod
+    def _validate_caused_by(cls, value: list[str]) -> list[str]:
+        if len(value) > 32:
+            raise ValueError("caused_by must contain at most 32 ids")
+        for item in value:
+            if not isinstance(item, str):
+                raise ValueError("caused_by entries must be strings")
+            if not 1 <= len(item) <= 128:
+                raise ValueError("caused_by entries must be 1-128 chars")
+        return value
+
+
+def _validate_caused_by_known(caused_by: list[str], known_ids: set[str]) -> None:
+    """Raise ValueError if any id in caused_by is not in known_ids."""
+    for cid in caused_by:
+        if cid not in known_ids:
+            raise ValueError(f"unknown caused_by id {cid!r}")
+
+
+def validate_caused_by(caused_by: list[str] | None, known_ids: set[str] | None = None) -> list[str]:
+    """Validate caused_by list and optionally check existence.
+
+    Caps are enforced (max 32, each 1-128 chars). When known_ids is given,
+    every entry must be present or ValueError is raised. Empty or None
+    returns [] for backward compat.
+    """
+    if not caused_by:
+        return []
+    if len(caused_by) > 32:
+        raise ValueError("caused_by must contain at most 32 ids")
+    for cid in caused_by:
+        if not isinstance(cid, str) or not 1 <= len(cid) <= 128:
+            raise ValueError("caused_by entries must be 1-128 chars")
+    if known_ids is not None:
+        _validate_caused_by_known(caused_by, known_ids)
+    return list(caused_by)
+
+
 class UnknownSideEffect(RuntimeError):
     """Raised when CONTINUUM cannot determine whether an external side effect occurred.
 

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -38,6 +38,8 @@ __all__ = [
     "ApprovalStatus",
     "PlanStepStatus",
     "utcnow",
+    "DecisionPayload",
+    "ActionRecordPayload",
     "Goal",
     "PlanStep",
     "Progress",
@@ -297,6 +299,36 @@ class Decision(BaseModel):
     invalidated_at: datetime | None = None
     invalidated_reason: str | None = None
     provenance: Provenance = Field(default_factory=Provenance)
+
+
+class DecisionPayload(BaseModel):
+    """Payload for DECISION_CREATED (issue #551).
+
+    ``caused_by`` records the event ids that caused this decision, enabling
+    the causal graph evidence -> finding -> decision -> action. Optional,
+    at most 32 ids of 1-128 chars each, defaults to [] for backward compat.
+    Unknown ids are refused by the writer (ValueError).
+    """
+
+    model_config = Frozen
+
+    decision_id: str = Field(default_factory=lambda: make_id("decision"))
+    decision: str
+    reason: str = ""
+    evidence: list[str] = Field(default_factory=list)
+    caused_by: list[str] = Field(default_factory=list)
+
+    @field_validator("caused_by")
+    @classmethod
+    def _validate_caused_by(cls, value: list[str]) -> list[str]:
+        if len(value) > 32:
+            raise ValueError("caused_by must contain at most 32 ids")
+        for item in value:
+            if not isinstance(item, str):
+                raise ValueError("caused_by entries must be strings")
+            if not 1 <= len(item) <= 128:
+                raise ValueError("caused_by entries must be 1-128 chars")
+        return value
 
 
 class Evidence(BaseModel):

--- a/src/continuum/storage/postgres.py
+++ b/src/continuum/storage/postgres.py
@@ -427,6 +427,23 @@ class PostgresStorage(Storage):
         (compaction) reuse this instead of :meth:`append_event`, which would
         commit the marker in its own autocommit transaction.
         """
+        if type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED) and payload is not None:
+            caused_by = payload.get("caused_by") if isinstance(payload, dict) else None
+            if caused_by is not None:
+                if not isinstance(caused_by, list):
+                    raise ValueError("caused_by must be a list")
+                if len(caused_by) > 32:
+                    raise ValueError("caused_by must contain at most 32 ids")
+                for cid in caused_by:
+                    if not isinstance(cid, str) or not 1 <= len(cid) <= 128:
+                        raise ValueError("caused_by entries must be 1-128 chars")
+                    exists = self._connection.execute(
+                        "SELECT 1 FROM events WHERE run_id = %s AND event_id = %s UNION ALL "
+                        "SELECT 1 FROM events_archive WHERE run_id = %s AND event_id = %s LIMIT 1",
+                        (run_id, cid, run_id, cid),
+                    ).fetchone()
+                    if exists is None:
+                        raise ValueError(f"unknown caused_by id {cid!r}")
         self._require_run(self._connection, run_id)
         head = self._connection.execute(
             "SELECT sequence, hash FROM events WHERE run_id = %s ORDER BY sequence DESC LIMIT 1",
@@ -454,7 +471,30 @@ class PostgresStorage(Storage):
         return event
 
     def append_sealed(self, event: Event) -> Event:
+        if event.type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED):
+            caused_by = event.payload.get("caused_by") if isinstance(event.payload, dict) else None
+            if caused_by is not None:
+                if not isinstance(caused_by, list):
+                    raise ValueError("caused_by must be a list")
+                if len(caused_by) > 32:
+                    raise ValueError("caused_by must contain at most 32 ids")
+                for cid in caused_by:
+                    if not isinstance(cid, str) or not 1 <= len(cid) <= 128:
+                        raise ValueError("caused_by entries must be 1-128 chars")
         with self._write():
+            if event.type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED):
+                caused_by = (
+                    event.payload.get("caused_by") if isinstance(event.payload, dict) else None
+                )
+                if caused_by:
+                    for cid in caused_by:
+                        exists = self._connection.execute(
+                            "SELECT 1 FROM events WHERE run_id = %s AND event_id = %s UNION ALL "
+                            "SELECT 1 FROM events_archive WHERE run_id = %s AND event_id = %s LIMIT 1",
+                            (event.run_id, cid, event.run_id, cid),
+                        ).fetchone()
+                        if exists is None:
+                            raise ValueError(f"unknown caused_by id {cid!r}")
             self._require_run(self._connection, event.run_id)
             head = self._connection.execute(
                 "SELECT sequence, hash FROM events WHERE run_id = %s "

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -351,6 +351,23 @@ class SQLiteStorage(Storage):
         (compaction) reuse this instead of :meth:`append_event`, which would
         try to nest a second transaction.
         """
+        if type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED) and payload is not None:
+            caused_by = payload.get("caused_by") if isinstance(payload, dict) else None
+            if caused_by is not None:
+                if not isinstance(caused_by, list):
+                    raise ValueError("caused_by must be a list")
+                if len(caused_by) > 32:
+                    raise ValueError("caused_by must contain at most 32 ids")
+                for cid in caused_by:
+                    if not isinstance(cid, str) or not 1 <= len(cid) <= 128:
+                        raise ValueError("caused_by entries must be 1-128 chars")
+                    exists = conn.execute(
+                        "SELECT 1 FROM events WHERE run_id = ? AND event_id = ? UNION ALL "
+                        "SELECT 1 FROM events_archive WHERE run_id = ? AND event_id = ? LIMIT 1",
+                        (run_id, cid, run_id, cid),
+                    ).fetchone()
+                    if exists is None:
+                        raise ValueError(f"unknown caused_by id {cid!r}")
         self._require_run(conn, run_id)
         head = conn.execute(
             "SELECT sequence, hash FROM events WHERE run_id = ? ORDER BY sequence DESC LIMIT 1",
@@ -378,7 +395,30 @@ class SQLiteStorage(Storage):
         return event
 
     def append_sealed(self, event: Event) -> Event:
+        if event.type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED):
+            caused_by = event.payload.get("caused_by") if isinstance(event.payload, dict) else None
+            if caused_by is not None:
+                if not isinstance(caused_by, list):
+                    raise ValueError("caused_by must be a list")
+                if len(caused_by) > 32:
+                    raise ValueError("caused_by must contain at most 32 ids")
+                for cid in caused_by:
+                    if not isinstance(cid, str) or not 1 <= len(cid) <= 128:
+                        raise ValueError("caused_by entries must be 1-128 chars")
         with self._write() as conn:
+            if event.type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED):
+                caused_by = (
+                    event.payload.get("caused_by") if isinstance(event.payload, dict) else None
+                )
+                if caused_by:
+                    for cid in caused_by:
+                        exists = conn.execute(
+                            "SELECT 1 FROM events WHERE run_id = ? AND event_id = ? UNION ALL "
+                            "SELECT 1 FROM events_archive WHERE run_id = ? AND event_id = ? LIMIT 1",
+                            (event.run_id, cid, event.run_id, cid),
+                        ).fetchone()
+                        if exists is None:
+                            raise ValueError(f"unknown caused_by id {cid!r}")
             self._require_run(conn, event.run_id)
             head = conn.execute(
                 "SELECT sequence, hash FROM events WHERE run_id = ? ORDER BY sequence DESC LIMIT 1",

--- a/tests/test_provenance_caused_by.py
+++ b/tests/test_provenance_caused_by.py
@@ -1,0 +1,179 @@
+"""Provenance caused_by payload tests (issue #551)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from continuum.events import EventLog, EventType
+from continuum.models import ActionRecordPayload, DecisionPayload
+from continuum.storage.sqlite import SQLiteStorage
+
+
+def test_decision_payload_caused_by_defaults_to_empty() -> None:
+    payload = DecisionPayload(decision="choose X")
+    assert payload.caused_by == []
+    restored = DecisionPayload.model_validate({"decision": "choose X"})
+    assert restored.caused_by == []
+
+
+def test_action_payload_caused_by_defaults_to_empty() -> None:
+    payload = ActionRecordPayload(action_type="send_email")
+    assert payload.caused_by == []
+    restored = ActionRecordPayload.model_validate({"action_type": "send_email"})
+    assert restored.caused_by == []
+
+
+def test_decision_caused_by_round_trips_via_sqlite() -> None:
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_caused_1"
+    from continuum.models import Run
+
+    storage.create_run(Run(run_id=run_id, goal="test"))
+    ev = storage.append_event(
+        run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1", "summary": "s"}
+    )
+    payload = DecisionPayload(decision="decide", caused_by=[ev.event_id]).model_dump()
+    dec = storage.append_event(run_id, EventType.DECISION_CREATED, payload)
+    assert dec.payload["caused_by"] == [ev.event_id]
+    events = storage.read_events(run_id)
+    found = [e for e in events if e.type == EventType.DECISION_CREATED][0]
+    assert found.payload["caused_by"] == [ev.event_id]
+
+
+def test_caused_by_survives_reopen() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        db = Path(tmp) / "test.db"
+        storage = SQLiteStorage(str(db))
+        run_id = "run_reopen"
+        from continuum.models import Run
+
+        storage.create_run(Run(run_id=run_id, goal="g"))
+        ev = storage.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev2"})
+        payload = DecisionPayload(decision="d", caused_by=[ev.event_id]).model_dump()
+        storage.append_event(run_id, EventType.DECISION_CREATED, payload)
+        storage.close()
+        storage2 = SQLiteStorage(str(db))
+        events = storage2.read_events(run_id)
+        dec = [e for e in events if e.type == EventType.DECISION_CREATED][0]
+        assert dec.payload["caused_by"] == [ev.event_id]
+        storage2.close()
+
+
+def test_unknown_caused_by_raises_via_storage() -> None:
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_unknown_storage"
+    from continuum.models import Run
+
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    storage.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
+    payload = DecisionPayload(decision="d", caused_by=["event_unknown_123"]).model_dump()
+    with pytest.raises(ValueError, match="unknown caused_by"):
+        storage.append_event(run_id, EventType.DECISION_CREATED, payload)
+
+
+def test_unknown_caused_by_raises_via_eventlog() -> None:
+    log = EventLog()
+    run_id = "run_unknown_log"
+    ev = log.append(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
+    with pytest.raises(ValueError, match="unknown caused_by"):
+        log.append(run_id, EventType.DECISION_CREATED, {"decision": "d", "caused_by": ["nope"]})
+    ok = log.append(
+        run_id, EventType.DECISION_CREATED, {"decision": "d", "caused_by": [ev.event_id]}
+    )
+    assert ok.payload["caused_by"] == [ev.event_id]
+
+
+def test_caused_by_is_hash_covered() -> None:
+    log = EventLog()
+    run_id = "run_hash"
+    ev = log.append(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
+    dec = log.append(
+        run_id, EventType.DECISION_CREATED, {"decision": "d", "caused_by": [ev.event_id]}
+    )
+    original_hash = dec.hash
+    tampered = dec.model_copy(update={"payload": {**dec.payload, "caused_by": ["tampered"]}})
+    assert tampered.digest() != original_hash
+    storage = SQLiteStorage(":memory:")
+    from continuum.models import Run
+
+    storage.create_run(Run(run_id="run_hash2", goal="g"))
+    e1 = storage.append_event("run_hash2", EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
+    d1 = storage.append_event(
+        "run_hash2", EventType.DECISION_CREATED, {"decision": "d", "caused_by": [e1.event_id]}
+    )
+    import json
+
+    with storage._write() as c:
+        c.execute(
+            "UPDATE events SET payload = ? WHERE event_id = ?",
+            (json.dumps({"decision": "d", "caused_by": ["x"]}), d1.event_id),
+        )
+    report2 = storage.verify_events("run_hash2")
+    assert not report2.ok
+
+
+def test_caused_by_caps_are_enforced() -> None:
+    with pytest.raises(ValueError, match="at most 32"):
+        DecisionPayload(decision="d", caused_by=[f"e{i}" for i in range(33)])
+    with pytest.raises(ValueError, match="1-128"):
+        DecisionPayload(decision="d", caused_by=[""])
+    with pytest.raises(ValueError, match="1-128"):
+        DecisionPayload(decision="d", caused_by=["x" * 129])
+    ok = DecisionPayload(decision="d", caused_by=["x" * 128])
+    assert len(ok.caused_by[0]) == 128
+    ok2 = DecisionPayload(decision="d", caused_by=[f"e{i}" for i in range(32)])
+    assert len(ok2.caused_by) == 32
+    with pytest.raises(ValueError, match="1-128"):
+        ActionRecordPayload(action_type="t", caused_by=["x" * 129])
+
+
+def test_empty_caused_by_round_trips() -> None:
+    storage = SQLiteStorage(":memory:")
+    from continuum.models import Run
+
+    run_id = "run_empty"
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    dec = storage.append_event(
+        run_id, EventType.DECISION_CREATED, {"decision": "d", "caused_by": []}
+    )
+    assert dec.payload["caused_by"] == []
+    events = storage.read_events(run_id)
+    assert events[0].payload["caused_by"] == []
+    dec2 = storage.append_event(run_id, EventType.DECISION_CREATED, {"decision": "d2"})
+    assert dec2.payload.get("caused_by", []) == []
+    log = EventLog()
+    e = log.append(run_id + "_log", EventType.DECISION_CREATED, {"decision": "d"})
+    assert e.payload.get("caused_by", []) == []
+
+
+def test_old_events_without_caused_by_project_as_empty() -> None:
+    from continuum.state.semantic import project
+
+    log = EventLog()
+    run_id = "run_old"
+    log.append(run_id, EventType.RUN_STARTED, {"goal": "g"})
+    log.append(run_id, EventType.DECISION_CREATED, {"decision": "old", "decision_id": "dec_old"})
+    state = project(run_id, log.events(run_id))
+    assert any(d.decision_id == "dec_old" for d in state.decisions)
+
+
+def test_action_record_caused_by_round_trip() -> None:
+    storage = SQLiteStorage(":memory:")
+    from continuum.models import Run
+
+    run_id = "run_action"
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    ev = storage.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
+    payload = ActionRecordPayload(action_type="send", caused_by=[ev.event_id]).model_dump()
+    payload.update(
+        {"key": "k1", "action": {"action_id": "a1", "run_id": run_id, "action_type": "send"}}
+    )
+    rec = storage.append_event(run_id, EventType.ACTION_RECORDED, payload)
+    assert rec.payload["caused_by"] == [ev.event_id]
+    events = storage.read_events(run_id)
+    assert [e for e in events if e.type == EventType.ACTION_RECORDED][0].payload["caused_by"] == [
+        ev.event_id
+    ]


### PR DESCRIPTION
## Description

Adds optional `caused_by: list[str]` to DECISION_CREATED and ACTION_RECORDED payloads as the first step of the provenance graph (issue #288, sub-issue #551). The list is capped at 32 ids of 1-128 chars each, defaults to [] for old events, unknown ids raise ValueError, and the field is part of the hash so tampering is detected by verify().

Changes:
- `src/continuum/models.py`: add `DecisionPayload` and `ActionRecordPayload` with caused_by validation, export them, and add `validate_caused_by` helper
- `src/continuum/events.py`: document caused_by on EventType members and validate in EventLog.append
- `src/continuum/storage/sqlite.py`: validate caused_by in SQLiteStorage append paths against live and archived events
- `tests/test_provenance_caused_by.py`: new coverage for defaults, round-trip via SQLiteStorage, reopen persistence, unknown id raises, hash tamper, caps, empty list and action record

## Related issues

Fixes #551
Refs #550
Parent epic #288

## Types of changes

- Type: feature

## Breaking changes

No

## How has this been tested?

```
/opt/miniconda3/bin/python -m pytest tests/test_provenance_caused_by.py -q
ruff check src/ tests/ examples/
ruff format --check src/ tests/ examples/
mypy src/continuum --ignore-missing-imports
rg -n "—" src/ tests/ docs/ examples/ benchmarks/
```

pytest 11 passed, ruff clean, format clean, mypy same 13 pre-existing errors as main, no new em dashes in changed files.

Falsifiable test: create decision with caused_by=[ev_id] and assert persisted id survives reopen; create with unknown id assert raises. Both covered.

## Checklist

Tests added for changed behaviour. Documentation updated where user-facing. CI passes on latest commit.

## Additional context

Pinned board #550, row #288a. No em dashes, no AI attribution, branch carries issue number, every commit contains Refs #551.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added causal references to decision and action records, allowing events to document the evidence or prior events that led to them.
  * Causal references are preserved through storage and remain available after reopening.
  * Existing records without causal references remain compatible.

* **Bug Fixes**
  * Added validation to reject invalid, unknown, or tampered causal references.
  * Included causal references in event integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->