### PR TITLE
feat(gate): memory store key convention with tenant-scoped dedup (Refs #565)

### DIFF
--- a/.continuum/gate.json.example
+++ b/.continuum/gate.json.example
@@ -1,0 +1,23 @@
+{
+  "tools": {
+    "pgvector.upsert": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}",
+      "action_type": "mem_write"
+    },
+    "pgvector.delete": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}",
+      "action_type": "mem_delete"
+    },
+    "mem0.write": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}",
+      "action_type": "mem_write"
+    },
+    "mem0.delete": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}",
+      "action_type": "mem_delete"
+    },
+    "mem_write": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}"
+    }
+  }
+}

--- a/docs/guides/memory-governance.md
+++ b/docs/guides/memory-governance.md
@@ -1,0 +1,172 @@
+# Memory mutation governance
+
+Governing long-term memory writes as claimed, provenance-stamped, tenant-scoped side effects. CONTINUUM is not a memory system, the ledger and gate are the control plane.
+
+## Why this exists
+
+Long-running agents accumulate state in external stores such as pgvector, Mem0, Letta, Zep, or bespoke vector tables. Four failure classes live there:
+
+* **Poisoned records** that persist across sessions and steer future behavior.
+* **Memory drift** where a shortcut learned from a few atypical interactions is applied ever after.
+* **Tenancy breaches** where retrieval crosses a user boundary. This is not a wrong answer, it is a data breach.
+* **Erasure gaps** where nobody can enumerate what the agent wrote, so right-to-erasure cannot be honored.
+
+Memory-store mutations are invisible to durability unless hand-registered in `.continuum/gate.json`. This guide fixes that by giving every memory write a stable identity that the ledger can deduplicate, scope to a tenant, and enumerate for deletion.
+
+## Key convention
+
+Every memory-mutating tool is registered in `.continuum/gate.json` with a stable key template that names its identity, not its arguments:
+
+```
+mem:{store_id}:{tenant}:{record_key}
+```
+
+* `store_id` identifies the concrete store, for example `pgvector_main`, `mem0`, `letta`.
+* `tenant` carries the tenancy boundary, the user or workspace that owns the record. Different tenants never dedupe against each other because the tenant is part of the key.
+* `record_key` is the record identity as the store defines it, for example a document id, chunk id, or memory id. Two writes with the same triple are the same record.
+
+Templates are rendered from top-level tool arguments using `gate.render_key`. Values are stripped of surrounding whitespace (`gate.normalize_key_value`) so ` " rec-42 "` and `"rec-42"` are one key. The gate and the gateway share this rule, therefore a value written through one seam is recognized at the other.
+
+### Tenant isolation
+
+Same `store_id` and `record_key` under different `tenant` values produce different keys, so tenancy is enforced by identity itself:
+
+* `mem:pgvector_main:acme:rec-42` does not collide with `mem:pgvector_main:globex:rec-42`.
+* A cross-tenant retry is not a dedup, it is a distinct write under its own tenant namespace.
+
+### Cross-run dedup
+
+Memory is global to the store, not to the run that wrote it. The ledger key for `mem:` identities is therefore unscoped, so `action_index` can catch a double-write from a later run:
+
+* Run `run_1` claims and completes `mem:pgvector_main:acme:rec-42`. The index stores it under its global key.
+* Run `run_2` attempts the same triple. Even though run_2's local log is empty, a foreign lookup via `storage.foreign_action(global_key, exclude_run=run_2)` finds the earlier completion and the gate reports already completed. The effect is not sent twice.
+
+This is the same exactly-once mechanism that protects invoices or charges, applied to memory records.
+
+## Registration
+
+Add entries under `tools` in `.continuum/gate.json`. Each entry names the tool as the harness sees it, the template, and the `action_type` the ledger will record.
+
+Minimal example:
+
+```json
+{
+  "tools": {
+    "mem_write": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}"
+    }
+  }
+}
+```
+
+Worked pgvector and Mem0 examples live in `.continuum/gate.json.example`. Copy that file to `.continuum/gate.json` and adjust `store_id` and tool names to match your harness.
+
+## Claim flow
+
+1. Derive the rendered key from arguments, for example `store_id=pgvector_main, tenant=acme, record_key=doc-42` renders `mem:pgvector_main:acme:doc-42`.
+2. Claim before firing:
+
+```python
+from continuum.actions.ledger import ActionLedger
+from continuum.actions.idempotency import idempotency_key
+
+rendered = "mem:pgvector_main:acme:doc-42"
+key = idempotency_key("mem_write", None, scope=None, key=rendered)
+outcome = ActionLedger(store, run_id).claim("mem_write", {}, key=rendered, scoped_to_run=False)
+if not outcome.fresh:
+    # already completed elsewhere, use outcome.result
+    pass
+```
+
+3. Perform the store mutation, then complete or fail the claim. The gate denies any unclaimed call with instructions to claim first, and denies an already completed key with an already completed message. Uncertain outcomes are blocked until reconciled, exactly as for any other external effect.
+
+For HTTP stores, the enforcing gateway derives the same key from the request body. Configure an upstream in `.continuum/gateway.json` with the same `key_template` and `action_type`:
+
+```json
+{
+  "upstreams": [
+    {
+      "host": "pgvector.internal",
+      "methods": ["POST"],
+      "prefix": "/upsert",
+      "action_type": "mem_write",
+      "key_template": "mem:{store_id}:{tenant}:{record_key}"
+    }
+  ]
+}
+```
+
+The gateway and the pre-tool gate share `normalize_key_value`, so one identity rule governs both seams.
+
+## pgvector walkthrough
+
+Tool: `pgvector.upsert` with arguments `store_id`, `tenant`, `record_key`, `embedding`, `metadata`.
+
+Gate entry:
+
+```json
+{
+  "tools": {
+    "pgvector.upsert": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}",
+      "action_type": "mem_write"
+    }
+  }
+}
+```
+
+Call 1, run_1, `pgvector_main, acme, doc-42`: renders `mem:pgvector_main:acme:doc-42`, claimed with `scoped_to_run=False`, completed after the upsert succeeds. Run_2 attempting the same triple sees the index entry and is refused as duplicate.
+
+Call 2, run_2, `pgvector_main, globex, doc-42`: renders `mem:pgvector_main:globex:doc-42`, a different key, so it proceeds independently. Tenancy breach by key confusion is not possible because the tenant is inside the identity.
+
+## Mem0 walkthrough
+
+Tool: `mem0.write` with arguments `store_id`, `tenant`, `record_key`, `content`.
+
+Gate entry:
+
+```json
+{
+  "tools": {
+    "mem0.write": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}",
+      "action_type": "mem_write"
+    }
+  }
+}
+```
+
+Same rules apply. A Mem0 record written as `mem:mem0:acme:user-pref-7` is exactly-once across restarts and across runs that share the store. Deleting or updating uses the same triple, so the delete is also claimed and audited.
+
+## Tenancy enforcement
+
+When a run is bound to a tenant identity, only keys whose `tenant` field matches that identity should be claimed. The gate keeps the check simple: the tenant is literally inside the key, so a claim for `globex` cannot be mistaken for one for `acme`. If your harness enforces a run-level tenant, reject at the application layer when `tenant` in the arguments differs from the bound identity, before claiming. The ledger then never sees a cross-tenant write to confuse enumeration later.
+
+## Poisoning forensics and erasure
+
+Every memory write is a ledger row keyed by tenant namespace. Enumeration is therefore a filter:
+
+```bash
+continuum actions <run> --json | python -c "import json,sys; data=json.load(sys.stdin); print([a for a in data['actions'] if 'mem:' in a['action_id']])"
+```
+
+A future `continuum forget --tenant X` builds on this enumeration to list exactly what to delete externally and to append a tombstone event. Chain verification keeps hashes, so logical deletion does not break `verify()`. Physical removal of historical hashes is out of scope by design, the chain keeps evidence that something was written and later tombstoned.
+
+## Limitations
+
+* Stores reachable through direct credentials in the sandbox that never pass through a gated tool or the gateway remain ungoverned. This is the same caveat that applies to shell commands that bypass the ledger. Governance covers what is claimed.
+* The key convention governs identity, not truth. It does not judge whether a memory is correct, only who wrote which record on whose behalf and how to take it back.
+* Vector recall quality, embedding policy, and compaction are out of scope. Those belong to the memory system itself.
+
+## Verification
+
+```bash
+pytest tests/test_memory_gate_keys.py -q
+ruff check src/ tests/ examples/
+ruff format --check src/ tests/ examples/
+mypy src/continuum --ignore-missing-imports
+# also verify no em dashes in changed files
+rg -n "$(printf '\\u2014')" src/ tests/ docs/ examples/ benchmarks/
+```
+
+See `.continuum/gate.json.example` for copy-pasteable pgvector and Mem0 templates and `src/continuum/gate.py` for the derivation and cross-run dedup logic.

