### PR TITLE
docs: clarify observe_command hook portability

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -98,9 +98,9 @@ settings files (for example `.claude/settings.json` or `.gemini/settings.json`).
 The installed `observe` command is baked in at install time and may take one of
 two shapes:
 
-- **`continuum` on PATH** — an absolute path to the resolved executable, for
+- **`continuum` on PATH**: an absolute path to the resolved executable, for
   example `/usr/local/bin/continuum observe`.
-- **Editable / interpreter-only installs** — `python -m continuum.cli observe`
+- **Editable / interpreter-only installs**: `/path/to/python -m continuum.cli observe`
   when no `continuum` executable is found on PATH.
 
 If you pass `--db`, that path is baked into the command too (for example
@@ -110,7 +110,7 @@ project root as cwd and the default database path would otherwise be ambiguous.
 To see what was installed, inspect the settings file after install:
 
 ```bash
-continuum hooks install claude-code --db /tmp/test.db
+continuum --db /tmp/test.db hooks install claude-code
 cat .claude/settings.json
 ```
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -110,9 +110,11 @@ project root as cwd and the default database path would otherwise be ambiguous.
 To see what was installed, inspect the settings file after install:
 
 ```bash
-continuum --db /tmp/test.db hooks install claude-code
+continuum hooks install claude-code --db /tmp/test.db
 cat .claude/settings.json
 ```
 
-If the command looks unexpected after moving a virtualenv, re-run
-`continuum hooks install` for that host; it rewrites the baked command path.
+If the command looks unexpected after moving a virtualenv, re-run the
+same install command for that host, including the original `--db` value
+when one was used (for example `continuum hooks install claude-code --db /tmp/test.db`);
+it rewrites the baked command path without changing the database target.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -90,3 +90,29 @@ output.
 with per-pin status (`present`, `absent`, `unverifiable`), grace deadline, and
 flagged set. Flagged pins render prominently in human text as `[!!]` lines
 coloured on TTY and plain when piped, byte-identical modulo colour (issue #419).
+
+## hooks
+
+`continuum hooks install` writes host-side observation hooks into agent
+settings files (for example `.claude/settings.json` or `.gemini/settings.json`).
+The installed `observe` command is baked in at install time and may take one of
+two shapes:
+
+- **`continuum` on PATH** — an absolute path to the resolved executable, for
+  example `/usr/local/bin/continuum observe`.
+- **Editable / interpreter-only installs** — `python -m continuum.cli observe`
+  when no `continuum` executable is found on PATH.
+
+If you pass `--db`, that path is baked into the command too (for example
+`continuum --db /abs/path.db observe`), because hook processes run with the
+project root as cwd and the default database path would otherwise be ambiguous.
+
+To see what was installed, inspect the settings file after install:
+
+```bash
+continuum hooks install claude-code --db /tmp/test.db
+cat .claude/settings.json
+```
+
+If the command looks unexpected after moving a virtualenv, re-run
+`continuum hooks install` for that host; it rewrites the baked command path.

--- a/src/continuum/clienthooks.py
+++ b/src/continuum/clienthooks.py
@@ -199,6 +199,19 @@ def observe_command(*, db: str | None = None) -> str:
     interpreter-plus-module form is used instead. An explicit ``db`` is baked
     in too, since the default resolves relative to the working directory and
     hook processes run with the project root as cwd.
+
+    Examples:
+        When ``continuum`` is on PATH::
+
+            /usr/local/bin/continuum observe
+
+        When the executable is not on PATH (editable install)::
+
+            /path/to/python -m continuum.cli observe
+
+        When ``--db`` is passed to ``hooks install``::
+
+            /usr/local/bin/continuum --db /abs/path.db observe
     """
     executable = shutil.which("continuum")
     parts = [executable] if executable else [sys.executable, "-m", "continuum.cli"]


### PR DESCRIPTION
## Summary

- Expands the `observe_command` docstring with examples for on-PATH, interpreter fallback, and `--db` baked-in forms.
- Adds a `hooks` section to `docs/api/cli.md` explaining installed command shapes and how to inspect settings files after `hooks install`.

Fixes #325

## Test plan

- [x] `markdownlint-cli2 docs/api/cli.md` passes
- [x] `pytest tests/test_cli_observe.py` — observe_command tests pass
- [ ] Maintainer review for doc accuracy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CLI documentation for installing and inspecting hooks, supported command invocation forms, database configuration, and reinstalling after virtual environment relocation.
  * Added usage examples for observing commands with different executable and interpreter configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->