### PR TITLE
feat(ledger,gateway): origin digest, forensic join and tenant deny (Refs #566)

### DIFF
--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -108,6 +108,7 @@ __all__ = [
     "LedgerError",
     "DuplicateAction",
     "ClaimLockError",
+    "forensic_join_across_runs",
 ]
 
 
@@ -703,6 +704,8 @@ class ActionLedger:
         event_type: EventType = EventType.ACTION_RECORDED,
         pinning: dict[str, str] | None = None,
         grant: dict[str, str] | None = None,
+        origin_digest: str | None = None,
+        rendered_key: str | None = None,
     ) -> Action:
         payload: dict[str, Any] = {
             "key": key,
@@ -722,6 +725,22 @@ class ActionLedger:
             # time; terminal records inherit it via the shared payload keys,
             # so scan_grants can mark consumption from either event type.
             payload["grant"] = dict(grant)
+        if origin_digest is not None or action.origin_digest is not None:
+            # Origin digest (issue #304, #566): hash of the originating
+            # observation that motivated this write. Stored both top-level
+            # for forensic filtering and inside the action for round-trip.
+            digest = origin_digest if origin_digest is not None else action.origin_digest
+            if digest is not None:
+                payload["origin_digest"] = digest
+        if rendered_key is not None:
+            payload["rendered_key"] = rendered_key
+        elif action.arguments and "record_key" in action.arguments:
+            # Fallback for callers that supplied record_key via arguments
+            # rather than explicit key; keep forensic searchable.
+            try:
+                payload["rendered_key"] = str(action.arguments.get("record_key"))
+            except Exception:
+                pass
         self.storage.append_event(self.run_id, event_type, payload)
         return action
 
@@ -738,6 +757,7 @@ class ActionLedger:
         dep_scope: str | None = None,
         pinning: dict[str, str] | None = None,
         grant: Mapping[str, str] | None = None,
+        origin_digest: str | None = None,
     ) -> ActionOutcome:
         """Register intent to perform an action, or report it already happened.
 
@@ -767,6 +787,7 @@ class ActionLedger:
         resolves it.
         """
         explicit_key = key is not None
+        _explicit_rendered = key
         idem = idempotency_key(
             action_type,
             arguments,
@@ -775,6 +796,7 @@ class ActionLedger:
             key=key,
         )
         key = idem
+        rendered_key = _explicit_rendered
         existing = self.get(key)
 
         if existing is None and not scoped_to_run:
@@ -852,6 +874,14 @@ class ActionLedger:
         if existing is None:
             if budget_auth_id is not None:
                 self._budget_consume_claim(action_type, budget_auth_id)
+            # Origin digest (issue #566): optional 64 hex, validated by Action.
+            # Fail closed on bad digest rather than storing garbage that
+            # forensic joins would then misattribute.
+            if origin_digest is not None:
+                import re as _re
+
+                if not _re.fullmatch(r"[0-9a-f]{64}", origin_digest):
+                    raise LedgerError(f"origin_digest must be 64 lowercase hex, got {origin_digest!r}")
             action = Action(
                 run_id=self.run_id,
                 action_type=action_type,
@@ -860,8 +890,11 @@ class ActionLedger:
                 arguments_hash=arguments_hash(arguments, volatile=volatile),
                 status=ActionStatus.STARTED,
                 started_at=utcnow(),
+                origin_digest=origin_digest,
             )
-            self._record(key, action, pinning=pinning, grant=grant_clean)
+            self._record(
+                key, action, pinning=pinning, grant=grant_clean, origin_digest=origin_digest, rendered_key=rendered_key
+            )
             return ActionOutcome(key=key, action=action, fresh=True)
 
         if existing.status is ActionStatus.COMPLETED:
@@ -1099,6 +1132,79 @@ class ActionLedger:
         )
         return self._record(key, action)
 
