### PR TITLE
chore(pre-commit): ship the ruff hook config, pinned to the ruff CI runs (#537)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# Local mirror of the CI "Lint & Type-check" job's ruff steps (issue #537).
+#
+# CONTRIBUTING.md described this file instead of shipping it, so `pre-commit
+# install` on a fresh clone installed a hook that ran nothing and the first PR
+# still met a red `ruff format --check` in CI.
+#
+# rev tracks the `ruff==` pin in pyproject.toml's dev extra. A hook running a
+# different ruff than CI would format a file one way locally and fail the same
+# file in CI, which is the failure this config exists to prevent: bump both
+# together.
+#
+# files scopes the hooks to the three directories CI lints. benchmarks/,
+# demo-run/ and _bugaudit/ are not ruff-clean and are not checked by CI, so
+# leaving them in would fail `pre-commit run --all-files` on an untouched tree
+# and rewrite files no gate asks about.
+#
+# mypy is deliberately absent: pre-commit hooks run in isolated environments
+# without the project's installed dependencies, so its results there are not
+# trustworthy. CI runs `mypy src/continuum` against a full environment. See the
+# "Pre-commit hooks" section of CONTRIBUTING.md.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.4
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+        files: ^(src|tests|examples)/
+      - id: ruff-format
+        files: ^(src|tests|examples)/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **`.pre-commit-config.yaml`, pinned to the ruff CI runs (#537).**
+  `CONTRIBUTING.md` described the file instead of shipping it, so
+  `pre-commit install` on a fresh clone installed a hook that ran nothing and
+  the first PR still met a red `ruff format --check src/ tests/ examples/`. The
+  config now lives at the repo root with the `ruff-check` and `ruff-format`
+  hooks, `rev` naming the same ruff version the `dev` extra pins so a hook and
+  CI cannot format one file two ways, and both hooks scoped to `src/`, `tests/`
+  and `examples/`, the three directories the lint job checks. `benchmarks/`,
+  `demo-run/` and `_bugaudit/` are not ruff-clean and no gate checks them, so in
+  scope they would fail `pre-commit run --all-files` on a tree nobody touched.
+  mypy stays out, as `CONTRIBUTING.md` already explains: hooks run in isolated
+  environments without the project's dependencies, where its results are not
+  trustworthy. Contributor tooling, no runtime change.
+
 ### Fixed
 
 - Make `continuum complete` idempotent for runs that are already completed (#356).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,10 @@ source .venv/bin/activate        # macOS / Linux
 
 # 3. Install in editable mode with all dev extras
 pip install -e ".[dev]"
+
+# 4. Install the pre-commit hooks (recommended, see below)
+pip install pre-commit
+pre-commit install
 ```
 
 Local CONTINUUM data lives in `.continuum/` (budgets, local `*.db` files). It is already listed in `.gitignore`, so do not commit it. If you cloned before this was added, run `echo ".continuum/" >> .gitignore`.
@@ -91,38 +95,45 @@ The CI pipeline runs all three on every PR. A clean PR must pass all checks.
 
 ### Pre-commit hooks (optional but recommended)
 
-To catch lint and formatting issues automatically before you commit, you can use
+To catch lint and formatting issues automatically before you commit, use
 [pre-commit](https://pre-commit.com/):
 
 ```bash
 pip install pre-commit
+pre-commit install
 ```
 
-Create a `.pre-commit-config.yaml` in the repo root with:
+`.pre-commit-config.yaml` is committed at the repo root, so there is nothing to
+write yourself. It runs the same two ruff steps as the CI `Lint & Type-check`
+job, pinned to the same ruff version as the `dev` extra in `pyproject.toml` and
+scoped to the same three directories CI lints (`src/`, `tests/`, `examples/`):
 
 ```yaml
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.3
+    rev: v0.16.4
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
+        files: ^(src|tests|examples)/
       - id: ruff-format
+        files: ^(src|tests|examples)/
 ```
 
-Then install the git hook:
-
-```bash
-pre-commit install
-```
-
-Now `ruff check --fix` and `ruff format` will run automatically on every `git commit`.
+Now `ruff check --fix` and `ruff format` run automatically on every `git commit`.
+A hook that rewrites a file fails the commit and leaves the fix unstaged, so
+`git add` the changed files and commit again.
 
 To run it manually against all files:
 
 ```bash
 pre-commit run --all-files
 ```
+
+If you bump the `ruff==` pin in `pyproject.toml`, bump `rev` in
+`.pre-commit-config.yaml` to the matching `vX.Y.Z` tag in the same PR. A hook
+running a different ruff than CI is how a locally formatted file still fails
+`ruff format --check` on the PR.
 
 **Note on mypy:** mypy is intentionally not included in this pre-commit setup.
 Pre-commit hooks run in isolated environments without the project's installed

--- a/tests/test_precommit_config.py
+++ b/tests/test_precommit_config.py
@@ -1,0 +1,108 @@
+"""Tests for the committed pre-commit configuration (issue #537).
+
+The hooks are a convenience, but a hook that disagrees with CI is worse than no
+hook: it formats a file one way locally and the same file fails
+`ruff format --check` on the PR. These pin the two agreements that keep the
+local gate and the CI gate honest about each other:
+
+* **One ruff version.** `rev` in `.pre-commit-config.yaml`, and the copy of it
+  quoted in `CONTRIBUTING.md`, name the same ruff the `dev` extra pins in
+  `pyproject.toml`.
+* **The same paths.** Every directory the CI lint job hands to ruff is in scope
+  for both hooks, and a directory CI does not lint stays out of scope, so
+  `pre-commit run --all-files` on an untouched tree has nothing to say.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRECOMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+# --------------------------------------------------------------------------- #
+# Readers
+# --------------------------------------------------------------------------- #
+
+
+def _pinned_ruff_version() -> str:
+    """Return the exact ruff version pinned by pyproject's ``dev`` extra."""
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    dev = data["project"]["optional-dependencies"]["dev"]
+    pins = [spec.split("==", 1)[1] for spec in dev if spec.startswith("ruff==")]
+    assert len(pins) == 1, f"expected exactly one ruff== pin in the dev extra, got {dev}"
+    return pins[0]
+
+
+def _hook_file_patterns() -> dict[str, str]:
+    """Map each configured hook id to its ``files`` pattern.
+
+    Parsed by line rather than with a YAML library: the config is four keys
+    deep, and the dev extra installs no YAML parser.
+    """
+    patterns: dict[str, str] = {}
+    hook_id: str | None = None
+    for line in PRECOMMIT_CONFIG.read_text(encoding="utf-8").splitlines():
+        identifier = re.match(r"\s*- id:\s*(\S+)\s*$", line)
+        if identifier:
+            hook_id = identifier.group(1)
+            continue
+        scope = re.match(r"\s*files:\s*(\S+)\s*$", line)
+        if scope and hook_id is not None:
+            patterns[hook_id] = scope.group(1)
+    return patterns
+
+
+def _ci_lint_directories() -> set[str]:
+    """Return the directories the CI lint job passes to ruff."""
+    directories: set[str] = set()
+    for line in CI_WORKFLOW.read_text(encoding="utf-8").splitlines():
+        invocation = re.match(r"\s*run:\s*ruff\s+(?:check|format)\s+(?P<rest>.+)$", line)
+        if invocation:
+            directories.update(
+                token.rstrip("/")
+                for token in invocation.group("rest").split()
+                if token.endswith("/")
+            )
+    return directories
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+def test_precommit_pins_the_ruff_version_from_the_dev_extra() -> None:
+    expected = f"v{_pinned_ruff_version()}"
+    for path in (PRECOMMIT_CONFIG, CONTRIBUTING):
+        revisions = re.findall(r"^\s*rev:\s*(\S+)\s*$", path.read_text(encoding="utf-8"), re.M)
+        assert revisions == [expected], (
+            f"{path.name} must name the ruff version pinned in pyproject's dev extra "
+            f"({expected}), got {revisions}"
+        )
+
+
+def test_hooks_are_scoped_to_the_directories_ci_lints() -> None:
+    patterns = _hook_file_patterns()
+    assert set(patterns) == {"ruff-check", "ruff-format"}, (
+        f"expected a scoped ruff-check and ruff-format hook, got {patterns}"
+    )
+    linted = _ci_lint_directories()
+    assert linted, "found no ruff invocation in the CI lint job"
+    # benchmarks/ is not ruff-clean and CI does not lint it: in scope, the hooks
+    # would fail on a tree nobody touched.
+    assert "benchmarks" not in linted
+    for hook_id, pattern in patterns.items():
+        for directory in linted:
+            assert re.match(pattern, f"{directory}/module.py"), (
+                f"{hook_id} does not cover {directory}/, which CI lints"
+            )
+        assert not re.match(pattern, "benchmarks/run.py"), (
+            f"{hook_id} covers benchmarks/, which CI does not lint"
+        )


### PR DESCRIPTION
## Description

`CONTRIBUTING.md` described `.pre-commit-config.yaml` instead of shipping it, so `pre-commit install` on a fresh clone installed a hook that ran nothing, and a first PR still met a red `ruff format --check src/ tests/ examples/` in the `Lint & Type-check` job. This commits the config.

Two details are deliberate, and both are the difference between a hook that helps and one that misleads:

- **`rev` names the ruff the `dev` extra pins** (`ruff==0.16.4`, so `rev: v0.16.4`). A hook running a different ruff than CI is exactly how a locally formatted file still fails the format check on the PR. The snippet in `CONTRIBUTING.md` had already drifted here: it documented `rev: v0.16.3` against a `0.16.4` pin.
- **Both hooks are scoped to `src/`, `tests/`, `examples/`**, the three directories the CI lint job checks. `benchmarks/`, `demo-run/` and `_bugaudit/` are not ruff-clean today (verified: `4 files would be reformatted`, `Found 9 errors`) and no gate checks them, so leaving them in scope would fail `pre-commit run --all-files` on a tree nobody touched and rewrite files no gate asks about.

`mypy` is left out, for the reason `CONTRIBUTING.md` already gives: pre-commit hooks run in isolated environments without the project's installed dependencies, so its results there are not trustworthy. CI keeps running `mypy src/continuum` against a full environment.

Nothing under `src/` changes, and no dependency is added: `pre-commit` stays a `pip install pre-commit` for contributors who want it, exactly as `CONTRIBUTING.md` says.

## Related issues

Fixes #537

## Types of changes

- Type: `ci`

## Breaking changes

No.

## How has this been tested?

Environment: Windows 11, Python 3.11.15, `pre-commit` 4.6.2. The local `.venv` carries ruff 0.16.3, so every ruff gate below was run through `uvx ruff@0.16.4`, the version `pyproject.toml` pins and CI installs.

Acceptance criteria from the issue, checked in order:

```console
$ pre-commit run --all-files
ruff check...............................................................Passed
ruff format..............................................................Passed
```

A deliberately unformatted in-scope file is flagged and fixed before the commit lands:

```console
$ printf 'x   =    1\nimport os\n' > tests/test_zz_scratch_fmt.py
$ pre-commit run --files tests/test_zz_scratch_fmt.py
ruff check...............................................................Failed
- hook id: ruff-check
- files were modified by this hook
Found 1 error (1 fixed, 0 remaining).
ruff format..............................................................Failed
- hook id: ruff-format
- files were modified by this hook
1 file reformatted
```

An out-of-scope file is left alone, so `benchmarks/` cannot fail a commit CI would have passed:

```console
$ pre-commit run --files benchmarks/zz_scratch_fmt.py
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
```

Both scratch files were deleted afterwards; neither is in this diff.

Repository gates:

```console
$ pytest --tb=short -q          # exit code 0, 1825 tests collected
$ uvx ruff@0.16.4 check src/ tests/ examples/
All checks passed!
$ uvx ruff@0.16.4 format --check src/ tests/ examples/
261 files already formatted
$ mypy src/continuum
Success: no issues found in 114 source files
$ npx markdownlint-cli2 CONTRIBUTING.md CHANGELOG.md
Summary: 0 issues in 0 files
```

The new tests fail on the state before this commit, and on the drift they exist to catch:

```console
# with .pre-commit-config.yaml absent (main today)
FAILED tests/test_precommit_config.py::test_precommit_pins_the_ruff_version_from_the_dev_extra
FAILED tests/test_precommit_config.py::test_hooks_are_scoped_to_the_directories_ci_lints
E       FileNotFoundError: [Errno 2] No such file or directory: '.pre-commit-config.yaml'

# with rev: v0.16.3, the version CONTRIBUTING.md documented against a 0.16.4 pin
FAILED tests/test_precommit_config.py::test_precommit_pins_the_ruff_version_from_the_dev_extra
E       assert ['v0.16.3'] == ['v0.16.4']
```

One caveat, reported rather than hidden: an earlier full-suite run on this branch hit `TimeoutError: timed out` in `tests/test_gateway.py::test_claimed_request_is_forwarded_settled_and_recorded`, a socket read against the local test server. `pytest tests/test_gateway.py` passes on its own (13 passed) and the next full run was green, so this looks like local flakiness under load on Windows rather than anything this diff touches, which adds no runtime code.

## Checklist

Tests added (`tests/test_precommit_config.py`, two cases). Documentation updated (`CONTRIBUTING.md` Setup step 4 and the Pre-commit hooks section, now pointing at the committed file instead of asking contributors to write one). `CHANGELOG.md` updated under `[Unreleased]`, `Added`. No security-relevant behaviour changes.

## Additional context

The tests read `.pre-commit-config.yaml` line by line rather than with a YAML parser, since the `dev` extra installs none and the file is four keys deep. They derive the expected directories from `.github/workflows/ci.yml`, so adding a directory to the CI lint step fails the test until the hooks cover it too.

Two adjacent things this PR deliberately leaves alone, as separate concerns:

- The `Linting & Type-Checking` section still documents `ruff check src/ tests/` without `examples/`, while CI lints all three. The hooks now cover `examples/` regardless.
- `docs/UPGRADE_SPEC.md` still lists #537 as an open item.
