### PR TITLE
docs: update STATUS.md in-flight section for merged PRs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,10 +17,9 @@ believed, and what is neither.
 
 ---
 
-## In flight: unprojectable logs degrade instead of dying (#383, PR #385)
+## Unprojectable logs degrade instead of dying (2026-08-25)
 
-As of 2026-08-25, PR #383's fix is open on `fix/degrade-unprojectable-fold`
-(three commits), reviewed through two rounds. The fold accepts
+PR #385 (fix for #383) was merged on 2026-08-25. The fold accepts
 `on_unprojectable="raise"|"degrade"` (default byte-for-byte unchanged);
 degrade returns the last-good prefix marked `SemanticState.status=INVALID`
 naming where folding stopped; recovery decides REQUEST_HUMAN and the contract


### PR DESCRIPTION
Updated status of unprojectable logs to reflect recent changes and merged PR.

<!--
Thank you for contributing to CONTINUUM.

Please fill out each section below. Sections left empty may delay review.
The PR title should follow conventional commits, for example:
feat: add recovery validator for partial checkpoints

-->

## Description

<!-- Describe what this PR changes. Explain the approach where the approach itself is non-obvious. -->

## Related issues
Fixes #637 
<!--
Link the issue this PR addresses.
Use "Fixes #N" if merging this PR fully resolves the issue,
otherwise use "Addresses #N" or "Refs #N".
If there is no related issue, explain why here.
-->

## Types of changes

<!-- Keep the one that applies, delete the rest. -->

- Type: `bugfix` | `feature` | `refactor` | `performance` | `docs` | `tests` | `build` | `ci`

## Breaking changes

<!-- State Yes or No. If Yes, describe the impact and the migration path for users. -->

## How has this been tested?

<!-- Describe the tests you ran to verify your changes. Include the exact commands and note the environment. For example:

pytest tests/test_recovery.py --tb=short -q
ruff check src/ tests/
mypy src/continuum

Mention any configuration or environment details relevant to reproducing the run.
-->

## Checklist

<!-- Reviewers will check these during review. Confirm them before requesting review. -->

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

<!-- Anything else reviewers should know: benchmarks, design tradeoffs, alternatives considered. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project status information to indicate that the unprojectable-log handling fix was completed and merged on August 25, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->