+    def forensic_lookup(self, record_key: str) -> list[dict[str, Any]]:
+        """Find actions whose rendered key contains ``record_key``.
+
+        Scans this run's ledger for memory writes whose stored
+        ``rendered_key`` contains the given substring. For each hit, also
+        resolves the originating observation event by ``origin_digest`` when
+        present. This is the poisoning forensics join: given a bad record,
+        walk back to what caused it, then enumerate siblings from the same
+        contaminated origin.
+
+        Returns a list of ``{"action": Action, "rendered_key": str,
+        "origin_digest": str | None, "observation_event": Event | None}``
+        entries. Empty when nothing matches. Searches only this run; for
+        store-global enumeration use :func:`forensic_join_across_runs`.
+        """
+        hits: list[dict[str, Any]] = []
+        # Map observation digest to event for this run
+        obs_by_digest: dict[str, Any] = {}
+        try:
+            from continuum.security.hashing import stable_hash as _sh
+
+            for ev in self.storage.read_events(self.run_id):
+                if ev.type == EventType.PERCEPTION_OBSERVED:
+                    try:
+                        digest = _sh(dict(ev.payload))
+                    except Exception:
+                        continue
+                    obs_by_digest[digest] = ev
+                    # Also index by content_hash if present
+                    ch = ev.payload.get("content_hash")
+                    if isinstance(ch, str):
+                        obs_by_digest[ch] = ev
+        except Exception:
+            obs_by_digest = {}
+        for ev in self.storage.read_events(self.run_id):
+            if ev.type not in _ACTION_EVENT_TYPES:
+                continue
+            payload = dict(ev.payload)
+            rendered = payload.get("rendered_key") or payload.get("key") or ""
+            # The stored key is hashed, so check rendered_key first, then
+            # fallback to substring search inside action arguments or key.
+            match = False
+            if isinstance(rendered, str) and record_key in rendered:
+                match = True
+            else:
+                # Fallback: check action arguments for record_key
+                try:
+                    act = payload.get("action") or {}
+                    args = act.get("arguments") or {}
+                    if record_key in str(args):
+                        match = True
+                    if record_key in str(payload.get("key", "")):
+                        match = True
+                except Exception:
+                    pass
+            if not match:
+                continue
+            try:
+                action = Action.model_validate(payload["action"])
+            except Exception:
+                continue
+            digest = payload.get("origin_digest") or action.origin_digest
+            obs_ev = obs_by_digest.get(digest) if isinstance(digest, str) else None
+            hits.append(
+                {
+                    "action": action,
+                    "rendered_key": rendered,
+                    "origin_digest": digest,
+                    "observation_event": obs_ev,
+                }
+            )
+        return hits
+
     def _require(self, key: str) -> tuple[str, Action]:
         """Resolve ``key`` to its stored key and action, or explain what is wrong.
 
@@ -1121,3 +1227,74 @@ class ActionLedger:
                 f"continuum_list_actions, and pass the action_key or action_id from there."
             )
         return resolved, self._replay()[resolved]
+
+def forensic_join_across_runs(storage: Storage, record_key: str) -> list[dict[str, Any]]:
+    """Store-global forensic join: record_key -> originating observations.
+
+    Scans every run in ``storage`` for memory actions whose rendered key
+    contains ``record_key``, returning the same shape as
+    :meth:`ActionLedger.forensic_lookup` but across all runs. This powers
+    enumeration for poisoning forensics where a contaminated origin may have
+    produced sibling writes in different runs.
+
+    Each hit includes ``run_id``, ``action``, ``rendered_key``,
+    ``origin_digest`` and ``observation_event`` (or None when the digest
+    has no matching PERCEPTION_OBSERVED in that run).
+    """
+    from continuum.security.hashing import stable_hash as _sh
+
+    hits: list[dict[str, Any]] = []
+    for run in storage.list_runs():
+        run_id = run.run_id
+        # Build per-run observation index
+        obs_by_digest: dict[str, Any] = {}
+        try:
+            for ev in storage.read_events(run_id):
+                if ev.type == EventType.PERCEPTION_OBSERVED:
+                    try:
+                        digest = _sh(dict(ev.payload))
+                    except Exception:
+                        continue
+                    obs_by_digest[digest] = ev
+                    ch = ev.payload.get("content_hash")
+                    if isinstance(ch, str):
+                        obs_by_digest[ch] = ev
+        except Exception:
+            obs_by_digest = {}
+        try:
+            events = storage.read_events(run_id)
+        except Exception:
+            continue
+        for ev in events:
+            if ev.type not in _ACTION_EVENT_TYPES:
+                continue
+            payload = dict(ev.payload)
+            rendered = payload.get("rendered_key") or ""
+            match = isinstance(rendered, str) and record_key in rendered
+            if not match:
+                try:
+                    act = payload.get("action") or {}
+                    args = act.get("arguments") or {}
+                    if record_key in str(args):
+                        match = True
+                except Exception:
+                    pass
+            if not match:
+                continue
+            try:
+                action = Action.model_validate(payload["action"])
+            except Exception:
+                continue
+            digest = payload.get("origin_digest") or getattr(action, "origin_digest", None)
+            obs_ev = obs_by_digest.get(digest) if isinstance(digest, str) else None
+            hits.append(
+                {
+                    "run_id": run_id,
+                    "action": action,
+                    "rendered_key": rendered,
+                    "origin_digest": digest,
+                    "observation_event": obs_ev,
+                }
+            )
+    return hits
+

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable, Iterator, Mapping, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import timedelta
 from functools import wraps
@@ -737,10 +737,8 @@ class ActionLedger:
         elif action.arguments and "record_key" in action.arguments:
             # Fallback for callers that supplied record_key via arguments
             # rather than explicit key; keep forensic searchable.
-            try:
+            with suppress(Exception):
                 payload["rendered_key"] = str(action.arguments.get("record_key"))
-            except Exception:
-                pass
         self.storage.append_event(self.run_id, event_type, payload)
         return action
 
@@ -881,7 +879,9 @@ class ActionLedger:
                 import re as _re
 
                 if not _re.fullmatch(r"[0-9a-f]{64}", origin_digest):
-                    raise LedgerError(f"origin_digest must be 64 lowercase hex, got {origin_digest!r}")
+                    raise LedgerError(
+                        f"origin_digest must be 64 lowercase hex, got {origin_digest!r}"
+                    )
             action = Action(
                 run_id=self.run_id,
                 action_type=action_type,
@@ -893,7 +893,12 @@ class ActionLedger:
                 origin_digest=origin_digest,
             )
             self._record(
-                key, action, pinning=pinning, grant=grant_clean, origin_digest=origin_digest, rendered_key=rendered_key
+                key,
+                action,
+                pinning=pinning,
+                grant=grant_clean,
+                origin_digest=origin_digest,
+                rendered_key=rendered_key,
             )
             return ActionOutcome(key=key, action=action, fresh=True)
 
@@ -1193,7 +1198,7 @@ class ActionLedger:
                 action = Action.model_validate(payload["action"])
             except Exception:
                 continue
-            digest = payload.get("origin_digest") or action.origin_digest
+            digest = payload.get("origin_digest") or action.origin_digest  # type: ignore[assignment]
             obs_ev = obs_by_digest.get(digest) if isinstance(digest, str) else None
             hits.append(
                 {
@@ -1227,6 +1232,7 @@ class ActionLedger:
                 f"continuum_list_actions, and pass the action_key or action_id from there."
             )
         return resolved, self._replay()[resolved]
+
 
 def forensic_join_across_runs(storage: Storage, record_key: str) -> list[dict[str, Any]]:
     """Store-global forensic join: record_key -> originating observations.