--- a/docs/guides/memory_governance.md
+++ b/docs/guides/memory_governance.md
@@ -1,0 +1,172 @@
+# Memory mutation governance
+
+Governing long-term memory writes as claimed, provenance-stamped, tenant-scoped side effects. CONTINUUM is not a memory system, the ledger and gate are the control plane.
+
+## Why this exists
+
+Long-running agents accumulate state in external stores such as pgvector, Mem0, Letta, Zep, or bespoke vector tables. Four failure classes live there:
+
+* **Poisoned records** that persist across sessions and steer future behavior.
+* **Memory drift** where a shortcut learned from a few atypical interactions is applied ever after.
+* **Tenancy breaches** where retrieval crosses a user boundary. This is not a wrong answer, it is a data breach.
+* **Erasure gaps** where nobody can enumerate what the agent wrote, so right-to-erasure cannot be honored.
+
+Memory-store mutations are invisible to durability unless hand-registered in `.continuum/gate.json`. This guide fixes that by giving every memory write a stable identity that the ledger can deduplicate, scope to a tenant, and enumerate for deletion.
+
+## Key convention
+
+Every memory-mutating tool is registered in `.continuum/gate.json` with a stable key template that names its identity, not its arguments:
+
+```
+mem:{store_id}:{tenant}:{record_key}
+```
+
+* `store_id` identifies the concrete store, for example `pgvector_main`, `mem0`, `letta`.
+* `tenant` carries the tenancy boundary, the user or workspace that owns the record. Different tenants never dedupe against each other because the tenant is part of the key.
+* `record_key` is the record identity as the store defines it, for example a document id, chunk id, or memory id. Two writes with the same triple are the same record.
+
+Templates are rendered from top-level tool arguments using `gate.render_key`. Values are stripped of surrounding whitespace (`gate.normalize_key_value`) so ` " rec-42 "` and `"rec-42"` are one key. The gate and the gateway share this rule, therefore a value written through one seam is recognized at the other.
+
+### Tenant isolation
+
+Same `store_id` and `record_key` under different `tenant` values produce different keys, so tenancy is enforced by identity itself:
+
+* `mem:pgvector_main:acme:rec-42` does not collide with `mem:pgvector_main:globex:rec-42`.
+* A cross-tenant retry is not a dedup, it is a distinct write under its own tenant namespace.
+
+### Cross-run dedup
+
+Memory is global to the store, not to the run that wrote it. The ledger key for `mem:` identities is therefore unscoped, so `action_index` can catch a double-write from a later run:
+
+* Run `run_1` claims and completes `mem:pgvector_main:acme:rec-42`. The index stores it under its global key.
+* Run `run_2` attempts the same triple. Even though run_2's local log is empty, a foreign lookup via `storage.foreign_action(global_key, exclude_run=run_2)` finds the earlier completion and the gate reports already completed. The effect is not sent twice.
+
+This is the same exactly-once mechanism that protects invoices or charges, applied to memory records.
+
+## Registration
+
+Add entries under `tools` in `.continuum/gate.json`. Each entry names the tool as the harness sees it, the template, and the `action_type` the ledger will record.
+
+Minimal example:
+
+```json
+{
+  "tools": {
+    "mem_write": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}"
+    }
+  }
+}
+```
+
+Worked pgvector and Mem0 examples live in `.continuum/gate.json.example`. Copy that file to `.continuum/gate.json` and adjust `store_id` and tool names to match your harness.
+
+## Claim flow
+
+1. Derive the rendered key from arguments, for example `store_id=pgvector_main, tenant=acme, record_key=doc-42` renders `mem:pgvector_main:acme:doc-42`.
+2. Claim before firing:
+
+```python
+from continuum.actions.ledger import ActionLedger
+from continuum.actions.idempotency import idempotency_key
+
+rendered = "mem:pgvector_main:acme:doc-42"
+key = idempotency_key("mem_write", None, scope=None, key=rendered)
+outcome = ActionLedger(store, run_id).claim("mem_write", {}, key=rendered, scoped_to_run=False)
+if not outcome.fresh:
+    # already completed elsewhere, use outcome.result
+    pass
+```
+
+3. Perform the store mutation, then complete or fail the claim. The gate denies any unclaimed call with instructions to claim first, and denies an already completed key with an already completed message. Uncertain outcomes are blocked until reconciled, exactly as for any other external effect.
+
+For HTTP stores, the enforcing gateway derives the same key from the request body. Configure an upstream in `.continuum/gateway.json` with the same `key_template` and `action_type`:
+
+```json
+{
+  "upstreams": [
+    {
+      "host": "pgvector.internal",
+      "methods": ["POST"],
+      "prefix": "/upsert",
+      "action_type": "mem_write",
+      "key_template": "mem:{store_id}:{tenant}:{record_key}"
+    }
+  ]
+}
+```
+
+The gateway and the pre-tool gate share `normalize_key_value`, so one identity rule governs both seams.
+
+## pgvector walkthrough
+
+Tool: `pgvector.upsert` with arguments `store_id`, `tenant`, `record_key`, `embedding`, `metadata`.
+
+Gate entry:
+
+```json
+{
+  "tools": {
+    "pgvector.upsert": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}",
+      "action_type": "mem_write"
+    }
+  }
+}
+```
+
+Call 1, run_1, `pgvector_main, acme, doc-42`: renders `mem:pgvector_main:acme:doc-42`, claimed with `scoped_to_run=False`, completed after the upsert succeeds. Run_2 attempting the same triple sees the index entry and is refused as duplicate.
+
+Call 2, run_2, `pgvector_main, globex, doc-42`: renders `mem:pgvector_main:globex:doc-42`, a different key, so it proceeds independently. Tenancy breach by key confusion is not possible because the tenant is inside the identity.
+
+## Mem0 walkthrough
+
+Tool: `mem0.write` with arguments `store_id`, `tenant`, `record_key`, `content`.
+
+Gate entry:
+
+```json
+{
+  "tools": {
+    "mem0.write": {
+      "key_template": "mem:{store_id}:{tenant}:{record_key}",
+      "action_type": "mem_write"
+    }
+  }
+}
+```
+
+Same rules apply. A Mem0 record written as `mem:mem0:acme:user-pref-7` is exactly-once across restarts and across runs that share the store. Deleting or updating uses the same triple, so the delete is also claimed and audited.
+
+## Tenancy enforcement
+
+When a run is bound to a tenant identity, only keys whose `tenant` field matches that identity should be claimed. The gate keeps the check simple: the tenant is literally inside the key, so a claim for `globex` cannot be mistaken for one for `acme`. If your harness enforces a run-level tenant, reject at the application layer when `tenant` in the arguments differs from the bound identity, before claiming. The ledger then never sees a cross-tenant write to confuse enumeration later.
+
+## Poisoning forensics and erasure
+
+Every memory write is a ledger row keyed by tenant namespace. Enumeration is therefore a filter:
+
+```bash
+continuum actions <run> --json | python -c "import json,sys; data=json.load(sys.stdin); print([a for a in data['actions'] if 'mem:' in a['action_id']])"
+```
+
+A future `continuum forget --tenant X` builds on this enumeration to list exactly what to delete externally and to append a tombstone event. Chain verification keeps hashes, so logical deletion does not break `verify()`. Physical removal of historical hashes is out of scope by design, the chain keeps evidence that something was written and later tombstoned.
+
+## Limitations
+
+* Stores reachable through direct credentials in the sandbox that never pass through a gated tool or the gateway remain ungoverned. This is the same caveat that applies to shell commands that bypass the ledger. Governance covers what is claimed.
+* The key convention governs identity, not truth. It does not judge whether a memory is correct, only who wrote which record on whose behalf and how to take it back.
+* Vector recall quality, embedding policy, and compaction are out of scope. Those belong to the memory system itself.
+
+## Verification
+
+```bash
+pytest tests/test_memory_gate_keys.py -q
+ruff check src/ tests/ examples/
+ruff format --check src/ tests/ examples/
+mypy src/continuum --ignore-missing-imports
+# also verify no em dashes in changed files
+rg -n "$(printf '\\u2014')" src/ tests/ docs/ examples/ benchmarks/
+```
+
+See `.continuum/gate.json.example` for copy-pasteable pgvector and Mem0 templates and `src/continuum/gate.py` for the derivation and cross-run dedup logic.

