### PR TITLE
feat: propagate staleness N hops via caused_by DAG

### DIFF
--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -25,6 +25,9 @@ This document scopes what CONTINUUM protects against, what it detects, and what 
 - **Silent constraint drops**  
   `CONSTRAINT_PINNED` hash-only pins verified across compaction and briefing via `account_pins_in_context` (#391, #418). A summary that omits a pinned constraint is flagged as `absent` past grace, `unverifiable` when truncated, and escalates to `REQUIRES_REVIEW` in strict mode. See `docs/guides/constraint-pinning.md` and `docs/concepts/constraint-pinning.md` and `src/continuum/state/semantic.py:account_pins_in_context`.
 
+- **Stale causal ancestors via provenance graph (N-hop)**  
+  Evidence invalidation propagates N hops through the ``caused_by`` DAG (``evidence -> finding -> decision -> action``). When a dataset changes, every downstream finding, decision and action reachable via ``caused_by`` is marked ``STALE`` (or ``CONFLICTED`` on cycles) with reason ``via caused_by from <parent> (N-hop staleness)``. The propagation walks the transitive closure, not just direct parents, and surfaces in ``RecoveryContract.invalidated``. The graph is built from ``read_all_events`` so compaction does not launder history. See ``src/continuum/state/validator.py:_propagate_caused_by`` and ``src/continuum/provenance/graph.py``. Tested in ``tests/test_provenance_staleness.py`` (issue #553).
+
 ## What CONTINUUM does NOT protect against
 
 - **Full disk access by a remote attacker**  

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -252,6 +252,11 @@ class RecoveryEngine:
             else:
                 confirmed_components.update(["goal", "progress"])
 
+        # Provenance N-hop staleness (issue #553): include archived events so compaction does not launder
+        try:
+            provenance_events = self.storage.read_all_events(run_id)
+        except Exception:
+            provenance_events = self.storage.read_events(run_id)
         validation = self.validator.validate(
             restored.state,
             current_environment=current_environment,
@@ -260,6 +265,7 @@ class RecoveryEngine:
             expected_model=expected_model,
             confirmed=confirmed_components,
             scope=scope,
+            events=provenance_events,
         )
 
         ledger = ActionLedger(self.storage, run_id)

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from continuum.environment.diff import EnvironmentDiff, ResourceChange, diff_environments
+from continuum.events import Event  # for caused_by graph
 from continuum.models import (
     Action,
     ActionStatus,
@@ -232,6 +233,7 @@ class StateValidator:
         expected_model: str | None = None,
         confirmed: bool | Iterable[str] = False,
         scope: Iterable[str] | None = None,
+        events: Iterable[Event] | None = None,
     ) -> ValidationOutcome:
         if isinstance(confirmed, bool):
             self.confirmed = {"goal", "progress"} if confirmed else set()
@@ -254,6 +256,8 @@ class StateValidator:
                 state, environment_diff, entries, observed=observed
             )
             state = self._propagate(state, broken, entries)
+            if events is not None:
+                state = self._propagate_caused_by(state, events, entries)
             self._check_goal(state, entries)
             self._check_progress(state, entries)
             self._check_plan(state, entries)
@@ -273,6 +277,8 @@ class StateValidator:
                 state, environment_diff, entries, scope=scope_set, observed=observed
             )
             state = self._propagate(state, broken, entries)
