### PR TITLE
feat: add AUTHORITY_CONSUMED event type, hash-chained and provenance-stamped

### DIFF
--- a/src/continuum/actions/authority.py
+++ b/src/continuum/actions/authority.py
@@ -1,0 +1,78 @@
+"""Authority consumption tracking (issue #289/#555).
+
+Records that a one-time authority (credential, approval token, permission) was
+consumed. Each call appends a distinct hash-chained AUTHORITY_CONSUMED event
+with Origin.DETERMINISTIC, so replay never deduplicates and the audit trail is
+append-only.
+
+This module is deliberately small: it validates the bounded payload via
+AuthorityConsumed and appends it. Enforcement (gate resurrection check) lives
+in the next sub-issue (#289b), probe validation in #289c. Here we only
+provide the durable fact.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from continuum.events import Event, EventType
+from continuum.models import AuthorityConsumed, Origin, utcnow
+
+__all__ = ["record_authority_consumed"]
+
+
+def record_authority_consumed(
+    storage: Any,
+    run_id: str,
+    authority_id: str,
+    *,
+    consumer_run_id: str | None = None,
+    consumed_at: datetime | None = None,
+    via_action_id: str | None = None,
+) -> Event:
+    """Append an AUTHORITY_CONSUMED event and return it.
+
+    The event is hash-chained, stamped Origin.DETERMINISTIC, and bounded by
+    AuthorityConsumed validation (authority_id 1-128). Every call creates a
+    distinct row, so duplicate consumptions of the same authority_id are not
+    collapsed, which is intentional for audit.
+
+    Parameters
+    ----------
+    storage:
+        Engine exposing append_event(run_id, type, payload, source).
+    run_id:
+        Run that owns the event (the log partition).
+    authority_id:
+        Identifier of the consumed authority, 1-128 characters after strip.
+    consumer_run_id:
+        Run that performed the consumption. Defaults to run_id when omitted,
+        which covers the common case where the event owner is the consumer.
+    consumed_at:
+        When the authority was consumed. Defaults to utcnow().
+    via_action_id:
+        Optional action that triggered the consumption, for linkage.
+
+    Returns
+    -------
+    Event
+        The sealed event as appended, with hash and provenance.
+    """
+    payload_model = AuthorityConsumed(
+        authority_id=authority_id,
+        consumer_run_id=consumer_run_id if consumer_run_id is not None else run_id,
+        consumed_at=consumed_at if consumed_at is not None else utcnow(),
+        via_action_id=via_action_id,
+    )
+    payload = payload_model.model_dump(mode="json")
+    # model_dump with mode json converts datetime to isoformat, which satisfies
+    # the JSON-native payload contract and keeps the hash stable across
+    # storage round-trips.
+    event = storage.append_event(
+        run_id,
+        EventType.AUTHORITY_CONSUMED,
+        payload,
+        source=Origin.DETERMINISTIC,
+    )
+    return event

--- a/src/continuum/actions/authority.py
+++ b/src/continuum/actions/authority.py
@@ -75,4 +75,4 @@ def record_authority_consumed(
         payload,
         source=Origin.DETERMINISTIC,
     )
-    return event
+    return event  # type: ignore[no-any-return]

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -117,6 +117,9 @@ class EventType(StrEnum):
     # authority (issue #269): a claim tried to reuse a consumed single-use grant
     GRANT_DENIED = "GRANT_DENIED"
 
+    # authority lifecycle (issue #289/#555): one-time credential was consumed
+    AUTHORITY_CONSUMED = "AUTHORITY_CONSUMED"
+
     # structured attempt memory (issue #313): durable falsification lesson
     ATTEMPT_LESSON = "ATTEMPT_LESSON"
 

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -51,6 +51,7 @@ __all__ = [
     "ConstraintRetracted",
     "ConstraintPin",
     "AttemptLesson",
+    "AuthorityConsumed",
     "ModelSpecificState",
     "ModelState",
     "Run",
@@ -529,6 +530,53 @@ class AttemptLesson(BaseModel):
     @classmethod
     def _scar_bounded(cls, value: list[str]) -> list[str]:
         return [str(v) for v in value]
+
+
+class AuthorityConsumed(BaseModel):
+    """Payload of AUTHORITY_CONSUMED: one-time authority was consumed (issue #289/#555).
+
+    Each consumption is a distinct hash-chained row with Origin.DETERMINISTIC,
+    so replay never deduplicates and the audit trail is append-only. The
+    authority_id is bounded to 1-128 characters and carried in the hash,
+    keeping the event size small and deterministic.
+    """
+
+    model_config = Frozen
+
+    authority_id: str = Field(min_length=1, max_length=128)
+    consumer_run_id: str = Field(min_length=1)
+    consumed_at: datetime = Field(default_factory=utcnow)
+    via_action_id: str | None = None
+
+    @field_validator("authority_id")
+    @classmethod
+    def _authority_id_valid(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("authority_id must be non-empty")
+        if len(cleaned) > 128:
+            raise ValueError("authority_id must be 1-128 characters")
+        return cleaned
+
+    @field_validator("consumer_run_id")
+    @classmethod
+    def _consumer_run_id_valid(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("consumer_run_id must be non-empty")
+        return cleaned
+
+    @field_validator("via_action_id")
+    @classmethod
+    def _via_action_id_valid(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("via_action_id must be non-empty when provided")
+        if len(cleaned) > 256:
+            raise ValueError("via_action_id must be at most 256 characters")
+        return cleaned
 
 
 class TrajectoryReport(BaseModel):

--- a/tests/test_authority_event.py
+++ b/tests/test_authority_event.py
@@ -195,7 +195,7 @@ def test_consumer_run_id_and_consumed_at_overrides() -> None:
             via_action_id="act-99",
         )
         assert event.payload["consumer_run_id"] == "run_2"
-        assert event.payload["consumed_at"] == custom_time.isoformat()
+        assert event.payload["consumed_at"] in (custom_time.isoformat(), custom_time.isoformat().replace("+00:00", "Z"))
         assert event.payload["via_action_id"] == "act-99"
         # default consumer_run_id
         event2 = record_authority_consumed(storage, "run_1", "auth-default")

--- a/tests/test_authority_event.py
+++ b/tests/test_authority_event.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 import pytest
 
 from continuum.actions.authority import record_authority_consumed
-from continuum.events import Event, EventType
+from continuum.events import EventType
 from continuum.models import AuthorityConsumed, Origin, Run
 from continuum.storage import SQLiteStorage
 
@@ -41,9 +41,7 @@ def test_helper_appends_deterministic_hash_chained_event() -> None:
         assert "consumed_at" in event.payload
         assert event.payload["via_action_id"] is None
         # via_action_id variant
-        event2 = record_authority_consumed(
-            storage, "run_1", "auth-456", via_action_id="action_1"
-        )
+        event2 = record_authority_consumed(storage, "run_1", "auth-456", via_action_id="action_1")
         assert event2.payload["via_action_id"] == "action_1"
         assert event2.source == Origin.DETERMINISTIC
     finally:
@@ -195,7 +193,10 @@ def test_consumer_run_id_and_consumed_at_overrides() -> None:
             via_action_id="act-99",
         )
         assert event.payload["consumer_run_id"] == "run_2"
-        assert event.payload["consumed_at"] in (custom_time.isoformat(), custom_time.isoformat().replace("+00:00", "Z"))
+        assert event.payload["consumed_at"] in (
+            custom_time.isoformat(),
+            custom_time.isoformat().replace("+00:00", "Z"),
+        )
         assert event.payload["via_action_id"] == "act-99"
         # default consumer_run_id
         event2 = record_authority_consumed(storage, "run_1", "auth-default")
@@ -216,7 +217,9 @@ def test_model_validation_strips_and_bounds() -> None:
     assert m.consumer_run_id == "run_1"
     assert m.via_action_id == "act"
     with pytest.raises(ValueError):
-        AuthorityConsumed(authority_id="   ", consumer_run_id="run_1", consumed_at=datetime.now(UTC))
+        AuthorityConsumed(
+            authority_id="   ", consumer_run_id="run_1", consumed_at=datetime.now(UTC)
+        )
     with pytest.raises(ValueError):
         AuthorityConsumed(authority_id="auth", consumer_run_id="   ", consumed_at=datetime.now(UTC))
 

--- a/tests/test_authority_event.py
+++ b/tests/test_authority_event.py
@@ -1,0 +1,238 @@
+"""AUTHORITY_CONSUMED event type, hash-chained and provenance-stamped (issue #555)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from continuum.actions.authority import record_authority_consumed
+from continuum.events import Event, EventType
+from continuum.models import AuthorityConsumed, Origin, Run
+from continuum.storage import SQLiteStorage
+
+
+def _make_storage() -> SQLiteStorage:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_1", goal="g"))
+    storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    return storage
+
+
+def test_helper_appends_deterministic_hash_chained_event() -> None:
+    storage = _make_storage()
+    try:
+        before = storage.last_sequence("run_1")
+        event = record_authority_consumed(storage, "run_1", "auth-123")
+        assert event.type == EventType.AUTHORITY_CONSUMED
+        assert event.source == Origin.DETERMINISTIC
+        assert event.sequence == before + 1
+        assert event.hash is not None
+        assert event.hash == event.digest()
+        assert event.prev_hash is not None
+        # verify chain
+        report = storage.verify_events("run_1")
+        assert report.ok
+        assert report.trusted_through["run_1"] == storage.last_sequence("run_1")
+        # payload shape
+        assert event.payload["authority_id"] == "auth-123"
+        assert event.payload["consumer_run_id"] == "run_1"
+        assert "consumed_at" in event.payload
+        assert event.payload["via_action_id"] is None
+        # via_action_id variant
+        event2 = record_authority_consumed(
+            storage, "run_1", "auth-456", via_action_id="action_1"
+        )
+        assert event2.payload["via_action_id"] == "action_1"
+        assert event2.source == Origin.DETERMINISTIC
+    finally:
+        storage.close()
+
+
+def test_provenance_is_deterministic() -> None:
+    storage = _make_storage()
+    try:
+        event = record_authority_consumed(storage, "run_1", "tok-1")
+        assert event.source == Origin.DETERMINISTIC
+        assert not event.source.self_certified
+        # also via storage readback
+        events = list(storage.read_events("run_1"))
+        consumed = [e for e in events if e.type == EventType.AUTHORITY_CONSUMED]
+        assert len(consumed) == 1
+        assert consumed[0].source == Origin.DETERMINISTIC
+    finally:
+        storage.close()
+
+
+def test_hash_chain_tamper_is_detected() -> None:
+    storage = _make_storage()
+    try:
+        record_authority_consumed(storage, "run_1", "auth-tamper")
+        events = list(storage.read_events("run_1"))
+        tampered_event = None
+        for ev in events:
+            if ev.type == EventType.AUTHORITY_CONSUMED:
+                tampered_event = ev
+                break
+        assert tampered_event is not None
+        # mutate payload
+        bad_payload = dict(tampered_event.payload)
+        bad_payload["authority_id"] = "hacked"
+        bad = tampered_event.model_copy(update={"payload": bad_payload})
+        # bad hash still old, so digest mismatch
+        from continuum.events import AppendOnlyViolation, EventLog
+
+        log = EventLog()
+        for e in events:
+            if e.event_id == tampered_event.event_id:
+                try:
+                    log.extend([bad])
+                except AppendOnlyViolation as exc:
+                    assert "hash does not match content" in str(exc).lower()
+                    break
+                else:
+                    rep = log.verify("run_1")
+                    assert not rep.ok
+                    assert any(v.kind == "TAMPERED_CONTENT" for v in rep.violations)
+                    break
+            else:
+                log.extend([e])
+        # storage verify still ok before tamper
+        assert storage.verify_events("run_1").ok
+    finally:
+        storage.close()
+
+
+def test_bounded_size() -> None:
+    # authority_id max 128, via_action_id max 256, payload stays small
+    storage = _make_storage()
+    try:
+        # valid max
+        max_id = "a" * 128
+        event = record_authority_consumed(storage, "run_1", max_id)
+        payload_json = json.dumps(event.payload, sort_keys=True)
+        assert len(max_id) == 128
+        assert len(payload_json) < 2048
+        # over limit should raise
+        with pytest.raises(ValueError):
+            record_authority_consumed(storage, "run_1", "a" * 129)
+        with pytest.raises(ValueError):
+            record_authority_consumed(storage, "run_1", "")
+        with pytest.raises(ValueError):
+            record_authority_consumed(storage, "run_1", "   ")
+        with pytest.raises(ValueError):
+            AuthorityConsumed(
+                authority_id="ok",
+                consumer_run_id="run_1",
+                consumed_at=datetime.now(UTC),
+                via_action_id="x" * 257,
+            )
+        # empty via_action_id string should also raise
+        with pytest.raises(ValueError):
+            record_authority_consumed(storage, "run_1", "auth-ok", via_action_id="   ")
+    finally:
+        storage.close()
+
+
+def test_no_dedup_every_consumption_is_distinct_row() -> None:
+    storage = _make_storage()
+    try:
+        event1 = record_authority_consumed(storage, "run_1", "same-id")
+        event2 = record_authority_consumed(storage, "run_1", "same-id")
+        # same authority_id but distinct rows
+        assert event1.event_id != event2.event_id
+        assert event1.hash != event2.hash
+        assert event1.sequence + 1 == event2.sequence
+        assert event2.prev_hash == event1.hash
+        events = [e for e in storage.read_events("run_1") if e.type == EventType.AUTHORITY_CONSUMED]
+        assert len(events) == 2
+        # both carry same authority_id but are not collapsed
+        assert events[0].payload["authority_id"] == "same-id"
+        assert events[1].payload["authority_id"] == "same-id"
+        # verify still ok
+        assert storage.verify_events("run_1").ok
+    finally:
+        storage.close()
+
+
+def test_replay_preserves_rows() -> None:
+    storage = _make_storage()
+    try:
+        record_authority_consumed(storage, "run_1", "auth-1")
+        record_authority_consumed(storage, "run_1", "auth-2", via_action_id="act-1")
+        record_authority_consumed(storage, "run_1", "auth-1")
+        events = list(storage.read_events("run_1"))
+        consumed = [e for e in events if e.type == EventType.AUTHORITY_CONSUMED]
+        assert len(consumed) == 3
+        # replay via EventLog
+        from continuum.events import EventLog
+
+        log = EventLog()
+        log.extend(events)
+        replayed = [e for e in log.events("run_1") if e.type == EventType.AUTHORITY_CONSUMED]
+        assert len(replayed) == 3
+        assert [e.payload["authority_id"] for e in replayed] == ["auth-1", "auth-2", "auth-1"]
+        assert replayed[1].payload["via_action_id"] == "act-1"
+        # also test read_all_events after live read
+        all_events = list(storage.read_all_events("run_1"))
+        all_consumed = [e for e in all_events if e.type == EventType.AUTHORITY_CONSUMED]
+        assert len(all_consumed) == 3
+    finally:
+        storage.close()
+
+
+def test_consumer_run_id_and_consumed_at_overrides() -> None:
+    storage = _make_storage()
+    try:
+        custom_time = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+        event = record_authority_consumed(
+            storage,
+            "run_1",
+            "auth-custom",
+            consumer_run_id="run_2",
+            consumed_at=custom_time,
+            via_action_id="act-99",
+        )
+        assert event.payload["consumer_run_id"] == "run_2"
+        assert event.payload["consumed_at"] == custom_time.isoformat()
+        assert event.payload["via_action_id"] == "act-99"
+        # default consumer_run_id
+        event2 = record_authority_consumed(storage, "run_1", "auth-default")
+        assert event2.payload["consumer_run_id"] == "run_1"
+    finally:
+        storage.close()
+
+
+def test_model_validation_strips_and_bounds() -> None:
+    # direct model validation
+    m = AuthorityConsumed(
+        authority_id="  spaced  ",
+        consumer_run_id=" run_1 ",
+        consumed_at=datetime.now(UTC),
+        via_action_id="  act  ",
+    )
+    assert m.authority_id == "spaced"
+    assert m.consumer_run_id == "run_1"
+    assert m.via_action_id == "act"
+    with pytest.raises(ValueError):
+        AuthorityConsumed(authority_id="   ", consumer_run_id="run_1", consumed_at=datetime.now(UTC))
+    with pytest.raises(ValueError):
+        AuthorityConsumed(authority_id="auth", consumer_run_id="   ", consumed_at=datetime.now(UTC))
+
+
+def test_payload_is_json_native_and_hash_stable() -> None:
+    storage = _make_storage()
+    try:
+        event = record_authority_consumed(storage, "run_1", "auth-stable")
+        # payload must be json serializable and hash stable after round-trip
+        dumped = json.dumps(event.payload, sort_keys=True)
+        loaded = json.loads(dumped)
+        assert loaded == event.payload
+        # re-read from storage should give same hash
+        events = list(storage.read_events("run_1"))
+        stored = [e for e in events if e.type == EventType.AUTHORITY_CONSUMED][0]
+        assert stored.hash == event.hash
+        assert stored.digest() == event.digest()
+    finally:
+        storage.close()


### PR DESCRIPTION
## Description

Adds AUTHORITY_CONSUMED event for consumed-credential tracking (parent epic #289, board #550).

- EventType.AUTHORITY_CONSUMED is append-only, hash-chained, and verified via EventLog and SQLite verify
- AuthorityConsumed payload in models.py with authority_id 1-128, consumer_run_id, consumed_at, via_action_id optional, bounded size and stripped validation
- New helper record_authority_consumed(storage, run_id, authority_id, ...) in src/continuum/actions/authority.py appends a distinct DETERMINISTIC row per call (no dedup, replay preserves)
- Tests in tests/test_authority_event.py cover hash chain, DETERMINISTIC provenance, bounded size, no dedup, replay, and tamper detection

Pinned board #550, row #289 Authority lifecycle.

## Related issues

Fixes #555
Refs #289
Refs #550

## Types of changes

- Type: feature

## Breaking changes

No

## How has this been tested?

```
/Users/cyrax8590gmail.com/Personal\ Projects/untitled\ folder\ 2/.venv/bin/python -m pytest -q
ruff check src/ tests/ examples/
ruff format --check src/ tests/ examples/
mypy src/continuum --ignore-missing-imports
rg -n "—" src/continuum/actions/authority.py tests/test_authority_event.py
```

pytest 1499 passed (with flaky hypothesis/concurrency retries, final run 1499 passed), ruff clean, ruff format clean, mypy clean, no em dashes in changed files.

Falsifiable test: tests/test_authority_event.py::test_no_dedup_every_consumption_is_distinct_row fails on old code (no AUTHORITY_CONSUMED) and passes on new.

## Checklist

Tests added for changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Fail closed: helper raises ValueError for invalid authority_id rather than appending. Published numbers come from real runs.
