### PR TITLE
feat(mcp): forward consumed_inputs on complete and reconcile tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Completed actions record consumed inputs for restore-point admissibility (#558).**
+  `ActionLedger.complete` and `reconcile` accept an optional `consumed_inputs`
+  mapping (`checkpoint_seq`, `event_positions`, `component_ids`, `action_ids`),
+  validated and stored on the action row and in the `action_index` projection.
+  Rows written before the field existed load as empty and stay admissible. The
+  MCP `complete` and `reconcile` tools and the sidecar `complete_action` and
+  `reconcile_action` handlers forward the field, so agent-driven callers can
+  declare what state an effect was computed from.
+
 - **`examples/demo.ipynb`, the crash-recovery walkthrough as a notebook (#283).**
   The lowest-friction way to watch a recovery was `docker run`, which still wants
   a daemon; this wants a browser. Colab and Binder badges in the Quick Start

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -1391,7 +1391,10 @@ def build_server(
             "Report that an intercepted action succeeded. Call this immediately "
             "after performing the side effect, using the action_key returned by "
             "continuum_intercept_action. Skipping it leaves the action uncertain "
-            "and blocks recovery."
+            "and blocks recovery. You may also pass consumed_inputs naming the "
+            "checkpoint and prior outputs this effect was computed from "
+            "(checkpoint_seq, event_positions, component_ids, action_ids); it is "
+            "recorded for restore-point admissibility and defaults to none."
         ),
         annotations=mutating,
     )
@@ -1401,9 +1404,12 @@ def build_server(
         action_key: str,
         external_id: str | None = None,
         result: dict[str, Any] | None = None,
+        consumed_inputs: dict[str, Any] | None = None,
     ) -> str:
         """Mark a claimed action as completed."""
-        action = ctx.ledger(run_id).complete(action_key, external_id=external_id, result=result)
+        action = ctx.ledger(run_id).complete(
+            action_key, external_id=external_id, result=result, consumed_inputs=consumed_inputs
+        )
         return _json(
             {
                 "run_id": run_id,
@@ -1464,18 +1470,21 @@ def build_server(
         external_id: str | None = None,
         result: dict[str, Any] | None = None,
         note: str = "",
+        consumed_inputs: dict[str, Any] | None = None,
     ) -> str:
         """Resolve an uncertain action using external evidence."""
         # `result` is accepted here because `complete` refuses an UNKNOWN action
         # (issue #366) and this is the route it points at. Without it, structured
         # evidence gathered by the probe had nowhere to go over MCP even though
-        # `ActionLedger.reconcile` has always stored it.
+        # `ActionLedger.reconcile` has always stored it. `consumed_inputs` rides
+        # the same route for the same reason (issue #558).
         action = ctx.ledger(run_id).reconcile(
             action_key,
             occurred=occurred,
             external_id=external_id,
             result=result,
             note=note,
+            consumed_inputs=consumed_inputs,
         )
         return _json(
             {

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -878,12 +878,17 @@ def _h_intercept_action(server: SidecarServer, params: dict[str, Any]) -> dict[s
 def _h_complete_action(server: SidecarServer, params: dict[str, Any]) -> dict[str, Any]:
     run_id = _require(params, "run_id")
     action_key = _require(params, "action_key")
-    action = server._ledger(run_id).complete(
-        action_key,
-        external_id=params.get("external_id"),
-        result=params.get("result"),
-        consumed_inputs=params.get("consumed_inputs"),
-    )
+    try:
+        action = server._ledger(run_id).complete(
+            action_key,
+            external_id=params.get("external_id"),
+            result=params.get("result"),
+            consumed_inputs=params.get("consumed_inputs"),
+        )
+    except ValueError as exc:
+        # Malformed caller input (e.g. consumed_inputs shape) is a parameter
+        # error, not a server failure (#645 review).
+        raise BadParams(str(exc)) from exc
     return {
         "run_id": run_id,
         "action_id": action.action_id,
@@ -910,13 +915,16 @@ def _h_reconcile_action(server: SidecarServer, params: dict[str, Any]) -> dict[s
     run_id = _require(params, "run_id")
     action_key = _require(params, "action_key")
     occurred = _require(params, "occurred")
-    action = server._ledger(run_id).reconcile(
-        action_key,
-        occurred=occurred,
-        external_id=params.get("external_id"),
-        note=params.get("note", ""),
-        consumed_inputs=params.get("consumed_inputs"),
-    )
+    try:
+        action = server._ledger(run_id).reconcile(
+            action_key,
+            occurred=occurred,
+            external_id=params.get("external_id"),
+            note=params.get("note", ""),
+            consumed_inputs=params.get("consumed_inputs"),
+        )
+    except ValueError as exc:
+        raise BadParams(str(exc)) from exc
     return {
         "run_id": run_id,
         "action_id": action.action_id,

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -879,7 +879,10 @@ def _h_complete_action(server: SidecarServer, params: dict[str, Any]) -> dict[st
     run_id = _require(params, "run_id")
     action_key = _require(params, "action_key")
     action = server._ledger(run_id).complete(
-        action_key, external_id=params.get("external_id"), result=params.get("result")
+        action_key,
+        external_id=params.get("external_id"),
+        result=params.get("result"),
+        consumed_inputs=params.get("consumed_inputs"),
     )
     return {
         "run_id": run_id,
@@ -912,6 +915,7 @@ def _h_reconcile_action(server: SidecarServer, params: dict[str, Any]) -> dict[s
         occurred=occurred,
         external_id=params.get("external_id"),
         note=params.get("note", ""),
+        consumed_inputs=params.get("consumed_inputs"),
     )
     return {
         "run_id": run_id,

--- a/tests/test_mcp_consumed_inputs.py
+++ b/tests/test_mcp_consumed_inputs.py
@@ -1,0 +1,171 @@
+"""consumed_inputs over MCP (issue #295, sub-issue #558).
+
+The ledger has accepted ``consumed_inputs`` on ``complete`` and ``reconcile``
+for a while, but the MCP tools never forwarded it, so an agent reporting
+through the server had no way to record what its effect was computed from.
+These tests drive both tools through the real dispatch path and assert the
+commitment lands in the fold and in the ``action_index`` projection.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from continuum.mcp.authz import AuthorizationPolicy
+from continuum.mcp.server import build_server
+from continuum.models import ConsumedInputs
+from continuum.storage import SQLiteStorage
+from tests.mcp_helpers import fake_context as _ctx
+
+TEST_CLIENT = "pytest-client"
+
+
+@pytest.fixture
+def server_ctx() -> Iterator[tuple[Any, Any]]:
+    """A server whose caller is authorized to mutate (mirrors test_mcp_server)."""
+    storage = SQLiteStorage(":memory:")
+    server, ctx = build_server(storage=storage, policy=AuthorizationPolicy([TEST_CLIENT]))
+    yield server, ctx
+    ctx.close()
+
+
+async def call(server: Any, name: str, **arguments: Any) -> dict[str, Any]:
+    """Invoke a tool the way a client would and parse its JSON result."""
+    result = await server.call_tool(name, arguments, context=_ctx(TEST_CLIENT))
+    assert result.content, f"{name} returned no content"
+    return json.loads(result.content[0].text)
+
+
+async def seed_run(server: Any, run_id: str = "run_1") -> None:
+    await call(
+        server,
+        "continuum_record_progress",
+        run_id=run_id,
+        completed=20,
+        total=100,
+        goal="Analyze 100 documents",
+    )
+
+
+async def test_complete_tool_records_consumed_inputs(server_ctx: tuple[Any, Any]) -> None:
+    """The commitment an agent reports must reach the fold and the index."""
+    server, ctx = server_ctx
+    await seed_run(server)
+    done = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="db.write",
+        arguments={"row": 7},
+        key="ci:row-7",
+    )
+    await call(
+        server,
+        "continuum_complete_action",
+        run_id="run_1",
+        action_key=done["action_key"],
+        consumed_inputs={
+            "checkpoint_seq": 3,
+            "event_positions": [4, 5],
+            "component_ids": ["finding_1"],
+            "action_ids": ["action_prev"],
+        },
+    )
+    folded = ctx.ledger("run_1").folded()
+    stored = folded[done["action_key"]].consumed_inputs
+    assert stored == ConsumedInputs(
+        checkpoint_seq=3,
+        event_positions=[4, 5],
+        component_ids=["finding_1"],
+        action_ids=["action_prev"],
+    )
+    row = ctx.storage._connection.execute(
+        "SELECT action_json FROM action_index WHERE key = ?", (done["action_key"],)
+    ).fetchone()
+    assert row is not None
+    assert json.loads(row["action_json"])["consumed_inputs"]["checkpoint_seq"] == 3
+
+
+async def test_complete_tool_defaults_to_empty(server_ctx: tuple[Any, Any]) -> None:
+    """Omitting the param keeps old callers admissible (issue #558)."""
+    server, ctx = server_ctx
+    await seed_run(server)
+    done = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="db.write",
+        arguments={"row": 8},
+        key="ci:row-8",
+    )
+    await call(server, "continuum_complete_action", run_id="run_1", action_key=done["action_key"])
+    folded = ctx.ledger("run_1").folded()
+    assert folded[done["action_key"]].consumed_inputs == ConsumedInputs()
+
+
+async def test_complete_tool_rejects_malformed_inputs(server_ctx: tuple[Any, Any]) -> None:
+    """A bad commitment is a validation refusal, not a stored row (fail closed)."""
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, ctx = server_ctx
+    await seed_run(server)
+    done = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="db.write",
+        arguments={"row": 9},
+        key="ci:row-9",
+    )
+    with pytest.raises(ToolError, match="checkpoint_seq"):
+        await server.call_tool(
+            "continuum_complete_action",
+            {
+                "run_id": "run_1",
+                "action_key": done["action_key"],
+                "consumed_inputs": {"checkpoint_seq": -1},
+            },
+            context=_ctx(TEST_CLIENT),
+        )
+    folded = ctx.ledger("run_1").folded()
+    assert folded[done["action_key"]].consumed_inputs == ConsumedInputs()
+
+
+async def test_reconcile_tool_records_consumed_inputs(server_ctx: tuple[Any, Any]) -> None:
+    """The evidence route carries commitments too (issue #558, #366)."""
+    server, ctx = server_ctx
+    await seed_run(server)
+    done = await call(
+        server,
+        "continuum_intercept_action",
+        run_id="run_1",
+        action_type="card.charge",
+        arguments={"amount": 100},
+        key="ci:charge-100",
+    )
+    await call(
+        server,
+        "continuum_fail_action",
+        run_id="run_1",
+        action_key=done["action_key"],
+        error="gateway timeout after the charge request was sent",
+        certain=False,
+    )
+    await call(
+        server,
+        "continuum_reconcile_action",
+        run_id="run_1",
+        action_key=done["action_key"],
+        occurred=True,
+        note="charge visible in ledger dashboard",
+        consumed_inputs={"checkpoint_seq": 1, "action_ids": ["action_probe"]},
+    )
+    folded = ctx.ledger("run_1").folded()
+    stored = folded[done["action_key"]].consumed_inputs
+    assert stored.checkpoint_seq == 1
+    assert stored.action_ids == ["action_probe"]
+    assert folded[done["action_key"]].status.value == "completed"

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -236,6 +236,40 @@ def test_intercept_then_complete_action() -> None:
     assert listed["actions"][0]["status"] == "completed"
 
 
+def test_complete_and_reconcile_forward_consumed_inputs() -> None:
+    """Sidecar complete/reconcile record caller-supplied consumed_inputs (#558)."""
+    from continuum.actions.ledger import fold_action_events
+
+    srv = make_server()
+    srv.dispatch("record_progress", {"run_id": "r1", "completed": 1, "goal": "g"})
+    claim = srv.dispatch("intercept_action", {"run_id": "r1", "action_type": "x.do", "key": "k1"})
+    ci = {
+        "checkpoint_seq": 2,
+        "event_positions": [1],
+        "component_ids": ["d1"],
+        "action_ids": ["a1"],
+    }
+    done = srv.dispatch(
+        "complete_action",
+        {"run_id": "r1", "action_key": claim["action_key"], "consumed_inputs": ci},
+    )
+    assert done["status"] == "completed"
+    folded = fold_action_events(srv.storage.read_events("r1"))
+    assert folded[claim["action_key"]].consumed_inputs.checkpoint_seq == 2
+    assert folded[claim["action_key"]].consumed_inputs.action_ids == ["a1"]
+    srv.dispatch(
+        "reconcile_action",
+        {
+            "run_id": "r1",
+            "action_key": claim["action_key"],
+            "occurred": True,
+            "consumed_inputs": {"checkpoint_seq": 3},
+        },
+    )
+    refolded = fold_action_events(srv.storage.read_events("r1"))
+    assert refolded[claim["action_key"]].consumed_inputs.checkpoint_seq == 3
+
+
 def test_unknown_method_is_not_found() -> None:
     srv = make_server()
     with pytest.raises(MethodNotFound):

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -532,3 +532,31 @@ def json_line(rid: int, method: str, params: dict) -> str:
     import json
 
     return json.dumps({"id": rid, "method": method, "params": params})
+
+
+def test_malformed_consumed_inputs_is_bad_params_not_internal() -> None:
+    """Ledger validation failures surface as parameter errors (#645 review)."""
+    from continuum.serve.server import BadParams
+
+    srv = make_server()
+    srv.dispatch("record_progress", {"run_id": "r1", "completed": 1, "goal": "g"})
+    claim = srv.dispatch("intercept_action", {"run_id": "r1", "action_type": "x.do", "key": "k1"})
+    with pytest.raises(BadParams, match="greater than or equal"):
+        srv.dispatch(
+            "complete_action",
+            {
+                "run_id": "r1",
+                "action_key": claim["action_key"],
+                "consumed_inputs": {"checkpoint_seq": -1},
+            },
+        )
+    with pytest.raises(BadParams, match="consumed_inputs"):
+        srv.dispatch(
+            "reconcile_action",
+            {
+                "run_id": "r1",
+                "action_key": claim["action_key"],
+                "occurred": True,
+                "consumed_inputs": [1, 2],
+            },
+        )


### PR DESCRIPTION
## Description

Closes the last gaps in #558. The ledger has accepted `consumed_inputs` on `complete` and `reconcile` for a while (with validator, engine, and contract mapping behind it), but the agent-facing surfaces never forwarded it, so an agent reporting through the server or sidecar had no way to record what its effect was computed from. The MCP `complete` and `reconcile` tools and the sidecar `complete_action` and `reconcile_action` handlers now accept an optional `consumed_inputs` mapping and pass it through. Malformed input fails closed through the existing ledger validation. Also adds the missing CHANGELOG entry for the track.

## Related issues

Fixes #558
Refs #295, refs #550

## Types of changes

- Type: `feature`

## Breaking changes

No. The parameter is optional and defaults to empty, so old callers stay admissible.

## How has this been tested?

Python 3.14, editable installation.

- New tests/test_mcp_consumed_inputs.py through the real tool-dispatch path: complete records into the fold and the action_index projection, omission defaults to empty, malformed input raises ToolError and stores nothing, reconcile carries commitments too.
- New sidecar round-trip test through real dispatch: complete records the inputs, reconcile overwrites them, verified by refolding the log.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,035 passed, 23 skipped.
- .venv/bin/ruff check src/ tests/ examples/: passed.
- .venv/bin/ruff format --check src/ tests/ examples/: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Tool descriptions document the new parameter. Changelog updated.

## Additional context

The sidecar handlers pass the field straight to ledger complete/reconcile, so malformed shapes are rejected by the existing ledger validation. Adapters that complete internally without the field are unaffected since it defaults to empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Action completion and reconciliation tools now accept optional consumed-input details, recording the checkpoint and prior outputs used to compute an effect.
  - Sidecar requests now support forwarding consumed-input details.
  - Omitted consumed-input details default to an empty value.

- **Bug Fixes**
  - Invalid consumed-input commitments are rejected without storing incomplete data.

- **Tests**
  - Added integration coverage for completion and reconciliation workflows, including persistence, forwarding, default handling, and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->