### PR TITLE
fix(mypy): type-check a core install without the extras (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,30 @@ All notable changes to this project are documented here. The format follows
   surrounding whitespace; a run whose in-flight claim was recorded under a
   padded key will not match the stripped key derived after upgrading.
 
+- **`mypy src/continuum` passes on a core install (#315).** `CONTRIBUTING.md`
+  asks for three checks before a PR, and on a fresh `pip install -e .` clone the
+  third opened with 26 errors: `cryptography`, `mcp`, `langgraph`, `agents` and
+  `langchain_core` had no `[[tool.mypy.overrides]]` family, so every lazy import
+  of an optional package read as a missing library. Nothing was wrong with the
+  code, and the only way to a quiet run was to install the extras the core is
+  built not to need, which is the opposite of what a dependency-free recovery
+  library should ask of a first-time contributor. The five families are now
+  excused the way `psycopg`, `playwright` and `kubernetes` already were, and the
+  `opentelemetry` and `crewai` section that had drifted below the coverage
+  tables moved back under `[tool.mypy]`.
+
+  Excusing the import is half of it: the names it supplied become `Any`, and
+  strict mode then refused the `BaseCheckpointSaver` and `RunHooks` subclasses
+  and the twelve MCP tools registered through the server's own decorator. Those
+  14 errors are answered by scoping `disallow_subclassing_any` off for
+  `continuum.adapters.langgraph_store` and `continuum.adapters.openai`, and
+  `disallow_untyped_decorators` off for `continuum.mcp.server`, the three
+  modules that hold an optional seam. `strict = true` is untouched everywhere
+  else, and CI checks all three with the packages installed, where the real
+  signatures apply. `tests/test_mypy_overrides.py` walks the package's imports
+  and fails when one has no family, so the next optional dependency cannot
+  quietly put the 26 errors back.
+
 - **The gateway answers malformed JSON with 400 instead of hiding it (#323).**
   `_body` caught `JSONDecodeError` and returned an empty mapping, so a request
   whose body never parsed was carried on to key derivation and refused with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,13 @@ warn_unused_configs = true
 plugins = ["pydantic.mypy"]
 files = ["src/continuum"]
 
+# Every optional dependency is imported lazily, behind a `try` or under
+# `TYPE_CHECKING`, so each module that reaches for one still has to type-check on
+# an install that does not have it. A plain `pip install -e .` clone has only
+# pydantic, and the families below are what stand between that clone and 26
+# errors from `mypy src/continuum` that say nothing about the code (#315). An
+# optional import added without a family here brings the errors back.
+
 # psycopg is an optional runtime dependency (the [postgres] extra). It is
 # imported lazily, so the module must type-check without it installed.
 [[tool.mypy.overrides]]
@@ -116,6 +123,47 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["playwright", "playwright.*", "kubernetes"]
 ignore_missing_imports = true
+
+# opentelemetry backs the [otel] span bridge and crewai the thin hook adapter.
+[[tool.mypy.overrides]]
+module = ["opentelemetry.*", "crewai", "crewai.*", "crewai.hooks"]
+ignore_missing_imports = true
+
+# cryptography signs the event chain for `continuum attest` (the [attest]
+# extra). The recovery path must import with no crypto installed, so the import
+# sits inside the signing call.
+[[tool.mypy.overrides]]
+module = ["cryptography.*"]
+ignore_missing_imports = true
+
+# The MCP server stack (the [mcp] extra). The core library and CLI never import
+# it, so a dependency-free install must still type-check the server module.
+[[tool.mypy.overrides]]
+module = ["mcp.*"]
+ignore_missing_imports = true
+
+# The framework adapters: langgraph, openai-agents (imported as `agents`) and
+# langchain-core. Each has its own extra and its own availability guard, so none
+# of the three is present in a core install.
+[[tool.mypy.overrides]]
+module = ["langgraph.*", "agents", "agents.*", "langchain_core"]
+ignore_missing_imports = true
+
+# Silencing the missing import is half the job: the names it supplied are now
+# `Any`, and two strict checks refuse `Any` where these three modules need it.
+# `langgraph_store` subclasses LangGraph's `BaseCheckpointSaver` and the openai
+# adapter subclasses `RunHooks`, which `disallow_subclassing_any` rejects; every
+# MCP tool is registered through the server's own decorator, which
+# `disallow_untyped_decorators` rejects. Both are checked in CI, where the
+# packages are installed and the real signatures apply. Scoped to the three
+# modules that hold an optional seam so strict stays whole everywhere else.
+[[tool.mypy.overrides]]
+module = ["continuum.adapters.langgraph_store", "continuum.adapters.openai"]
+disallow_subclassing_any = false
+
+[[tool.mypy.overrides]]
+module = ["continuum.mcp.server"]
+disallow_untyped_decorators = false
 
 [tool.pydantic.mypy]
 init_forbid_extra = true
@@ -138,6 +186,3 @@ branch = true
 [tool.coverage.report]
 show_missing = true
 skip_covered = false
-[[tool.mypy.overrides]]
-module = ["opentelemetry.*", "crewai", "crewai.*", "crewai.hooks"]
-ignore_missing_imports = true

--- a/tests/test_mypy_overrides.py
+++ b/tests/test_mypy_overrides.py
@@ -1,0 +1,168 @@
+"""Tests for the mypy overrides that keep a core install type-checkable (#315).
+
+`mypy src/continuum` is one of the three checks `CONTRIBUTING.md` asks of a
+contributor, and the core library declares exactly one dependency: pydantic.
+Every optional package is imported lazily, behind a `try` or inside the call that
+needs it, so a recovery tool never fails to import when it is needed most. That
+leaves the type checker reading imports which resolve to nothing on a plain
+`pip install -e .` clone, and without the per-module sections in `pyproject.toml`
+that clone opens with 26 errors, none of them about the code.
+
+These tests hold the config to the imports rather than to a list someone has to
+remember to edit:
+
+* Every third-party module `src/continuum` imports is covered by an
+  `ignore_missing_imports` family, so a new optional import cannot land without
+  one and quietly re-break a fresh clone.
+* The strict relaxations that follow from those imports being `Any` stay scoped
+  to modules that exist and hold an optional seam, so `strict = true` cannot be
+  widened away under cover of this fix.
+* All of the mypy config stays under `[tool.mypy]`, because the override that
+  drifted below the coverage tables is how the missing families went unnoticed.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import tomllib
+from fnmatch import fnmatch
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PACKAGE = REPO_ROOT / "src" / "continuum"
+
+# pydantic is the one hard runtime dependency: always importable, and it ships
+# its own types. Every other third-party import is optional by design.
+ALWAYS_INSTALLED = {"pydantic", "pydantic_core"}
+
+# The only strict checks an absent optional package is allowed to switch off.
+# Both fire on `Any` that is only `Any` because the package is not installed.
+RELAXABLE = {"disallow_subclassing_any", "disallow_untyped_decorators"}
+
+
+# --------------------------------------------------------------------------- #
+# Readers
+# --------------------------------------------------------------------------- #
+
+
+def _mypy_config() -> dict[str, object]:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    config: dict[str, object] = data["tool"]["mypy"]
+    return config
+
+
+def _overrides() -> list[dict[str, object]]:
+    overrides = _mypy_config().get("overrides")
+    assert isinstance(overrides, list) and overrides, (
+        "pyproject declares no [[tool.mypy.overrides]] sections"
+    )
+    return overrides
+
+
+def _module_patterns(override: dict[str, object]) -> list[str]:
+    modules = override["module"]
+    if isinstance(modules, str):
+        return [modules]
+    assert isinstance(modules, list), f"`module` must be a string or a list, got {modules!r}"
+    return [str(module) for module in modules]
+
+
+def _excused_patterns() -> list[str]:
+    """Every module pattern let off a missing implementation or stub."""
+    patterns: list[str] = []
+    for override in _overrides():
+        if override.get("ignore_missing_imports"):
+            patterns.extend(_module_patterns(override))
+    return patterns
+
+
+def _third_party_imports() -> dict[str, list[str]]:
+    """Map each third-party module imported under `src/continuum` to its files.
+
+    Walked with `ast` rather than by importing anything: the point is to see the
+    imports an uninstalled environment would trip over, including the ones inside
+    a function body or a `TYPE_CHECKING` block.
+    """
+    imported: dict[str, set[str]] = {}
+    for path in sorted(PACKAGE.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                # A relative import has no third-party module to resolve.
+                names = [node.module] if node.level == 0 and node.module else []
+            else:
+                continue
+            for name in names:
+                root = name.split(".", 1)[0]
+                if root in sys.stdlib_module_names or root in {"continuum", "__future__"}:
+                    continue
+                if root in ALWAYS_INSTALLED:
+                    continue
+                imported.setdefault(name, set()).add(path.relative_to(REPO_ROOT).as_posix())
+    return {name: sorted(files) for name, files in sorted(imported.items())}
+
+
+def _module_is_real(module: str) -> bool:
+    base = REPO_ROOT / "src" / Path(*module.split("."))
+    return base.with_suffix(".py").is_file() or (base / "__init__.py").is_file()
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+def test_every_optional_import_is_excused() -> None:
+    patterns = _excused_patterns()
+    uncovered = {
+        module: files
+        for module, files in _third_party_imports().items()
+        if not any(fnmatch(module, pattern) for pattern in patterns)
+    }
+    assert not uncovered, (
+        "these modules are imported but not excused from missing-import errors, so "
+        f"`mypy src/continuum` fails on an install that lacks them: {uncovered}. Add "
+        "the family to [[tool.mypy.overrides]] in pyproject.toml."
+    )
+
+
+def test_strict_is_relaxed_only_for_the_modules_holding_an_optional_seam() -> None:
+    assert _mypy_config().get("strict") is True, "the type-check gate is strict mode"
+
+    for override in _overrides():
+        relaxed = {key for key, value in override.items() if key != "module" and value is False}
+        if not relaxed:
+            continue
+        assert relaxed <= RELAXABLE, (
+            f"{sorted(relaxed)} switches off more than the checks an absent optional "
+            f"package can account for ({sorted(RELAXABLE)})"
+        )
+        for module in _module_patterns(override):
+            assert module.startswith("continuum."), (
+                f"{module} is not a first-party module: relax strict only where the "
+                "optional import is, never for a third-party family"
+            )
+            assert _module_is_real(module), (
+                f"{module} has no file under src/, so this section relaxes nothing "
+                "and mypy reports it as unused config"
+            )
+
+
+def test_mypy_config_is_not_split_across_the_file() -> None:
+    lines = PYPROJECT.read_text(encoding="utf-8").splitlines()
+    mypy_sections = [i for i, line in enumerate(lines) if line.startswith("[[tool.mypy.")]
+    others = [
+        i
+        for i, line in enumerate(lines)
+        if line.startswith("[tool.") and not line.startswith("[tool.mypy]")
+    ]
+    assert mypy_sections, "found no [[tool.mypy.overrides]] section to place"
+    next_unrelated = min((i for i in others if i > min(mypy_sections)), default=len(lines))
+    assert max(mypy_sections) < next_unrelated, (
+        "a [[tool.mypy.overrides]] section sits below an unrelated [tool.*] table. "
+        "Keep them together under [tool.mypy]: the one that drifted to the end of "
+        "the file is why the missing families were not noticed (#315)."
+    )


### PR DESCRIPTION
Fixes #315.

`CONTRIBUTING.md` asks for three checks before a PR. On a fresh `pip install -e .` clone the third one, `mypy src/continuum`, opened with **26 errors**, none of them about the code: `cryptography`, `mcp`, `langgraph`, `agents` and `langchain_core` had no `[[tool.mypy.overrides]]` family, so every lazy import of an optional package read as a missing library. The only route to a quiet run was to install the extras the core is built not to need.

## What changed

**`pyproject.toml`**

- Five families excused with `ignore_missing_imports`, the way `psycopg`, `playwright` and `kubernetes` already were: `cryptography.*`, `mcp.*`, `langgraph.*`, `agents` / `agents.*`, `langchain_core`. Patterns are the ones mypy actually resolves, so none of them lands as a new `unused section` note.
- The `opentelemetry` and `crewai` section that had drifted below the coverage tables moved back under `[tool.mypy]`, module list byte-identical, so all the mypy config is in one place again.
- Excusing the import is half the job. The names it supplied are now `Any`, and strict mode rejects the `BaseCheckpointSaver` and `RunHooks` subclasses and the twelve MCP tools registered through the server's own decorator, so the issue's steps taken literally leave **14** errors. Those are answered by scoping two checks off for the three modules that hold an optional seam: `disallow_subclassing_any` for `continuum.adapters.langgraph_store` and `continuum.adapters.openai`, `disallow_untyped_decorators` for `continuum.mcp.server`. `strict = true` is untouched everywhere else, and CI installs those packages, so the real signatures are what gets checked there. An inline `type: ignore` would not work here: with the packages installed, `warn_unused_ignores` turns each one into a CI failure.

**`tests/test_mypy_overrides.py`** (new, 3 tests)

Walks the package's own imports with `ast` instead of a list someone has to remember to edit, so the next optional dependency added without a family fails the suite rather than the next fresh clone. It also holds `strict = true` on, keeps the two relaxations pointed at first-party modules that exist, and keeps the mypy config from splitting across the file again. Both tests that reproduce #315 fail against the config as it stands on `main`.

## Verification

| check | before | after |
| --- | --- | --- |
| `mypy src/continuum`, core install (pydantic only) | 26 errors in 6 files | clean |
| `mypy src/continuum`, `[dev]` extra (what CI runs) | clean | clean |
| `pytest` | 1823 passed | 1826 passed |
| `ruff check src/ tests/ examples/` | pass | pass |
| `ruff format --check src/ tests/ examples/` | pass | pass |

This machine is offline, so instead of the issue's `/tmp/clean` venv the core-only run was reproduced by pointing mypy at a venv holding only pydantic and its dependency closure: `mypy --python-executable <core-venv>/python src/continuum`. That is the same package resolution the recipe in the issue produces, and it gives the same 26 errors the issue predicts.

One line of mypy output survives, and it predates this PR:

```
pyproject.toml: note: unused section(s): module = ['crewai.*', 'crewai.hooks']
```

Both patterns match nothing while crewai is absent, which is true of a core install and of the `[dev]` extra. `crewai.hooks` is redundant with `crewai.*` either way, but pruning them is a behaviour question for someone with crewai installed, so I moved the list without editing it. Say the word and I will take it in this PR.

## Notes for review

- Config and one test file. Nothing under `src/continuum` is touched, so there is no runtime change.
- Merges cleanly on `main` and against all eleven open PRs (checked with `git merge-tree`). The changelog entry sits mid-list in `### Fixed` on purpose: #578 and #579 both open an `### Added` at the top of `[Unreleased]` and #573, #577 and #581 all append at the bottom, so either end would have conflicted with two or three of them. Happy to move it wherever you prefer once those land.
- README's "roughly 1,380 tests" is left alone as #316's business.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documented the `continuum_record_plan` MCP tool and expanded MCP tool coverage.

* **Documentation**
  * Corrected MCP tool totals and classifications.
  * Added validation to help keep MCP documentation complete and accurate.

* **Bug Fixes**
  * Improved static analysis reliability for installations without optional dependencies.
  * Added safeguards to keep type-checking configuration aligned with optional integrations.

* **Tests**
  * Added automated checks for optional imports and correctly scoped configuration rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->