@@ -1285,7 +1291,7 @@ def forensic_join_across_runs(storage: Storage, record_key: str) -> list[dict[st
                 action = Action.model_validate(payload["action"])
             except Exception:
                 continue
-            digest = payload.get("origin_digest") or getattr(action, "origin_digest", None)
+            digest = payload.get("origin_digest") or getattr(action, "origin_digest", None)  # type: ignore[assignment]
             obs_ev = obs_by_digest.get(digest) if isinstance(digest, str) else None
             hits.append(
                 {
@@ -1297,4 +1303,3 @@ def forensic_join_across_runs(storage: Storage, record_key: str) -> list[dict[st
                 }
             )
     return hits
-

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -2037,6 +2037,7 @@ def cmd_gateway(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
         GatewayConfigError,
         GatewayServer,
         load_gateway_config,
+        load_gateway_tenant,
     )
 
     config_path = Path(args.config) if args.config else Path(DEFAULT_GATEWAY_CONFIG_PATH)
@@ -2053,9 +2054,12 @@ def cmd_gateway(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
         )
         return ExitCode.ERROR
 
+    bound_tenant = load_gateway_tenant(config_path)
     active = storage.get_active_run()
     run_id = args.run_id or (active.run_id if active else None)
-    server = GatewayServer(lambda: open_storage(args.db), run_id, routes, port=args.port)
+    server = GatewayServer(
+        lambda: open_storage(args.db), run_id, routes, port=args.port, bound_tenant=bound_tenant
+    )
     print(
         f"CONTINUUM gateway listening on 127.0.0.1:{server.port} "
         f"({len(routes)} upstream route(s), run={run_id or 'dynamic'})",

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -41,13 +41,14 @@ from pathlib import Path
 from typing import Any
 
 from continuum.events import EventType
-from continuum.gate import normalize_key_value
+from continuum.gate import is_memory_key, normalize_key_value
 from continuum.models import Origin
 
 __all__ = [
     "DEFAULT_GATEWAY_CONFIG_PATH",
     "GatewayConfigError",
     "load_gateway_config",
+    "load_gateway_tenant",
     "match_route",
     "GatewayServer",
 ]
@@ -125,6 +126,29 @@ def load_gateway_config(path: Path) -> list[Route]:
     return routes
 
 
+def load_gateway_tenant(path: Path) -> str | None:
+    """Read optional bound tenant from gateway config.
+
+    When present, memory-store routes (``mem:``) are tenant-scoped: a
+    request whose ``tenant`` field does not match the bound identity is
+    denied at the gateway rather than surfacing later as a breach. This
+    is configuration and a check, not new infrastructure (issue #566,
+    parent #304).
+    """
+    if not path.exists():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    bound = raw.get("bound_tenant") or raw.get("tenant")
+    if isinstance(bound, str) and bound.strip():
+        return bound.strip()
+    return None
+
+
 def render_key(template: str, body: dict[str, Any]) -> str:
     """Substitute ``{field}`` placeholders from the request body.
 
@@ -150,6 +174,8 @@ def match_route(
     body: dict[str, Any],
     actions_by_key: dict[str, Any],
     run_id: str,
+    bound_tenant: str | None = None,
+    storage: Any | None = None,
 ) -> Decision:
     """The gateway's verdict for one request, mirroring gate's table."""
     from continuum.actions.idempotency import idempotency_key
@@ -172,9 +198,54 @@ def match_route(
     except GatewayConfigError as exc:
         return Decision(False, f"gateway configuration error: {exc}")
 
-    key = str(idempotency_key(route.action_type, None, scope=run_id, key=rendered))
+    # Tenant deny (issue #566): memory keys carry tenant in the
+    # rendered identity. When a bound tenant is configured, a claim
+    # whose tenant prefix does not match is denied at the gate rather
+    # than surfacing later as a breach.
+    if is_memory_key(rendered) and bound_tenant is not None:
+        # Extract tenant from rendered mem key: mem:store:tenant:record
+        try:
+            parts = rendered.split(":")
+            # mem:{store_id}:{tenant}:{record_key} -> tenant is third segment
+            if len(parts) >= 4:
+                tenant_in_key = parts[2]
+                if tenant_in_key != bound_tenant:
+                    return Decision(
+                        False,
+                        f"tenant mismatch: bound {bound_tenant!r} but key {rendered!r} carries tenant {tenant_in_key!r}",
+                        route=route,
+                    )
+            else:
+                # Malformed mem key but already rendered; deny closed
+                return Decision(False, f"malformed memory key {rendered!r}", route=route)
+        except Exception:
+            return Decision(False, f"tenant check failed for {rendered!r}", route=route)
+
+    # Memory keys are global to the store, not the run, so use scope=None
+    # to let the action_index catch cross-run double-writes.
+    if is_memory_key(rendered):
+        key = str(idempotency_key(route.action_type, None, scope=None, key=rendered))
+    else:
+        key = str(idempotency_key(route.action_type, None, scope=run_id, key=rendered))
+    # For memory keys, also check foreign index when local misses
+    foreign_action = None
     action = actions_by_key.get(key)
-    if action is None or action.action_type != route.action_type:
+    if action is None and is_memory_key(rendered) and storage is not None:
+        try:
+            if getattr(storage, "supports_action_index", False):
+                foreign_action = storage.foreign_action(key, exclude_run=run_id)
+                if foreign_action is not None:
+                    action = foreign_action
+        except Exception:
+            action = None
+    else:
+        # action already from local, foreign stays None
+        pass
+    # If we already resolved action via foreign, we need to handle status below
+    # Reuse variable action; key already computed
+    # To avoid double lookup, we will have a flag
+
+    if action is None or getattr(action, "action_type", None) != route.action_type:
         return Decision(
             False,
             f"side effect {route.action_type!r} key {rendered!r} has no ledger claim. "
@@ -213,10 +284,12 @@ class GatewayServer:
         run_id: str | None,
         routes: list[Route],
         port: int = 0,
+        bound_tenant: str | None = None,
     ) -> None:
         self._storage_factory = storage_factory
         self._run_id = run_id
         self._routes = routes
+        self._bound_tenant = bound_tenant
         server = self
 
         class Handler(BaseHTTPRequestHandler):
@@ -330,6 +403,8 @@ class GatewayServer:
                         body=body,
                         actions_by_key=actions,
                         run_id=run_id,
+                        bound_tenant=getattr(server, "_bound_tenant", None),
+                        storage=storage,
                     )
                     if not decision.allow or decision.route is None or decision.key is None:
                         self._respond(

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -722,9 +722,27 @@ class Action(BaseModel):
     side_effect_uncertain: bool = False
     compensated_by: list[str] = Field(default_factory=list)
     last_error: str | None = None
+    origin_digest: str | None = None
+    """Optional hash of the originating observation that motivated this write.
+
+    Stored as 64 lowercase hex (SHA-256) when present. Gives poisoning
+    forensics: a bad record can be joined back to the perception or
+    tool result that caused it, then sibling writes from the same
+    contaminated origin can be enumerated. Round-tripped via the ledger
+    payload and ``Action`` so the chain keeps the attribution.
+    """
     created_at: datetime = Field(default_factory=utcnow)
     started_at: datetime | None = None
     completed_at: datetime | None = None
+
+    @field_validator("origin_digest")
+    @classmethod
+    def _origin_digest_is_sha256(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not _SHA256_PATTERN.fullmatch(value):
+            raise ValueError("origin_digest must be 64 lowercase hex characters")
+        return value
 
 
 class UnknownSideEffect(RuntimeError):

--- a/src/continuum/security/trust_gate.py
+++ b/src/continuum/security/trust_gate.py
@@ -22,6 +22,7 @@ __all__ = [
     "verify_observation",
     "resolve_branch",
     "record_observation",
+    "record_memory_observation",
 ]
 
 
@@ -122,6 +123,37 @@ def verify_observation(
         record_observation(storage, run_id, obs)
 
     return obs
+
+
+def record_memory_observation(
+    storage: object,
+    run_id: str,
+    content_hash: str,
+    raw_claim: str,
+    *,
+    observation_id: str | None = None,
+) -> Event:
+    """Record a memory-derived observation as unverified.
+
+    Memory retrievals are external observations whose trust cannot be
+    assumed. Like any ``PERCEPTION_OBSERVED`` they start as
+    ``unverified`` and a high-risk plan branch gated on them escalates
+    per the Secure Planning Loop. Callers should use the content hash
+    of the retrieved record as ``content_hash`` so forensic joins can
+    later link a poisoned ``origin_digest`` back to this observation.
+
+    Returns the appended ``PERCEPTION_OBSERVED`` event.
+    """
+    obs = ObservationProvenance(
+        observation_id=observation_id or make_id("obs"),
+        source="memory",
+        trust_level="unverified",
+        verifier="memory_retrieval",
+        content_hash=content_hash,
+        q_vlm_model="memory",
+        raw_claim=raw_claim,
+    )
+    return record_observation(storage, run_id, obs)
 
 
 def record_observation(storage: object, run_id: str, obs: ObservationProvenance) -> Event:

--- a/src/continuum/security/trust_gate.py
+++ b/src/continuum/security/trust_gate.py
@@ -146,7 +146,7 @@ def record_memory_observation(
     """
     obs = ObservationProvenance(
         observation_id=observation_id or make_id("obs"),
-        source="memory",
+        source="environment_observed",
         trust_level="unverified",
         verifier="memory_retrieval",
         content_hash=content_hash,

--- a/tests/test_memory_forensic.py
+++ b/tests/test_memory_forensic.py
@@ -1,0 +1,245 @@
+"""Origin digest, forensic join and gateway tenant deny (issue #566, parent #304).
+
+Covers:
+- claim metadata carries optional origin_digest, ledger round-trips it
+- forensic query joins record_key back to originating observations
+- gateway denies cross-tenant namespace claims
+- adapters mark memory-derived inputs unverified and escalate
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from continuum.actions.ledger import ActionLedger, fold_action_events, forensic_join_across_runs
+from continuum.events import EventType
+from continuum.gateway import GatewayConfigError, load_gateway_config, match_route
+from continuum.gate import derive_memory_key, is_memory_key
+from continuum.models import ActionStatus, Run
+from continuum.security.hashing import stable_hash
+from continuum.security.provenance import PlanBranch
+from continuum.security.trust_gate import record_memory_observation, resolve_branch
+from continuum.storage import SQLiteStorage
+
+
+def test_origin_digest_round_trips_via_ledger(tmp_path) -> None:
+    path = str(tmp_path / "mem.db")
+    digest = "a" * 64
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(store, "run_1")
+        rendered = "mem:pgvector_main:acme:rec-42"
+        outcome = ledger.claim("mem_write", {}, key=rendered, scoped_to_run=False, origin_digest=digest)
+        assert outcome.fresh is True
+        assert outcome.action.origin_digest == digest
+        # Payload top-level also carries it
+        ev = list(store.read_events("run_1"))[-1]
+        assert ev.payload.get("origin_digest") == digest
+        assert ev.payload.get("rendered_key") == rendered
+        # Round-trip via get and fold
+        fetched = ledger.get(outcome.key)
+        assert fetched is not None
+        assert fetched.origin_digest == digest
+        folded = fold_action_events(store.read_events("run_1"))
+        assert folded[outcome.key].origin_digest == digest
+
+
+def test_origin_digest_rejects_bad_hex(tmp_path) -> None:
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(store, "run_1")
+        with pytest.raises(Exception, match="origin_digest"):
+            ledger.claim("mem_write", {}, key="mem:pgvector_main:acme:rec-42", scoped_to_run=False, origin_digest="bad")
+
+
+def test_forensic_join_record_key_to_observation(tmp_path) -> None:
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        # Create an observation that will be the origin
+        obs_payload = {"content_hash": "obs_hash_1", "raw_claim": "poisoned content"}
+        digest = stable_hash(obs_payload)
+        # Record observation via direct event
+        store.append_event("run_1", EventType.PERCEPTION_OBSERVED, obs_payload)
+        # Claim a memory write that cites that observation
+        ledger = ActionLedger(store, "run_1")
+        rendered = "mem:pgvector_main:acme:rec-99"
+        outcome = ledger.claim("mem_write", {}, key=rendered, scoped_to_run=False, origin_digest=digest)
+        # Also claim a sibling write from same origin
+        rendered2 = "mem:pgvector_main:acme:rec-100"
+        outcome2 = ledger.claim("mem_write", {}, key=rendered2, scoped_to_run=False, origin_digest=digest)
+        assert outcome.fresh and outcome2.fresh
+        # Forensic lookup by record_key should find both and join to observation
+        hits = ledger.forensic_lookup("rec-99")
+        assert len(hits) == 1
+        assert hits[0]["origin_digest"] == digest
+        assert hits[0]["rendered_key"] == rendered
+        # Observation event should be joined (we stored PERCEPTION_OBSERVED with same payload hash)
+        # Our forensic maps digest via stable_hash of payload, so it should find it
+        assert hits[0]["observation_event"] is not None
+        assert hits[0]["observation_event"].payload == obs_payload
+        # Cross-run join should also find them
+        hits_all = forensic_join_across_runs(store, "rec-")
+        # Should find at least the two we created (maybe more)
+        found = {h["rendered_key"] for h in hits_all}
+        assert rendered in found
+        assert rendered2 in found
+
+
+def test_forensic_join_across_runs_tenant_scoped(tmp_path) -> None:
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        for rid in ("run_1", "run_2"):
+            store.create_run(Run(run_id=rid, goal="g"))
+            store.append_event(rid, EventType.RUN_STARTED, {"goal": "g"})
+        ledger1 = ActionLedger(store, "run_1")
+        digest = "b" * 64
+        ledger1.claim("mem_write", {}, key="mem:pgvector_main:acme:rec-42", scoped_to_run=False, origin_digest=digest)
+        ledger2 = ActionLedger(store, "run_2")
+        # Different tenant, same record_key, should be separate hits
+        ledger2.claim("mem_write", {}, key="mem:pgvector_main:globex:rec-42", scoped_to_run=False, origin_digest=digest)
+        hits = forensic_join_across_runs(store, "rec-42")
+        # Both tenants should appear
+        tenants = set()
+        for h in hits:
+            rk = h["rendered_key"]
+            if "acme" in rk:
+                tenants.add("acme")
+            if "globex" in rk:
+                tenants.add("globex")
+        assert "acme" in tenants
+        assert "globex" in tenants
+
+
+def test_gateway_tenant_deny(tmp_path) -> None:
+    # Memory route with mem template
+    routes = load_gateway_config(tmp_path / "nope.json")  # empty
+    # Manually construct route
+    from continuum.gateway import Route
+
+    route = Route(
+        host="pgvector.internal",
+        methods=("POST",),
+        prefix="/upsert",
+        action_type="mem_write",
+        key_template="mem:{store_id}:{tenant}:{record_key}",
+    )
+    routes = [route]
+    # Create a claimed action for acme
+    path = str(tmp_path / "gw.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        ledger = ActionLedger(store, "run_1")
+        rendered_acme = "mem:pgvector_main:acme:rec-42"
+        outcome = ledger.claim("mem_write", {}, key=rendered_acme, scoped_to_run=False)
+        assert outcome.fresh
+        # Complete it so gateway sees STARTED? Actually gateway allows only STARTED, not COMPLETED.
+        # For this test we want live claim, so keep STARTED.
+        actions = fold_action_events(store.read_events("run_1"))
+        # Bound acme, request acme -> should be allowed (if claim exists)
+        body_acme = {"store_id": "pgvector_main", "tenant": "acme", "record_key": "rec-42"}
+        decision = match_route(
+            routes,
+            host="pgvector.internal",
+            method="POST",
+            body=body_acme,
+            actions_by_key=actions,
+            run_id="run_1",
+            bound_tenant="acme",
+            storage=store,
+        )
+        assert decision.allow is True
+        # Bound acme, request globex -> deny tenant mismatch before ledger check
+        body_globex = {"store_id": "pgvector_main", "tenant": "globex", "record_key": "rec-42"}
+        decision2 = match_route(
+            routes,
+            host="pgvector.internal",
+            method="POST",
+            body=body_globex,
+            actions_by_key=actions,
+            run_id="run_1",
+            bound_tenant="acme",
+            storage=store,
+        )
+        assert decision2.allow is False
+        assert "tenant mismatch" in decision2.reason
+        # No bound Tenant -> cross-tenant would be allowed if claim existed, but globex has no claim
+        # So it should be denied as unclaimed, not tenant mismatch
+        decision3 = match_route(
+            routes,
+            host="pgvector.internal",
+            method="POST",
+            body=body_globex,
+            actions_by_key=actions,
+            run_id="run_1",
+            bound_tenant=None,
+            storage=store,
+        )
+        assert decision3.allow is False
+        assert "has no ledger claim" in decision3.reason
+
+
+def test_gateway_tenant_deny_before_ledger(tmp_path) -> None:
+    from continuum.gateway import Route
+
+    route = Route(
+        host="pgvector.internal",
+        methods=("POST",),
+        prefix="/upsert",
+        action_type="mem_write",
+        key_template="mem:{store_id}:{tenant}:{record_key}",
+    )
+    path = str(tmp_path / "gw.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        actions = fold_action_events(store.read_events("run_1"))
+        # No claim at all, but tenant mismatch should still deny with tenant mismatch
+        body = {"store_id": "pgvector_main", "tenant": "globex", "record_key": "rec-99"}
+        decision = match_route(
+            [route],
+            host="pgvector.internal",
+            method="POST",
+            body=body,
+            actions_by_key=actions,
+            run_id="run_1",
+            bound_tenant="acme",
+        )
+        assert decision.allow is False
+        assert "tenant mismatch" in decision.reason
+
+
+def test_memory_observation_unverified_escalates(tmp_path) -> None:
+    path = str(tmp_path / "mem.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+        # Memory retrieval is unverified by default
+        content_hash = stable_hash({"record": "rec-42", "content": "suspicious"})
+        ev = record_memory_observation(store, "run_1", content_hash, "retrieved rec-42")
+        assert ev.type == EventType.PERCEPTION_OBSERVED
+        assert ev.payload["trust_level"] == "unverified"
+        assert ev.payload["source"] == "memory"
+        # High-risk branch gated on that observation should require review
+        branch = PlanBranch(branch_id="b1", risk_tier="high", description="use memory rec-42")
+        # Fetch the observation provenance back
+        from continuum.security.provenance import ObservationProvenance
+
+        obs = ObservationProvenance.model_validate(ev.payload)
+        gate = resolve_branch(branch, obs, storage=store, run_id="run_1")
+        assert gate.requires_review is True
+        # Low-risk branch should not
+        branch_low = PlanBranch(branch_id="b2", risk_tier="low", description="read rec-42")
+        gate2 = resolve_branch(branch_low, obs)
+        assert gate2.requires_review is False
+
+
+def test_derive_memory_key_and_is_memory_helpers() -> None:
+    assert is_memory_key("mem:pgvector_main:acme:rec-1") is True
+    rendered = derive_memory_key({"store_id": "pgvector_main", "tenant": "acme", "record_key": "rec-42"})
+    assert rendered == "mem:pgvector_main:acme:rec-42"

--- a/tests/test_memory_forensic.py
+++ b/tests/test_memory_forensic.py
@@ -13,9 +13,9 @@ import pytest
 
 from continuum.actions.ledger import ActionLedger, fold_action_events, forensic_join_across_runs
 from continuum.events import EventType
-from continuum.gateway import GatewayConfigError, load_gateway_config, match_route
 from continuum.gate import derive_memory_key, is_memory_key
-from continuum.models import ActionStatus, Run
+from continuum.gateway import load_gateway_config, match_route
+from continuum.models import Run
 from continuum.security.hashing import stable_hash
 from continuum.security.provenance import PlanBranch
 from continuum.security.trust_gate import record_memory_observation, resolve_branch
@@ -30,7 +30,9 @@ def test_origin_digest_round_trips_via_ledger(tmp_path) -> None:
         store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
         ledger = ActionLedger(store, "run_1")
         rendered = "mem:pgvector_main:acme:rec-42"
-        outcome = ledger.claim("mem_write", {}, key=rendered, scoped_to_run=False, origin_digest=digest)
+        outcome = ledger.claim(
+            "mem_write", {}, key=rendered, scoped_to_run=False, origin_digest=digest
+        )
         assert outcome.fresh is True
         assert outcome.action.origin_digest == digest
         # Payload top-level also carries it
@@ -52,7 +54,13 @@ def test_origin_digest_rejects_bad_hex(tmp_path) -> None:
         store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
         ledger = ActionLedger(store, "run_1")
         with pytest.raises(Exception, match="origin_digest"):
-            ledger.claim("mem_write", {}, key="mem:pgvector_main:acme:rec-42", scoped_to_run=False, origin_digest="bad")
+            ledger.claim(
+                "mem_write",
+                {},
+                key="mem:pgvector_main:acme:rec-42",
+                scoped_to_run=False,
+                origin_digest="bad",
+            )
 
 
 def test_forensic_join_record_key_to_observation(tmp_path) -> None:
@@ -68,10 +76,14 @@ def test_forensic_join_record_key_to_observation(tmp_path) -> None:
         # Claim a memory write that cites that observation
         ledger = ActionLedger(store, "run_1")
         rendered = "mem:pgvector_main:acme:rec-99"
-        outcome = ledger.claim("mem_write", {}, key=rendered, scoped_to_run=False, origin_digest=digest)
+        outcome = ledger.claim(
+            "mem_write", {}, key=rendered, scoped_to_run=False, origin_digest=digest
+        )
         # Also claim a sibling write from same origin
         rendered2 = "mem:pgvector_main:acme:rec-100"
-        outcome2 = ledger.claim("mem_write", {}, key=rendered2, scoped_to_run=False, origin_digest=digest)
+        outcome2 = ledger.claim(
+            "mem_write", {}, key=rendered2, scoped_to_run=False, origin_digest=digest
+        )
         assert outcome.fresh and outcome2.fresh
         # Forensic lookup by record_key should find both and join to observation
         hits = ledger.forensic_lookup("rec-99")
@@ -98,10 +110,22 @@ def test_forensic_join_across_runs_tenant_scoped(tmp_path) -> None:
             store.append_event(rid, EventType.RUN_STARTED, {"goal": "g"})
         ledger1 = ActionLedger(store, "run_1")
         digest = "b" * 64
-        ledger1.claim("mem_write", {}, key="mem:pgvector_main:acme:rec-42", scoped_to_run=False, origin_digest=digest)
+        ledger1.claim(
+            "mem_write",
+            {},
+            key="mem:pgvector_main:acme:rec-42",
+            scoped_to_run=False,
+            origin_digest=digest,
+        )
         ledger2 = ActionLedger(store, "run_2")
         # Different tenant, same record_key, should be separate hits
-        ledger2.claim("mem_write", {}, key="mem:pgvector_main:globex:rec-42", scoped_to_run=False, origin_digest=digest)
+        ledger2.claim(
+            "mem_write",
+            {},
+            key="mem:pgvector_main:globex:rec-42",
+            scoped_to_run=False,
+            origin_digest=digest,
+        )
         hits = forensic_join_across_runs(store, "rec-42")
         # Both tenants should appear
         tenants = set()
@@ -224,9 +248,14 @@ def test_memory_observation_unverified_escalates(tmp_path) -> None:
         ev = record_memory_observation(store, "run_1", content_hash, "retrieved rec-42")
         assert ev.type == EventType.PERCEPTION_OBSERVED
         assert ev.payload["trust_level"] == "unverified"
-        assert ev.payload["source"] == "memory"
+        assert ev.payload["source"] == "environment_observed"
         # High-risk branch gated on that observation should require review
-        branch = PlanBranch(branch_id="b1", risk_tier="high", description="use memory rec-42")
+        branch = PlanBranch(
+            branch_id="b1",
+            risk_tier="high",
+            action_intent="submit_payment",
+            depends_on_observation=True,
+        )
         # Fetch the observation provenance back
         from continuum.security.provenance import ObservationProvenance
 
@@ -234,12 +263,16 @@ def test_memory_observation_unverified_escalates(tmp_path) -> None:
         gate = resolve_branch(branch, obs, storage=store, run_id="run_1")
         assert gate.requires_review is True
         # Low-risk branch should not
-        branch_low = PlanBranch(branch_id="b2", risk_tier="low", description="read rec-42")
+        branch_low = PlanBranch(
+            branch_id="b2", risk_tier="low", action_intent="read_text", depends_on_observation=True
+        )
         gate2 = resolve_branch(branch_low, obs)
         assert gate2.requires_review is False
 
 
 def test_derive_memory_key_and_is_memory_helpers() -> None:
     assert is_memory_key("mem:pgvector_main:acme:rec-1") is True
-    rendered = derive_memory_key({"store_id": "pgvector_main", "tenant": "acme", "record_key": "rec-42"})
+    rendered = derive_memory_key(
+        {"store_id": "pgvector_main", "tenant": "acme", "record_key": "rec-42"}
+    )
     assert rendered == "mem:pgvector_main:acme:rec-42"


### PR DESCRIPTION
## Description
Implements origin provenance on memory writes and tenant enforcement at the gateway (parent #304, sub-issue #566).

Changes:
- `src/continuum/models.py`: add `Action.origin_digest` optional 64 hex, validated, for poisoning forensics.
- `src/continuum/actions/ledger.py`: `claim(origin_digest)` validates and stores digest top-level and inside Action, captures `rendered_key` for forensic search, adds `ActionLedger.forensic_lookup(record_key)` per-run and `forensic_join_across_runs(storage, record_key)` store-global join that maps record_key substring to actions plus originating `PERCEPTION_OBSERVED` events via stable hash or content_hash.
- `src/continuum/gateway.py`: global memory keys (`scope=None`) for cross-run dedup, `load_gateway_tenant()` reads `bound_tenant` from gateway.json, `match_route(..., bound_tenant, storage)` denies tenant mismatch before ledger check, handles cross-run foreign lookup via `storage.foreign_action` for memory keys.
- `src/continuum/cli/main.py`: gateway command loads bound tenant and passes to GatewayServer.
- `src/continuum/security/trust_gate.py`: `record_memory_observation()` helper that records memory retrievals as `environment_observed` unverified, so high-risk branches escalate per Secure Planning Loop.
- `tests/test_memory_forensic.py`: covers digest round-trip, bad hex rejection, forensic join single and cross-run tenant-scoped, gateway tenant deny/allow, memory observation unverified escalation, and helper correctness.

## Related issues
Refs #566
Parent #304
Depends on #565

## Types of changes
- Type: `feature`

## Breaking changes
No

## How has this been tested?
```bash
pytest tests/test_memory_forensic.py tests/test_memory_gate_keys.py -q  # 21 passed
pytest -q  # 1823 passed, 24 skipped (1 flaky concurrency lease re-passed)
ruff check src/ tests/  # All checks passed
ruff format --check src/ tests/  # 251 formatted
mypy src/continuum --ignore-missing-imports  # Success no issues in 114 files
```

Verified tenant isolation via gateway deny before ledger, origin digest stored both top-level and inside Action for forensic filtering, and memory observation escalation mirrors contested-observation flow.

## Checklist
Tests added. Docs updated via guide (previous PR). CI passes. Limitations: stores bypassing gateway/gate remain ungoverned (same caveat as shell).

## Additional context
Tenant is the namespace in spec, stored as `tenant` placeholder. Forensic join uses stable_hash of observation payload or content_hash. Gateway tenant check extracts tenant as third colon segment of `mem:{store}:{tenant}:{record}`.
