### PR TITLE
docs: align resolve_authorization_id token wording with the predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **`resolve_authorization_id` docstring matches the token predicate (#613).**
+  The function claimed that "status words" never produce an id. There is no
+  status-word category: a token is dropped only when it is shorter than three
+  characters or appears in `_WEAK_TOKENS` or `_STOPWORDS`. Words such as
+  `pending` and `queued` therefore bind an id, and the old sentence contradicted
+  testing. Wording only; no runtime change.
+
 - Make `continuum complete` idempotent for runs that are already completed (#356).
 
 - **Derived keys ignore surrounding whitespace in argument values (#361).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ All notable changes to this project are documented here. The format follows
   status-word category: a token is dropped only when it is shorter than three
   characters or appears in `_WEAK_TOKENS` or `_STOPWORDS`. Words such as
   `pending` and `queued` therefore bind an id, and the old sentence contradicted
-  testing. Wording only; no runtime change.
+  testing. The same false "status words" claim in `identity_tokens` is corrected
+  for consistency. Wording only; no runtime change.
 
 - Make `continuum complete` idempotent for runs that are already completed (#356).
 

--- a/src/continuum/actions/idempotency.py
+++ b/src/continuum/actions/idempotency.py
@@ -553,8 +553,9 @@ def resolve_authorization_id(
        by shared identity tokens anchors the id, reusing the same containment,
        derivation and location-agreement checks as ``ActionLedger.claim``'s
        fallback; without a ledger the id is the hash of the canonical leaf
-       tokens of the incoming arguments. Weak tokens (counts, status words,
-       stopwords) never produce an id.
+       tokens of the incoming arguments. A token is dropped when it is
+       shorter than three characters or appears in the fixed weak-token or
+       stopword lists. Arguments made only of such tokens produce no id.
     3. Unbound (neither key nor distinctive tokens, or an ambiguous
        multi-match): ``None`` is returned. The caller keeps today's
        behaviour (no authorization-bound budget) byte-identical.

--- a/src/continuum/actions/idempotency.py
+++ b/src/continuum/actions/idempotency.py
@@ -308,8 +308,9 @@ def identity_tokens(
     rendered as one, since a row id of ``4821`` identifies a row as well as
     ``INV-001`` identifies an invoice (issue #36) -- plus the basename and
     basename-stem of any path-like value, and the same for ``external_id``.
-    Weak tokens are dropped so the fallback never matches on incidental values
-    like counts or status words.
+    Weak tokens are dropped so the fallback never matches on incidental values:
+    tokens shorter than three characters, or ones that appear in the fixed
+    weak-token or stopword lists.
     """
     tokens: set[str] = set()
 


### PR DESCRIPTION
﻿## Summary

- Corrects `resolve_authorization_id` so it describes the real token predicate (`len >= 3`, not in `_WEAK_TOKENS` / `_STOPWORDS`) instead of a non-existent "status words" category.
- Records the wording fix in the unreleased changelog.

Fixes #613

## Test plan

- [x] Compared docstring to `_is_strong_token` at `src/continuum/actions/idempotency.py`
- [x] No runtime change (docstring + changelog only)
- [ ] Maintainer review that the new sentence matches the lists at `_WEAK_TOKENS` / `_STOPWORDS`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified authorization ID resolution documentation to accurately describe when tokens are ignored.
  * Documented that inputs containing only short, weak, or stopword tokens do not produce an ID.
  * No runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->