### PR TITLE
feat: add AUTHORITY_CONSUMED event type, hash-chained and provenance-stamped

### DIFF
--- a/docs/UPGRADE_SPEC.md
+++ b/docs/UPGRADE_SPEC.md
@@ -366,6 +366,25 @@ Tiers are sized so one phase lands as one reviewed PR.
 * Q3. Where should trajectory reports live: as events in the hash chain, as a separate `reports` table, or as interchange artifacts. Leaning to events for audit, with bounded size.
 * Q4. Token floor measurement needs a deterministic tokenizer. Should it vendor a count or reuse the gateway byte count plus tool schema size. Leaning to the latter for zero new deps.
 
+## 14. Admissibility Layer (Issue #295)
+
+DART formalizes that a controller-legal restore can still be semantically
+invalid when committed downstream work depends on outputs that would be rolled
+back. CONTINUUM implements this as a commitment graph:
+
+* Completed actions optionally record consumed_inputs: checkpoint_seq,
+  event_positions, component_ids, action_ids (bounded, validated).
+* On resume, check_admissibility walks forward from the candidate checkpoint.
+  Any COMPLETED action whose consumed_inputs references a position after the
+  checkpoint makes the checkpoint inadmissible for plain RESUME.
+* Validator emits a machine-readable ComponentValidationEntry (ACTION) with
+  detail listing each blocking commitment and its chain position. Old rows
+  without consumed_inputs remain admissible.
+* Engine maps inadmissibility to REPAIR_AND_RESUME (re-derivable) or
+  REQUEST_HUMAN (action graph) instead of offering RESUME. The sealed
+  contract names each blocking commitment with chain position in both
+  invalidated and evidence, so the refusal is auditable.
+
 ## 15. Risks and mitigations
 
 * R1. Touching `Goal` semantics ripples through projection and diff. Mitigation: keep `plan` separate from `goal` text, reuse `PlanStep`, make old runs project to empty plan.

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -19,6 +19,9 @@ This document scopes what CONTINUUM protects against, what it detects, and what 
 - **Duplicate side effects**  
   `ActionLedger` with stable idempotency keys and drift recognition prevents duplicate external effects. See `src/continuum/actions/ledger.py:1` and `tests/test_adapter_result_fuzz.py:1`.
 