--- a/src/continuum/gate.py
+++ b/src/continuum/gate.py
@@ -40,9 +40,14 @@ from continuum.actions.idempotency import idempotency_key
 __all__ = [
     "DEFAULT_GATE_CONFIG_PATH",
     "Decision",
+    "MEMORY_KEY_PREFIX",
+    "MEMORY_REQUIRED_FIELDS",
+    "is_memory_template",
+    "is_memory_key",
     "load_gate_config",
     "normalize_key_value",
     "render_key",
+    "derive_memory_key",
     "decide",
 ]
 
@@ -50,6 +55,17 @@ __all__ = [
 #: runs in. JSON, matching the existing ``.continuum/mcp-policy.json``
 #: convention.
 DEFAULT_GATE_CONFIG_PATH = ".continuum/gate.json"
+
+#: Prefix for memory-store keys. The gate treats this as a global namespace
+#: so the ledger's ``action_index`` can catch a double-write from a later run.
+#: See ``docs/guides/memory_governance.md`` and issue #565 (parent #304).
+MEMORY_KEY_PREFIX = "mem:"
+
+#: Required placeholders for a memory-store template. ``tenant`` carries the
+#: tenancy boundary, ``store_id`` names the backing store, ``record_key`` is
+#: the record identity. Different tenants produce different keys, so a key for
+#: acme never dedupes against one for globex even when the record_key matches.
+MEMORY_REQUIRED_FIELDS = ("store_id", "tenant", "record_key")
 
 
 class GateConfigError(ValueError):
@@ -66,6 +82,21 @@ class Decision:
     #: resembles by resource tokens. Non-empty only on unclaimed denials that
     #: look like deliberate divergence after a restore, never on allow.
     fork_candidates: tuple[Any, ...] = ()
+
+
+def is_memory_template(template: str) -> bool:
+    """Whether a template governs a memory-store write.
+
+    Memory templates are identified by the ``mem:`` prefix. The prefix makes
+    the identity tenant-scoped and global to the store, not to the run, so
+    the ledger's ``action_index`` can catch a double-write from a later run.
+    """
+    return template.startswith(MEMORY_KEY_PREFIX)
+
+
+def is_memory_key(rendered: str) -> bool:
+    """Whether a rendered key is a memory-store identity."""
+    return rendered.startswith(MEMORY_KEY_PREFIX)
 
 
 def load_gate_config(path: Path) -> dict[str, dict[str, Any]] | None:
@@ -95,6 +126,17 @@ def load_gate_config(path: Path) -> dict[str, dict[str, Any]] | None:
             raise GateConfigError(f"{location}: tool {tool!r} needs a string 'key_template'")
         if spec.get("action_type") is not None and not isinstance(spec.get("action_type"), str):
             raise GateConfigError(f"{location}: tool {tool!r} 'action_type' must be a string")
+        template = spec.get("key_template", "")
+        if is_memory_template(template):
+            import string as _string
+
+            fields = {name for _, name, _, _ in _string.Formatter().parse(template) if name}
+            missing = [f for f in MEMORY_REQUIRED_FIELDS if f not in fields]
+            if missing:
+                raise GateConfigError(
+                    f"{location}: tool {tool!r} memory template {template!r} "
+                    f"must include placeholders {MEMORY_REQUIRED_FIELDS}, missing {missing}"
+                )
     return tools
 
 
@@ -141,8 +183,32 @@ def render_key(template: str, tool_input: Mapping[str, Any]) -> str:
 
 
 def _expected_key(action_type: str, run_id: str, rendered: str) -> str:
-    """The exact ledger key a claim of this operation must have produced."""
+    """The exact ledger key a claim of this operation must have produced.
+
+    Memory keys (``mem:``) are global to the store, not to the run, so they
+    use ``scope=None``. This lets the ledger's ``action_index`` catch a
+    double-write from a later run, which is the tenancy and erasure property
+    memory governance needs (issue #565). All other keys stay run-scoped.
+    """
+    if is_memory_key(rendered):
+        return str(idempotency_key(action_type, None, scope=None, key=rendered))
     return str(idempotency_key(action_type, None, scope=run_id, key=rendered))
+
+
+def derive_memory_key(
+    tool_input: Mapping[str, Any], *, template: str = "mem:{store_id}:{tenant}:{record_key}"
+) -> str:
+    """Derive a tenant-scoped memory key from arguments using a template.
+
+    Convenience wrapper around :func:`render_key` that enforces the memory
+    convention. The default template matches the documented example
+    ``mem:{store_id}:{tenant}:{record_key}`` and the pgvector and Mem0
+    examples in ``.continuum/gate.json.example``.
+    """
+    rendered = render_key(template, tool_input)
+    if not is_memory_key(rendered):
+        raise GateConfigError(f"memory key must start with {MEMORY_KEY_PREFIX!r}, got {rendered!r}")
+    return rendered
 
 
 def decide(
@@ -152,12 +218,17 @@ def decide(
     *,
     run_id: str,
     actions_by_key: Mapping[str, Any],
+    storage: Any | None = None,
 ) -> Decision:
     """Decide whether one tool call may proceed.
 
     ``actions_by_key`` maps ledger keys to Action records (the output of
     ``fold_action_events`` over the run's event log). Ungated tools pass
-    immediately without touching anything else.
+    immediately without touching anything else. When ``storage`` is supplied
+    and the rendered key is a memory-store identity (``mem:``), a foreign
+    lookup via the ledger's ``action_index`` also denies a duplicate that
+    was completed in another run, which is the cross-run tenancy guarantee
+    for memory writes (issue #565).
     """
     if config is None:
         return Decision(True, "no gate configured")
@@ -171,6 +242,69 @@ def decide(
         _expected_key(action_type, run_id, rendered)
     except GateConfigError as exc:
         return Decision(False, f"gate configuration error: {exc}")
+
+    # Memory-store keys are global to the backing store, not to the run.
+    # Besides the local ``actions_by_key`` check below, consult the ledger's
+    # action_index when a storage handle is available so a double-write from
+    # a later run is caught even though that run's local log is empty.
+    if is_memory_key(rendered):
+        from continuum.models import ActionStatus
+
+        global_key = _expected_key(action_type, run_id, rendered)
+        action = actions_by_key.get(global_key)
+        if action is None and storage is not None:
+            try:
+                if getattr(storage, "supports_action_index", False):
+                    foreign = storage.foreign_action(global_key, exclude_run=run_id)
+                    if foreign is not None:
+                        action = foreign
+            except Exception:
+                action = None
+        if action is None:
+            from continuum.recovery.fork import detect_fork_candidates
+
+            candidates = tuple(
+                detect_fork_candidates(
+                    action_type=action_type,
+                    tool_input=tool_input,
+                    actions_by_key=actions_by_key,
+                )
+            )
+            message = (
+                f"side effect {action_type!r} with key {rendered!r} has no ledger claim. "
+                f"Call the MCP tool continuum_intercept_action with run_id={run_id!r}, "
+                f"action_type={action_type!r}, key={rendered!r} first, then repeat this call."
+            )
+            if candidates:
+                neighbour = candidates[0]
+                message += (
+                    f" This call resembles journalled action {neighbour.action_id[:14]} "
+                    f"({neighbour.status}, shared tokens: {', '.join(neighbour.shared_tokens[:3])}). "
+                    f"If it is a deliberate new direction, branch it with: "
+                    f"continuum fork {run_id} --reason '<why>' --child <new-run-id>"
+                )
+            return Decision(False, message, fork_candidates=candidates)
+        if action.status is ActionStatus.STARTED:
+            return Decision(True, f"live claim {rendered!r}")
+        if action.status is ActionStatus.COMPLETED:
+            return Decision(
+                False,
+                f"{action_type!r} with key {rendered!r} was already completed"
+                + (f" (external id {action.external_id!r})" if action.external_id else "")
+                + ". Do not repeat it.",
+            )
+        if action.status is ActionStatus.UNKNOWN:
+            return Decision(
+                False,
+                f"{action_type!r} with key {rendered!r} has an unknown outcome. Call "
+                f"continuum_reconcile_action for it before attempting anything further.",
+            )
+        return Decision(
+            False,
+            f"the previous attempt of {action_type!r} with key {rendered!r} is closed "
+            f"(status {action.status.value}). Claim it again "
+            f"through continuum_intercept_action before retrying.",
+        )
 
     from continuum.replayguard import GuardKind
     from continuum.replayguard import evaluate as core_evaluate

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -312,6 +312,7 @@ class RecoveryEngine:
             has_action_ref = any(d["consumed_inputs"]["action_ids"] for d in admissibility.details)
             status = StateStatus.REQUIRES_REVIEW if has_action_ref else StateStatus.STALE
             from continuum.models import Component, ComponentValidationEntry
+
             entries = list(validation.report.statuses)
             entries.append(
                 ComponentValidationEntry(
@@ -322,6 +323,7 @@ class RecoveryEngine:
                 )
             )
             from continuum.models import StateValidationResult
+
             new_report = StateValidationResult(
                 run_id=validation.report.run_id,
                 checkpoint_version=validation.report.checkpoint_version,
@@ -331,6 +333,7 @@ class RecoveryEngine:
                 validated_at=validation.report.validated_at,
             )
             from continuum.state.validator import ValidationOutcome
+
             validation = ValidationOutcome(
                 state=validation.state,
                 report=new_report,
@@ -342,7 +345,9 @@ class RecoveryEngine:
             strict_unknown=self.validator.strict_unknown,
             unprojectable=unprojectable,
         )
-        mode, rationale = self._decide(validation, uncertain, plan, restored, self.strict_unknown, admissibility)
+        mode, rationale = self._decide(
+            validation, uncertain, plan, restored, self.strict_unknown, admissibility
+        )
 
         reason = "; ".join(rationale) if rationale else validation.report.reason
 

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -43,7 +43,13 @@ from continuum.models import (
     utcnow,
 )
 
-__all__ = ["StateValidator", "ValidationOutcome", "validate_state", "AdmissibilityResult", "check_admissibility"]
+__all__ = [
+    "StateValidator",
+    "ValidationOutcome",
+    "validate_state",
+    "AdmissibilityResult",
+    "check_admissibility",
+]
 
 
 #: Statuses that mean the component cannot be relied on as-is.
@@ -122,15 +128,24 @@ def check_admissibility(
         if action.status is not ActionStatus.COMPLETED:
             continue
         ci = action.consumed_inputs
-        if ci.checkpoint_seq == 0 and not ci.event_positions and not ci.component_ids and not ci.action_ids:
+        if (
+            ci.checkpoint_seq == 0
+            and not ci.event_positions
+            and not ci.component_ids
+            and not ci.action_ids
+        ):
             continue
         reasons: list[str] = []
         chain_pos = idx + 1
         if ci.checkpoint_seq > checkpoint.version:
-            reasons.append(f"checkpoint_seq {ci.checkpoint_seq} after checkpoint version {checkpoint.version}")
+            reasons.append(
+                f"checkpoint_seq {ci.checkpoint_seq} after checkpoint version {checkpoint.version}"
+            )
         for pos in ci.event_positions:
             if pos > checkpoint.state.source_sequence:
-                reasons.append(f"event position {pos} after checkpoint source_sequence {checkpoint.state.source_sequence}")
+                reasons.append(
+                    f"event position {pos} after checkpoint source_sequence {checkpoint.state.source_sequence}"
+                )
                 break
         if ci.component_ids:
             for cid in ci.component_ids:
@@ -152,11 +167,16 @@ def check_admissibility(
             )
     if not blocking:
         return AdmissibilityResult(admissible=True, blocking=(), reason="", details=())
-    reason = f"checkpoint v{checkpoint.version} inadmissible: {len(blocking)} blocking commitment(s): " + "; ".join(
-        f"{d['action_id'][:12]} at position {d['chain_position']} ({d['reason']})" for d in details[:3]
+    reason = (
+        f"checkpoint v{checkpoint.version} inadmissible: {len(blocking)} blocking commitment(s): "
+        + "; ".join(
+            f"{d['action_id'][:12]} at position {d['chain_position']} ({d['reason']})"
+            for d in details[:3]
+        )
     )
-    return AdmissibilityResult(admissible=False, blocking=tuple(blocking), reason=reason, details=tuple(details))
-
+    return AdmissibilityResult(
+        admissible=False, blocking=tuple(blocking), reason=reason, details=tuple(details)
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_admissibility_check.py
+++ b/tests/test_admissibility_check.py
@@ -22,7 +22,15 @@ def test_admissible_when_no_consumed_after() -> None:
     store, run_id = _store_with_checkpoint("run_adm_ok")
     ledger = ActionLedger(store, run_id)
     out = ledger.claim("a.do", {"x": 1})
-    ledger.complete(out.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [], "component_ids": [], "action_ids": []})
+    ledger.complete(
+        out.key,
+        consumed_inputs={
+            "checkpoint_seq": 0,
+            "event_positions": [],
+            "component_ids": [],
+            "action_ids": [],
+        },
+    )
     out2 = ledger.claim("a.do2", {"y": 2})
     ledger.complete(out2.key)
     mgr = CheckpointManager(store)
@@ -42,7 +50,15 @@ def test_inadmissible_via_event_position() -> None:
     seq = cp.state.source_sequence
     ledger = ActionLedger(store, run_id)
     out = ledger.claim("a.downstream", {"v": 1})
-    ledger.complete(out.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [seq + 5], "component_ids": [], "action_ids": []})
+    ledger.complete(
+        out.key,
+        consumed_inputs={
+            "checkpoint_seq": 0,
+            "event_positions": [seq + 5],
+            "component_ids": [],
+            "action_ids": [],
+        },
+    )
     restored = mgr.restore(run_id)
     result = check_admissibility(restored.checkpoint, ledger.all())
     assert result.admissible is False
@@ -60,7 +76,15 @@ def test_inadmissible_via_component_id() -> None:
     assert cp is not None
     ledger = ActionLedger(store, run_id)
     out = ledger.claim("a.comp", {})
-    ledger.complete(out.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [], "component_ids": ["decision_unknown"], "action_ids": []})
+    ledger.complete(
+        out.key,
+        consumed_inputs={
+            "checkpoint_seq": 0,
+            "event_positions": [],
+            "component_ids": ["decision_unknown"],
+            "action_ids": [],
+        },
+    )
     restored = mgr.restore(run_id)
     result = check_admissibility(restored.checkpoint, ledger.all())
     assert result.admissible is False
@@ -75,7 +99,15 @@ def test_inadmissible_via_checkpoint_seq() -> None:
     assert cp is not None
     ledger = ActionLedger(store, run_id)
     out = ledger.claim("a.seq", {})
-    ledger.complete(out.key, consumed_inputs={"checkpoint_seq": cp.version + 1, "event_positions": [], "component_ids": [], "action_ids": []})
+    ledger.complete(
+        out.key,
+        consumed_inputs={
+            "checkpoint_seq": cp.version + 1,
+            "event_positions": [],
+            "component_ids": [],
+            "action_ids": [],
+        },
+    )
     restored = mgr.restore(run_id)
     result = check_admissibility(restored.checkpoint, ledger.all())
     assert result.admissible is False
@@ -85,12 +117,20 @@ def test_inadmissible_via_checkpoint_seq() -> None:
 
 def test_engine_maps_event_to_repair() -> None:
     store, run_id = _store_with_checkpoint("run_engine_repair")
-    mgr = CheckpointManager(store)
+    CheckpointManager(store)
     cp = store.latest_checkpoint(run_id)
     assert cp is not None
     ledger = ActionLedger(store, run_id)
     out = ledger.claim("a.repair", {})
-    ledger.complete(out.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [cp.state.source_sequence + 1], "component_ids": [], "action_ids": []})
+    ledger.complete(
+        out.key,
+        consumed_inputs={
+            "checkpoint_seq": 0,
+            "event_positions": [cp.state.source_sequence + 1],
+            "component_ids": [],
+            "action_ids": [],
+        },
+    )
     engine = RecoveryEngine(store)
     decision = engine.assess(run_id)
     assert decision.mode.value == "repair_and_resume"
@@ -101,14 +141,22 @@ def test_engine_maps_event_to_repair() -> None:
 
 def test_engine_maps_action_ids_to_request_human() -> None:
     store, run_id = _store_with_checkpoint("run_engine_human")
-    mgr = CheckpointManager(store)
+    CheckpointManager(store)
     cp = store.latest_checkpoint(run_id)
     assert cp is not None
     ledger = ActionLedger(store, run_id)
     out1 = ledger.claim("a.first", {})
     ledger.complete(out1.key)
     out2 = ledger.claim("a.second", {})
-    ledger.complete(out2.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [], "component_ids": [], "action_ids": [out1.action.action_id]})
+    ledger.complete(
+        out2.key,
+        consumed_inputs={
+            "checkpoint_seq": 0,
+            "event_positions": [],
+            "component_ids": [],
+            "action_ids": [out1.action.action_id],
+        },
+    )
     engine = RecoveryEngine(store)
     decision = engine.assess(run_id)
     assert decision.mode.value == "request_human"

--- a/tests/test_admissibility_e2e.py
+++ b/tests/test_admissibility_e2e.py
@@ -20,15 +20,17 @@ def test_crash_downstream_refused_with_contract() -> None:
     store.append_event(run_id, EventType.RUN_STARTED, {"goal": "e2e admissibility"})
     # some work
     store.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1", "summary": "s"})
-    store.append_event(run_id, EventType.FINDING_ADDED, {"finding_id": "f1", "claim": "c", "evidence": ["ev1"]})
+    store.append_event(
+        run_id, EventType.FINDING_ADDED, {"finding_id": "f1", "claim": "c", "evidence": ["ev1"]}
+    )
     mgr = CheckpointManager(store)
     cp1 = mgr.checkpoint(run_id)
     assert cp1 is not None
-    seq1 = cp1.state.source_sequence
-    ver1 = cp1.version
     # more work after checkpoint
     store.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev2", "summary": "s2"})
-    store.append_event(run_id, EventType.FINDING_ADDED, {"finding_id": "f2", "claim": "c2", "evidence": ["ev2"]})
+    store.append_event(
+        run_id, EventType.FINDING_ADDED, {"finding_id": "f2", "claim": "c2", "evidence": ["ev2"]}
+    )
     # checkpoint again to have a later checkpoint that is still before downstream
     cp2 = mgr.checkpoint(run_id)
     assert cp2 is not None

--- a/tests/test_admissibility_inputs.py
+++ b/tests/test_admissibility_inputs.py
@@ -42,7 +42,7 @@ def test_old_row_without_consumed_inputs_is_admissible() -> None:
 
 def test_old_event_without_field_survives_fold() -> None:
     store = _new_store_with_run("run_old")
-    ledger = ActionLedger(store, "run_old")
+    ActionLedger(store, "run_old")
     # Manually craft an ACTION_RECORDED event whose action dict lacks consumed_inputs
     action = Action(run_id="run_old", action_type="a.do", status=ActionStatus.COMPLETED)
     raw_payload = action.model_dump(mode="json")
@@ -123,7 +123,11 @@ def test_empty_consumed_inputs_is_valid() -> None:
 
     # Also via dict form with empty lists
     a2 = Action.model_validate(
-        {"run_id": "r", "action_type": "t", "consumed_inputs": {"checkpoint_seq": 0, "event_positions": [], "action_ids": []}}
+        {
+            "run_id": "r",
+            "action_type": "t",
+            "consumed_inputs": {"checkpoint_seq": 0, "event_positions": [], "action_ids": []},
+        }
     )
     assert a2.consumed_inputs == empty
 
@@ -133,13 +137,18 @@ def test_complete_accepts_both_mapping_and_model() -> None:
     ledger = ActionLedger(store, "run_both")
     outcome = ledger.claim("a.do", {}, key="k-both")
     # Mapping form
-    ledger.complete(outcome.key, consumed_inputs={"checkpoint_seq": 1, "event_positions": [], "action_ids": []})
+    ledger.complete(
+        outcome.key, consumed_inputs={"checkpoint_seq": 1, "event_positions": [], "action_ids": []}
+    )
     fetched = ledger.get(outcome.key)
     assert fetched is not None
     assert fetched.consumed_inputs.checkpoint_seq == 1
 
     # Model form (update on already completed)
-    ledger.complete(outcome.key, consumed_inputs=ConsumedInputs(checkpoint_seq=9, event_positions=[9], action_ids=["a1"]))
+    ledger.complete(
+        outcome.key,
+        consumed_inputs=ConsumedInputs(checkpoint_seq=9, event_positions=[9], action_ids=["a1"]),
+    )
     refetched = ledger.get(outcome.key)
     assert refetched is not None
     assert refetched.consumed_inputs.checkpoint_seq == 9
@@ -170,11 +179,17 @@ def test_complete_validates_invalid_consumed_inputs() -> None:
     store = _new_store_with_run("run_val")
     ledger = ActionLedger(store, "run_val")
     outcome = ledger.claim("a.do", {}, key="k-val")
-    with pytest.raises(Exception):
-        ledger.complete(outcome.key, consumed_inputs={"checkpoint_seq": -5, "event_positions": [], "action_ids": []})
+    with pytest.raises(Exception):  # noqa: B017
+        ledger.complete(
+            outcome.key,
+            consumed_inputs={"checkpoint_seq": -5, "event_positions": [], "action_ids": []},
+        )
     # Also via action_ids too long
-    with pytest.raises(Exception):
-        ledger.complete(outcome.key, consumed_inputs={"checkpoint_seq": 0, "event_positions": [], "action_ids": [""]})
+    with pytest.raises(Exception):  # noqa: B017
+        ledger.complete(
+            outcome.key,
+            consumed_inputs={"checkpoint_seq": 0, "event_positions": [], "action_ids": [""]},
+        )
     store.close()
 
 

--- a/tests/test_memory_gate_keys.py
+++ b/tests/test_memory_gate_keys.py
@@ -1,0 +1,311 @@
+"""Memory-store gate key convention (issue #565, parent #304).
+
+Tenancy and cross-run dedup are the two properties the key convention must
+deliver: the same (store_id, tenant, record_key) triple is one identity no
+matter which run wrote it, and the same record_key under a different tenant
+is a different identity.
+
+These tests pin the documented example ``mem:{store_id}:{tenant}:{record_key}``
+for pgvector and Mem0 against the real ledger and gate, including the
+``action_index`` foreign lookup that catches a double-write from a later run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.actions.ledger import ActionLedger, fold_action_events
+from continuum.events import EventType
+from continuum.gate import (
+    MEMORY_KEY_PREFIX,
+    GateConfigError,
+    derive_memory_key,
+    is_memory_key,
+    is_memory_template,
+    load_gate_config,
+    render_key,
+)
+from continuum.gate import decide as gate_decide
+from continuum.models import ActionStatus, Run
+from continuum.storage import SQLiteStorage
+
+CONFIG = {
+    "tools": {
+        "pgvector.upsert": {
+            "key_template": "mem:{store_id}:{tenant}:{record_key}",
+            "action_type": "mem_write",
+        },
+        "mem0.write": {
+            "key_template": "mem:{store_id}:{tenant}:{record_key}",
+            "action_type": "mem_write",
+        },
+        "mem_write": {
+            "key_template": "mem:{store_id}:{tenant}:{record_key}",
+        },
+    }
+}
+
+
+def _fold(db: SQLiteStorage, run_id: str) -> dict[str, object]:
+    return fold_action_events(db.read_events(run_id))
+
+
+# --- helpers: template and derive contract --------------------------------- #
+
+
+def test_is_memory_template_and_key_helpers() -> None:
+    assert is_memory_template("mem:{store_id}:{tenant}:{record_key}") is True
+    assert is_memory_template("invoice:{id}") is False
+    assert is_memory_key("mem:pgvector:acme:rec-1") is True
+    assert is_memory_key("invoice:acme:7") is False
+    assert MEMORY_KEY_PREFIX == "mem:"
+
+
+def test_derive_memory_key_strips_whitespace() -> None:
+    rendered = derive_memory_key(
+        {"store_id": " pgvector_main ", "tenant": " acme\n", "record_key": " rec-42 "},
+    )
+    assert rendered == "mem:pgvector_main:acme:rec-42"
+    # Same triple with clean values must render identically.
+    clean = derive_memory_key(
+        {"store_id": "pgvector_main", "tenant": "acme", "record_key": "rec-42"},
+    )
+    assert rendered == clean
+
+
+def test_render_key_for_memory_template() -> None:
+    rendered = render_key(
+        "mem:{store_id}:{tenant}:{record_key}",
+        {"store_id": "mem0", "tenant": "acme", "record_key": "user-pref-7"},
+    )
+    assert rendered == "mem:mem0:acme:user-pref-7"
+
+
+def test_load_gate_config_rejects_memory_template_missing_tenant(tmp_path: Path) -> None:
+    bad = tmp_path / "gate.json"
+    bad.write_text(
+        json.dumps(
+            {
+                "tools": {
+                    "pgvector.upsert": {
+                        "key_template": "mem:{store_id}:{record_key}",
+                        "action_type": "mem_write",
+                    }
+                }
+            }
+        )
+    )
+    with pytest.raises(GateConfigError, match="must include placeholders"):
+        load_gate_config(bad)
+
+
+def test_load_gate_config_accepts_documented_example(tmp_path: Path) -> None:
+    example = tmp_path / "gate.json"
+    example.write_text(json.dumps(CONFIG))
+    loaded = load_gate_config(example)
+    assert loaded is not None
+    assert "pgvector.upsert" in loaded
+    assert loaded["pgvector.upsert"]["key_template"] == "mem:{store_id}:{tenant}:{record_key}"
+
+
+# --- ledger: cross-run dedup via action_index ------------------------------ #
+
+
+def test_same_record_same_tenant_dedupes_locally(tmp_path: Path) -> None:
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(store, "run_1")
+        rendered = "mem:pgvector_main:acme:rec-42"
+        first = ledger.claim("mem_write", {}, key=rendered, scoped_to_run=False)
+        assert first.fresh is True
+        ledger.complete(first.key, external_id="rec-42")
+        folded = fold_action_events(store.read_events("run_1"))
+        decision = gate_decide(
+            CONFIG["tools"],
+            "pgvector.upsert",
+            {"store_id": "pgvector_main", "tenant": "acme", "record_key": "rec-42"},
+            run_id="run_1",
+            actions_by_key=folded,
+        )
+        assert decision.allow is False
+        assert "already completed" in decision.reason
+
+
+def test_same_record_same_tenant_dedupes_cross_run_via_index(tmp_path: Path) -> None:
+    """The ledger's action_index catches a double-write from a later run.
+
+    Run_1 completes ``mem:pgvector_main:acme:rec-42`` with a global key.
+    Run_2's local log is empty, but the gate consults ``storage.foreign_action``
+    for mem keys, so the duplicate is still denied. This is the property the
+    memory governance guide promises.
+    """
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        for rid in ("run_1", "run_2"):
+            store.create_run(Run(run_id=rid, goal="g"))
+            store.append_event(rid, EventType.RUN_STARTED, {"goal": "g"})
+        # Run_1 writes and completes the record globally.
+        a = ActionLedger(store, "run_1")
+        rendered = "mem:pgvector_main:acme:rec-42"
+        first = a.claim("mem_write", {}, key=rendered, scoped_to_run=False)
+        a.complete(first.key, external_id="rec-42")
+        # Run_2 attempts the same triple. Its local fold is empty.
+        folded_run2 = fold_action_events(store.read_events("run_2"))
+        assert folded_run2 == {}
+        # Without storage, the gate sees no local claim and would deny as
+        # unclaimed, not as duplicate. With storage, it finds the foreign
+        # completion and reports already completed --- the cross-run dedup.
+        no_store = gate_decide(
+            CONFIG["tools"],
+            "pgvector.upsert",
+            {"store_id": "pgvector_main", "tenant": "acme", "record_key": "rec-42"},
+            run_id="run_2",
+            actions_by_key=folded_run2,
+        )
+        assert no_store.allow is False
+        assert "has no ledger claim" in no_store.reason
+        with_store = gate_decide(
+            CONFIG["tools"],
+            "pgvector.upsert",
+            {"store_id": "pgvector_main", "tenant": "acme", "record_key": "rec-42"},
+            run_id="run_2",
+            actions_by_key=folded_run2,
+            storage=store,
+        )
+        assert with_store.allow is False
+        assert "already completed" in with_store.reason
+
+
+def test_ledger_cross_run_dedup_without_gate(tmp_path: Path) -> None:
+    """Direct ledger claim with global scope dedupes without any gate.
+
+    This is the underlying guarantee the gate builds on: the same global
+    idempotency key claimed in run_2 returns fresh=False when run_1 already
+    completed it, via the action_index foreign lookup.
+    """
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        for rid in ("run_1", "run_2"):
+            store.create_run(Run(run_id=rid, goal="g"))
+            store.append_event(rid, EventType.RUN_STARTED, {"goal": "g"})
+        a = ActionLedger(store, "run_1")
+        b = ActionLedger(store, "run_2")
+        rendered = "mem:mem0:acme:user-pref-7"
+        first = a.claim("mem_write", {}, key=rendered, scoped_to_run=False)
+        a.complete(first.key, external_id="user-pref-7")
+        second = b.claim("mem_write", {}, key=rendered, scoped_to_run=False)
+        assert second.fresh is False
+        assert second.action.external_id == "user-pref-7"
+        assert second.action.status is ActionStatus.COMPLETED
+
+
+def test_different_tenant_same_record_does_not_dedupe(tmp_path: Path) -> None:
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(store, "run_1")
+        first = ledger.claim(
+            "mem_write", {}, key="mem:pgvector_main:acme:rec-42", scoped_to_run=False
+        )
+        ledger.complete(first.key, external_id="rec-42")
+        folded = fold_action_events(store.read_events("run_1"))
+        # Same record_key but different tenant renders a different key.
+        decision = gate_decide(
+            CONFIG["tools"],
+            "pgvector.upsert",
+            {"store_id": "pgvector_main", "tenant": "globex", "record_key": "rec-42"},
+            run_id="run_1",
+            actions_by_key=folded,
+        )
+        assert decision.allow is False
+        assert "has no ledger claim" in decision.reason
+        # Claiming the different-tenant key is fresh.
+        second = ledger.claim(
+            "mem_write", {}, key="mem:pgvector_main:globex:rec-42", scoped_to_run=False
+        )
+        assert second.fresh is True
+
+
+def test_different_tenant_cross_run_does_not_dedupe(tmp_path: Path) -> None:
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        for rid in ("run_1", "run_2"):
+            store.create_run(Run(run_id=rid, goal="g"))
+            store.append_event(rid, EventType.RUN_STARTED, {"goal": "g"})
+        a = ActionLedger(store, "run_1")
+        first = a.claim("mem_write", {}, key="mem:pgvector_main:acme:rec-42", scoped_to_run=False)
+        a.complete(first.key, external_id="rec-42")
+        # Run_2 writes same record_key under a different tenant: must be fresh.
+        b = ActionLedger(store, "run_2")
+        second = b.claim(
+            "mem_write", {}, key="mem:pgvector_main:globex:rec-42", scoped_to_run=False
+        )
+        assert second.fresh is True
+        folded2 = fold_action_events(store.read_events("run_2"))
+        decision = gate_decide(
+            CONFIG["tools"],
+            "pgvector.upsert",
+            {"store_id": "pgvector_main", "tenant": "globex", "record_key": "rec-42"},
+            run_id="run_2",
+            actions_by_key=folded2,
+            storage=store,
+        )
+        # The globex key has a local STARTED claim, so it is allowed.
+        assert decision.allow is True
+
+
+def test_padded_tenant_still_hits_same_key(tmp_path: Path) -> None:
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(store, "run_1")
+        first = ledger.claim(
+            "mem_write", {}, key="mem:pgvector_main:acme:rec-42", scoped_to_run=False
+        )
+        ledger.complete(first.key, external_id="rec-42")
+        folded = fold_action_events(store.read_events("run_1"))
+        decision = gate_decide(
+            CONFIG["tools"],
+            "pgvector.upsert",
+            {"store_id": "pgvector_main", "tenant": " acme ", "record_key": "rec-42"},
+            run_id="run_1",
+            actions_by_key=folded,
+        )
+        assert decision.allow is False
+        assert "already completed" in decision.reason
+
+
+def test_gateway_derived_key_matches_gate(tmp_path: Path) -> None:
+    """The gateway normalizes the same way the gate does (issue #361).
+
+    Both seams share ``normalize_key_value``, so a padded tenant renders the
+    same mem key wherever it is derived.
+    """
+    from continuum.gateway import render_key as gw_render
+
+    body = {"store_id": "pgvector_main", "tenant": " acme ", "record_key": "rec-42"}
+    gate_rendered = render_key("mem:{store_id}:{tenant}:{record_key}", body)
+    gw_rendered = gw_render("mem:{store_id}:{tenant}:{record_key}", body)
+    assert gate_rendered == gw_rendered == "mem:pgvector_main:acme:rec-42"
+
+
+def test_scoped_non_memory_keys_do_not_cross_run_dedupe(tmp_path: Path) -> None:
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        for rid in ("run_1", "run_2"):
+            store.create_run(Run(run_id=rid, goal="g"))
+            store.append_event(rid, EventType.RUN_STARTED, {"goal": "g"})
+        a = ActionLedger(store, "run_1")
+        first = a.claim("send_invoice", {}, key="invoice:7", scoped_to_run=True)
+        a.complete(first.key, external_id="INV-7")
+        # Same key but run-scoped: run_2's claim is fresh, not a duplicate.
+        b = ActionLedger(store, "run_2")
+        second = b.claim("send_invoice", {}, key="invoice:7", scoped_to_run=True)
+        assert second.fresh is True


### PR DESCRIPTION
## Description
Governs memory-store mutations (pgvector, Mem0, Letta) as claimed, tenant-scoped side effects. Implements the documented key convention `mem:{store_id}:{tenant}:{record_key}` so the ledger can deduplicate, scope to tenant, and enumerate for erasure. This is the control plane, not a memory system.

Changes:
- `src/continuum/gate.py`: adds `MEMORY_KEY_PREFIX`, `MEMORY_REQUIRED_FIELDS`, helpers `is_memory_template`, `is_memory_key`, `derive_memory_key`; validates memory templates require store_id, tenant, record_key; derives global ledger keys (`scope=None`) for `mem:` identities and consults `action_index` for cross-run dedup via `storage.foreign_action`.
- `.continuum/gate.json.example`: worked pgvector and Mem0 examples (`pgvector.upsert`, `pgvector.delete`, `mem0.write`, `mem0.delete`, `mem_write`).
- `docs/guides/memory-governance.md` (and underscore alias): full guide covering key convention, tenant isolation, cross-run dedup, registration, claim flow, gateway parity, pgvector/Mem0 walkthroughs, poisoning forensics, and limitations.

## Related issues
Fixes #565
Parent #304

## Types of changes
- Type: `feature`

## Breaking changes
No

## How has this been tested?
```bash
pytest tests/test_memory_gate_keys.py -q  # 13 passed
pytest -q  # 1823 passed, 24 skipped, 1 flaky (concurrency lease) re-passed on retry
ruff check src/ tests/  # All checks passed
ruff format --check src/ tests/  # 250 files formatted
mypy src/continuum --ignore-missing-imports  # Success, no issues in 114 files
```

Verified:
- same triple same tenant dedupes locally and cross-run via index
- different tenant same record_key does not dedupe (local and cross-run)
- padded whitespace normalizes to same key via `normalize_key_value`
- gateway render matches gate render
- non-memory scoped keys do not cross-run dedupe

## Checklist
Tests added. Docs updated. CI passes. Limitations stated in guide (direct DB credentials bypass, identity not truth, no recall quality).

## Additional context
Tenant is the namespace in the spec, stored as `tenant` placeholder. Memory keys use global scope so `action_index` catches double-writes from later runs. See `docs/guides/memory-governance.md` for verification steps and `rg -n "\\u2014" src/ tests/ docs/` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added governance for long-term memory writes across supported memory stores.
  * Memory records now use consistent store, tenant, and record identifiers.
  * Duplicate writes are prevented across runs while keeping tenants isolated.
  * Added an example configuration for memory upsert and delete actions.

* **Documentation**
  * Added a guide covering memory registration, tenancy enforcement, provenance, deduplication, poisoning investigations, erasure workflows, and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->