### PR TITLE
docs: add Windows PowerShell setup to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,24 @@ source .venv/bin/activate        # macOS / Linux
 pip install -e ".[dev]"
 ```
 
+On **Windows PowerShell**, use the same steps with these commands instead:
+
+```powershell
+# 1. Clone the repo (same as above)
+git clone https://github.com/Cyrax321/CONTINUUM.git
+cd CONTINUUM
+
+# 2. Create and activate a virtual environment
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+
+# 3. Install in editable mode with all dev extras
+pip install -e ".[dev]"
+
+# Optional: run the Windows demo launcher
+powershell -ExecutionPolicy Bypass -File .\try-it.ps1
+```
+
 Local CONTINUUM data lives in `.continuum/` (budgets, local `*.db` files). It is already listed in `.gitignore`, so do not commit it. If you cloned before this was added, run `echo ".continuum/" >> .gitignore`.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,13 @@ pip install -e ".[dev]"
 On **Windows PowerShell**, use the same steps with these commands instead:
 
 ```powershell
-# 1. Clone the repo (same as above)
+# 1. Clone the repo
 git clone https://github.com/Cyrax321/CONTINUUM.git
 cd CONTINUUM
 
 # 2. Create and activate a virtual environment
 python -m venv .venv
-.venv\Scripts\Activate.ps1
+.\.venv\Scripts\Activate.ps1
 
 # 3. Install in editable mode with all dev extras
 pip install -e ".[dev]"


### PR DESCRIPTION
## Summary

- Adds a Windows PowerShell Setup block to `CONTRIBUTING.md` alongside the existing bash instructions.
- Covers venv activation via `.venv\Scripts\Activate.ps1`, editable install, and optional `.\try-it.ps1` demo launcher.

Fixes #548

## Test plan

- [x] `markdownlint-cli2 CONTRIBUTING.md` passes (0 issues)
- [ ] Maintainer review for copy-paste accuracy on Windows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Corrected the Windows PowerShell virtual-environment activation command.
  - Simplified the project cloning instructions for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->