### PR TITLE
docs: list community contributors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,9 +543,10 @@ Thanks to our community contributors, ordered by contributions:
 [@timothyanderson096-ocdealcheck](https://github.com/timothyanderson096-ocdealcheck),
 [@unmoha](https://github.com/unmoha), [@aastha-m22](https://github.com/aastha-m22),
 [@as950118](https://github.com/as950118), [@asarakhatun17-lgtm](https://github.com/asarakhatun17-lgtm),
-[@challenge456](https://github.com/challenge456), [@ItzSaurav](https://github.com/ItzSaurav),
+[@challenge456](https://github.com/challenge456),
+[@gouthamkrishnak2003](https://github.com/gouthamkrishnak2003), [@ItzSaurav](https://github.com/ItzSaurav),
 [@mhaye9545](https://github.com/mhaye9545), [@Newer1107](https://github.com/Newer1107),
-[@okestroHjJeong](https://github.com/okestroHjJeong), [@quangshuynh](https://github.com/quangshuynh),
+[@okestroHjJeong](https://github.com/okestroHjJeong), [@quangshuynh](https://github.com/quangshuynh), [@Rahul-pamula](https://github.com/Rahul-pamula),
 [@Shaisolaris](https://github.com/Shaisolaris), [@VedantMadane](https://github.com/VedantMadane),
 [@zynx-real](https://github.com/zynx-real).
 

--- a/README.md
+++ b/README.md
@@ -532,6 +532,23 @@ Open an issue before submitting large PRs. See [CONTRIBUTING.md](CONTRIBUTING.md
   <img src="https://contrib.rocks/image?repo=Cyrax321/CONTINUUM" />
 </a>
 
+Thanks to our community contributors, ordered by contributions:
+[@Adhi1-2](https://github.com/Adhi1-2), [@abyyxhek](https://github.com/abyyxhek),
+[@Amiirhosseini](https://github.com/Amiirhosseini), [@yuki-fuyutsuki](https://github.com/yuki-fuyutsuki),
+[@vjymisal0](https://github.com/vjymisal0), [@adity982](https://github.com/adity982),
+[@dchaudhari7177](https://github.com/dchaudhari7177), [@tasodoufu](https://github.com/tasodoufu),
+[@anya-research](https://github.com/anya-research), [@lesbass](https://github.com/lesbass),
+[@Parthipashok04](https://github.com/Parthipashok04), [@Samearth17](https://github.com/Samearth17),
+[@stoppo22](https://github.com/stoppo22),
+[@timothyanderson096-ocdealcheck](https://github.com/timothyanderson096-ocdealcheck),
+[@unmoha](https://github.com/unmoha), [@aastha-m22](https://github.com/aastha-m22),
+[@as950118](https://github.com/as950118), [@asarakhatun17-lgtm](https://github.com/asarakhatun17-lgtm),
+[@challenge456](https://github.com/challenge456), [@ItzSaurav](https://github.com/ItzSaurav),
+[@mhaye9545](https://github.com/mhaye9545), [@Newer1107](https://github.com/Newer1107),
+[@okestroHjJeong](https://github.com/okestroHjJeong), [@quangshuynh](https://github.com/quangshuynh),
+[@Shaisolaris](https://github.com/Shaisolaris), [@VedantMadane](https://github.com/VedantMadane),
+[@zynx-real](https://github.com/zynx-real).
+
 ## Sponsor
 
 If CONTINUUM helps your agents recover reliably, consider sponsoring to support long term maintenance.


### PR DESCRIPTION
## Description

Adds an explicit linked list of all 27 community contributors under the existing Contributors section in README.md, keeping the contrib.rocks avatar wall in place. The avatar wall and the contributors graph both lag new merges by hours, so the explicit list keeps the credits accurate immediately (this also picks up the newest contributor right away).

Ordering follows the contributors graph (by contributions, descending). The maintainer is already credited in About and dependabot[bot] is automation, so neither is in the community list.

## Related issues

No related issue. Small docs follow-up requested directly by the maintainer after PR #642.

## Types of changes

- Type: `docs`

## Breaking changes

No.

## How has this been tested?

`npx markdownlint-cli2 --config .markdownlint-cli2.jsonc README.md` (the same config CI uses): 0 errors. All 27 profile links verified against the GitHub API, 27/27 resolve.

## Checklist

No behaviour change, so no tests added. CI passes on the latest commit (markdown lint verified locally, full CI will run on the PR). No security-relevant changes.

## Additional context

The five translated READMEs carry the same avatar block and will drift from the English list. Left untouched deliberately; the list portion is language-neutral, so mirroring it there is easy if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README’s Contributors section to recognize 28 community contributors.
  - Added gouthamkrishnak2003 and Rahul-pamula to the contribution-ordered username list.
  - Retained the community thank-you message and existing contributor acknowledgments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->