### PR TITLE
fix(models): suppress mypy false positive for origin_digest validator

### DIFF
--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -934,7 +934,7 @@ def validate_caused_by(caused_by: list[str] | None, known_ids: set[str] | None =
         _validate_caused_by_known(caused_by, known_ids)
     return list(caused_by)
 
-    @field_validator("origin_digest")
+    @field_validator("origin_digest")  # type: ignore[misc]
     @classmethod
     def _origin_digest_is_sha256(cls, value: str | None) -> str | None:
         if value is None:


### PR DESCRIPTION
Fix mypy strict clean after memory governance merges. The validator uses @field_validator + @classmethod which mypy flags as misc, same as other validators, but our new one triggered it. Add type ignore to make warn_unused_configs clean.

Refs #566

How tested: mypy src/continuum --ignore-missing-imports passes, ruff clean, pytest green.