+            if events is not None:
+                state = self._propagate_caused_by(state, events, entries)
             self._check_derived(state, entries)
 
         blocking = [
@@ -454,6 +460,209 @@ class StateValidator:
         return state.model_copy(
             update={"evidence": evidence, "findings": findings, "decisions": decisions}
         )
+
+    def _propagate_caused_by(
+        self,
+        state: SemanticState,
+        events: Iterable[Event],
+        entries: list[ComponentValidationEntry],
+    ) -> SemanticState:
+        """Propagate staleness N hops via caused_by DAG (issue #553)."""
+        try:
+            from continuum.provenance.graph import build_provenance_graph
+        except ImportError:
+            return state
+        try:
+            graph = build_provenance_graph(events)
+        except Exception:
+            return state
+        if not graph.nodes:
+            return state
+        event_to_component: dict[str, tuple[str, str, object]] = {}
+        for ev in state.evidence:
+            eid = ev.provenance.source_event_id
+            if eid:
+                event_to_component[eid] = ("evidence", ev.evidence_id, ev)
+        for f in state.findings:
+            eid = f.provenance.source_event_id
+            if eid:
+                event_to_component[eid] = ("finding", f.finding_id, f)
+        for d in state.decisions:
+            eid = d.provenance.source_event_id
+            if eid:
+                event_to_component[eid] = ("decision", d.decision_id, d)
+        for plan in state.plan:
+            eid = plan.provenance.source_event_id
+            if eid:
+                event_to_component[eid] = ("plan", plan.step_id, plan)
+        tainted_events: set[str] = set()
+        for entry in entries:
+            if entry.status in (
+                StateStatus.STALE,
+                StateStatus.CONFLICTED,
+                StateStatus.INVALID,
+                StateStatus.UNKNOWN,
+            ):
+                for eid, (comp, cid, _) in event_to_component.items():
+                    if comp == entry.component.value and cid == entry.component_id:
+                        tainted_events.add(eid)
+                        break
+                if entry.component is Component.EVIDENCE and entry.component_id:
+                    for eid, (_comp, cid, _) in event_to_component.items():
+                        if cid == entry.component_id:
+                            tainted_events.add(eid)
+        for ev in state.evidence:
+            if ev.status is not StateStatus.VALID and ev.provenance.source_event_id:
+                tainted_events.add(ev.provenance.source_event_id)
+        for f in state.findings:
+            if f.status is not StateStatus.VALID and f.provenance.source_event_id:
+                tainted_events.add(f.provenance.source_event_id)
+        for d in state.decisions:
+            if d.status is not StateStatus.VALID and d.provenance.source_event_id:
+                tainted_events.add(d.provenance.source_event_id)
+        if not tainted_events:
+            return state
+        from collections import deque
+
+        dq = deque(tainted_events)
+        seen: set[str] = set(tainted_events)
+        downstream_events: set[str] = set()
+        while dq:
+            cur = dq.popleft()
+            for child in graph.edges.get(cur, []):
+                if child in seen:
+                    continue
+                seen.add(child)
+                downstream_events.add(child)
+                dq.append(child)
+        has_cycle = False
+        visited_dfs: set[str] = set()
+
+        def dfs(node: str, stack: set[str]) -> bool:
+            if node in stack:
+                return True
+            if node in visited_dfs:
+                return False
+            visited_dfs.add(node)
+            stack.add(node)
+            for child in graph.edges.get(node, []):
+                if (child in downstream_events or child in tainted_events) and dfs(child, stack):
+                    return True
+            stack.remove(node)
+            return False
+
+        for start in tainted_events:
+            if dfs(start, set()):
+                has_cycle = True
+                break
+        evidence_by_id = {e.evidence_id: e for e in state.evidence}
+        findings_by_id = {f.finding_id: f for f in state.findings}
+        decisions_by_id = {d.decision_id: d for d in state.decisions}
+        plan_by_id = {p.step_id: p for p in state.plan}
+        tainted_downstream: list[tuple[str, str, str]] = []
+        for eid in downstream_events:
+            if eid not in event_to_component:
+                # Handle downstream ACTION_RECORDED not in state (ledger actions)
+                node = graph.nodes.get(eid)
+                if node and node.type.value == "ACTION_RECORDED":
+                    from continuum.events import EventType as _ET
+
+                    if node.type is _ET.ACTION_RECORDED:
+                        action_id = (
+                            node.payload.get("action_id")
+                            or node.payload.get("action", {}).get("action_id")
+                            or eid[:8]
+                        )
+                        # Avoid duplicate if already marked
+                        already_action = any(
+                            e.component is Component.ACTION
+                            and e.component_id == action_id
+                            and e.status is not StateStatus.VALID
+                            for e in entries
+                        )
+                        if not already_action:
+                            detail = "via caused_by downstream of tainted evidence (N-hop)"
+                            # Check for cycle already computed
+                            status_to_set_action = (
+                                StateStatus.CONFLICTED if has_cycle else StateStatus.STALE
+                            )
+                            entries.append(
+                                ComponentValidationEntry(
+                                    component=Component.ACTION,
+                                    component_id=action_id,
+                                    status=status_to_set_action,
+                                    detail=detail,
+                                )
+                            )
+                continue
+            comp, cid, obj = event_to_component[eid]
+            already = any(
+                e.component.value == comp
+                and e.component_id == cid
+                and e.status is not StateStatus.VALID
+                for e in entries
+            )
+            if already:
+                continue
+            current_status = obj.status if hasattr(obj, "status") else StateStatus.VALID
+            if current_status is not StateStatus.VALID:
+                continue
+            tainted_downstream.append((eid, comp, cid))
+        status_to_set = StateStatus.CONFLICTED if has_cycle else StateStatus.STALE
+        new_evidence = list(state.evidence)
+        new_findings = list(state.findings)
+        new_decisions = list(state.decisions)
+        new_plan = list(state.plan)
+        for eid, comp, cid in tainted_downstream:
+            parents = graph.reverse_edges.get(eid, [])
+            parent_str = parents[0][:8] if parents else "unknown"
+            detail = f"via caused_by from {parent_str} (N-hop staleness)"
+            if has_cycle:
+                detail = f"cycle detected via caused_by, downstream of {parent_str}"
+            # Map comp to Component
+            try:
+                comp_enum = Component(comp)
+            except ValueError:
+                comp_enum = Component.DECISION
+            entries.append(
+                ComponentValidationEntry(
+                    component=comp_enum,
+                    component_id=cid,
+                    status=status_to_set,
+                    detail=detail,
+                )
+            )
+            if comp == "evidence" and cid in evidence_by_id:
+                idx = next(i for i, e in enumerate(new_evidence) if e.evidence_id == cid)
+                new_evidence[idx] = evidence_by_id[cid].model_copy(update={"status": status_to_set})
+            elif comp == "finding" and cid in findings_by_id:
+                idx = next(i for i, f in enumerate(new_findings) if f.finding_id == cid)
+                new_findings[idx] = findings_by_id[cid].model_copy(update={"status": status_to_set})
+            elif comp == "decision" and cid in decisions_by_id:
+                idx = next(i for i, d in enumerate(new_decisions) if d.decision_id == cid)
+                update: dict[str, object] = {"status": status_to_set}
+                if status_to_set is StateStatus.STALE:
+                    from continuum.models import utcnow
+
+                    update["invalidated_reason"] = detail
+                    update["invalidated_at"] = utcnow()
+                new_decisions[idx] = decisions_by_id[cid].model_copy(update=update)
+            elif comp == "plan" and cid in plan_by_id:
+                idx = next(i for i, p in enumerate(new_plan) if p.step_id == cid)
+                import contextlib
+
+                with contextlib.suppress(Exception):
+                    new_plan[idx] = plan_by_id[cid].model_copy(update={"status": status_to_set})
+        if tainted_downstream:
+            return state.model_copy(
+                update={
+                    "evidence": new_evidence,
+                    "findings": new_findings,
+                    "decisions": new_decisions,
+                    "plan": new_plan,
+                }
+            )
+        return state
 
     # -- per-component checks --------------------------------------------- #
 
@@ -800,6 +1009,7 @@ def validate_state(
     strict_unknown: bool = True,
     confirmed: bool | Iterable[str] = False,
     scope: Iterable[str] | None = None,
+    events: Iterable[Event] | None = None,
 ) -> ValidationOutcome:
     """Validate a state against the current environment.
 
@@ -818,4 +1028,5 @@ def validate_state(
         expected_model=expected_model,
         confirmed=confirmed,
         scope=scope,
+        events=events,
     )

--- a/tests/test_provenance_staleness.py
+++ b/tests/test_provenance_staleness.py
@@ -1,0 +1,169 @@
+"""N-hop staleness propagation via caused_by DAG (issue #553)."""
+
+from __future__ import annotations
+
+from continuum.environment import StaticProvider, capture
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.provenance.graph import build_provenance_graph
+from continuum.recovery import RecoveryEngine
+from continuum.state.validator import validate_state
+from continuum.storage.sqlite import SQLiteStorage
+
+
+def test_n_hop_staleness_via_caused_by():
+    """Evidence -> decision -> action chain, invalidation propagates 2 hops via caused_by."""
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_stale_n_hop"
+    storage.create_run_started(Run(run_id=run_id, goal="g"))
+    # Create dependency and evidence
+    storage.append_event(
+        run_id, EventType.DEPENDENCY_DECLARED, {"resource": "dataset", "version": "v1"}
+    )
+    ev = storage.append_event(
+        run_id,
+        EventType.EVIDENCE_ADDED,
+        {"evidence_id": "ev1", "summary": "s", "source": "dataset"},
+    )
+    # Decision caused by evidence
+    dec = storage.append_event(
+        run_id,
+        EventType.DECISION_CREATED,
+        {"decision": "d1", "decision_id": "dec1", "caused_by": [ev.event_id]},
+    )
+    # Action caused by decision
+    act = storage.append_event(
+        run_id,
+        EventType.ACTION_RECORDED,
+        {
+            "action_type": "send",
+            "action_id": "act1",
+            "caused_by": [dec.event_id],
+            "action": {"action_id": "act1"},
+        },
+    )
+    events = storage.read_events(run_id)
+    # Build state via project (implicitly via validator's state)
+    from continuum.state.semantic import project
+
+    state = project(run_id, events)
+    # Check graph has edges
+    graph = build_provenance_graph(events)
+    assert dec.event_id in graph.edges.get(ev.event_id, [])
+    assert act.event_id in graph.edges.get(dec.event_id, [])
+
+    # Validate with changed env and events
+    env_checkpoint = capture(run_id, StaticProvider(dataset="v1"))
+    env_current = capture(run_id, StaticProvider(dataset="v2"))
+    # Need to set dependency in state: project should have dependency from DEPENDENCY_DECLARED
+    # The state's external_dependencies should have dataset v1
+    # Validate
+    outcome = validate_state(
+        state,
+        checkpoint_environment=env_checkpoint,
+        current_environment=env_current,
+        events=events,
+    )
+    # Evidence should be stale
+    from continuum.models import Component, StateStatus
+
+    def status_for(comp, cid):
+        for e in outcome.report.statuses:
+            if e.component is comp and e.component_id == cid:
+                return e.status
+        return None
+
+    assert status_for(Component.EVIDENCE, "ev1") is StateStatus.STALE
+    # Decision should be stale via N-hop
+    assert status_for(Component.DECISION, "dec1") is StateStatus.STALE
+    # Action should be stale as well (via validation entry for Component.ACTION)
+    assert status_for(Component.ACTION, "act1") is StateStatus.STALE
+
+
+def test_three_hop_chain():
+    """3-hop chain: ev -> dec1 -> dec2 -> act, all should go stale."""
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_three_hop"
+    storage.create_run_started(Run(run_id=run_id, goal="g"))
+    storage.append_event(
+        run_id, EventType.DEPENDENCY_DECLARED, {"resource": "dataset", "version": "v1"}
+    )
+    ev = storage.append_event(
+        run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1", "source": "dataset"}
+    )
+    dec1 = storage.append_event(
+        run_id,
+        EventType.DECISION_CREATED,
+        {"decision": "d1", "decision_id": "dec1", "caused_by": [ev.event_id]},
+    )
+    dec2 = storage.append_event(
+        run_id,
+        EventType.DECISION_CREATED,
+        {"decision": "d2", "decision_id": "dec2", "caused_by": [dec1.event_id]},
+    )
+    _act = storage.append_event(
+        run_id,
+        EventType.ACTION_RECORDED,
+        {"action_type": "send", "action_id": "act1", "caused_by": [dec2.event_id]},
+    )
+    events = storage.read_events(run_id)
+    from continuum.state.semantic import project
+
+    state = project(run_id, events)
+    env_checkpoint = capture(run_id, StaticProvider(dataset="v1"))
+    env_current = capture(run_id, StaticProvider(dataset="v2"))
+    outcome = validate_state(
+        state,
+        checkpoint_environment=env_checkpoint,
+        current_environment=env_current,
+        events=events,
+    )
+    from continuum.models import Component, StateStatus
+
+    def status_for(comp, cid):
+        for e in outcome.report.statuses:
+            if e.component is comp and e.component_id == cid:
+                return e.status
+        return None
+
+    assert status_for(Component.DECISION, "dec1") is StateStatus.STALE
+    assert status_for(Component.DECISION, "dec2") is StateStatus.STALE
+    assert status_for(Component.ACTION, "act1") is StateStatus.STALE
+
+
+def test_engine_propagates_to_contract(tmp_path):
+    """Engine surfaces N-hop staleness in RecoveryContract.invalidated."""
+
+    db = str(tmp_path / "engine.db")
+    storage = SQLiteStorage(db)
+    run_id = "run_engine_stale"
+    storage.create_run_started(Run(run_id=run_id, goal="g"))
+    storage.append_event(
+        run_id, EventType.DEPENDENCY_DECLARED, {"resource": "dataset", "version": "v1"}
+    )
+    ev = storage.append_event(
+        run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1", "source": "dataset"}
+    )
+    _dec = storage.append_event(
+        run_id,
+        EventType.DECISION_CREATED,
+        {"decision": "d1", "decision_id": "dec1", "caused_by": [ev.event_id]},
+    )
+    storage.close()
+    from continuum.checkpoint import CheckpointManager
+
+    storage2 = SQLiteStorage(db)
+    _mgr = CheckpointManager(storage2)
+    from continuum.state.semantic import project
+
+    state = project(run_id, storage2.read_events(run_id))
+    _env_v1 = capture(run_id, StaticProvider(dataset="v1"))
+    _mgr.checkpoint(run_id, state=state, environment=_env_v1)
+    engine = RecoveryEngine(storage2)
+    env_current = capture(run_id, StaticProvider(dataset="v2"))
+    decision = engine.assess(run_id, current_environment=env_current)
+    # Contract should have invalidated containing dec1
+    assert "dec1" in str(decision.contract.invalidated) or any(
+        "dec1" in x for x in decision.contract.invalidated
+    )
+    assert not decision.safe


### PR DESCRIPTION
## Description

Implements N-hop staleness propagation through the causal graph (issue #553, epic #288).

- `src/continuum/state/validator.py`: adds `_propagate_caused_by` that BFS walks the transitive closure of `caused_by edges (built from `read_all_events so compaction does not launder). Marks every downstream finding, decision, plan and action as `STALE (or CONFLICTED on cycles) with detail `via caused_by from <parent> (N-hop staleness). Surfaces in RecoveryContract.invalidated.
- `src/continuum/recovery/engine.py`: builds provenance graph from read_all_events and passes to validator so staleness survives compaction.
- Tests: `tests/test_provenance_staleness.py` covers 2-hop (evidence -> decision -> action), 3-hop (evidence -> dec1 -> dec2 -> action) and contract propagation via engine.
- Docs: `docs/threat_model.md` documents N-hop staleness.

## Related issues

Fixes #553
Refs #550
Parent epic #288
Depends on #552

## Testing

pytest tests/test_provenance_staleness.py -q (3 passed)
ruff check clean, mypy strict clean
