### PR TITLE
fix: preserve archived history in authority and memory checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,13 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- Preserve archived action history in grant and authority enforcement, CLI and
+  gateway gate decisions, cross-run action scans, and memory enumeration and
+  forensic joins (#615, #616). Compaction no longer hides spent authority or
+  memory records from those consumers. Existing uncertainty checks still govern
+  unfinished retries; forgetting records continues to enumerate external deletion
+  targets and append a tombstone, without deleting external data itself.
+
 - **The published image's default command runs the demo again (#280).**
   `Dockerfile` installs the sources root-owned under `/opt/continuum` and then
   drops to an unprivileged user, while `examples/crash_recovery_agent.py` pinned

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -72,7 +72,7 @@ from continuum.budgets import (
     would_refuse,
 )
 from continuum.concurrency.lease import LeaseCoordinator
-from continuum.events import EventType
+from continuum.events import Event, EventType
 from continuum.models import Action, ActionStatus, ConsumedInputs, UnknownSideEffect, utcnow
 from continuum.security.hashing import stable_hash
 from continuum.storage.base import Storage
@@ -856,8 +856,10 @@ class ActionLedger:
         # before anything fires. A live attempt carrying the same grant under
         # the same key is an ordinary mid-flight retry and passes through.
         grant_clean = normalize_grant(grant)
+        authority_history: Sequence[Event] | None = None
         if grant_clean is not None:
-            spent, grants_by_key = scan_grants(self.storage.read_all_events(self.run_id))
+            authority_history = self.storage.read_all_events(self.run_id)
+            spent, grants_by_key = scan_grants(authority_history)
             prior = spent.get(grant_clean["id"])
             live_match = (
                 existing is not None
@@ -896,7 +898,9 @@ class ActionLedger:
         if authority_id is not None:
             from continuum.gate import collect_consumed_authorities
 
-            consumed = collect_consumed_authorities(self.storage.read_all_events(self.run_id))
+            if authority_history is None:
+                authority_history = self.storage.read_all_events(self.run_id)
+            consumed = collect_consumed_authorities(authority_history)
             prior_ev = consumed.get(authority_id)
             # Allow live retry under same key with same authority
             live_auth_match = (

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -556,7 +556,7 @@ class ActionLedger:
         for run in self.storage.list_runs():
             if run.run_id == self.run_id:
                 continue
-            folded = fold_action_events(self.storage.read_events(run.run_id))
+            folded = fold_action_events(self.storage.read_all_events(run.run_id))
             candidate = folded.get(key)
             if candidate is not None:
                 found = candidate
@@ -857,7 +857,7 @@ class ActionLedger:
         # the same key is an ordinary mid-flight retry and passes through.
         grant_clean = normalize_grant(grant)
         if grant_clean is not None:
-            spent, grants_by_key = scan_grants(self.storage.read_events(self.run_id))
+            spent, grants_by_key = scan_grants(self.storage.read_all_events(self.run_id))
             prior = spent.get(grant_clean["id"])
             live_match = (
                 existing is not None
@@ -896,7 +896,7 @@ class ActionLedger:
         if authority_id is not None:
             from continuum.gate import collect_consumed_authorities
 
-            consumed = collect_consumed_authorities(self.storage.read_events(self.run_id))
+            consumed = collect_consumed_authorities(self.storage.read_all_events(self.run_id))
             prior_ev = consumed.get(authority_id)
             # Allow live retry under same key with same authority
             live_auth_match = (
@@ -1239,7 +1239,7 @@ class ActionLedger:
         try:
             from continuum.security.hashing import stable_hash as _sh
 
-            for ev in self.storage.read_events(self.run_id):
+            for ev in self.storage.read_all_events(self.run_id):
                 if ev.type == EventType.PERCEPTION_OBSERVED:
                     try:
                         digest = _sh(dict(ev.payload))
@@ -1252,7 +1252,7 @@ class ActionLedger:
                         obs_by_digest[ch] = ev
         except Exception:
             obs_by_digest = {}
-        for ev in self.storage.read_events(self.run_id):
+        for ev in self.storage.read_all_events(self.run_id):
             if ev.type not in _ACTION_EVENT_TYPES:
                 continue
             payload = dict(ev.payload)
@@ -1336,7 +1336,7 @@ def forensic_join_across_runs(storage: Storage, record_key: str) -> list[dict[st
         # Build per-run observation index
         obs_by_digest: dict[str, Any] = {}
         try:
-            for ev in storage.read_events(run_id):
+            for ev in storage.read_all_events(run_id):
                 if ev.type == EventType.PERCEPTION_OBSERVED:
                     try:
                         digest = _sh(dict(ev.payload))
@@ -1349,7 +1349,7 @@ def forensic_join_across_runs(storage: Storage, record_key: str) -> list[dict[st
         except Exception:
             obs_by_digest = {}
         try:
-            events = storage.read_events(run_id)
+            events = storage.read_all_events(run_id)
         except Exception:
             continue
         for ev in events:

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -2782,9 +2782,11 @@ def cmd_gate(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
         )
         return 2
 
-    actions_by_key = fold_action_events(storage.read_events(run_id)) if run_id is not None else {}
+    actions_by_key = (
+        fold_action_events(storage.read_all_events(run_id)) if run_id is not None else {}
+    )
     consumed = (
-        collect_consumed_authorities(storage.read_events(run_id)) if run_id is not None else {}
+        collect_consumed_authorities(storage.read_all_events(run_id)) if run_id is not None else {}
     )
     decision = gate_decide(
         config,
@@ -3096,7 +3098,7 @@ def cmd_forget(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
 
     for run in runs_to_scan:
         try:
-            events = storage.read_events(run.run_id)
+            events = storage.read_all_events(run.run_id)
         except Exception:
             continue
         for ev in events:

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -2782,12 +2782,9 @@ def cmd_gate(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> 
         )
         return 2
 
-    actions_by_key = (
-        fold_action_events(storage.read_all_events(run_id)) if run_id is not None else {}
-    )
-    consumed = (
-        collect_consumed_authorities(storage.read_all_events(run_id)) if run_id is not None else {}
-    )
+    history = storage.read_all_events(run_id) if run_id is not None else []
+    actions_by_key = fold_action_events(history)
+    consumed = collect_consumed_authorities(history)
     decision = gate_decide(
         config,
         tool_name,

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -452,10 +452,10 @@ class GatewayServer:
                         return
                     from continuum.actions.ledger import fold_action_events
 
-                    actions = fold_action_events(storage.read_events(run_id))
+                    actions = fold_action_events(storage.read_all_events(run_id))
                     from continuum.gate import collect_consumed_authorities
 
-                    consumed = collect_consumed_authorities(storage.read_events(run_id))
+                    consumed = collect_consumed_authorities(storage.read_all_events(run_id))
                     decision = match_route(
                         server._routes,
                         host=host.split(":")[0],

--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -452,10 +452,11 @@ class GatewayServer:
                         return
                     from continuum.actions.ledger import fold_action_events
 
-                    actions = fold_action_events(storage.read_all_events(run_id))
+                    history = storage.read_all_events(run_id)
+                    actions = fold_action_events(history)
                     from continuum.gate import collect_consumed_authorities
 
-                    consumed = collect_consumed_authorities(storage.read_all_events(run_id))
+                    consumed = collect_consumed_authorities(history)
                     decision = match_route(
                         server._routes,
                         host=host.split(":")[0],

--- a/src/continuum/storage/base.py
+++ b/src/continuum/storage/base.py
@@ -138,7 +138,11 @@ class Storage(ABC):
         provenance calculation that reads only live events would miss an
         archived ``EXTERNAL_AGENT`` fact and launder it to ``DETERMINISTIC``.
         Callers that compute ``derived_origin`` over a run's history must use
-        this helper so min is honest. Sorted to keep hash chain order stable.
+        this helper so min is honest. Authority enforcement, memory enumeration,
+        forensic joins, and cross-run action scans likewise require full history:
+        compaction moves facts but does not revoke their consequences. Checkpoint
+        projection may intentionally read only the live tail instead.
+        Sorted to keep hash chain order stable.
         """
         archived = list(self.read_archived_events(run_id))
         live = list(self.read_events(run_id))

--- a/src/continuum/storage/base.py
+++ b/src/continuum/storage/base.py
@@ -142,6 +142,8 @@ class Storage(ABC):
         forensic joins, and cross-run action scans likewise require full history:
         compaction moves facts but does not revoke their consequences. Checkpoint
         projection may intentionally read only the live tail instead.
+        Callers folding the same history more than once should reuse the returned
+        sequence within that operation instead of rescanning the archive.
         Sorted to keep hash chain order stable.
         """
         archived = list(self.read_archived_events(run_id))

--- a/tests/test_archived_action_history.py
+++ b/tests/test_archived_action_history.py
@@ -1,0 +1,150 @@
+"""Compaction must preserve authority enforcement and memory history (#615, #616)."""
+
+import io
+import json
+
+import pytest
+
+from continuum.actions.authority import record_authority_consumed
+from continuum.actions.grants import GrantDenied
+from continuum.actions.ledger import ActionLedger, LedgerError, forensic_join_across_runs
+from continuum.cli import main
+from continuum.events import EventType
+from continuum.models import Run, UnknownSideEffect
+from continuum.security.hashing import stable_hash
+from continuum.storage import SQLiteStorage
+
+
+def cli(db, *args):
+    out, err = io.StringIO(), io.StringIO()
+    code = main(["--db", str(db), *args], out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+def compact(db, rid="run_1"):
+    code, out, err = cli(db, "compact", rid, "--force")
+    assert code == 0, (out, err)
+    with SQLiteStorage(str(db)) as store:
+        assert store.read_archived_events(rid)
+
+
+@pytest.fixture
+def db(tmp_path):
+    path = tmp_path / "history.db"
+    with SQLiteStorage(str(path)) as store:
+        store.create_run_started(Run(run_id="run_1", goal="history"))
+    return path
+
+
+@pytest.mark.parametrize("kind", ["grant", "authority"])
+def test_consumed_authority_stays_consumed(db, kind):
+    with SQLiteStorage(str(db)) as store:
+        ledger = ActionLedger(store, "run_1")
+        grant = {"id": "spent", "scope": "refund"} if kind == "grant" else None
+        first = ledger.claim("refund", {}, key="first", grant=grant)
+        ledger.complete(first.key, external_id="receipt", result={})
+        if kind == "authority":
+            record_authority_consumed(store, "run_1", "spent", via_action_id=first.action.action_id)
+    for count in range(2):
+        if count:
+            compact(db)
+        with SQLiteStorage(str(db)) as store:
+            with pytest.raises(GrantDenied if kind == "grant" else LedgerError, match="spent"):
+                ActionLedger(store, "run_1").claim(
+                    "refund", {"authority_id": "spent"}, key=f"fresh-{count}", grant=grant
+                )
+            assert store.verify_events("run_1").ok
+
+
+@pytest.mark.parametrize("kind", ["grant", "authority"])
+def test_archived_live_retry_preserves_uncertainty(db, kind):
+    grant = {"id": "live", "scope": "refund"} if kind == "grant" else None
+    with SQLiteStorage(str(db)) as store:
+        first = ActionLedger(store, "run_1").claim("refund", {}, key="live", grant=grant)
+        if kind == "authority":
+            record_authority_consumed(store, "run_1", "live", via_action_id=first.action.action_id)
+    compact(db)
+    with SQLiteStorage(str(db)) as store:
+        with pytest.raises(UnknownSideEffect):
+            ActionLedger(store, "run_1").claim(
+                "refund", {"authority_id": "live"}, key="live", grant=grant
+            )
+        assert not any(e.type == EventType.GRANT_DENIED for e in store.read_all_events("run_1"))
+
+
+def test_cli_gate_retains_consumed_authority(db, tmp_path):
+    with SQLiteStorage(str(db)) as store:
+        record_authority_consumed(store, "run_1", "spent", via_action_id="old-action")
+    compact(db)
+    config = tmp_path / "gate.json"
+    config.write_text(json.dumps({"tools": {"refund": {"key_template": "refund:{id}"}}}))
+    payload = tmp_path / "payload.json"
+    payload.write_text(
+        json.dumps({"tool_name": "refund", "tool_input": {"id": "new", "authority_id": "spent"}})
+    )
+    code, out, err = cli(
+        db,
+        "--json",
+        "gate",
+        "--run-id",
+        "run_1",
+        "--config",
+        str(config),
+        "--payload-file",
+        str(payload),
+    )
+    assert code == 2, (out, err)
+    assert "spent" in err and "consumed at seq" in err
+
+
+@pytest.mark.parametrize("run_specific", [False, True])
+def test_forget_and_forensics_include_archived_observations(db, run_specific):
+    with SQLiteStorage(str(db)) as store:
+        for rid in ["run_1", "run_2"]:
+            if rid != "run_1":
+                store.create_run_started(Run(run_id=rid, goal="history"))
+            observation = {"content": rid}
+            store.append_event(rid, EventType.PERCEPTION_OBSERVED, observation)
+            ledger = ActionLedger(store, rid)
+            ledger.claim(
+                "mem_write",
+                {},
+                key=f"mem:vector:acme:{rid}",
+                scoped_to_run=False,
+                origin_digest=stable_hash(observation),
+            )
+            ledger.claim("mem_write", {}, key=f"mem:vector:other:{rid}", scoped_to_run=False)
+    for rid in ["run_1", "run_2"]:
+        compact(db, rid)
+    with SQLiteStorage(str(db)) as store:
+        for rid in ["run_1", "run_2"]:
+            hits = ActionLedger(store, rid).forensic_lookup(f"acme:{rid}")
+            assert len(hits) == 1
+            assert hits[0]["observation_event"].payload["content"] == rid
+        hits = forensic_join_across_runs(store, "acme:")
+        assert len(hits) == 2
+        assert all(h["observation_event"] is not None for h in hits)
+    scope = ["--run-id", "run_1"] if run_specific else []
+    expected = ["run_1"] if run_specific else ["run_1", "run_2"]
+    for mode in [["--dry-run"], []]:
+        code, out, err = cli(db, "--json", "forget", "--tenant", "acme", *scope, *mode)
+        assert code == 0, (out, err)
+        assert sorted(json.loads(out)["record_keys"]) == expected
+    with SQLiteStorage(str(db)) as store:
+        for rid in ["run_1", "run_2"]:
+            assert store.verify_events(rid).ok
+
+
+def test_foreign_action_scan_includes_archive(db):
+    class ScanStorage(SQLiteStorage):
+        supports_action_index = False
+
+    with ScanStorage(str(db)) as store:
+        first = ActionLedger(store, "run_1").claim("refund", {}, key="global", scoped_to_run=False)
+        ActionLedger(store, "run_1").complete(first.key, external_id="receipt", result={})
+    compact(db)
+    with ScanStorage(str(db)) as store:
+        store.create_run_started(Run(run_id="run_2", goal="history"))
+        retry = ActionLedger(store, "run_2").claim("refund", {}, key="global", scoped_to_run=False)
+        assert not retry.fresh
+        assert retry.action.action_id == first.action.action_id

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -371,3 +371,15 @@ def test_transfer_encoding_closes_gateway_connection(db: str, gateway: str) -> N
     assert b"Connection: close" in response
     assert b"transfer encoding is not supported" in response
     assert b"501" not in response
+
+
+def test_compacted_consumed_authority_still_denies(db: str, gateway: str) -> None:
+    from continuum.actions.authority import record_authority_consumed
+    from continuum.cli import main
+
+    with SQLiteStorage(db) as store:
+        record_authority_consumed(store, "run_1", "spent", via_action_id="original-action")
+    assert main(["--db", db, "compact", "run_1", "--force"]) == 0
+    status, body = post(gateway, "/v1/invoices", {"id": "new", "authority_id": "spent"})
+    assert status == 403
+    assert "spent" in body["reason"] and "consumed at seq" in body["reason"]


### PR DESCRIPTION
## Description

Compaction moves old events into the archive, but authority checks and memory-history consumers were still reading only the live tail. A completed grant could therefore be accepted under a fresh key after compaction, and archived memory writes disappeared from forget/forensic results.

Use the existing `Storage.read_all_events` contract for ledger grant and authority checks, CLI and HTTP gateway gate inputs, memory enumeration and forensic observation joins, and the non-indexed cross-run action fallback. Keep checkpoint-tail projection unchanged. Document the distinction in the storage contract and changelog.

## Related issues

Fixes #615
Fixes #616

## Types of changes

- Type: `bugfix`

## Breaking changes

No API or storage schema change. Previously missed archived facts now affect the same checks as live facts. Unfinished same-key retries retain the existing `UnknownSideEffect` behavior.

## How has this been tested?

Python 3.12.13 on macOS, editable `.[dev]` installation.

- `env -u NO_COLOR TERM=xterm .venv/bin/pytest`: 2,029 passed, 24 skipped.
- `.venv/bin/ruff check src/ tests/ examples/`: passed.
- `.venv/bin/ruff format --check src/ tests/ examples/`: passed.
- `.venv/bin/mypy src/continuum`: passed, 121 source files.
- `git diff --check`: passed.

Seven regression cases fail against unchanged upstream production code. Coverage uses real SQLite compaction and CLI dispatch, an actual local HTTP gateway, both grant and explicit-authority consumption, preserved unfinished-retry uncertainty, run-specific/store-wide forget, archived observation joins, non-indexed cross-run lookup, and hash-chain verification after denials and tombstones. The initial full run had two terminal-color failures with ambient color settings; the final command above controls those settings.

## Checklist

Tests added for changed behavior. Storage contract and changelog updated. Local validation is reported above; GitHub CI has not yet run on this PR. Security limitations are stated below.

## Additional context

The authority defense still depends on recorded consumption; this does not replace issuer-side credential validation. `forget` enumerates external deletion targets and appends a tombstone, but does not delete external data. Full-history scans include the archive and therefore scale with retained history. PostgreSQL integration was not run locally. A separate second-compaction failure (missing RUN_STARTED during anchoring) observed during testing remains outside this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Archived action history and memory records remain available after compaction.
  - Authority and grant enforcement continue to reject previously consumed credentials.
  - CLI and gateway decisions now account for complete event histories.
  - Forensics, cross-run scans, and memory enumeration include archived records.
  - Forgetting records continue to identify external deletion targets without deleting external data.
  - Unfinished retries retain existing uncertainty checks.

- **Documentation**
  - Clarified when complete event histories are required for enforcement and forensic operations.

- **Tests**
  - Added coverage for archived history, compaction, gateway enforcement, CLI behavior, and forensic lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->