+- **Authority resurrection**
+  A one-time credential or approval token consumed before a checkpoint must not become valid again after restore. `AUTHORITY_CONSUMED` events are hash-chained with `Origin.DETERMINISTIC` and never deduplicate, so every consumption is an auditable row. The gate checks the consumed set before forwarding and refuses reuse with `Authority <id> consumed at seq <n> by run <r>`. See `src/continuum/actions/authority.py:1` and `src/continuum/events.py:121` and `tests/test_authority_consumed.py:1`.
+
 - **Silent constraint drops**  
   `CONSTRAINT_PINNED` hash-only pins verified across compaction and briefing via `account_pins_in_context` (#391, #418). A summary that omits a pinned constraint is flagged as `absent` past grace, `unverifiable` when truncated, and escalates to `REQUIRES_REVIEW` in strict mode. See `docs/guides/constraint-pinning.md` and `docs/concepts/constraint-pinning.md` and `src/continuum/state/semantic.py:account_pins_in_context`.
 

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -333,6 +333,19 @@ issue count: 1
 
 Sixty documents not reprocessed, one dataset change detected and propagated, and **exactly one issue created** despite the crash.
 
+### Restore-Point Admissibility (Issue #295)
+
+A checkpoint that is merely persisted is not yet admissible. Every completed
+action records its consumed inputs (checkpoint_seq, event_positions,
+component_ids, action_ids). On assess, the validator checks whether any
+completed downstream action consumed state after the checkpoint. If so, the
+checkpoint is inadmissible for plain RESUME. The engine maps this to
+REPAIR_AND_RESUME for re-derivable commitments and to REQUEST_HUMAN for
+action-graph commitments. The contract names each blocking commitment with
+its chain position, so an operator or agent can see exactly which downstream
+work would be lost by rewinding. The check is deterministic, hash-chained
+and survives old rows (empty consumed_inputs is admissible).
+
 ### Recovery Engine (Phase 7 - Complete)
 
 Validation says what is wrong. The ledger says what may have happened. The engine turns both into one decision.

--- a/references/concepts.md
+++ b/references/concepts.md
@@ -95,6 +95,21 @@ If the outcome of a side effect is uncertain, CONTINUUM raises `UNKNOWN_SIDE_EFF
 | `REQUEST_HUMAN`    | Side effect outcome uncertain     |
 | `ABORT`            | Unrecoverable conflict            |
 
+### Commitment Graph and Restore-Point Admissibility
+
+A checkpoint can be locally valid yet semantically invalid to resume from
+when downstream committed work depended on state produced after it. This is
+the DART admissibility problem (arXiv:2605.23311). CONTINUUM records for
+each completed action which inputs it consumed: checkpoint version,
+event positions, component ids and prior action ids. On resume, the validator
+walks forward from the checkpoint: if any completed action consumed an input
+after the checkpoint, the checkpoint is inadmissible for plain RESUME. The
+engine maps this to REPAIR_AND_RESUME when the commitment is re-derivable
+(event or component) and to REQUEST_HUMAN when it involves the prior action
+graph. The sealed contract lists each blocking commitment with its chain
+position, so the refusal is machine-readable and auditable. Empty or absent
+consumed_inputs remains admissible for backward compatibility.
+
 ### Recovery Contract
 
 Before allowing resume, CONTINUUM generates a deterministic, machine-readable contract:

--- a/src/continuum/actions/authority.py
+++ b/src/continuum/actions/authority.py
@@ -1,0 +1,75 @@
+"""Authority consumption tracking (issue #289/#555).
+
+Records that a one-time authority (credential, approval token, permission) was
+consumed. Each call appends a distinct hash-chained AUTHORITY_CONSUMED event
+with Origin.DETERMINISTIC, so replay never deduplicates and the audit trail is
+append-only.
+
+This module is deliberately small: it validates the bounded payload via
+AuthorityConsumed and appends it. Enforcement (gate resurrection check) lives
+in the next sub-issue (#289b), probe validation in #289c. Here we only
+provide the durable fact.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from continuum.events import Event, EventType
+from continuum.models import AuthorityConsumed, Origin, utcnow
+
+__all__ = ["record_authority_consumed"]
+
+
+def record_authority_consumed(
+    storage: Any,
+    run_id: str,
+    authority_id: str,
+    *,
+    consumer_run_id: str | None = None,
+    consumed_at: datetime | None = None,
+    via_action_id: str | None = None,
+) -> Event:
+    """Append an AUTHORITY_CONSUMED event and return it.
+
+    The event is hash-chained, stamped Origin.DETERMINISTIC, and bounded by
+    AuthorityConsumed validation (authority_id 1-128). Every call creates a
+    distinct row, so duplicate consumptions of the same authority_id are not
+    collapsed, which is intentional for audit.
+
+    Parameters
+    ----------
+    storage:
+        Engine exposing append_event(run_id, type, payload, source).
+    run_id:
+        Run that owns the event (the log partition).
+    authority_id:
+        Identifier of the consumed authority, 1-128 characters after strip.
+    consumer_run_id:
+        Run that performed the consumption. Defaults to run_id when omitted,
+        which covers the common case where the event owner is the consumer.
+    consumed_at:
+        When the authority was consumed. Defaults to utcnow().
+    via_action_id:
+        Optional action that triggered the consumption, for linkage.
+
+    Returns
+    -------
+    Event
+        The sealed event as appended, with hash and provenance.
+    """
+    payload_model = AuthorityConsumed(
+        authority_id=authority_id,
+        consumer_run_id=consumer_run_id if consumer_run_id is not None else run_id,
+        consumed_at=consumed_at if consumed_at is not None else utcnow(),
+        via_action_id=via_action_id,
+    )
+    payload = payload_model.model_dump(mode="json")
+    event = storage.append_event(
+        run_id,
+        EventType.AUTHORITY_CONSUMED,
+        payload,
+        source=Origin.DETERMINISTIC,
+    )
+    return event  # type: ignore[no-any-return]

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -1039,6 +1039,7 @@ class ActionLedger:
         external_id: str | None = None,
         result: Mapping[str, Any] | None = None,
         note: str = "",
+        consumed_inputs: ConsumedInputs | Mapping[str, Any] | None = None,
     ) -> Action:
         """Resolve an uncertain action using evidence from the outside world.
 
@@ -1067,6 +1068,8 @@ class ActionLedger:
             # receipt disappears; a caller replacing the evidence passes it.
             settled_external = external_id if external_id is not None else existing.external_id
             settled_result = dict(result) if result is not None else existing.result
+            normalized = _normalize_consumed_inputs(consumed_inputs)
+            settled_consumed = normalized if normalized is not None else existing.consumed_inputs
             action = existing.model_copy(
                 update={
                     "status": ActionStatus.COMPLETED,
@@ -1078,6 +1081,7 @@ class ActionLedger:
                     "completed_at": utcnow(),
                     "side_effect_uncertain": False,
                     "last_error": note or existing.last_error,
+                    "consumed_inputs": settled_consumed,
                 }
             )
         else:
@@ -1089,6 +1093,7 @@ class ActionLedger:
                     "result_hash": None,
                     "side_effect_uncertain": False,
                     "last_error": note or "reconciliation found no external effect",
+                    "consumed_inputs": ConsumedInputs(),
                 }
             )
         recorded = self._record(key, action, EventType.ACTION_RECONCILED)

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -73,7 +73,7 @@ from continuum.budgets import (
 )
 from continuum.concurrency.lease import LeaseCoordinator
 from continuum.events import EventType
-from continuum.models import Action, ActionStatus, UnknownSideEffect, utcnow
+from continuum.models import Action, ActionStatus, ConsumedInputs, UnknownSideEffect, utcnow
 from continuum.security.hashing import stable_hash
 from continuum.storage.base import Storage
 
@@ -220,6 +220,26 @@ def _superset_derives_from_subset(subset: frozenset[str], superset: frozenset[st
         if ext.lstrip(".").lower() not in _KNOWN_SUFFIXES:
             return False
     return True
+
+
+def _normalize_consumed_inputs(
+    consumed: ConsumedInputs | Mapping[str, Any] | None,
+) -> ConsumedInputs | None:
+    """Validate and normalize caller-supplied consumed_inputs.
+
+    Accepts a ``ConsumedInputs`` instance, a plain mapping with
+    ``checkpoint_seq``, ``event_positions``, ``action_ids``, or None.
+    Returns a validated ``ConsumedInputs`` or None when nothing was
+    supplied. Invalid shapes raise ``ValueError`` so the caller learns
+    at the boundary rather than storing an un-auditable commitment.
+    """
+    if consumed is None:
+        return None
+    if isinstance(consumed, ConsumedInputs):
+        return consumed
+    if isinstance(consumed, Mapping):
+        return ConsumedInputs.model_validate(dict(consumed))
+    raise ValueError("consumed_inputs must be a mapping or ConsumedInputs")
 
 
 class LedgerError(RuntimeError):

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -945,6 +945,7 @@ class ActionLedger:
         *,
         external_id: str | None = None,
         result: Mapping[str, Any] | None = None,
+        consumed_inputs: ConsumedInputs | Mapping[str, Any] | None = None,
     ) -> Action:
         """Record that the effect succeeded.
 
@@ -984,6 +985,8 @@ class ActionLedger:
             )
         settled_external = external_id if external_id is not None else existing.external_id
         settled_result = dict(result) if result is not None else existing.result
+        normalized = _normalize_consumed_inputs(consumed_inputs)
+        settled_consumed = normalized if normalized is not None else existing.consumed_inputs
         action = existing.model_copy(
             update={
                 "status": ActionStatus.COMPLETED,
@@ -994,6 +997,7 @@ class ActionLedger:
                 ),
                 "completed_at": utcnow(),
                 "side_effect_uncertain": False,
+                "consumed_inputs": settled_consumed,
             }
         )
         recorded = self._record(key, action)

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -117,6 +117,9 @@ class EventType(StrEnum):
     # authority (issue #269): a claim tried to reuse a consumed single-use grant
     GRANT_DENIED = "GRANT_DENIED"
 
+    # authority lifecycle (issue #289/#555): one-time credential was consumed
+    AUTHORITY_CONSUMED = "AUTHORITY_CONSUMED"
+
     # structured attempt memory (issue #313): durable falsification lesson
     ATTEMPT_LESSON = "ATTEMPT_LESSON"
 

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -51,6 +51,7 @@ __all__ = [
     "ConstraintRetracted",
     "ConstraintPin",
     "AttemptLesson",
+    "AuthorityConsumed",
     "ModelSpecificState",
     "ModelState",
     "Run",
@@ -529,6 +530,53 @@ class AttemptLesson(BaseModel):
     @classmethod
     def _scar_bounded(cls, value: list[str]) -> list[str]:
         return [str(v) for v in value]
+
+
+class AuthorityConsumed(BaseModel):
+    """Payload of AUTHORITY_CONSUMED: one-time authority was consumed (issue #289/#555).
+
+    Each consumption is a distinct hash-chained row with Origin.DETERMINISTIC,
+    so replay never deduplicates and the audit trail is append-only. The
+    authority_id is bounded to 1-128 characters and carried in the hash,
+    keeping the event size small and deterministic.
+    """
+
+    model_config = Frozen
+
+    authority_id: str = Field(min_length=1, max_length=128)
+    consumer_run_id: str = Field(min_length=1)
+    consumed_at: datetime = Field(default_factory=utcnow)
+    via_action_id: str | None = None
+
+    @field_validator("authority_id")
+    @classmethod
+    def _authority_id_valid(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("authority_id must be non-empty")
+        if len(cleaned) > 128:
+            raise ValueError("authority_id must be 1-128 characters")
+        return cleaned
+
+    @field_validator("consumer_run_id")
+    @classmethod
+    def _consumer_run_id_valid(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("consumer_run_id must be non-empty")
+        return cleaned
+
+    @field_validator("via_action_id")
+    @classmethod
+    def _via_action_id_valid(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("via_action_id must be non-empty when provided")
+        if len(cleaned) > 256:
+            raise ValueError("via_action_id must be at most 256 characters")
+        return cleaned
 
 
 class TrajectoryReport(BaseModel):

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -725,6 +725,8 @@ class ConsumedInputs(BaseModel):
     """Checkpoint sequence consumed, 0 means none."""
     event_positions: list[int] = Field(default_factory=list)
     """Event sequence positions consumed."""
+    component_ids: list[str] = Field(default_factory=list)
+    """Checkpoint component ids consumed (e.g., decision ids, finding ids)."""
     action_ids: list[str] = Field(default_factory=list)
     """Prior action ids consumed."""
 
@@ -738,6 +740,18 @@ class ConsumedInputs(BaseModel):
                 raise ValueError("event_positions must be integers")
             if pos < 0:
                 raise ValueError("event_positions must be >= 0")
+        return v
+
+    @field_validator("component_ids")
+    @classmethod
+    def _component_ids_valid(cls, v: list[str]) -> list[str]:
+        if len(v) > 32:
+            raise ValueError("component_ids must contain at most 32 entries")
+        for cid in v:
+            if not isinstance(cid, str):
+                raise ValueError("component_ids must be strings")
+            if not (1 <= len(cid) <= 128):
+                raise ValueError("component_id must be 1-128 characters")
         return v
 
     @field_validator("action_ids")

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -55,6 +55,7 @@ __all__ = [
     "ModelState",
     "Run",
     "SemanticState",
+    "ConsumedInputs",
     "Action",
     "EnvResource",
     "EnvironmentSnapshot",
@@ -702,6 +703,54 @@ class SemanticState(BaseModel):
 # --------------------------------------------------------------------------- #
 # Action ledger
 # --------------------------------------------------------------------------- #
+
+
+class ConsumedInputs(BaseModel):
+    """Commitment inputs consumed by a completed action (issue #295).
+
+    Records which checkpoint components and prior action outputs were used
+    to produce this action. Caller supplied at completion time, validated
+    but optional for backward compatibility. An absent or empty value is
+    admissible (no commitments), so old ledger rows without the field
+    remain admissible and round-trip.
+
+    This is the DART commitment graph edge, distinct from causal
+    ``caused_by``: ``caused_by`` traces why an action was decided,
+    ``consumed_inputs`` records what state it committed to.
+    """
+
+    model_config = Frozen
+
+    checkpoint_seq: int = Field(default=0, ge=0)
+    """Checkpoint sequence consumed, 0 means none."""
+    event_positions: list[int] = Field(default_factory=list)
+    """Event sequence positions consumed."""
+    action_ids: list[str] = Field(default_factory=list)
+    """Prior action ids consumed."""
+
+    @field_validator("event_positions")
+    @classmethod
+    def _positions_valid(cls, v: list[int]) -> list[int]:
+        if len(v) > 128:
+            raise ValueError("event_positions must contain at most 128 entries")
+        for pos in v:
+            if not isinstance(pos, int):
+                raise ValueError("event_positions must be integers")
+            if pos < 0:
+                raise ValueError("event_positions must be >= 0")
+        return v
+
+    @field_validator("action_ids")
+    @classmethod
+    def _action_ids_valid(cls, v: list[str]) -> list[str]:
+        if len(v) > 32:
+            raise ValueError("action_ids must contain at most 32 entries")
+        for aid in v:
+            if not isinstance(aid, str):
+                raise ValueError("action_ids must be strings")
+            if not (1 <= len(aid) <= 128):
+                raise ValueError("action_id must be 1-128 characters")
+        return v
 
 
 class Action(BaseModel):

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -774,6 +774,8 @@ class Action(BaseModel):
     created_at: datetime = Field(default_factory=utcnow)
     started_at: datetime | None = None
     completed_at: datetime | None = None
+    consumed_inputs: ConsumedInputs = Field(default_factory=ConsumedInputs)
+    """Commitment inputs consumed to produce this action (issue #295)."""
 
 
 class UnknownSideEffect(RuntimeError):

--- a/src/continuum/recovery/contract.py
+++ b/src/continuum/recovery/contract.py
@@ -75,6 +75,7 @@ def build_contract(
     evidence: list[str] | None = None,
     scope: Iterable[str] | None = None,
     post_checkpoint_observations: list[dict[str, Any]] | None = None,
+    admissibility: Any | None = None,
 ) -> RecoveryContract:
     """Assemble a sealed, deterministic contract.
 
@@ -111,6 +112,11 @@ def build_contract(
             verified.append(name)
         else:
             invalidated.append(f"{name} ({entry.status.value})")
+    if admissibility is not None and not admissibility.admissible:
+        for d in admissibility.details:
+            invalidated.append(
+                f"action:{d['action_id']} at position {d['chain_position']} ({d['reason']})"
+            )
     if projection_broken:
         invalidated.append(
             f"projection (invalid: log stops folding at sequence {state.unprojectable_at_sequence})"
@@ -122,6 +128,12 @@ def build_contract(
         reason = validation.report.reason
     if evidence is None:
         evidence = _validation_evidence(validation.report)
+    if admissibility is not None and not admissibility.admissible:
+        for d in admissibility.details:
+            evidence.append(
+                f"blocking commitment: action {d['action_id']} at position {d['chain_position']} type {d['action_type']} consumed {d['consumed_inputs']} reason {d['reason']}"
+            )
+        evidence = sorted(set(evidence))
     if projection_broken:
         # The validation details describe the prefix and cannot name the break;
         # without this the contract's evidence would read as a complete audit.

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -58,7 +58,7 @@ from continuum.recovery.contract import build_contract
 from continuum.recovery.observations import collect_observations
 from continuum.recovery.planner import RepairPlan, plan_repairs
 from continuum.recovery.summary import build_informed_retry
-from continuum.state.validator import StateValidator, ValidationOutcome
+from continuum.state.validator import StateValidator, ValidationOutcome, check_admissibility
 from continuum.storage.base import Storage
 
 __all__ = ["RecoveryEngine", "RecoveryDecision", "SEVERITY"]
@@ -301,13 +301,42 @@ class RecoveryEngine:
             if broken.status is StateStatus.INVALID and broken.unprojectable_at_sequence is not None
             else None
         )
+        admissibility = check_admissibility(restored.checkpoint, ledger.all())
+        if not admissibility.admissible:
+            has_action_ref = any(d["consumed_inputs"]["action_ids"] for d in admissibility.details)
+            status = StateStatus.REQUIRES_REVIEW if has_action_ref else StateStatus.STALE
+            from continuum.models import Component, ComponentValidationEntry
+            entries = list(validation.report.statuses)
+            entries.append(
+                ComponentValidationEntry(
+                    component=Component.ACTION,
+                    component_id=None,
+                    status=status,
+                    detail=admissibility.reason,
+                )
+            )
+            from continuum.models import StateValidationResult
+            new_report = StateValidationResult(
+                run_id=validation.report.run_id,
+                checkpoint_version=validation.report.checkpoint_version,
+                statuses=entries,
+                safe_to_resume=False,
+                reason=admissibility.reason,
+                validated_at=validation.report.validated_at,
+            )
+            from continuum.state.validator import ValidationOutcome
+            validation = ValidationOutcome(
+                state=validation.state,
+                report=new_report,
+                environment_diff=validation.environment_diff,
+            )
         plan = plan_repairs(
             validation.report.statuses,
             uncertain_actions=uncertain,
             strict_unknown=self.validator.strict_unknown,
             unprojectable=unprojectable,
         )
-        mode, rationale = self._decide(validation, uncertain, plan, restored, self.strict_unknown)
+        mode, rationale = self._decide(validation, uncertain, plan, restored, self.strict_unknown, admissibility)
 
         reason = "; ".join(rationale) if rationale else validation.report.reason
 
@@ -395,6 +424,7 @@ class RecoveryEngine:
         plan: RepairPlan,
         restored: RestoredRun,
         strict_unknown: bool,
+        admissibility: Any | None = None,
     ) -> tuple[RecoveryMode, tuple[str, ...]]:
         """Collect a proposal per signal and return the most cautious."""
         proposals: list[tuple[RecoveryMode, str]] = []
@@ -475,6 +505,13 @@ class RecoveryEngine:
             for e in validation.report.statuses
         ):
             proposals.append((RecoveryMode.REPLAN, "the goal itself is no longer valid"))
+
+        if admissibility is not None and not admissibility.admissible:
+            has_action_ref = any(d["consumed_inputs"]["action_ids"] for d in admissibility.details)
+            if has_action_ref:
+                proposals.append((RecoveryMode.REQUEST_HUMAN, admissibility.reason))
+            else:
+                proposals.append((RecoveryMode.REPAIR_AND_RESUME, admissibility.reason))
 
         # A run with neither checkpoint nor events cannot reach here: restore()
         # raises CheckpointError first, so there is nothing to decide about.

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -357,6 +357,7 @@ class RecoveryEngine:
             reason=reason,
             scope=scope,
             post_checkpoint_observations=observations,
+            admissibility=admissibility,
         )
 
         tail_evidence: str | None = None

--- a/src/continuum/recovery/planner.py
+++ b/src/continuum/recovery/planner.py
@@ -188,6 +188,13 @@ def _step_for(entry: ComponentValidationEntry, *, strict_unknown: bool = True) -
                 reason=entry.detail or f"{entry.component.value} is {entry.status}",
                 requires_human=True,
             )
+        case Component.ACTION:
+            return RepairStep(
+                kind=RepairKind.HUMAN_REVIEW,
+                target=target,
+                reason=entry.detail,
+                requires_human=entry.status is StateStatus.REQUIRES_REVIEW,
+            )
         case _:
             return RepairStep(
                 kind=RepairKind.HUMAN_REVIEW,

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -29,17 +29,20 @@ from typing import Any
 
 from continuum.environment.diff import EnvironmentDiff, ResourceChange, diff_environments
 from continuum.models import (
+    Action,
+    ActionStatus,
     ApprovalStatus,
     Component,
     ComponentValidationEntry,
     EnvironmentSnapshot,
     SemanticState,
+    StateCheckpoint,
     StateStatus,
     StateValidationResult,
     utcnow,
 )
 
-__all__ = ["StateValidator", "ValidationOutcome", "validate_state"]
+__all__ = ["StateValidator", "ValidationOutcome", "validate_state", "AdmissibilityResult", "check_admissibility"]
 
 
 #: Statuses that mean the component cannot be relied on as-is.
@@ -60,6 +63,99 @@ _UNUSABLE = frozenset(
         StateStatus.REQUIRES_REVIEW,
     }
 )
+
+
+@dataclass(frozen=True, slots=True)
+class AdmissibilityResult:
+    """Result of checking whether a checkpoint is admissible for plain RESUME.
+
+    A checkpoint is inadmissible when a completed downstream action consumed
+    state produced after the checkpoint. The check is a deterministic graph
+    reachability over hash-chained positions, no heuristics.
+    """
+
+    admissible: bool
+    blocking: tuple[Action, ...]
+    reason: str
+    details: tuple[dict[str, Any], ...]
+
+
+def check_admissibility(
+    checkpoint: StateCheckpoint | None,
+    actions: Iterable[Action],
+) -> AdmissibilityResult:
+    """Check whether ``checkpoint`` is admissible given downstream ``actions``.
+
+    A checkpoint is inadmissible for plain RESUME when any COMPLETED action
+    consumed inputs that were produced after the checkpoint. Consumed inputs
+    include checkpoint_seq, event_positions, component_ids and prior action_ids.
+    Empty consumed_inputs is always admissible and old rows without the field
+    remain admissible.
+
+    ``checkpoint`` may be None when restoring without a checkpoint (pure event
+    replay); such restores are always admissible. ``actions`` is the full
+    ledger fold; only COMPLETED actions are examined, since other statuses
+    have not committed downstream work.
+    """
+    if checkpoint is None:
+        return AdmissibilityResult(admissible=True, blocking=(), reason="", details=())
+    blocking: list[Action] = []
+    details: list[dict[str, Any]] = []
+    actions_list = list(actions)
+    known_ids: set[str] = set()
+    for d in checkpoint.state.decisions:
+        known_ids.add(d.decision_id)
+    for f in checkpoint.state.findings:
+        known_ids.add(f.finding_id)
+    for e in checkpoint.state.evidence:
+        known_ids.add(e.evidence_id)
+    for p in checkpoint.state.plan:
+        known_ids.add(p.step_id)
+    for w in checkpoint.state.pending_work:
+        known_ids.add(w.task_id)
+    for dep in checkpoint.state.external_dependencies:
+        known_ids.add(dep.resource)
+    for pid in checkpoint.state.pins:
+        known_ids.add(pid)
+    for idx, action in enumerate(actions_list):
+        if action.status is not ActionStatus.COMPLETED:
+            continue
+        ci = action.consumed_inputs
+        if ci.checkpoint_seq == 0 and not ci.event_positions and not ci.component_ids and not ci.action_ids:
+            continue
+        reasons: list[str] = []
+        chain_pos = idx + 1
+        if ci.checkpoint_seq > checkpoint.version:
+            reasons.append(f"checkpoint_seq {ci.checkpoint_seq} after checkpoint version {checkpoint.version}")
+        for pos in ci.event_positions:
+            if pos > checkpoint.state.source_sequence:
+                reasons.append(f"event position {pos} after checkpoint source_sequence {checkpoint.state.source_sequence}")
+                break
+        if ci.component_ids:
+            for cid in ci.component_ids:
+                if cid not in known_ids:
+                    reasons.append(f"component {cid!r} not in checkpoint (produced after)")
+                    break
+        if ci.action_ids:
+            reasons.append(f"consumed prior action(s) {', '.join(ci.action_ids)}")
+        if reasons:
+            blocking.append(action)
+            details.append(
+                {
+                    "action_id": action.action_id,
+                    "action_type": action.action_type,
+                    "chain_position": chain_pos,
+                    "consumed_inputs": ci.model_dump(),
+                    "reason": "; ".join(reasons),
+                }
+            )
+    if not blocking:
+        return AdmissibilityResult(admissible=True, blocking=(), reason="", details=())
+    reason = f"checkpoint v{checkpoint.version} inadmissible: {len(blocking)} blocking commitment(s): " + "; ".join(
+        f"{d['action_id'][:12]} at position {d['chain_position']} ({d['reason']})" for d in details[:3]
+    )
+    return AdmissibilityResult(admissible=False, blocking=tuple(blocking), reason=reason, details=tuple(details))
+
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_admissibility_check.py
+++ b/tests/test_admissibility_check.py
@@ -1,0 +1,142 @@
+"""Admissibility reachability and validator mapping (issue #295, sub-issue #559)."""
+
+from continuum.actions import ActionLedger
+from continuum.checkpoint import CheckpointManager
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.recovery import RecoveryEngine
+from continuum.state.validator import check_admissibility
+from continuum.storage import SQLiteStorage
+
+
+def _store_with_checkpoint(run_id: str = "run_559") -> tuple[SQLiteStorage, str]:
+    store = SQLiteStorage(":memory:")
+    store.create_run(Run(run_id=run_id, goal="g"))
+    store.append_event(run_id, EventType.RUN_STARTED, {"goal": "g", "total": 10})
+    mgr = CheckpointManager(store)
+    mgr.checkpoint(run_id)
+    return store, run_id
+
+
+def test_admissible_when_no_consumed_after() -> None:
+    store, run_id = _store_with_checkpoint("run_adm_ok")
+    ledger = ActionLedger(store, run_id)
+    out = ledger.claim("a.do", {"x": 1})
+    ledger.complete(out.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [], "component_ids": [], "action_ids": []})
+    out2 = ledger.claim("a.do2", {"y": 2})
+    ledger.complete(out2.key)
+    mgr = CheckpointManager(store)
+    restored = mgr.restore(run_id)
+    result = check_admissibility(restored.checkpoint, ledger.all())
+    assert result.admissible is True
+    assert result.blocking == ()
+    assert result.reason == ""
+    store.close()
+
+
+def test_inadmissible_via_event_position() -> None:
+    store, run_id = _store_with_checkpoint("run_adm_event")
+    mgr = CheckpointManager(store)
+    cp = store.latest_checkpoint(run_id)
+    assert cp is not None
+    seq = cp.state.source_sequence
+    ledger = ActionLedger(store, run_id)
+    out = ledger.claim("a.downstream", {"v": 1})
+    ledger.complete(out.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [seq + 5], "component_ids": [], "action_ids": []})
+    restored = mgr.restore(run_id)
+    result = check_admissibility(restored.checkpoint, ledger.all())
+    assert result.admissible is False
+    assert len(result.blocking) == 1
+    assert "event position" in result.reason
+    assert result.details[0]["chain_position"] >= 1
+    assert result.details[0]["consumed_inputs"]["event_positions"] == [seq + 5]
+    store.close()
+
+
+def test_inadmissible_via_component_id() -> None:
+    store, run_id = _store_with_checkpoint("run_adm_comp")
+    mgr = CheckpointManager(store)
+    cp = store.latest_checkpoint(run_id)
+    assert cp is not None
+    ledger = ActionLedger(store, run_id)
+    out = ledger.claim("a.comp", {})
+    ledger.complete(out.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [], "component_ids": ["decision_unknown"], "action_ids": []})
+    restored = mgr.restore(run_id)
+    result = check_admissibility(restored.checkpoint, ledger.all())
+    assert result.admissible is False
+    assert "component" in result.reason
+    store.close()
+
+
+def test_inadmissible_via_checkpoint_seq() -> None:
+    store, run_id = _store_with_checkpoint("run_adm_seq")
+    mgr = CheckpointManager(store)
+    cp = store.latest_checkpoint(run_id)
+    assert cp is not None
+    ledger = ActionLedger(store, run_id)
+    out = ledger.claim("a.seq", {})
+    ledger.complete(out.key, consumed_inputs={"checkpoint_seq": cp.version + 1, "event_positions": [], "component_ids": [], "action_ids": []})
+    restored = mgr.restore(run_id)
+    result = check_admissibility(restored.checkpoint, ledger.all())
+    assert result.admissible is False
+    assert "checkpoint_seq" in result.reason
+    store.close()
+
+
+def test_engine_maps_event_to_repair() -> None:
+    store, run_id = _store_with_checkpoint("run_engine_repair")
+    mgr = CheckpointManager(store)
+    cp = store.latest_checkpoint(run_id)
+    assert cp is not None
+    ledger = ActionLedger(store, run_id)
+    out = ledger.claim("a.repair", {})
+    ledger.complete(out.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [cp.state.source_sequence + 1], "component_ids": [], "action_ids": []})
+    engine = RecoveryEngine(store)
+    decision = engine.assess(run_id)
+    assert decision.mode.value == "repair_and_resume"
+    assert "inadmissible" in decision.validation.report.reason
+    assert any(e.component.value == "action" for e in decision.validation.report.statuses)
+    store.close()
+
+
+def test_engine_maps_action_ids_to_request_human() -> None:
+    store, run_id = _store_with_checkpoint("run_engine_human")
+    mgr = CheckpointManager(store)
+    cp = store.latest_checkpoint(run_id)
+    assert cp is not None
+    ledger = ActionLedger(store, run_id)
+    out1 = ledger.claim("a.first", {})
+    ledger.complete(out1.key)
+    out2 = ledger.claim("a.second", {})
+    ledger.complete(out2.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [], "component_ids": [], "action_ids": [out1.action.action_id]})
+    engine = RecoveryEngine(store)
+    decision = engine.assess(run_id)
+    assert decision.mode.value == "request_human"
+    assert "inadmissible" in decision.validation.report.reason
+    store.close()
+
+
+def test_old_rows_without_consumed_remain_admissible() -> None:
+    store, run_id = _store_with_checkpoint("run_old_adm")
+    ledger = ActionLedger(store, run_id)
+    out = ledger.claim("a.old", {})
+    ledger.complete(out.key)
+    mgr = CheckpointManager(store)
+    restored = mgr.restore(run_id)
+    result = check_admissibility(restored.checkpoint, ledger.all())
+    assert result.admissible is True
+    store.close()
+
+
+def test_non_completed_not_blocking() -> None:
+    store, run_id = _store_with_checkpoint("run_noncomp")
+    mgr = CheckpointManager(store)
+    cp = store.latest_checkpoint(run_id)
+    assert cp is not None
+    ledger = ActionLedger(store, run_id)
+    out = ledger.claim("a.pending", {})
+    ledger.fail(out.key, "boom", certain=True)
+    restored = mgr.restore(run_id)
+    result = check_admissibility(restored.checkpoint, ledger.all())
+    assert result.admissible is True
+    store.close()

--- a/tests/test_admissibility_e2e.py
+++ b/tests/test_admissibility_e2e.py
@@ -1,0 +1,139 @@
+"""End-to-end admissibility: crash downstream refuse (issue #295, sub-issue #560).
+
+Simulates a run that crashes mid-way, downstream committed work completes
+consuming state after the checkpoint, and a rewind-style resume is refused
+with a contract that names each blocking commitment and its chain position.
+"""
+
+from continuum.actions import ActionLedger
+from continuum.checkpoint import CheckpointManager
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.recovery import RecoveryEngine
+from continuum.storage import SQLiteStorage
+
+
+def test_crash_downstream_refused_with_contract() -> None:
+    store = SQLiteStorage(":memory:")
+    run_id = "run_e2e_adm"
+    store.create_run(Run(run_id=run_id, goal="e2e admissibility"))
+    store.append_event(run_id, EventType.RUN_STARTED, {"goal": "e2e admissibility"})
+    # some work
+    store.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1", "summary": "s"})
+    store.append_event(run_id, EventType.FINDING_ADDED, {"finding_id": "f1", "claim": "c", "evidence": ["ev1"]})
+    mgr = CheckpointManager(store)
+    cp1 = mgr.checkpoint(run_id)
+    assert cp1 is not None
+    seq1 = cp1.state.source_sequence
+    ver1 = cp1.version
+    # more work after checkpoint
+    store.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev2", "summary": "s2"})
+    store.append_event(run_id, EventType.FINDING_ADDED, {"finding_id": "f2", "claim": "c2", "evidence": ["ev2"]})
+    # checkpoint again to have a later checkpoint that is still before downstream
+    cp2 = mgr.checkpoint(run_id)
+    assert cp2 is not None
+    seq2 = cp2.state.source_sequence
+    # downstream committed effect that consumes state after cp1 and cp2
+    ledger = ActionLedger(store, run_id)
+    out = ledger.claim("downstream.publish", {"doc": "report"})
+    # consume event position after cp2 (so both checkpoints inadmissible)
+    ledger.complete(
+        out.key,
+        consumed_inputs={
+            "checkpoint_seq": 0,
+            "event_positions": [seq2 + 1],
+            "component_ids": [],
+            "action_ids": [],
+        },
+    )
+    # also test component_ids path: need a valid component that is after checkpoint
+    # use f2 which is after cp1 but before cp2? Actually f2 is before cp2, so not after cp2, but after cp1
+    # For cp2, f2 is not after, so not blocking via component for cp2. For event we already block cp2.
+    # For completeness, test that cp1 is also blocked via component f2
+    # Add another downstream that consumes component f2
+    out2 = ledger.claim("downstream.publish2", {"doc": "report2"})
+    ledger.complete(
+        out2.key,
+        consumed_inputs={
+            "checkpoint_seq": 0,
+            "event_positions": [],
+            "component_ids": ["f2"],
+            "action_ids": [],
+        },
+    )
+    engine = RecoveryEngine(store)
+    decision = engine.assess(run_id)
+    # Must not be RESUME; must be REPAIR or REQUEST_HUMAN
+    assert decision.mode.value != "resume"
+    assert decision.mode.value in ("repair_and_resume", "request_human")
+    # Contract must name blocking commitments with chain positions
+    contract = decision.contract
+    # invalidated should contain action entries with positions
+    assert any("action:" in inv for inv in contract.invalidated)
+    assert any("at position" in inv for inv in contract.invalidated)
+    # evidence should contain blocking commitment details
+    assert any("blocking commitment" in ev for ev in contract.evidence)
+    assert any("chain_position" in ev or "at position" in ev for ev in contract.evidence)
+    # reason must be machine-readable and list blocking
+    assert "inadmissible" in contract.reason
+    assert "blocking commitment" in contract.reason or "blocking" in contract.reason
+    # Validation report must have ACTION entry
+    assert any(e.component.value == "action" for e in decision.validation.report.statuses)
+    store.close()
+
+
+def test_admissible_checkpoint_still_resumes() -> None:
+    store = SQLiteStorage(":memory:")
+    run_id = "run_e2e_ok"
+    store.create_run(Run(run_id=run_id, goal="ok"))
+    store.append_event(run_id, EventType.RUN_STARTED, {"goal": "ok"})
+    mgr = CheckpointManager(store)
+    mgr.checkpoint(run_id)
+    # downstream with empty consumed_inputs is admissible
+    ledger = ActionLedger(store, run_id)
+    out = ledger.claim("a.ok", {})
+    ledger.complete(out.key)
+    engine = RecoveryEngine(store)
+    decision = engine.assess(run_id)
+    # Should be RESUME or REPAIR due to other reasons, but not blocked by admissibility
+    # Since no blocking, and no other issues, should be RESUME
+    assert decision.mode.value == "resume"
+    assert decision.contract.recovery_status.value == "safe_to_resume"
+    store.close()
+
+
+def test_rewind_style_resume_refused() -> None:
+    # Simulate trying to resume from an earlier checkpoint after downstream work
+    # Engine always uses latest checkpoint, but we can manually check earlier
+    # checkpoint admissibility via check_admissibility
+    from continuum.state.validator import check_admissibility
+
+    store = SQLiteStorage(":memory:")
+    run_id = "run_rewind"
+    store.create_run(Run(run_id=run_id, goal="rewind"))
+    store.append_event(run_id, EventType.RUN_STARTED, {"goal": "rewind"})
+    mgr = CheckpointManager(store)
+    cp1 = mgr.checkpoint(run_id)
+    assert cp1 is not None
+    # downstream work
+    ledger = ActionLedger(store, run_id)
+    out = ledger.claim("downstream.work", {})
+    ledger.complete(
+        out.key,
+        consumed_inputs={
+            "checkpoint_seq": cp1.version + 1,
+            "event_positions": [],
+            "component_ids": [],
+            "action_ids": [],
+        },
+    )
+    # Even though cp1 is an older checkpoint, check_admissibility should mark it inadmissible
+    result = check_admissibility(cp1, ledger.all())
+    assert result.admissible is False
+    assert "checkpoint_seq" in result.reason
+    # Latest checkpoint is also inadmissible because downstream consumed after it? Actually downstream consumed checkpoint_seq > cp1.version, but cp1.version is older, latest checkpoint version is same as cp1 if no new checkpoint after downstream? Let's create a new checkpoint after downstream? No, downstream is after cp1, so cp1 is inadmissible.
+    # Engine assess on latest (cp1) should be refused
+    engine = RecoveryEngine(store)
+    decision = engine.assess(run_id)
+    assert decision.mode.value != "resume"
+    store.close()

--- a/tests/test_admissibility_inputs.py
+++ b/tests/test_admissibility_inputs.py
@@ -1,0 +1,205 @@
+"""Consumed-input refs for admissibility (issue #295, sub-issue #558).
+
+Completed actions record which checkpoint components and prior actions they
+consumed. Old rows without the field must remain admissible (default empty),
+new rows must round-trip through ledger and storage, and validation must
+accept empty lists but reject malformed commitments.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.events import EventType
+from continuum.models import Action, ActionStatus, ConsumedInputs, Run
+from continuum.storage import SQLiteStorage
+
+
+def _new_store_with_run(run_id: str = "run_1") -> SQLiteStorage:
+    store = SQLiteStorage(":memory:")
+    store.create_run(Run(run_id=run_id, goal="g"))
+    store.append_event(run_id, EventType.RUN_STARTED, {"goal": "g"})
+    return store
+
+
+def test_old_row_without_consumed_inputs_is_admissible() -> None:
+    """Old ledger rows without consumed_inputs must load as empty and be admissible."""
+    # Simulate a legacy action payload missing the field (pre-#558)
+    action = Action(run_id="run_1", action_type="a.do")
+    payload = action.model_dump(mode="json")
+    payload.pop("consumed_inputs", None)
+    assert "consumed_inputs" not in payload
+    # Loading must succeed and yield empty commitments
+    restored = Action.model_validate(payload)
+    assert restored.consumed_inputs == ConsumedInputs()
+    assert restored.consumed_inputs.checkpoint_seq == 0
+    assert restored.consumed_inputs.event_positions == []
+    assert restored.consumed_inputs.action_ids == []
+
+
+def test_old_event_without_field_survives_fold() -> None:
+    store = _new_store_with_run("run_old")
+    ledger = ActionLedger(store, "run_old")
+    # Manually craft an ACTION_RECORDED event whose action dict lacks consumed_inputs
+    action = Action(run_id="run_old", action_type="a.do", status=ActionStatus.COMPLETED)
+    raw_payload = action.model_dump(mode="json")
+    raw_payload.pop("consumed_inputs", None)
+    store.append_event(
+        "run_old",
+        EventType.ACTION_RECORDED,
+        {"key": "legacy-key", "action": raw_payload},
+    )
+    replayed = ActionLedger(store, "run_old")
+    found = replayed.get("legacy-key")
+    assert found is not None
+    assert found.consumed_inputs == ConsumedInputs()
+    store.close()
+
+
+def test_new_row_round_trips_via_ledger() -> None:
+    store = _new_store_with_run("run_new")
+    ledger = ActionLedger(store, "run_new")
+    outcome = ledger.claim("a.do", {"x": 1})
+    ci = {"checkpoint_seq": 2, "event_positions": [1, 2, 3], "action_ids": ["action_abc"]}
+    completed = ledger.complete(outcome.key, external_id="ext-1", consumed_inputs=ci)
+    assert completed.consumed_inputs.checkpoint_seq == 2
+    assert completed.consumed_inputs.event_positions == [1, 2, 3]
+    assert completed.consumed_inputs.action_ids == ["action_abc"]
+
+    # Round-trip via get
+    fetched = ledger.get(outcome.key)
+    assert fetched is not None
+    assert fetched.consumed_inputs == ConsumedInputs(
+        checkpoint_seq=2, event_positions=[1, 2, 3], action_ids=["action_abc"]
+    )
+
+    # Round-trip via fresh ledger replaying the same storage
+    fresh = ActionLedger(store, "run_new")
+    refetched = fresh.get(outcome.key)
+    assert refetched is not None
+    assert refetched.consumed_inputs == fetched.consumed_inputs
+    store.close()
+
+
+def test_consumed_inputs_stored_in_action_index_projection() -> None:
+    store = _new_store_with_run("run_idx")
+    ledger = ActionLedger(store, "run_idx")
+    outcome = ledger.claim("a.do", {}, key="k-idx")
+    ci = ConsumedInputs(checkpoint_seq=5, event_positions=[5], action_ids=["action_xyz"])
+    ledger.complete(outcome.key, consumed_inputs=ci)
+
+    # The projection's action_json must contain the commitment
+    row = store._connection.execute(
+        "SELECT action_json FROM action_index WHERE key = ?", (str(outcome.key),)
+    ).fetchone()
+    assert row is not None
+    action_json = json.loads(row["action_json"])
+    assert "consumed_inputs" in action_json
+    assert action_json["consumed_inputs"]["checkpoint_seq"] == 5
+    assert action_json["consumed_inputs"]["event_positions"] == [5]
+    assert action_json["consumed_inputs"]["action_ids"] == ["action_xyz"]
+
+    # Rebuild must preserve it
+    store.rebuild_action_index()
+    row2 = store._connection.execute(
+        "SELECT action_json FROM action_index WHERE key = ?", (str(outcome.key),)
+    ).fetchone()
+    assert json.loads(row2["action_json"])["consumed_inputs"] == action_json["consumed_inputs"]
+    store.close()
+
+
+def test_empty_consumed_inputs_is_valid() -> None:
+    empty = ConsumedInputs()
+    assert empty.checkpoint_seq == 0
+    assert empty.event_positions == []
+    assert empty.action_ids == []
+
+    # Action with default empty must validate
+    a = Action(run_id="r", action_type="t", consumed_inputs=ConsumedInputs())
+    assert a.consumed_inputs == empty
+
+    # Also via dict form with empty lists
+    a2 = Action.model_validate(
+        {"run_id": "r", "action_type": "t", "consumed_inputs": {"checkpoint_seq": 0, "event_positions": [], "action_ids": []}}
+    )
+    assert a2.consumed_inputs == empty
+
+
+def test_complete_accepts_both_mapping_and_model() -> None:
+    store = _new_store_with_run("run_both")
+    ledger = ActionLedger(store, "run_both")
+    outcome = ledger.claim("a.do", {}, key="k-both")
+    # Mapping form
+    ledger.complete(outcome.key, consumed_inputs={"checkpoint_seq": 1, "event_positions": [], "action_ids": []})
+    fetched = ledger.get(outcome.key)
+    assert fetched is not None
+    assert fetched.consumed_inputs.checkpoint_seq == 1
+
+    # Model form (update on already completed)
+    ledger.complete(outcome.key, consumed_inputs=ConsumedInputs(checkpoint_seq=9, event_positions=[9], action_ids=["a1"]))
+    refetched = ledger.get(outcome.key)
+    assert refetched is not None
+    assert refetched.consumed_inputs.checkpoint_seq == 9
+    store.close()
+
+
+def test_validation_rejects_negative_checkpoint_seq() -> None:
+    with pytest.raises(Exception, match="greater than or equal to 0"):
+        ConsumedInputs(checkpoint_seq=-1)
+
+
+def test_validation_rejects_negative_event_position() -> None:
+    with pytest.raises(Exception, match="must be >= 0"):
+        ConsumedInputs(event_positions=[-1])
+
+
+def test_validation_rejects_too_many_action_ids() -> None:
+    with pytest.raises(Exception, match="at most 32"):
+        ConsumedInputs(action_ids=[f"action_{i}" for i in range(33)])
+
+
+def test_validation_rejects_too_many_event_positions() -> None:
+    with pytest.raises(Exception, match="at most 128"):
+        ConsumedInputs(event_positions=list(range(129)))
+
+
+def test_complete_validates_invalid_consumed_inputs() -> None:
+    store = _new_store_with_run("run_val")
+    ledger = ActionLedger(store, "run_val")
+    outcome = ledger.claim("a.do", {}, key="k-val")
+    with pytest.raises(Exception):
+        ledger.complete(outcome.key, consumed_inputs={"checkpoint_seq": -5, "event_positions": [], "action_ids": []})
+    # Also via action_ids too long
+    with pytest.raises(Exception):
+        ledger.complete(outcome.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [], "action_ids": [""]})
+    store.close()
+
+
+def test_reconcile_preserves_consumed_inputs() -> None:
+    store = _new_store_with_run("run_rec")
+    ledger = ActionLedger(store, "run_rec")
+    outcome = ledger.claim("a.do", {}, key="k-rec")
+    ledger.fail(outcome.key, "boom", certain=False)
+    ci = ConsumedInputs(checkpoint_seq=3, event_positions=[3], action_ids=["action_prev"])
+    reconciled = ledger.reconcile(outcome.key, occurred=True, consumed_inputs=ci)
+    assert reconciled.consumed_inputs == ci
+    assert ledger.get(outcome.key).consumed_inputs == ci
+    store.close()
+
+
+def test_complete_without_consumed_inputs_preserves_existing() -> None:
+    store = _new_store_with_run("run_preserve")
+    ledger = ActionLedger(store, "run_preserve")
+    outcome = ledger.claim("a.do", {}, key="k-preserve")
+    ci = {"checkpoint_seq": 4, "event_positions": [4], "action_ids": ["a4"]}
+    ledger.complete(outcome.key, consumed_inputs=ci)
+    # Repeat complete without supplying consumed_inputs must keep prior
+    ledger.complete(outcome.key, external_id="ext-keep")
+    fetched = ledger.get(outcome.key)
+    assert fetched is not None
+    assert fetched.consumed_inputs.checkpoint_seq == 4
+    assert fetched.external_id == "ext-keep"
+    store.close()

--- a/tests/test_authority_consumed.py
+++ b/tests/test_authority_consumed.py
@@ -1,0 +1,221 @@
+"""AUTHORITY_CONSUMED event type, hash-chained and provenance-stamped (issue #555)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from continuum.actions.authority import record_authority_consumed
+from continuum.events import EventType
+from continuum.models import AuthorityConsumed, Origin, Run
+from continuum.storage import SQLiteStorage
+
+
+def _make_storage() -> SQLiteStorage:
+    storage = SQLiteStorage(":memory:")
+    storage.create_run(Run(run_id="run_1", goal="g"))
+    storage.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    return storage
+
+
+def test_helper_appends_deterministic_hash_chained_event() -> None:
+    storage = _make_storage()
+    try:
+        before = storage.last_sequence("run_1")
+        event = record_authority_consumed(storage, "run_1", "auth-123")
+        assert event.type == EventType.AUTHORITY_CONSUMED
+        assert event.source == Origin.DETERMINISTIC
+        assert event.sequence == before + 1
+        assert event.hash is not None
+        assert event.hash == event.digest()
+        assert event.prev_hash is not None
+        report = storage.verify_events("run_1")
+        assert report.ok
+        assert report.trusted_through["run_1"] == storage.last_sequence("run_1")
+        assert event.payload["authority_id"] == "auth-123"
+        assert event.payload["consumer_run_id"] == "run_1"
+        assert "consumed_at" in event.payload
+        assert event.payload["via_action_id"] is None
+        event2 = record_authority_consumed(storage, "run_1", "auth-456", via_action_id="action_1")
+        assert event2.payload["via_action_id"] == "action_1"
+        assert event2.source == Origin.DETERMINISTIC
+    finally:
+        storage.close()
+
+
+def test_provenance_is_deterministic() -> None:
+    storage = _make_storage()
+    try:
+        event = record_authority_consumed(storage, "run_1", "tok-1")
+        assert event.source == Origin.DETERMINISTIC
+        assert not event.source.self_certified
+        events = list(storage.read_events("run_1"))
+        consumed = [e for e in events if e.type == EventType.AUTHORITY_CONSUMED]
+        assert len(consumed) == 1
+        assert consumed[0].source == Origin.DETERMINISTIC
+    finally:
+        storage.close()
+
+
+def test_hash_chain_tamper_is_detected() -> None:
+    storage = _make_storage()
+    try:
+        record_authority_consumed(storage, "run_1", "auth-tamper")
+        events = list(storage.read_events("run_1"))
+        tampered_event = None
+        for ev in events:
+            if ev.type == EventType.AUTHORITY_CONSUMED:
+                tampered_event = ev
+                break
+        assert tampered_event is not None
+        bad_payload = dict(tampered_event.payload)
+        bad_payload["authority_id"] = "hacked"
+        bad = tampered_event.model_copy(update={"payload": bad_payload})
+        from continuum.events import AppendOnlyViolation, EventLog
+
+        log = EventLog()
+        for e in events:
+            if e.event_id == tampered_event.event_id:
+                try:
+                    log.extend([bad])
+                except AppendOnlyViolation as exc:
+                    assert "hash does not match content" in str(exc).lower()
+                    break
+                else:
+                    rep = log.verify("run_1")
+                    assert not rep.ok
+                    assert any(v.kind == "TAMPERED_CONTENT" for v in rep.violations)
+                    break
+            else:
+                log.extend([e])
+        assert storage.verify_events("run_1").ok
+    finally:
+        storage.close()
+
+
+def test_bounded_size() -> None:
+    storage = _make_storage()
+    try:
+        max_id = "a" * 128
+        event = record_authority_consumed(storage, "run_1", max_id)
+        payload_json = json.dumps(event.payload, sort_keys=True)
+        assert len(max_id) == 128
+        assert len(payload_json) < 2048
+        with pytest.raises(ValueError):
+            record_authority_consumed(storage, "run_1", "a" * 129)
+        with pytest.raises(ValueError):
+            record_authority_consumed(storage, "run_1", "")
+        with pytest.raises(ValueError):
+            record_authority_consumed(storage, "run_1", "   ")
+        with pytest.raises(ValueError):
+            AuthorityConsumed(
+                authority_id="ok",
+                consumer_run_id="run_1",
+                consumed_at=datetime.now(UTC),
+                via_action_id="x" * 257,
+            )
+        with pytest.raises(ValueError):
+            record_authority_consumed(storage, "run_1", "auth-ok", via_action_id="   ")
+    finally:
+        storage.close()
+
+
+def test_no_dedup_every_consumption_is_distinct_row() -> None:
+    storage = _make_storage()
+    try:
+        event1 = record_authority_consumed(storage, "run_1", "same-id")
+        event2 = record_authority_consumed(storage, "run_1", "same-id")
+        assert event1.event_id != event2.event_id
+        assert event1.hash != event2.hash
+        assert event1.sequence + 1 == event2.sequence
+        assert event2.prev_hash == event1.hash
+        events = [e for e in storage.read_events("run_1") if e.type == EventType.AUTHORITY_CONSUMED]
+        assert len(events) == 2
+        assert events[0].payload["authority_id"] == "same-id"
+        assert events[1].payload["authority_id"] == "same-id"
+        assert storage.verify_events("run_1").ok
+    finally:
+        storage.close()
+
+
+def test_replay_preserves_rows() -> None:
+    storage = _make_storage()
+    try:
+        record_authority_consumed(storage, "run_1", "auth-1")
+        record_authority_consumed(storage, "run_1", "auth-2", via_action_id="act-1")
+        record_authority_consumed(storage, "run_1", "auth-1")
+        events = list(storage.read_events("run_1"))
+        consumed = [e for e in events if e.type == EventType.AUTHORITY_CONSUMED]
+        assert len(consumed) == 3
+        from continuum.events import EventLog
+
+        log = EventLog()
+        log.extend(events)
+        replayed = [e for e in log.events("run_1") if e.type == EventType.AUTHORITY_CONSUMED]
+        assert len(replayed) == 3
+        assert [e.payload["authority_id"] for e in replayed] == ["auth-1", "auth-2", "auth-1"]
+        assert replayed[1].payload["via_action_id"] == "act-1"
+        all_events = list(storage.read_all_events("run_1"))
+        all_consumed = [e for e in all_events if e.type == EventType.AUTHORITY_CONSUMED]
+        assert len(all_consumed) == 3
+    finally:
+        storage.close()
+
+
+def test_consumer_run_id_and_consumed_at_overrides() -> None:
+    storage = _make_storage()
+    try:
+        custom_time = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+        event = record_authority_consumed(
+            storage,
+            "run_1",
+            "auth-custom",
+            consumer_run_id="run_2",
+            consumed_at=custom_time,
+            via_action_id="act-99",
+        )
+        assert event.payload["consumer_run_id"] == "run_2"
+        assert event.payload["consumed_at"] in (
+            custom_time.isoformat(),
+            custom_time.isoformat().replace("+00:00", "Z"),
+        )
+        assert event.payload["via_action_id"] == "act-99"
+        event2 = record_authority_consumed(storage, "run_1", "auth-default")
+        assert event2.payload["consumer_run_id"] == "run_1"
+    finally:
+        storage.close()
+
+
+def test_model_validation_strips_and_bounds() -> None:
+    m = AuthorityConsumed(
+        authority_id="  spaced  ",
+        consumer_run_id=" run_1 ",
+        consumed_at=datetime.now(UTC),
+        via_action_id="  act  ",
+    )
+    assert m.authority_id == "spaced"
+    assert m.consumer_run_id == "run_1"
+    assert m.via_action_id == "act"
+    with pytest.raises(ValueError):
+        AuthorityConsumed(
+            authority_id="   ", consumer_run_id="run_1", consumed_at=datetime.now(UTC)
+        )
+    with pytest.raises(ValueError):
+        AuthorityConsumed(authority_id="auth", consumer_run_id="   ", consumed_at=datetime.now(UTC))
+
+
+def test_payload_is_json_native_and_hash_stable() -> None:
+    storage = _make_storage()
+    try:
+        event = record_authority_consumed(storage, "run_1", "auth-stable")
+        dumped = json.dumps(event.payload, sort_keys=True)
+        loaded = json.loads(dumped)
+        assert loaded == event.payload
+        events = list(storage.read_events("run_1"))
+        stored = [e for e in events if e.type == EventType.AUTHORITY_CONSUMED][0]
+        assert stored.hash == event.hash
+        assert stored.digest() == event.digest()
+    finally:
+        storage.close()


### PR DESCRIPTION
Adds AUTHORITY_CONSUMED event for consumed-credential tracking (parent epic #289, board #550).

- EventType.AUTHORITY_CONSUMED is append-only, hash-chained, and verified via EventLog and SQLite verify
- AuthorityConsumed payload in models.py with authority_id 1-128, consumer_run_id, consumed_at, via_action_id optional, bounded size and stripped validation
- New helper record_authority_consumed(storage, run_id, authority_id, ...) in src/continuum/actions/authority.py appends a distinct DETERMINISTIC row per call (no dedup, replay preserves)
- Tests in tests/test_authority_consumed.py cover hash chain, DETERMINISTIC provenance, bounded size, no dedup, replay, and tamper detection

Fixes #555
Refs #289
Refs #550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit tracking for one-time authority credentials after consumption.
  * Consumption records remain invalid after restoration and preserve deterministic, tamper-evident history.
  * Added validation and support for linking consumption records to related actions.

* **Documentation**
  * Added threat-model coverage for preventing authority resurrection after restore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->