### PR TITLE
feat: provenance DAG projector and CLI rendering with Origin

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -62,6 +62,7 @@ from continuum.models import (
     StateStatus,
 )
 from continuum.observability import render_dashboard
+from continuum.provenance.graph import build_provenance_graph, downstream_of
 from continuum.provenance_map import summarize
 from continuum.recovery import RecoveryEngine, render_contract
 from continuum.security.attestation import (
@@ -673,6 +674,74 @@ def cmd_events(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         as_json=args.json,
         stream=out,
     )
+    return ExitCode.OK
+
+
+def cmd_provenance(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Show provenance DAG with per-node Origin (issue #552). Read-only."""
+    storage.get_run(args.run_id)
+    events = storage.read_events(args.run_id)
+    graph = build_provenance_graph(events)
+    if getattr(args, "json", False):
+        payload = graph.to_dict()
+        payload["run_id"] = args.run_id
+        _emit(payload, "", as_json=True, stream=out)
+        return ExitCode.OK
+    lines = [
+        f"run: {args.run_id}  (provenance DAG)",
+        f"nodes: {len(graph.nodes)}  edges: {sum(len(v) for v in graph.edges.values())}",
+    ]
+    for node in sorted(graph.nodes.values(), key=lambda n: n.sequence):
+        parents = graph.reverse_edges.get(node.event_id, [])
+        children = graph.edges.get(node.event_id, [])
+        parents_str = ",".join(p[:8] for p in parents) if parents else "-"
+        children_str = ",".join(c[:8] for c in children) if children else "-"
+        lines.append(
+            f"  {node.sequence:>3}  {node.type.value:<18} {node.event_id[:8]}  origin={node.origin.value}  parents={parents_str}  children={children_str}  {node.label}"
+        )
+    _emit({}, "\n".join(lines), as_json=False, stream=out, palette=getattr(args, "_palette", None))
+    return ExitCode.OK
+
+
+def cmd_impact(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Show downstream impact of an evidence item (issue #552). Read-only."""
+    storage.get_run(args.run_id)
+    evidence_id = getattr(args, "evidence", None)
+    if not evidence_id:
+        print("error: --evidence is required", file=err)
+        return ExitCode.ERROR
+    events = storage.read_events(args.run_id)
+    graph = build_provenance_graph(events)
+    downstream = downstream_of(graph, evidence_id)
+    if getattr(args, "json", False):
+        payload = {
+            "run_id": args.run_id,
+            "evidence": evidence_id,
+            "downstream": [
+                {
+                    "event_id": n.event_id,
+                    "sequence": n.sequence,
+                    "type": n.type.value,
+                    "origin": n.origin.value,
+                    "label": n.label,
+                }
+                for n in downstream
+            ],
+        }
+        _emit(payload, "", as_json=True, stream=out)
+        return ExitCode.OK
+    if not downstream:
+        _emit({}, f"no downstream artefacts for {evidence_id!r}", as_json=False, stream=out)
+        return ExitCode.OK
+    lines = [
+        f"run: {args.run_id}  impact of {evidence_id!r}",
+        f"downstream: {len(downstream)} node(s)",
+    ]
+    for node in downstream:
+        lines.append(
+            f"  {node.sequence:>3}  {node.type.value:<18} {node.event_id[:8]}  origin={node.origin.value}  {node.label}"
+        )
+    _emit({}, "\n".join(lines), as_json=False, stream=out, palette=getattr(args, "_palette", None))
     return ExitCode.OK
 
 

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -2996,6 +2996,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     with_run(add("history", cmd_history, "List state versions and checkpoints."))
 
+    provenance = with_run(add("provenance", cmd_provenance, "Show provenance DAG. Read-only."))
+    impact = with_run(
+        add("impact", cmd_impact, "Show downstream impact of an evidence item. Read-only.")
+    )
+    impact.add_argument(
+        "--evidence", required=True, help="evidence event id or payload evidence_id"
+    )
+
     events = with_run(add("events", cmd_events, "List recorded events."))
     events.add_argument("--after", type=int, default=0)
     events.add_argument("--upto", type=int, default=None)

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -2996,7 +2996,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     with_run(add("history", cmd_history, "List state versions and checkpoints."))
 
-    provenance = with_run(add("provenance", cmd_provenance, "Show provenance DAG. Read-only."))
+    with_run(add("provenance", cmd_provenance, "Show provenance DAG. Read-only."))
     impact = with_run(
         add("impact", cmd_impact, "Show downstream impact of an evidence item. Read-only.")
     )

--- a/src/continuum/provenance/__init__.py
+++ b/src/continuum/provenance/__init__.py
@@ -1,0 +1,10 @@
+"""Provenance DAG package (issue #552)."""
+
+from continuum.provenance.graph import (
+    ProvenanceGraph,
+    ProvenanceNode,
+    build_provenance_graph,
+    downstream_of,
+)
+
+__all__ = ["ProvenanceGraph", "ProvenanceNode", "build_provenance_graph", "downstream_of"]

--- a/src/continuum/provenance/graph.py
+++ b/src/continuum/provenance/graph.py
@@ -183,9 +183,7 @@ def downstream_of(graph: ProvenanceGraph, evidence_id: str) -> list[ProvenanceNo
             or node.payload.get("finding_id")
             or node.payload.get("decision_id")
         )
-        if pid == evidence_id:
-            start_ids.append(node.event_id)
-        elif node.payload.get("evidence_id") == evidence_id:
+        if pid == evidence_id or node.payload.get("evidence_id") == evidence_id:
             start_ids.append(node.event_id)
     result: list[ProvenanceNode] = []
     seen: set[str] = set()

--- a/src/continuum/provenance/graph.py
+++ b/src/continuum/provenance/graph.py
@@ -17,7 +17,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import Any
 
-from continuum.events import Event, EventType
+from continuum.events import EventType
 from continuum.models import Origin, StateStatus
 
 __all__ = [
@@ -54,7 +54,13 @@ class ProvenanceNode:
     @property
     def label(self) -> str:
         """Human label for CLI rendering."""
-        pid = self.payload.get("evidence_id") or self.payload.get("finding_id") or self.payload.get("decision_id") or self.payload.get("action_id") or self.event_id[:8]
+        pid = (
+            self.payload.get("evidence_id")
+            or self.payload.get("finding_id")
+            or self.payload.get("decision_id")
+            or self.payload.get("action_id")
+            or self.event_id[:8]
+        )
         return f"{self.type.value}:{pid}"
 
 
@@ -172,7 +178,11 @@ def downstream_of(graph: ProvenanceGraph, evidence_id: str) -> list[ProvenanceNo
     # payload id match
     start_ids: list[str] = []
     for node in graph.nodes.values():
-        pid = node.payload.get("evidence_id") or node.payload.get("finding_id") or node.payload.get("decision_id")
+        pid = (
+            node.payload.get("evidence_id")
+            or node.payload.get("finding_id")
+            or node.payload.get("decision_id")
+        )
         if pid == evidence_id:
             start_ids.append(node.event_id)
         elif node.payload.get("evidence_id") == evidence_id:

--- a/src/continuum/provenance/graph.py
+++ b/src/continuum/provenance/graph.py
@@ -1,0 +1,187 @@
+"""Provenance DAG projector for claim-level causal graph (issue #552).
+
+Builds a read-only DAG from events where DECISION_CREATED and ACTION_RECORDED
+carry ``caused_by: list[event_id]`` edges. Nodes are hash-chained events of
+types EVIDENCE_ADDED, FINDING_ADDED, DECISION_CREATED, ACTION_RECORDED.
+Edges are caller-declared, never inferred. The graph is a pure fold over
+events, so it survives compaction when the caller supplies archived rows.
+
+Each node carries per-node Origin (DETERMINISTIC, EXTERNAL_AGENT, HUMAN) and
+a best-effort StateStatus (VALID unless the event payload itself says otherwise).
+Staleness propagation (issue #553) will later mark downstream nodes via BFS.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+from continuum.events import Event, EventType
+from continuum.models import Origin, StateStatus
+
+__all__ = [
+    "ProvenanceNode",
+    "ProvenanceGraph",
+    "build_provenance_graph",
+    "downstream_of",
+]
+
+
+#: Event types that become graph nodes. Others are ignored for the DAG view.
+_NODE_TYPES = frozenset(
+    {
+        EventType.EVIDENCE_ADDED,
+        EventType.FINDING_ADDED,
+        EventType.DECISION_CREATED,
+        EventType.ACTION_RECORDED,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProvenanceNode:
+    """One node in the provenance DAG."""
+
+    event_id: str
+    sequence: int
+    type: EventType
+    origin: Origin
+    status: StateStatus = StateStatus.VALID
+    caused_by: tuple[str, ...] = ()
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def label(self) -> str:
+        """Human label for CLI rendering."""
+        pid = self.payload.get("evidence_id") or self.payload.get("finding_id") or self.payload.get("decision_id") or self.payload.get("action_id") or self.event_id[:8]
+        return f"{self.type.value}:{pid}"
+
+
+@dataclass(slots=True)
+class ProvenanceGraph:
+    """Directed acyclic graph of provenance events."""
+
+    nodes: dict[str, ProvenanceNode] = field(default_factory=dict)
+    edges: dict[str, list[str]] = field(default_factory=dict)
+    reverse_edges: dict[str, list[str]] = field(default_factory=dict)
+
+    def add_node(self, node: ProvenanceNode) -> None:
+        self.nodes[node.event_id] = node
+        self.edges.setdefault(node.event_id, [])
+        self.reverse_edges.setdefault(node.event_id, [])
+
+    def add_edge(self, parent_id: str, child_id: str) -> None:
+        if parent_id not in self.nodes or child_id not in self.nodes:
+            return
+        if child_id not in self.edges.get(parent_id, []):
+            self.edges.setdefault(parent_id, []).append(child_id)
+        if parent_id not in self.reverse_edges.get(child_id, []):
+            self.reverse_edges.setdefault(child_id, []).append(parent_id)
+
+    def downstream(self, start_id: str) -> list[str]:
+        """BFS downstream from start_id, including direct and transitive children."""
+        if start_id not in self.nodes:
+            return []
+        visited: set[str] = set()
+        queue: deque[str] = deque([start_id])
+        result: list[str] = []
+        while queue:
+            current = queue.popleft()
+            for child in self.edges.get(current, []):
+                if child not in visited:
+                    visited.add(child)
+                    result.append(child)
+                    queue.append(child)
+        return result
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise for --json output."""
+        return {
+            "nodes": [
+                {
+                    "event_id": n.event_id,
+                    "sequence": n.sequence,
+                    "type": n.type.value,
+                    "origin": n.origin.value,
+                    "status": n.status.value,
+                    "caused_by": list(n.caused_by),
+                    "payload": dict(n.payload),
+                    "parents": list(self.reverse_edges.get(n.event_id, [])),
+                    "children": list(self.edges.get(n.event_id, [])),
+                }
+                for n in sorted(self.nodes.values(), key=lambda x: x.sequence)
+            ],
+            "edges": [
+                {"from": parent, "to": child}
+                for parent, children in self.edges.items()
+                for child in children
+            ],
+        }
+
+
+def build_provenance_graph(events: Any) -> ProvenanceGraph:
+    """Fold events into a DAG.
+
+    Only events of type in _NODE_TYPES become nodes. Edges are taken from
+    payload ``caused_by`` when present and referencing a known node. Unknown
+    ``caused_by`` ids are ignored (they were refused at write time, but old
+    events may have been written before validation).
+
+    The fold is deterministic and hash-stable: same events yield same graph.
+    """
+    graph = ProvenanceGraph()
+    # First pass: nodes
+    for ev in sorted(events, key=lambda e: e.sequence):
+        if ev.type not in _NODE_TYPES:
+            continue
+        caused_by = ev.payload.get("caused_by") if isinstance(ev.payload, dict) else None
+        if not isinstance(caused_by, list):
+            caused_by = []
+        # filter to strings only
+        caused_by_t = tuple(str(x) for x in caused_by if isinstance(x, str) and x)
+        node = ProvenanceNode(
+            event_id=ev.event_id,
+            sequence=ev.sequence,
+            type=ev.type,
+            origin=ev.source,
+            status=StateStatus.VALID,
+            caused_by=caused_by_t,
+            payload=dict(ev.payload) if isinstance(ev.payload, dict) else {},
+        )
+        graph.add_node(node)
+    # Second pass: edges
+    for node in list(graph.nodes.values()):
+        for parent_id in node.caused_by:
+            if parent_id in graph.nodes:
+                graph.add_edge(parent_id, node.event_id)
+    return graph
+
+
+def downstream_of(graph: ProvenanceGraph, evidence_id: str) -> list[ProvenanceNode]:
+    """Return downstream nodes for a given evidence payload id or event id.
+
+    ``evidence_id`` may be an event_id or a payload evidence_id (e.g. "ev1").
+    The function resolves both: first tries event_id, then scans payloads for
+    matching evidence_id / finding_id / decision_id.
+    """
+    # direct event id match
+    if evidence_id in graph.nodes:
+        downstream_ids = graph.downstream(evidence_id)
+        return [graph.nodes[did] for did in downstream_ids]
+    # payload id match
+    start_ids: list[str] = []
+    for node in graph.nodes.values():
+        pid = node.payload.get("evidence_id") or node.payload.get("finding_id") or node.payload.get("decision_id")
+        if pid == evidence_id:
+            start_ids.append(node.event_id)
+        elif node.payload.get("evidence_id") == evidence_id:
+            start_ids.append(node.event_id)
+    result: list[ProvenanceNode] = []
+    seen: set[str] = set()
+    for sid in start_ids:
+        for did in graph.downstream(sid):
+            if did not in seen:
+                seen.add(did)
+                result.append(graph.nodes[did])
+    return result

--- a/src/continuum/state/provenance_graph.py
+++ b/src/continuum/state/provenance_graph.py
@@ -1,0 +1,10 @@
+"""Wrapper for provenance graph (compatibility, issue #552)."""
+
+from continuum.provenance.graph import (
+    ProvenanceGraph,
+    ProvenanceNode,
+    build_provenance_graph,
+    downstream_of,
+)
+
+__all__ = ["ProvenanceGraph", "ProvenanceNode", "build_provenance_graph", "downstream_of"]

--- a/tests/test_provenance_graph.py
+++ b/tests/test_provenance_graph.py
@@ -1,0 +1,170 @@
+"""Provenance DAG projector tests (issue #552)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.provenance.graph import build_provenance_graph, downstream_of
+from continuum.storage.sqlite import SQLiteStorage
+
+# Use CLI helper from tests
+from tests.test_cli import run_cli  # type: ignore
+
+try:
+    from tests.test_cli import run as _run_cli  # fallback
+except ImportError:
+    _run_cli = None
+
+
+def _run(*args: str, db: str | None = None):
+    """Helper to run continuum CLI via subprocess."""
+    cmd = (
+        [sys.executable, "-m", "continuum.cli", "--db", db] + list(args)
+        if db
+        else [sys.executable, "-m", "continuum.cli"] + list(args)
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.returncode, result.stdout, result.stderr
+
+
+def test_build_graph_with_caused_by_edges():
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_prov_1"
+    storage.create_run(Run(run_id=run_id, goal="test"))
+    ev = storage.append_event(
+        run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1", "summary": "s"}
+    )
+    find = storage.append_event(
+        run_id, EventType.FINDING_ADDED, {"finding_id": "f1", "claim": "c", "evidence": ["ev1"]}
+    )
+    # decision caused by evidence
+    dec = storage.append_event(
+        run_id,
+        EventType.DECISION_CREATED,
+        {"decision": "d1", "decision_id": "dec1", "caused_by": [ev.event_id]},
+    )
+    # action caused by decision
+    act = storage.append_event(
+        run_id,
+        EventType.ACTION_RECORDED,
+        {"action_type": "send", "action_id": "act1", "caused_by": [dec.event_id]},
+    )
+    events = storage.read_events(run_id)
+    graph = build_provenance_graph(events)
+    assert len(graph.nodes) == 4
+    # edges: ev -> dec, dec -> act
+    assert act.event_id in graph.edges.get(dec.event_id, [])
+    assert dec.event_id in graph.edges.get(ev.event_id, [])
+    # downstream of ev should include dec and act (transitive)
+    downstream = graph.downstream(ev.event_id)
+    assert dec.event_id in downstream
+    assert act.event_id in downstream
+    # downstream via helper
+    ds_nodes = downstream_of(graph, ev.event_id)
+    assert any(n.event_id == dec.event_id for n in ds_nodes)
+    assert any(n.event_id == act.event_id for n in ds_nodes)
+
+
+def test_downstream_via_payload_evidence_id():
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_prov_2"
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    ev = storage.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev_payload_1"})
+    dec = storage.append_event(
+        run_id,
+        EventType.DECISION_CREATED,
+        {"decision": "d", "decision_id": "dec2", "caused_by": [ev.event_id]},
+    )
+    events = storage.read_events(run_id)
+    graph = build_provenance_graph(events)
+    # downstream via payload evidence_id "ev_payload_1"
+    ds = downstream_of(graph, "ev_payload_1")
+    assert any(n.event_id == dec.event_id for n in ds)
+
+
+def test_graph_nodes_carry_origin():
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_prov_origin"
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    ev = storage.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
+    dec = storage.append_event(
+        run_id, EventType.DECISION_CREATED, {"decision": "d", "caused_by": [ev.event_id]}
+    )
+    graph = build_provenance_graph(storage.read_events(run_id))
+    for node in graph.nodes.values():
+        assert node.origin is not None
+        assert node.origin.value in ("deterministic", "external_agent", "human", "llm", "imported")
+
+
+def test_cli_provenance_json(tmp_path: Path):
+    db = str(tmp_path / "prov.db")
+    storage = SQLiteStorage(db)
+    run_id = "run_cli_prov"
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    ev = storage.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
+    storage.append_event(
+        run_id, EventType.DECISION_CREATED, {"decision": "d", "caused_by": [ev.event_id]}
+    )
+    storage.close()
+    code, out, err = _run("provenance", run_id, "--json", db=db)
+    # try alternative helper if above fails
+    if code != 0:
+        # Use test_cli run helper with db param
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "-m", "continuum.cli", "--db", db, "--json", "provenance", run_id],
+            capture_output=True,
+            text=True,
+        )
+        code, out = result.returncode, result.stdout
+    assert code == 0, err
+    payload = json.loads(out)
+    assert payload["run_id"] == run_id
+    assert "nodes" in payload
+    assert len(payload["nodes"]) >= 2
+    for n in payload["nodes"]:
+        assert "origin" in n
+        assert "event_id" in n
+
+
+def test_cli_impact_json(tmp_path: Path):
+    db = str(tmp_path / "impact.db")
+    storage = SQLiteStorage(db)
+    run_id = "run_cli_impact"
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    ev = storage.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
+    dec = storage.append_event(
+        run_id, EventType.DECISION_CREATED, {"decision": "d", "caused_by": [ev.event_id]}
+    )
+    storage.close()
+    code, out, err = _run("impact", run_id, "--evidence", ev.event_id, "--json", db=db)
+    if code != 0:
+        import subprocess
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "continuum.cli",
+                "--db",
+                db,
+                "--json",
+                "impact",
+                run_id,
+                "--evidence",
+                ev.event_id,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        code, out = result.returncode, result.stdout
+    assert code == 0, err
+    payload = json.loads(out)
+    assert payload["evidence"] == ev.event_id
+    assert any(n["event_id"] == dec.event_id for n in payload["downstream"])

--- a/tests/test_provenance_graph.py
+++ b/tests/test_provenance_graph.py
@@ -32,7 +32,7 @@ def test_build_graph_with_caused_by_edges():
     ev = storage.append_event(
         run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1", "summary": "s"}
     )
-    find = storage.append_event(
+    _find = storage.append_event(
         run_id, EventType.FINDING_ADDED, {"finding_id": "f1", "claim": "c", "evidence": ["ev1"]}
     )
     # decision caused by evidence

--- a/tests/test_provenance_graph.py
+++ b/tests/test_provenance_graph.py
@@ -12,15 +12,8 @@ from continuum.models import Run
 from continuum.provenance.graph import build_provenance_graph, downstream_of
 from continuum.storage.sqlite import SQLiteStorage
 
+
 # Use CLI helper from tests
-from tests.test_cli import run_cli  # type: ignore
-
-try:
-    from tests.test_cli import run as _run_cli  # fallback
-except ImportError:
-    _run_cli = None
-
-
 def _run(*args: str, db: str | None = None):
     """Helper to run continuum CLI via subprocess."""
     cmd = (
@@ -92,7 +85,7 @@ def test_graph_nodes_carry_origin():
     run_id = "run_prov_origin"
     storage.create_run(Run(run_id=run_id, goal="g"))
     ev = storage.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
-    dec = storage.append_event(
+    storage.append_event(
         run_id, EventType.DECISION_CREATED, {"decision": "d", "caused_by": [ev.event_id]}
     )
     graph = build_provenance_graph(storage.read_events(run_id))


### PR DESCRIPTION
## Description

Implements provenance DAG projector for claim-level causal graph (issue #552, epic #288).

- `src/continuum/provenance/graph.py` (and wrapper `src/continuum/state/provenance_graph.py`): pure fold over events into DAG nodes (EVIDENCE_ADDED, FINDING_ADDED, DECISION_CREATED, ACTION_RECORDED) with edges from `caused_by`. Nodes carry per-node Origin and StateStatus. BFS downstream helper for impact queries.
- `src/continuum/cli/main.py`: adds `continuum provenance <run>` (text and --json with per-node Origin) and `continuum impact <run> --evidence <id>` (BFS downstream, text and --json). Read-only, exit 0.
- Tests: `tests/test_provenance_graph.py` covers DAG building with caused_by edges, downstream via payload id, Origin tags, and CLI --json for both commands.

## Related issues

Fixes #552
Refs #550
Parent epic #288

## Testing

pytest tests/test_provenance_graph.py -q (5 passed)
ruff check clean, ruff format clean, mypy strict clean
