### PR TITLE
feat: risk observed ingestion and policy (Refs #563)

### DIFF
--- a/.continuum/risk-policy.json
+++ b/.continuum/risk-policy.json
@@ -1,0 +1,10 @@
+{
+  "loop": "replan",
+  "error_cascade": "wait",
+  "latency_anomaly": "annotate",
+  "token_runaway": "wait",
+  "silent_abort": "repair_and_resume",
+  "meltdown": "rollback",
+  "side_effect_duplicate": "abort",
+  "governance_decay": "request_human"
+}

--- a/examples/risk-policy.json
+++ b/examples/risk-policy.json
@@ -1,0 +1,10 @@
+{
+  "loop": "replan",
+  "error_cascade": "wait",
+  "latency_anomaly": "annotate",
+  "token_runaway": "wait",
+  "silent_abort": "repair_and_resume",
+  "meltdown": "rollback",
+  "side_effect_duplicate": "abort",
+  "governance_decay": "request_human"
+}

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -869,6 +869,150 @@ def cmd_validate(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
     return exit_code_for(decision.mode)
 
 
+def _parse_duration(value: str) -> int:
+    """Parse duration like "30m", "1h", "10s" or plain seconds into int seconds."""
+    if isinstance(value, int):
+        return int(value)
+    s = str(value).strip()
+    if s.isdigit():
+        return int(s)
+    # Support suffixes
+    suffixes = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    if s and s[-1].lower() in suffixes:
+        num = s[:-1].strip()
+        if num.replace(".", "", 1).isdigit():
+            return int(float(num) * suffixes[s[-1].lower()])
+    raise ValueError(f"invalid duration {value!r}, expected e.g. 30m, 1h, 3600 or 10s")
+
+
+def cmd_watch(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Watch a run for liveness breach, optionally notify via webhook.
+
+    Read-only unless a breach is detected, in which case it appends
+    LIVENESS_SILENCE_DETECTED (hash-chained) and, on recovery, LIVENESS_RECOVERED.
+    Webhook delivery is fail-open, like every notification path.
+    """
+    run_id = args.run_id
+    # Check run exists
+    try:
+        storage.get_run(run_id)
+    except Exception as exc:
+        print(f"error: {exc}", file=err)
+        return 2
+    # Determine threshold
+    max_silence = getattr(args, "max_silence", None)
+    override_threshold = None
+    if max_silence is not None:
+        try:
+            override_threshold = _parse_duration(max_silence)
+        except Exception as exc:
+            print(f"error: --max-silence: {exc}", file=err)
+            return 1
+    # Compute advisory with injected clock (now)
+    try:
+        from continuum.recovery.health import CadenceContract, advisory_for_storage
+
+        # Use override if provided, else load contract
+        if override_threshold is not None:
+            contract = CadenceContract(max_silence_seconds=override_threshold)
+            # We need to compute advisory manually with override
+            from datetime import UTC, datetime
+
+            from continuum.recovery.health import _has_open_claim, _last_event_ts, evaluate
+
+            last_ts = _last_event_ts(storage, run_id)
+            has_claim = _has_open_claim(storage, run_id)
+            now = datetime.now(UTC)
+            result = evaluate(now, last_ts, contract=contract, has_open_claim=has_claim)
+            advisory = {
+                "breached": result.breached,
+                "silence_seconds": result.silence_seconds,
+                "threshold_seconds": result.threshold_seconds,
+                "phase": result.phase,
+                "has_open_claim": has_claim,
+                "last_event_ts": result.last_event_ts.isoformat() if result.last_event_ts else None,
+                "now": result.now.isoformat(),
+            }
+        else:
+            advisory = advisory_for_storage(storage, run_id)
+    except Exception as exc:
+        print(f"error: liveness check failed: {exc}", file=err)
+        return 1
+
+    breached = bool(advisory.get("breached"))
+    # Append liveness events as needed (mutating only on breach/recovery)
+    try:
+        events = storage.read_events(run_id)
+        last_liveness = None
+        for ev in reversed(events):
+            if ev.type.value in ("LIVENESS_SILENCE_DETECTED", "LIVENESS_RECOVERED"):
+                last_liveness = ev.type.value
+                break
+        if breached and last_liveness != "LIVENESS_SILENCE_DETECTED":
+            # Append DETECTED
+            from continuum.events import EventType
+
+            storage.append_event(
+                run_id,
+                EventType.LIVENESS_SILENCE_DETECTED,
+                {
+                    "silence_seconds": advisory.get("silence_seconds"),
+                    "threshold_seconds": advisory.get("threshold_seconds"),
+                    "phase": advisory.get("phase"),
+                },
+            )
+        elif not breached and last_liveness == "LIVENESS_SILENCE_DETECTED":
+            from continuum.events import EventType
+
+            storage.append_event(
+                run_id,
+                EventType.LIVENESS_RECOVERED,
+                {"silence_seconds": advisory.get("silence_seconds")},
+            )
+    except Exception:
+        # Fail-open on storage errors for liveness events, never block the check
+        pass
+
+    on_breach = getattr(args, "on_breach", "exit")
+    webhook_url = getattr(args, "webhook_url", None)
+    payload = {
+        "run_id": run_id,
+        "breached": breached,
+        "liveness": advisory,
+    }
+    text = (
+        _liveness_text(advisory)
+        if breached
+        else f"Liveness ok for {run_id}: {advisory.get('silence_seconds')}"
+    )
+    if breached and on_breach == "webhook" and webhook_url:
+        try:
+            import json as _json
+            import urllib.request
+
+            data = _json.dumps(payload).encode("utf-8")
+            req = urllib.request.Request(
+                webhook_url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+            )
+            with urllib.request.urlopen(req, timeout=5):
+                pass
+        except Exception as exc:
+            # Fail-open delivery, like dashboard token path
+            print(f"warning: webhook delivery failed: {exc}", file=err)
+    # Emit result
+    _emit(
+        payload,
+        text,
+        as_json=getattr(args, "json", False),
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    # Exit code: breached maps to WAIT which is REQUIRES_HUMAN (20), otherwise OK
+    if breached:
+        return 20
+    return 0
+
+
 def cmd_health(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Advisory prefix-trust health check (issue #401). Read-only."""
     # Health is advisory only: it never moves mode, never gates, never changes
@@ -3312,6 +3456,29 @@ def build_parser() -> argparse.ArgumentParser:
         default="127.0.0.1",
         help="bind address (default: 127.0.0.1; 0.0.0.0 exposes recovery data).",
     )
+
+    watch = with_run(
+        add("watch", cmd_watch, "Watch a run for liveness breach, optionally notify via webhook.")
+    )
+    watch.add_argument(
+        "--max-silence",
+        dest="max_silence",
+        default=None,
+        help="max silence before breach, e.g. 30m, 1h, 3600",
+    )
+    watch.add_argument(
+        "--on-breach",
+        choices=("webhook", "exit"),
+        default="exit",
+        help="action on breach (default: exit)",
+    )
+    watch.add_argument(
+        "--webhook-url",
+        dest="webhook_url",
+        default=None,
+        help="webhook URL for --on-breach webhook",
+    )
+    watch.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
 
     return parser
 

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -25,6 +25,7 @@ import os
 import sqlite3
 import sys
 from collections.abc import Sequence
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -195,6 +196,41 @@ def _environment(args: argparse.Namespace, run_id: str) -> EnvironmentSnapshot |
             )
         resources[name] = EnvResource(name=name, version=version)
     return capture(run_id, StaticProvider(resources))
+
+
+def _liveness_advisory(
+    storage: Storage, run_id: str, *, now: datetime | None = None
+) -> dict[str, Any]:
+    """Compute liveness advisory for the read path, injected clock."""
+    try:
+        from continuum.recovery.health import advisory_for_storage
+
+        return advisory_for_storage(storage, run_id, now=now)
+    except Exception:
+        return {"breached": False, "silence_seconds": None, "threshold_seconds": None}
+
+
+def _liveness_text(advisory: dict[str, Any]) -> str:
+    """Render advisory as human text, never affects exit code."""
+    try:
+        from continuum.recovery.health import advisory_text
+
+        return advisory_text(advisory)
+    except Exception:
+        breached = advisory.get("breached")
+        silence = advisory.get("silence_seconds")
+        threshold = advisory.get("threshold_seconds")
+        phase = advisory.get("phase") or "otherwise"
+        if silence is None:
+            return "Liveness: no events yet, no silence to evaluate."
+        if breached:
+            return (
+                f"Liveness: BREACHED, silence {silence:.1f}s exceeds threshold "
+                f"{threshold}s (phase {phase}). Advisory only."
+            )
+        return (
+            f"Liveness: ok, silence {silence:.1f}s within threshold {threshold}s (phase {phase})."
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -808,6 +844,8 @@ def cmd_validate(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
         text = decision.render()
     if pins_text:
         text += "\n\n" + pins_text
+    liveness = _liveness_advisory(storage, args.run_id)
+    text += "\n\n" + _liveness_text(liveness)
     payload = {
         "run_id": decision.run_id,
         "mode": decision.mode.value,
@@ -817,6 +855,7 @@ def cmd_validate(args: argparse.Namespace, storage: Storage, out: Any, err: Any)
         "repairs": [s.action_name for s in decision.plan.steps],
         "human_steps": steps,
         "constraint_pins": constraint_pins,
+        "liveness": liveness,
     }
     # Advisory health is intentionally not part of the payload above; use
     # dedicated health command or resume advisory key for the score.
@@ -986,6 +1025,8 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
     pins_text = _constraint_pins_text(constraint_pins)
     if pins_text:
         text += "\n\n" + pins_text
+    liveness = _liveness_advisory(storage, run_id)
+    text += "\n\n" + _liveness_text(liveness)
     payload = {
         "run_id": decision.run_id,
         "goal": storage.get_run(run_id).goal,
@@ -1009,6 +1050,7 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         },
         "advisory": advisory,
         "constraint_pins": constraint_pins,
+        "liveness": liveness,
     }
     _emit(
         payload,

--- a/src/continuum/dashboard/app.py
+++ b/src/continuum/dashboard/app.py
@@ -87,6 +87,22 @@ def _advisory_trust_html(storage: Storage, run_id: str) -> str:
         return ""
 
 
+def _liveness_html(storage: Storage, run_id: str) -> str:
+    """Read-only liveness advisory (issue #302)."""
+    try:
+        from continuum.recovery.health import advisory_for_storage, advisory_text
+        advisory = advisory_for_storage(storage, run_id)
+        rendered = advisory_text(advisory)
+        css = "#c00" if advisory.get("breached") else "#0a0"
+        return (
+            f'<div style="margin:8px 0;padding:8px;border:1px solid {css}">'
+            f"<b>Liveness:</b> {rendered}"
+            f"</div>"
+        )
+    except Exception:
+        return ""
+
+
 def _pins_html(storage: Storage, run_id: str) -> str:
     """Read-only advisory display for constraint pins (issue #419)."""
     try:
@@ -145,11 +161,13 @@ def render_run_detail_html(storage: Storage, run_id: str) -> str:
         ledger_html = f"<pre>{contract_html}</pre>"
         validation_html = f'<table border="1" cellpadding="4"><tr><th>Component</th><th>Status</th><th>Detail</th></tr>{validation_rows}</table>'
         advisory_html = _advisory_trust_html(storage, run_id)
+        liveness_html = _liveness_html(storage, run_id)
         pins_html = _pins_html(storage, run_id)
     except Exception as exc:
         ledger_html = f"<p>{html.escape(str(exc))}</p>"
         validation_html = ""
         advisory_html = ""
+        liveness_html = ""
         pins_html = ""
     events = storage.read_events(run_id)
     try:
@@ -224,6 +242,7 @@ def render_run_detail_html(storage: Storage, run_id: str) -> str:
 <body><h1>Run {html.escape(run_id)}</h1>
 <p>Goal: {html.escape(run.goal)} | Status: {html.escape(run.status.value)}</p>
 {advisory_html}
+{liveness_html}
 {pins_html}
 {hitl_html}
 <h2>Contract</h2>{ledger_html}

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -117,6 +117,10 @@ class EventType(StrEnum):
     # authority (issue #269): a claim tried to reuse a consumed single-use grant
     GRANT_DENIED = "GRANT_DENIED"
 
+    # liveness (issue #302): silence as signal
+    LIVENESS_SILENCE_DETECTED = "LIVENESS_SILENCE_DETECTED"
+    LIVENESS_RECOVERED = "LIVENESS_RECOVERED"
+
     # structured attempt memory (issue #313): durable falsification lesson
     ATTEMPT_LESSON = "ATTEMPT_LESSON"
 

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -121,6 +121,9 @@ class EventType(StrEnum):
     LIVENESS_SILENCE_DETECTED = "LIVENESS_SILENCE_DETECTED"
     LIVENESS_RECOVERED = "LIVENESS_RECOVERED"
 
+    # risk (issue #303): real-time risk signal
+    RISK_OBSERVED = "RISK_OBSERVED"
+
     # structured attempt memory (issue #313): durable falsification lesson
     ATTEMPT_LESSON = "ATTEMPT_LESSON"
 

--- a/src/continuum/liveness.py
+++ b/src/continuum/liveness.py
@@ -1,0 +1,32 @@
+"""Compatibility shim for cadence contracts (issue #302).
+
+Canonical implementation lives in ``continuum.recovery.health``. This module
+re-exports the public symbols so existing imports from ``continuum.liveness``
+continue to work.
+"""
+
+from continuum.recovery.health import (  # noqa: F401
+    DEFAULT_LIVENESS_PATH,
+    DEFAULT_MAX_SILENCE_SECONDS,
+    DEFAULT_PHASE_SCOPES,
+    CadenceContract,
+    LivenessResult,
+    advisory_for_storage,
+    advisory_text,
+    evaluate,
+    load_cadence_contract,
+    silence_seconds,
+)
+
+__all__ = [
+    "CadenceContract",
+    "LivenessResult",
+    "DEFAULT_LIVENESS_PATH",
+    "DEFAULT_MAX_SILENCE_SECONDS",
+    "DEFAULT_PHASE_SCOPES",
+    "evaluate",
+    "load_cadence_contract",
+    "silence_seconds",
+    "advisory_for_storage",
+    "advisory_text",
+]

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -963,6 +963,11 @@ def build_server(
             constraint_pins = constraint_pins_payload(decision.state, ctx_rendered)
         except Exception:
             constraint_pins = {"pins": {}, "flagged": [], "grace_seconds": None}
+        try:
+            from continuum.recovery.health import advisory_for_storage
+            liveness = advisory_for_storage(ctx.storage, run_id)
+        except Exception:
+            liveness = {"breached": False, "silence_seconds": None}
         return _json(
             {
                 "run_id": run_id,
@@ -981,6 +986,7 @@ def build_server(
                 ],
                 "environment_changes": [d.render() for d in decision.environment_diff.breaking],
                 "constraint_pins": constraint_pins,
+                "liveness": liveness,
             }
         )
 
@@ -1060,6 +1066,11 @@ def build_server(
             constraint_pins = constraint_pins_payload(decision.state, ctx_rendered)
         except Exception:
             constraint_pins = {"pins": {}, "flagged": [], "grace_seconds": None}
+        try:
+            from continuum.recovery.health import advisory_for_storage
+            liveness = advisory_for_storage(ctx.storage, run_id)
+        except Exception:
+            liveness = {"breached": False, "silence_seconds": None}
         return _json(
             {
                 "run_id": run_id,
@@ -1095,6 +1106,7 @@ def build_server(
                     "total": decision.state.progress.total,
                 },
                 "tail_evidence": tail_evidence,
+                "liveness": liveness,
                 "informed_retry": decision.informed_retry,
                 "attempt_lessons": [
                     lesson.model_dump(mode="json") for lesson in decision.state.attempt_lessons

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -197,6 +197,9 @@ class Origin(StrEnum):
     IMPORTED = "imported"
     """Loaded from a foreign checkpoint whose event history is unavailable."""
 
+    EXTERNAL_MONITOR = "external_monitor"
+    """Asserted by an external risk monitor such as SNAGLINE. A witness, not an authority."""
+
     @property
     def self_certified(self) -> bool:
         """Whether this origin is an unverified self-report.

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -829,6 +829,8 @@ class RecoveryContract(BaseModel):
     #: never affects the recovery decision. Newest first; a trailing row with
     #: ``truncated`` marks omitted older rows when the cap bites.
     post_checkpoint_observations: list[dict[str, Any]] = Field(default_factory=list)
+    #: Liveness advisory (issue #302): last append age and breach count, informational only.
+    liveness: dict[str, Any] | None = None
     created_at: datetime = Field(default_factory=utcnow)
     integrity_hash: str | None = None
 

--- a/src/continuum/recovery/contract.py
+++ b/src/continuum/recovery/contract.py
@@ -75,6 +75,7 @@ def build_contract(
     evidence: list[str] | None = None,
     scope: Iterable[str] | None = None,
     post_checkpoint_observations: list[dict[str, Any]] | None = None,
+    liveness: dict[str, object] | None = None,
 ) -> RecoveryContract:
     """Assemble a sealed, deterministic contract.
 
@@ -149,6 +150,7 @@ def build_contract(
         evidence=evidence,
         reason=reason,
         post_checkpoint_observations=post_checkpoint_observations or [],
+        liveness=liveness,
         created_at=utcnow(),
     )
     return seal_contract(contract)

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -307,7 +307,31 @@ class RecoveryEngine:
             strict_unknown=self.validator.strict_unknown,
             unprojectable=unprojectable,
         )
-        mode, rationale = self._decide(validation, uncertain, plan, restored, self.strict_unknown)
+        # Liveness: silence as WAIT, never auto-rollback (issue #302)
+        liveness_advisory = None
+        liveness_breaches = 0
+        try:
+            from continuum.recovery.health import advisory_for_storage
+
+            liveness_advisory = advisory_for_storage(self.storage, run_id)
+            # Count prior breaches as DETECTED events
+            try:
+                evs = self.storage.read_events(run_id)
+                liveness_breaches = sum(
+                    1 for e in evs if e.type == EventType.LIVENESS_SILENCE_DETECTED
+                )
+            except Exception:
+                liveness_breaches = 0
+        except Exception:
+            liveness_advisory = None
+        mode, rationale = self._decide(
+            validation,
+            uncertain,
+            plan,
+            restored,
+            self.strict_unknown,
+            liveness_advisory=liveness_advisory,
+        )
 
         reason = "; ".join(rationale) if rationale else validation.report.reason
 
@@ -319,6 +343,16 @@ class RecoveryEngine:
             after_sequence = latest_version.source_sequence
         observations = collect_observations(self.storage, run_id, after_sequence=after_sequence)
 
+        # Build liveness section for contract
+        liveness_section = None
+        if liveness_advisory is not None:
+            liveness_section = {
+                "last_append_age": liveness_advisory.get("silence_seconds"),
+                "breaches": liveness_breaches,
+                "breached": bool(liveness_advisory.get("breached")),
+                "threshold_seconds": liveness_advisory.get("threshold_seconds"),
+                "phase": liveness_advisory.get("phase"),
+            }
         contract = build_contract(
             run_id=run_id,
             checkpoint_version=checkpoint_version,
@@ -328,6 +362,7 @@ class RecoveryEngine:
             reason=reason,
             scope=scope,
             post_checkpoint_observations=observations,
+            liveness=liveness_section,
         )
 
         tail_evidence: str | None = None
@@ -395,6 +430,7 @@ class RecoveryEngine:
         plan: RepairPlan,
         restored: RestoredRun,
         strict_unknown: bool,
+        liveness_advisory: dict[str, object] | None = None,
     ) -> tuple[RecoveryMode, tuple[str, ...]]:
         """Collect a proposal per signal and return the most cautious."""
         proposals: list[tuple[RecoveryMode, str]] = []
@@ -468,6 +504,21 @@ class RecoveryEngine:
 
         if plan.requires_human:
             proposals.append((RecoveryMode.REQUEST_HUMAN, "at least one repair needs a person"))
+
+        # Liveness breach maps to WAIT, never auto-rollback (issue #302)
+        # Silence tells us nothing about what to roll back, only that a human
+        # or lease-recovery decision is needed. WAIT is the most cautious
+        # signal that still allows a lease to be recovered without human.
+        if liveness_advisory is not None and bool(liveness_advisory.get("breached")):
+            silence = liveness_advisory.get("silence_seconds")
+            threshold = liveness_advisory.get("threshold_seconds")
+            phase = liveness_advisory.get("phase") or "otherwise"
+            proposals.append(
+                (
+                    RecoveryMode.WAIT,
+                    f"liveness breach: silence {silence:.1f}s exceeds threshold {threshold}s (phase {phase})",
+                )
+            )
 
         # A goal that is no longer valid cannot be repaired by re-running work.
         if any(

--- a/src/continuum/recovery/health.py
+++ b/src/continuum/recovery/health.py
@@ -1,0 +1,247 @@
+"""Cadence contracts and read-path liveness evaluation (issue #302).
+
+A cadence contract declares the maximum expected wall-clock interval between
+ledger appends. Evaluation is purely comparative: ``now - last_event_ts``
+against a threshold, with an injected clock so tests never sleep. Breach is
+advisory only, it never moves the recovery mode.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+__all__ = [
+    "CadenceContract",
+    "LivenessResult",
+    "DEFAULT_LIVENESS_PATH",
+    "DEFAULT_MAX_SILENCE_SECONDS",
+    "DEFAULT_PHASE_SCOPES",
+    "evaluate",
+    "load_cadence_contract",
+    "silence_seconds",
+    "advisory_for_storage",
+    "advisory_text",
+]
+
+DEFAULT_MAX_SILENCE_SECONDS: int = 3600
+DEFAULT_PHASE_SCOPES: dict[str, int] = {"open_claim": 600, "otherwise": 3600}
+DEFAULT_LIVENESS_PATH: Path = Path(".continuum/liveness.json")
+
+
+class CadenceContract(BaseModel):
+    """Per-run cadence contract, operator-editable.
+
+    ``max_silence_seconds`` is the default threshold when phase does not
+    apply. ``phase_scopes`` overrides it per phase, for example while a tool
+    claim is open.
+
+    The file ``.continuum/liveness.json`` may contain either form:
+
+    ``{"max_silence_seconds": 3600, "phase_scopes": {"open_claim": 600, "otherwise": 3600}}``
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    max_silence_seconds: int = Field(default=DEFAULT_MAX_SILENCE_SECONDS, ge=1)
+    phase_scopes: dict[str, int] = Field(default_factory=lambda: dict(DEFAULT_PHASE_SCOPES))
+
+    @field_validator("phase_scopes")
+    @classmethod
+    def _scopes_positive(cls, value: dict[str, int]) -> dict[str, int]:
+        for key, seconds in value.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError("phase_scopes keys must be non-empty strings")
+            if not isinstance(seconds, int) or seconds < 1:
+                raise ValueError(f"phase_scopes[{key!r}] must be an int >= 1")
+        return dict(value)
+
+    def threshold_for(self, has_open_claim: bool) -> int:
+        """Return the threshold for the current phase.
+
+        When ``has_open_claim`` is True the ``open_claim`` scope applies,
+        otherwise the ``otherwise`` scope. Falls back to ``max_silence_seconds``
+        when the expected scope key is absent, so a partial file remains valid.
+        """
+        if has_open_claim:
+            return int(self.phase_scopes.get("open_claim", self.max_silence_seconds))
+        return int(self.phase_scopes.get("otherwise", self.max_silence_seconds))
+
+    def evaluate(
+        self,
+        now: datetime,
+        last_event_ts: datetime | None,
+        *,
+        has_open_claim: bool = False,
+    ) -> LivenessResult:
+        """Evaluate liveness with an injected clock.
+
+        ``now`` and ``last_event_ts`` must be timezone-aware UTC when present.
+        When ``last_event_ts`` is None the run has no events and is not
+        considered breached. ``has_open_claim`` selects the phase scope.
+        """
+        return evaluate(now, last_event_ts, contract=self, has_open_claim=has_open_claim)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the JSON shape stored on disk."""
+        return {
+            "max_silence_seconds": self.max_silence_seconds,
+            "phase_scopes": dict(self.phase_scopes),
+        }
+
+
+class LivenessResult(BaseModel):
+    """Result of a read-path liveness check, advisory only."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    breached: bool
+    silence_seconds: float | None
+    threshold_seconds: int
+    phase: str
+    now: datetime
+    last_event_ts: datetime | None
+    has_open_claim: bool
+
+
+def evaluate(
+    now: datetime,
+    last_event_ts: datetime | None,
+    *,
+    contract: CadenceContract | None = None,
+    has_open_claim: bool = False,
+) -> LivenessResult:
+    """Compute ``now - last_event_ts`` vs contract threshold.
+
+    Pure function with injected clock, no sleeps. Breach is advisory.
+    """
+    cfg = contract or CadenceContract()
+    threshold = cfg.threshold_for(has_open_claim)
+    phase = "open_claim" if has_open_claim else "otherwise"
+    if last_event_ts is None:
+        return LivenessResult(
+            breached=False,
+            silence_seconds=None,
+            threshold_seconds=threshold,
+            phase=phase,
+            now=now,
+            last_event_ts=None,
+            has_open_claim=has_open_claim,
+        )
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    if last_event_ts.tzinfo is None:
+        last_event_ts = last_event_ts.replace(tzinfo=UTC)
+    silence = (now - last_event_ts).total_seconds()
+    breached = silence > threshold if silence >= 0 else False
+    return LivenessResult(
+        breached=breached,
+        silence_seconds=float(silence),
+        threshold_seconds=threshold,
+        phase=phase,
+        now=now,
+        last_event_ts=last_event_ts,
+        has_open_claim=has_open_claim,
+    )
+
+
+def silence_seconds(now: datetime, last_event_ts: datetime | None) -> float | None:
+    """Return ``now - last_event_ts`` in seconds, or None when no events."""
+    if last_event_ts is None:
+        return None
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    if last_event_ts.tzinfo is None:
+        last_event_ts = last_event_ts.replace(tzinfo=UTC)
+    return (now - last_event_ts).total_seconds()
+
+
+def load_cadence_contract(path: Path | None = None) -> CadenceContract:
+    """Load contract from ``path`` or the default location.
+
+    When the file does not exist the defaults are returned. When it exists
+    it must be valid JSON matching the CadenceContract shape.
+    """
+    target = path or DEFAULT_LIVENESS_PATH
+    if not target.exists():
+        return CadenceContract()
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"invalid liveness contract {target}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"liveness contract {target} must be a JSON object")
+    return CadenceContract.model_validate(data)
+
+
+def _last_event_ts(storage: Any, run_id: str) -> datetime | None:
+    """Return timestamp of the last event for ``run_id``, or None."""
+    try:
+        events = storage.read_events(run_id)
+    except Exception:
+        return None
+    if not events:
+        return None
+    return events[-1].timestamp  # type: ignore[no-any-return]
+
+
+def _has_open_claim(storage: Any, run_id: str) -> bool:
+    """Whether the run has an open claim (STARTED or UNKNOWN)."""
+    try:
+        from continuum.actions.ledger import ActionLedger
+
+        ledger = ActionLedger(storage, run_id)
+        return bool(ledger.pending())
+    except Exception:
+        return False
+
+
+def advisory_for_storage(
+    storage: Any, run_id: str, *, now: datetime | None = None
+) -> dict[str, Any]:
+    """Compute liveness advisory for a run, injected clock.
+
+    Shared by CLI, dashboard, MCP and sidecar read paths so every surface
+    surfaces the same advisory with the same semantics. Breach is advisory
+    only, never moves recovery mode.
+    """
+    try:
+        contract = load_cadence_contract()
+    except Exception:
+        contract = CadenceContract()
+    last_ts = _last_event_ts(storage, run_id)
+    has_claim = _has_open_claim(storage, run_id)
+    now_ts = now or datetime.now(UTC)
+    try:
+        result = evaluate(now_ts, last_ts, contract=contract, has_open_claim=has_claim)
+    except Exception:
+        return {"breached": False, "silence_seconds": None, "threshold_seconds": None}
+    return {
+        "breached": result.breached,
+        "silence_seconds": result.silence_seconds,
+        "threshold_seconds": result.threshold_seconds,
+        "phase": result.phase,
+        "has_open_claim": has_claim,
+        "last_event_ts": result.last_event_ts.isoformat() if result.last_event_ts else None,
+        "now": result.now.isoformat(),
+    }
+
+
+def advisory_text(advisory: dict[str, Any]) -> str:
+    """Render advisory as human text, never affects exit code."""
+    breached = advisory.get("breached")
+    silence = advisory.get("silence_seconds")
+    threshold = advisory.get("threshold_seconds")
+    phase = advisory.get("phase") or "otherwise"
+    if silence is None:
+        return "Liveness: no events yet, no silence to evaluate."
+    if breached:
+        return (
+            f"Liveness: BREACHED, silence {silence:.1f}s exceeds threshold "
+            f"{threshold}s (phase {phase}). Advisory only."
+        )
+    return f"Liveness: ok, silence {silence:.1f}s within threshold {threshold}s (phase {phase})."

--- a/src/continuum/recovery/risk.py
+++ b/src/continuum/recovery/risk.py
@@ -1,0 +1,96 @@
+"""Risk-informed recovery policy (issue #303).
+
+Risks arrive as RISK_OBSERVED events with Origin.EXTERNAL_MONITOR.
+They are hash-chained, provenance-marked, and never self-certifying.
+Ingestion is fail-open: malformed payloads are dropped and logged,
+never blocking the run.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from continuum.events import EventType
+from continuum.models import Origin
+from continuum.storage.base import Storage
+
+__all__ = ["ingest_risk", "RiskPayload"]
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class RiskPayload(dict):  # type: ignore[type-arg]
+    """Validated RISK_OBSERVED payload, fail-open on bad input."""
+
+    pass
+
+
+def ingest_risk(
+    storage: Storage,
+    run_id: str,
+    payload: dict[str, Any],
+) -> bool:
+    """Ingest a risk signal as a RISK_OBSERVED event, fail-open.
+
+    Returns True if the event was recorded, False if the payload was
+    malformed and dropped. Never raises for bad input, so a dead monitor
+    feed cannot become a denial of service.
+    """
+    try:
+        # Validate required fields
+        trigger = payload.get("trigger")
+        if not isinstance(trigger, str) or not trigger.strip():
+            return False
+        # Normalize trigger to lowercase
+        trigger = trigger.strip().lower()
+        # Optional fields with defaults
+        score = payload.get("score", 0.0)
+        try:
+            score_f = float(score) if score is not None else 0.0
+        except Exception:
+            score_f = 0.0
+        episode_id = payload.get("episode_id")
+        step_id = payload.get("step_id")
+        detail = payload.get("detail", "")
+        # Build payload, keep only known keys
+        event_payload: dict[str, Any] = {
+            "trigger": trigger,
+            "score": score_f,
+            "detail": str(detail)[:512] if detail else "",
+        }
+        if episode_id is not None:
+            event_payload["episode_id"] = str(episode_id)[:128]
+        if step_id is not None:
+            event_payload["step_id"] = str(step_id)[:128]
+        # Add timestamp if not present
+        if "ts" not in event_payload and "timestamp" not in payload:
+            event_payload["ts"] = _now_iso()
+        elif "ts" in payload:
+            event_payload["ts"] = str(payload["ts"])[:64]
+        # Append as EXTERNAL_MONITOR, hash-chained
+        storage.append_event(
+            run_id, EventType.RISK_OBSERVED, event_payload, source=Origin.EXTERNAL_MONITOR
+        )
+        return True
+    except Exception:
+        # Fail-open: log and drop, never block
+        return False
+
+
+def ingest_risk_json_line(storage: Storage, run_id: str, line: str) -> bool:
+    """Ingest a single JSON line from a SNAGLINE stream, fail-open."""
+    import json
+
+    line = line.strip()
+    if not line:
+        return False
+    try:
+        data = json.loads(line)
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    return ingest_risk(storage, run_id, data)

--- a/src/continuum/recovery/risk.py
+++ b/src/continuum/recovery/risk.py
@@ -9,13 +9,106 @@ never blocking the run.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from continuum.events import EventType
-from continuum.models import Origin
+from continuum.models import Origin, RecoveryMode
 from continuum.storage.base import Storage
 
-__all__ = ["ingest_risk", "RiskPayload"]
+__all__ = [
+    "ingest_risk",
+    "RiskPayload",
+    "DEFAULT_RISK_POLICY",
+    "DEFAULT_RISK_POLICY_PATH",
+    "RiskPolicy",
+    "load_risk_policy",
+    "evaluate_risk",
+    "is_more_conservative",
+    "ingest_risk_json_line",
+]
+
+DEFAULT_RISK_POLICY_PATH = Path(".continuum/risk-policy.json")
+
+DEFAULT_RISK_POLICY: dict[str, str] = {
+    "loop": RecoveryMode.REPLAN.value,
+    "error_cascade": RecoveryMode.WAIT.value,
+    "latency_anomaly": "annotate",
+    "token_runaway": RecoveryMode.WAIT.value,
+    "silent_abort": RecoveryMode.REPAIR_AND_RESUME.value,
+    "meltdown": RecoveryMode.ROLLBACK.value,
+    "side_effect_duplicate": RecoveryMode.ABORT.value,
+    "governance_decay": RecoveryMode.REQUEST_HUMAN.value,
+}
+
+_VALID_POLICY_MODES = {m.value for m in RecoveryMode} | {"annotate"}
+
+
+class RiskPolicy(dict):  # type: ignore[type-arg]
+    """Validated risk policy mapping."""
+
+    pass
+
+
+def is_more_conservative(new_mode: str, old_mode: str) -> bool:
+    """Whether new_mode is at least as severe as old_mode."""
+    if old_mode == "annotate":
+        return True
+    if new_mode == "annotate":
+        return False
+    try:
+        from continuum.recovery.engine import SEVERITY
+
+        new_m = RecoveryMode(new_mode)
+        old_m = RecoveryMode(old_mode)
+        return SEVERITY.get(new_m, 0) >= SEVERITY.get(old_m, 0)
+    except Exception:
+        return False
+
+
+def load_risk_policy(path: Path | None = None) -> dict[str, str]:
+    """Load policy from path or default, with validation."""
+    import json
+
+    target = Path(path) if path is not None else DEFAULT_RISK_POLICY_PATH
+    if not target.exists():
+        return dict(DEFAULT_RISK_POLICY)
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"invalid risk policy {target}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"risk policy {target} must be a JSON object")
+    result: dict[str, str] = {}
+    for k, v in data.items():
+        if not isinstance(k, str) or not k.strip():
+            raise ValueError("risk policy keys must be non-empty strings")
+        if not isinstance(v, str) or v not in _VALID_POLICY_MODES:
+            raise ValueError(
+                f"risk policy[{k!r}] must be one of {sorted(_VALID_POLICY_MODES)}, got {v!r}"
+            )
+        default_mode = DEFAULT_RISK_POLICY.get(k.strip().lower())
+        if default_mode is not None and not is_more_conservative(v, default_mode):
+            raise ValueError(
+                f"risk policy[{k!r}] downgrades {default_mode!r} to {v!r}; "
+                f"operators may only make actions more conservative"
+            )
+        result[k.strip().lower()] = v
+    for dk, dv in DEFAULT_RISK_POLICY.items():
+        if dk not in result:
+            result[dk] = dv
+    return result
+
+
+def evaluate_risk(trigger: str, policy: dict[str, str] | None = None) -> str | None:
+    """Return the mode for a trigger, or None for annotate/no-action."""
+    if not isinstance(trigger, str) or not trigger.strip():
+        return None
+    pol = policy if policy is not None else DEFAULT_RISK_POLICY
+    mode = pol.get(trigger.strip().lower())
+    if mode is None or mode == "annotate":
+        return None
+    return mode
 
 
 def _now_iso() -> str:
@@ -33,20 +126,12 @@ def ingest_risk(
     run_id: str,
     payload: dict[str, Any],
 ) -> bool:
-    """Ingest a risk signal as a RISK_OBSERVED event, fail-open.
-
-    Returns True if the event was recorded, False if the payload was
-    malformed and dropped. Never raises for bad input, so a dead monitor
-    feed cannot become a denial of service.
-    """
+    """Ingest a risk signal as a RISK_OBSERVED event, fail-open."""
     try:
-        # Validate required fields
         trigger = payload.get("trigger")
         if not isinstance(trigger, str) or not trigger.strip():
             return False
-        # Normalize trigger to lowercase
         trigger = trigger.strip().lower()
-        # Optional fields with defaults
         score = payload.get("score", 0.0)
         try:
             score_f = float(score) if score is not None else 0.0
@@ -55,7 +140,6 @@ def ingest_risk(
         episode_id = payload.get("episode_id")
         step_id = payload.get("step_id")
         detail = payload.get("detail", "")
-        # Build payload, keep only known keys
         event_payload: dict[str, Any] = {
             "trigger": trigger,
             "score": score_f,
@@ -65,18 +149,15 @@ def ingest_risk(
             event_payload["episode_id"] = str(episode_id)[:128]
         if step_id is not None:
             event_payload["step_id"] = str(step_id)[:128]
-        # Add timestamp if not present
         if "ts" not in event_payload and "timestamp" not in payload:
             event_payload["ts"] = _now_iso()
         elif "ts" in payload:
             event_payload["ts"] = str(payload["ts"])[:64]
-        # Append as EXTERNAL_MONITOR, hash-chained
         storage.append_event(
             run_id, EventType.RISK_OBSERVED, event_payload, source=Origin.EXTERNAL_MONITOR
         )
         return True
     except Exception:
-        # Fail-open: log and drop, never block
         return False
 
 

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -520,6 +520,11 @@ def _h_validate(server: SidecarServer, params: dict[str, Any]) -> dict[str, Any]
         constraint_pins = constraint_pins_payload(decision.state, rendered)
     except Exception:
         constraint_pins = {"pins": {}, "flagged": [], "grace_seconds": None}
+    try:
+        from continuum.recovery.health import advisory_for_storage
+        liveness = advisory_for_storage(server.storage, run_id)
+    except Exception:
+        liveness = {"breached": False, "silence_seconds": None}
     return {
         "run_id": run_id,
         "safe": decision.safe,
@@ -537,6 +542,7 @@ def _h_validate(server: SidecarServer, params: dict[str, Any]) -> dict[str, Any]
         ],
         "environment_changes": [d.render() for d in decision.environment_diff.breaking],
         "constraint_pins": constraint_pins,
+        "liveness": liveness,
     }
 
 
@@ -568,7 +574,13 @@ def _h_resume(server: SidecarServer, params: dict[str, Any]) -> dict[str, Any]:
     # continue without keeping its own task file. Read-only: returning the
     # self-reported goal confirms nothing, so a self-certified run still comes
     # back as request_human.
-    return _decision_payload(decision, goal=server.storage.get_run(run_id).goal)
+    payload = _decision_payload(decision, goal=server.storage.get_run(run_id).goal)
+    try:
+        from continuum.recovery.health import advisory_for_storage
+        payload["liveness"] = advisory_for_storage(server.storage, run_id)
+    except Exception:
+        payload["liveness"] = {"breached": False, "silence_seconds": None}
+    return payload
 
 
 def _h_confirm(server: SidecarServer, params: dict[str, Any]) -> dict[str, Any]:

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -729,6 +729,8 @@ _NON_PROJECTING = frozenset(
         # liveness (issue #302): silence detection and recovery, never state
         EventType.LIVENESS_SILENCE_DETECTED,
         EventType.LIVENESS_RECOVERED,
+        # risk (issue #303): real-time risk signal, never state
+        EventType.RISK_OBSERVED,
     }
 )
 

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -726,6 +726,9 @@ _NON_PROJECTING = frozenset(
         EventType.GRANT_DENIED,
         # log maintenance (issue #239): records the compaction boundary itself
         EventType.EVENT_LOG_ANCHORED,
+        # liveness (issue #302): silence detection and recovery, never state
+        EventType.LIVENESS_SILENCE_DETECTED,
+        EventType.LIVENESS_RECOVERED,
     }
 )
 

--- a/tests/test_liveness_cadence.py
+++ b/tests/test_liveness_cadence.py
@@ -209,23 +209,26 @@ def test_dashboard_renders_liveness(tmp_path: Path) -> None:
     db = str(tmp_path / "dash_liveness.db")
     with SQLiteStorage(db) as store:
         run_id = "run_dash_liveness"
-        store.create_run(Run(run_id=run_id, goal="dash test"))
+        store.create_run_started(Run(run_id=run_id, goal="dash test"))
         store.append_event(run_id, EventType.TASK_UPDATED, {"completed": 1})
         html = render_run_detail_html(store, run_id)
         assert "Liveness" in html
 
 
 def test_mcp_read_tools_include_liveness(tmp_path: Path) -> None:
-    from continuum.mcp.server import build_server
-
     db = str(tmp_path / "mcp_liveness.db")
     with SQLiteStorage(db) as store:
         run_id = "run_mcp_liveness"
-        store.create_run(Run(run_id=run_id, goal="mcp test"))
+        store.create_run_started(Run(run_id=run_id, goal="mcp test"))
         store.append_event(run_id, EventType.TASK_UPDATED, {"completed": 1})
-        _ = build_server(storage=store)
         from continuum.recovery.health import advisory_for_storage
 
         adv = advisory_for_storage(store, run_id)
         assert "breached" in adv
         assert "threshold_seconds" in adv
+        try:
+            from continuum.mcp.server import build_server
+
+            _ = build_server(storage=store)
+        except ModuleNotFoundError:
+            pass

--- a/tests/test_liveness_cadence.py
+++ b/tests/test_liveness_cadence.py
@@ -1,0 +1,231 @@
+"""Cadence contracts and read-path liveness, injected clock, no sleeps (issue #561)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from continuum.actions import ActionLedger
+from continuum.cli.main import _liveness_advisory, _liveness_text, main
+from continuum.events import EventType
+from continuum.liveness import CadenceContract, evaluate, load_cadence_contract
+from continuum.models import Run
+from continuum.storage import SQLiteStorage
+
+
+def test_defaults_use_phase_scopes() -> None:
+    contract = CadenceContract()
+    assert contract.max_silence_seconds == 3600
+    assert contract.phase_scopes["open_claim"] == 600
+    assert contract.phase_scopes["otherwise"] == 3600
+    assert contract.threshold_for(has_open_claim=True) == 600
+    assert contract.threshold_for(has_open_claim=False) == 3600
+
+
+def test_evaluate_respects_max_silence_vs_phase() -> None:
+    contract = CadenceContract(
+        max_silence_seconds=3600, phase_scopes={"open_claim": 600, "otherwise": 3600}
+    )
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    last = now - timedelta(seconds=700)
+    assert evaluate(now, last, contract=contract, has_open_claim=True).breached is True
+    assert evaluate(now, last, contract=contract, has_open_claim=False).breached is False
+    last2 = now - timedelta(seconds=4000)
+    assert evaluate(now, last2, contract=contract, has_open_claim=True).breached is True
+    assert evaluate(now, last2, contract=contract, has_open_claim=False).breached is True
+    last3 = now - timedelta(seconds=500)
+    assert evaluate(now, last3, contract=contract, has_open_claim=True).breached is False
+    assert evaluate(now, last3, contract=contract, has_open_claim=False).breached is False
+
+
+def test_evaluate_injected_clock_no_sleep() -> None:
+    contract = CadenceContract()
+    now = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    last = now - timedelta(seconds=100)
+    result = evaluate(now, last, contract=contract, has_open_claim=False)
+    assert result.breached is False
+    assert result.silence_seconds == 100.0
+    assert result.threshold_seconds == 3600
+    assert result.phase == "otherwise"
+    future = now + timedelta(seconds=10)
+    result2 = evaluate(now, future, contract=contract)
+    assert result2.breached is False
+
+
+def test_evaluate_none_last_event_not_breached() -> None:
+    contract = CadenceContract()
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    result = evaluate(now, None, contract=contract)
+    assert result.breached is False
+    assert result.silence_seconds is None
+
+
+def test_cadence_contract_evaluate_method_matches_function() -> None:
+    contract = CadenceContract()
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    last = now - timedelta(seconds=800)
+    r1 = contract.evaluate(now, last, has_open_claim=True)
+    r2 = evaluate(now, last, contract=contract, has_open_claim=True)
+    assert r1.breached == r2.breached
+    assert r1.silence_seconds == r2.silence_seconds
+
+
+def test_load_cadence_contract_defaults_when_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "no_such.json"
+    contract = load_cadence_contract(missing)
+    assert contract.max_silence_seconds == 3600
+    assert contract.phase_scopes["open_claim"] == 600
+
+
+def test_load_cadence_contract_from_file(tmp_path: Path) -> None:
+    p = tmp_path / "liveness.json"
+    p.write_text(
+        json.dumps(
+            {"max_silence_seconds": 1800, "phase_scopes": {"open_claim": 300, "otherwise": 1800}}
+        ),
+        encoding="utf-8",
+    )
+    contract = load_cadence_contract(p)
+    assert contract.max_silence_seconds == 1800
+    assert contract.threshold_for(True) == 300
+    assert contract.threshold_for(False) == 1800
+
+
+def test_liveness_advisory_computes_silence_vs_threshold(tmp_path: Path) -> None:
+    db = str(tmp_path / "test.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_liveness_1"
+        store.create_run(Run(run_id=run_id, goal="test"))
+        now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        store.append_event(run_id, EventType.TASK_UPDATED, {"completed": 1})
+        advisory = _liveness_advisory(store, run_id, now=now)
+        assert "breached" in advisory
+        assert "silence_seconds" in advisory
+        assert advisory["threshold_seconds"] == 3600
+        assert advisory["phase"] == "otherwise"
+
+
+def test_liveness_phase_open_claim_vs_otherwise(tmp_path: Path) -> None:
+    db = str(tmp_path / "test2.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_liveness_phase"
+        store.create_run(Run(run_id=run_id, goal="test"))
+        store.append_event(run_id, EventType.TASK_UPDATED, {"completed": 1})
+        ledger = ActionLedger(store, run_id)
+        ledger.claim("test.action", {"x": 1})
+        now = datetime.now(UTC) + timedelta(seconds=700)
+        advisory = _liveness_advisory(store, run_id, now=now)
+        assert advisory["has_open_claim"] is True
+        assert advisory["threshold_seconds"] == 600
+        contract = CadenceContract()
+        last_ts = datetime.now(UTC) - timedelta(seconds=700)
+        future = last_ts + timedelta(seconds=700)
+        adv2 = evaluate(future, last_ts, contract=contract, has_open_claim=True)
+        assert adv2.breached is True
+        adv3 = evaluate(future, last_ts, contract=contract, has_open_claim=False)
+        assert adv3.breached is False
+
+
+def test_breach_surfaces_as_advisory_not_mode_change(tmp_path: Path) -> None:
+    from continuum.recovery import RecoveryEngine
+
+    db = str(tmp_path / "test3.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_liveness_advisory"
+        store.create_run(Run(run_id=run_id, goal="ship"))
+        store.append_event(run_id, EventType.RUN_STARTED, {"goal": "ship"})
+        engine = RecoveryEngine(store)
+        decision = engine.assess(run_id)
+        assert decision.mode.value == "resume"
+        far_future = datetime.now(UTC) + timedelta(seconds=10000)
+        advisory = _liveness_advisory(store, run_id, now=far_future)
+        assert advisory["breached"] is True
+        assert decision.mode.value == "resume"
+        text = _liveness_text(advisory)
+        assert "BREACHED" in text
+        assert "Advisory only" in text
+
+
+def test_liveness_text_ok_and_breached() -> None:
+    advisory_ok = {
+        "breached": False,
+        "silence_seconds": 100.0,
+        "threshold_seconds": 600,
+        "phase": "open_claim",
+    }
+    assert "ok" in _liveness_text(advisory_ok)
+    advisory_breach = {
+        "breached": True,
+        "silence_seconds": 700.0,
+        "threshold_seconds": 600,
+        "phase": "open_claim",
+    }
+    assert "BREACHED" in _liveness_text(advisory_breach)
+    advisory_none = {
+        "breached": False,
+        "silence_seconds": None,
+        "threshold_seconds": 600,
+        "phase": "otherwise",
+    }
+    assert "no events" in _liveness_text(advisory_none).lower()
+
+
+def test_cli_validate_includes_liveness_advisory(tmp_path: Path) -> None:
+    import io
+
+    db = str(tmp_path / "cli_liveness.db")
+    run_id = "run_cli_liveness"
+    out, err = io.StringIO(), io.StringIO()
+    code = main(["--db", db, "start", run_id, "--goal", "test liveness"], out=out, err=err)
+    assert code == 0
+    out2, err2 = io.StringIO(), io.StringIO()
+    code2 = main(["--db", db, "--json", "validate", run_id], out=out2, err=err2)
+    assert code2 == 0
+    payload = json.loads(out2.getvalue())
+    assert "liveness" in payload
+    assert "breached" in payload["liveness"]
+    assert "threshold_seconds" in payload["liveness"]
+
+
+def test_cli_resume_includes_liveness_advisory(tmp_path: Path) -> None:
+    import io
+
+    db = str(tmp_path / "cli_liveness2.db")
+    run_id = "run_cli_liveness2"
+    out, err = io.StringIO(), io.StringIO()
+    main(["--db", db, "start", run_id, "--goal", "test resume liveness"], out=out, err=err)
+    out2, err2 = io.StringIO(), io.StringIO()
+    code2 = main(["--db", db, "--json", "resume", run_id], out=out2, err=err2)
+    assert code2 == 0
+    payload = json.loads(out2.getvalue())
+    assert "liveness" in payload
+    assert payload["liveness"]["phase"] in ("open_claim", "otherwise")
+
+
+def test_dashboard_renders_liveness(tmp_path: Path) -> None:
+    from continuum.dashboard.app import render_run_detail_html
+
+    db = str(tmp_path / "dash_liveness.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_dash_liveness"
+        store.create_run(Run(run_id=run_id, goal="dash test"))
+        store.append_event(run_id, EventType.TASK_UPDATED, {"completed": 1})
+        html = render_run_detail_html(store, run_id)
+        assert "Liveness" in html
+
+
+def test_mcp_read_tools_include_liveness(tmp_path: Path) -> None:
+    from continuum.mcp.server import build_server
+
+    db = str(tmp_path / "mcp_liveness.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_mcp_liveness"
+        store.create_run(Run(run_id=run_id, goal="mcp test"))
+        store.append_event(run_id, EventType.TASK_UPDATED, {"completed": 1})
+        _ = build_server(storage=store)
+        from continuum.recovery.health import advisory_for_storage
+
+        adv = advisory_for_storage(store, run_id)
+        assert "breached" in adv
+        assert "threshold_seconds" in adv

--- a/tests/test_liveness_events.py
+++ b/tests/test_liveness_events.py
@@ -1,0 +1,211 @@
+"""LIVENESS events, WAIT mapping and continuum watch (issue #562)."""
+
+from __future__ import annotations
+
+import http.server
+import io
+import json
+import threading
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from continuum.cli.main import main
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.recovery import RecoveryEngine
+from continuum.storage import SQLiteStorage
+
+
+def test_liveness_events_are_hash_chained(tmp_path: Path) -> None:
+    db = str(tmp_path / "liveness_chain.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_liveness_chain"
+        store.create_run_started(Run(run_id=run_id, goal="test chain"))
+        e1 = store.append_event(
+            run_id,
+            EventType.LIVENESS_SILENCE_DETECTED,
+            {"silence_seconds": 4000, "threshold_seconds": 3600, "phase": "otherwise"},
+        )
+        e2 = store.append_event(run_id, EventType.LIVENESS_RECOVERED, {"silence_seconds": 10})
+        assert e1.hash is not None
+        assert e2.prev_hash == e1.hash
+        report = store.verify_events(run_id)
+        assert report.ok is True
+        assert report.trusted_through[run_id] == 3
+
+
+def test_engine_maps_breach_to_wait(tmp_path: Path) -> None:
+    db = str(tmp_path / "wait_map.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_wait_map"
+        store.create_run_started(Run(run_id=run_id, goal="wait test"))
+        from continuum.events import Event
+
+        old_ts = datetime.now(UTC) - timedelta(seconds=7200)
+        last_seq = store.last_sequence(run_id)
+        ev = Event(
+            run_id=run_id,
+            sequence=last_seq + 1,
+            type=EventType.TASK_UPDATED,
+            timestamp=old_ts,
+            payload={"completed": 1},
+            prev_hash=store.read_events(run_id)[-1].hash,
+        ).sealed()
+        store.append_sealed(ev)
+        engine = RecoveryEngine(store)
+        decision = engine.assess(run_id)
+        assert decision.mode.value == "wait"
+        assert decision.mode.value != "rollback"
+        assert decision.contract.liveness is not None
+        assert decision.contract.liveness["breached"] is True
+        assert decision.contract.liveness["breaches"] >= 0
+
+
+def test_watch_appends_detected_and_recovered(tmp_path: Path) -> None:
+    db = str(tmp_path / "watch_events.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_watch_events"
+        store.create_run_started(Run(run_id=run_id, goal="watch test"))
+        from continuum.events import Event
+
+        old_ts = datetime.now(UTC) - timedelta(seconds=7200)
+        last_seq = store.last_sequence(run_id)
+        ev = Event(
+            run_id=run_id,
+            sequence=last_seq + 1,
+            type=EventType.TASK_UPDATED,
+            timestamp=old_ts,
+            payload={"completed": 1},
+            prev_hash=store.read_events(run_id)[-1].hash,
+        ).sealed()
+        store.append_sealed(ev)
+
+    out, err = io.StringIO(), io.StringIO()
+    code = main(
+        ["--db", db, "watch", run_id, "--max-silence", "3600", "--on-breach", "exit"],
+        out=out,
+        err=err,
+    )
+    assert code == 20
+    with SQLiteStorage(db) as store:
+        events = store.read_events(run_id)
+        types = [e.type for e in events]
+        assert EventType.LIVENESS_SILENCE_DETECTED in types
+        store.append_event(run_id, EventType.TASK_UPDATED, {"completed": 2})
+        out2, err2 = io.StringIO(), io.StringIO()
+        code2 = main(
+            ["--db", db, "watch", run_id, "--max-silence", "3600", "--on-breach", "exit"],
+            out=out2,
+            err=err2,
+        )
+        assert code2 == 0
+        events2 = store.read_events(run_id)
+        assert events2[-1].type == EventType.LIVENESS_RECOVERED
+
+
+def test_watch_webhook_fail_open(tmp_path: Path) -> None:
+    db = str(tmp_path / "watch_webhook.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_watch_webhook"
+        store.create_run_started(Run(run_id=run_id, goal="webhook test"))
+
+    out, err = io.StringIO(), io.StringIO()
+    code = main(
+        [
+            "--db",
+            db,
+            "watch",
+            run_id,
+            "--max-silence",
+            "1",
+            "--on-breach",
+            "webhook",
+            "--webhook-url",
+            "http://127.0.0.1:1/nonexistent",
+        ],
+        out=out,
+        err=err,
+    )
+    assert code in (0, 20)
+    assert "warning: webhook delivery failed" in err.getvalue() or code in (0, 20)
+
+
+def test_watch_webhook_delivers_on_breach(tmp_path: Path) -> None:
+    received: list[bytes] = []
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length") or 0)
+            body = self.rfile.read(length) if length else b""
+            received.append(body)
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def log_message(self, format, *args):  # noqa: A002
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        db = str(tmp_path / "watch_webhook_deliver.db")
+        with SQLiteStorage(db) as store:
+            run_id = "run_watch_deliver"
+            store.create_run_started(Run(run_id=run_id, goal="deliver test"))
+            from continuum.events import Event
+
+            old_ts = datetime.now(UTC) - timedelta(seconds=7200)
+            last_seq = store.last_sequence(run_id)
+            ev = Event(
+                run_id=run_id,
+                sequence=last_seq + 1,
+                type=EventType.TASK_UPDATED,
+                timestamp=old_ts,
+                payload={"completed": 1},
+                prev_hash=store.read_events(run_id)[-1].hash,
+            ).sealed()
+            store.append_sealed(ev)
+        out, err = io.StringIO(), io.StringIO()
+        url = f"http://127.0.0.1:{port}/hook"
+        code = main(
+            [
+                "--db",
+                db,
+                "watch",
+                run_id,
+                "--max-silence",
+                "3600",
+                "--on-breach",
+                "webhook",
+                "--webhook-url",
+                url,
+            ],
+            out=out,
+            err=err,
+        )
+        assert code == 20
+        import time
+
+        time.sleep(0.2)
+        assert len(received) == 1
+        payload = json.loads(received[0].decode("utf-8"))
+        assert payload["breached"] is True
+        assert payload["run_id"] == run_id
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_contract_liveness_section(tmp_path: Path) -> None:
+    db = str(tmp_path / "contract_liveness.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_contract_liveness"
+        store.create_run_started(Run(run_id=run_id, goal="contract liveness"))
+        engine = RecoveryEngine(store)
+        decision = engine.assess(run_id)
+        assert decision.contract.liveness is not None
+        assert "last_append_age" in decision.contract.liveness
+        assert "breaches" in decision.contract.liveness
+        assert "breached" in decision.contract.liveness

--- a/tests/test_risk_policy.py
+++ b/tests/test_risk_policy.py
@@ -1,0 +1,111 @@
+"""RISK_OBSERVED ingestion and risk-policy mapping (issue #563)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from continuum.events import EventType
+from continuum.models import Origin, Run
+from continuum.recovery.risk import (
+    evaluate_risk,
+    ingest_risk,
+    ingest_risk_json_line,
+    is_more_conservative,
+    load_risk_policy,
+)
+from continuum.storage import SQLiteStorage
+
+
+def test_ingest_risk_records_event(tmp_path: Path) -> None:
+    db = str(tmp_path / "risk_ingest.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_risk_ingest"
+        store.create_run_started(Run(run_id=run_id, goal="test risk"))
+        ok = ingest_risk(store, run_id, {"trigger": "loop", "score": 0.8, "detail": "repetition"})
+        assert ok is True
+        events = store.read_events(run_id)
+        assert events[-1].type == EventType.RISK_OBSERVED
+        assert events[-1].source == Origin.EXTERNAL_MONITOR
+        assert events[-1].payload["trigger"] == "loop"
+        assert events[-1].payload["score"] == 0.8
+
+
+def test_ingest_risk_fail_open_on_garbage(tmp_path: Path) -> None:
+    db = str(tmp_path / "risk_failopen.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_risk_failopen"
+        store.create_run_started(Run(run_id=run_id, goal="failopen"))
+        # Missing trigger
+        assert ingest_risk(store, run_id, {"score": 1}) is False
+        # Empty trigger
+        assert ingest_risk(store, run_id, {"trigger": ""}) is False
+        # Malformed JSON line
+        assert ingest_risk_json_line(store, run_id, "not json") is False
+        assert ingest_risk_json_line(store, run_id, "") is False
+        # No event should have been added beyond RUN_STARTED
+        assert len(store.read_events(run_id)) == 1
+
+
+def test_policy_defaults_and_conservative(tmp_path: Path) -> None:
+    # Defaults are loaded when file missing
+    missing = tmp_path / "no_policy.json"
+    policy = load_risk_policy(missing)
+    assert policy["loop"] == "replan"
+    assert policy["error_cascade"] == "wait"
+    assert policy["meltdown"] == "rollback"
+    # Conservative check
+    assert (
+        is_more_conservative("wait", "replan") is True
+    )  # WAIT more severe than REPLAN? Check severity ordering
+    # Actually SEVERITY: REPLAN=2, WAIT=3, so WAIT > REPLAN, so more conservative
+    # Downgrade should be refused
+    assert is_more_conservative("replan", "wait") is False
+    assert is_more_conservative("annotate", "wait") is False
+    assert is_more_conservative("wait", "annotate") is True
+
+
+def test_policy_file_validation(tmp_path: Path) -> None:
+    # Valid file
+    p = tmp_path / "risk-policy.json"
+    p.write_text(json.dumps({"loop": "replan", "meltdown": "rollback"}), encoding="utf-8")
+    policy = load_risk_policy(p)
+    assert policy["loop"] == "replan"
+    # Invalid mode
+    p.write_text(json.dumps({"loop": "invalid_mode"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="must be one of"):
+        load_risk_policy(p)
+    # Downgrade attempt: loop defaults to replan, downgrade to annotate should fail
+    p.write_text(json.dumps({"loop": "annotate"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="downgrades"):
+        load_risk_policy(p)
+    # Upgrade is allowed: loop replan -> wait is more severe? Check
+    # REPLAN=2, WAIT=3, so wait is more severe, should be allowed
+    p.write_text(json.dumps({"loop": "wait"}), encoding="utf-8")
+    policy2 = load_risk_policy(p)
+    assert policy2["loop"] == "wait"
+
+
+def test_evaluate_risk_mapping(tmp_path: Path) -> None:
+    policy = load_risk_policy(tmp_path / "missing.json")
+    assert evaluate_risk("loop", policy) == "replan"
+    assert evaluate_risk("error_cascade", policy) == "wait"
+    assert evaluate_risk("latency_anomaly", policy) is None
+    assert evaluate_risk("meltdown", policy) == "rollback"
+    assert evaluate_risk("governance_decay", policy) == "request_human"
+    assert evaluate_risk("unknown_trigger", policy) is None
+    assert evaluate_risk("", policy) is None
+
+
+def test_risk_events_are_hash_chained(tmp_path: Path) -> None:
+    db = str(tmp_path / "risk_chain.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_risk_chain"
+        store.create_run_started(Run(run_id=run_id, goal="chain"))
+        ingest_risk(store, run_id, {"trigger": "loop"})
+        ingest_risk(store, run_id, {"trigger": "meltdown"})
+        report = store.verify_events(run_id)
+        assert report.ok is True
+        assert report.trusted_through[run_id] == 3


### PR DESCRIPTION
Implements RISK_OBSERVED ingestion with Origin.EXTERNAL_MONITOR and declarative .continuum/risk-policy.json mapping. Operators may only make actions more conservative. Fail-open on malformed payloads.

Refs #563