### PR TITLE
fix(reconcile): settle over archived history after compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,11 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- Reconcile and authority settle see archived history after compaction (#647).
+  The probe-driven settle path folded only the live tail, so an archived
+  uncertain action crashed `reconcile --auto` with `LookupError` and authority
+  probes ran on an empty payload. Both scans now use full history.
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/src/continuum/reconcilers.py
+++ b/src/continuum/reconcilers.py
@@ -239,7 +239,7 @@ def _key_for(storage: Storage, run_id: str, action: Action) -> Any:
     """
     from continuum.actions.ledger import fold_action_events
 
-    folded = fold_action_events(storage.read_events(run_id))
+    folded = fold_action_events(storage.read_all_events(run_id))
     for key, candidate in folded.items():
         if candidate.action_id == action.action_id:
             return key
@@ -339,7 +339,7 @@ def settle_authority(
     from continuum.models import Origin
 
     payload: dict[str, Any] = {"authority_id": authority_id}
-    for ev in reversed(list(storage.read_events(run_id))):
+    for ev in reversed(list(storage.read_all_events(run_id))):
         if (
             ev.type is not None
             and str(ev.type) == "AUTHORITY_CONSUMED"

--- a/tests/test_reconcile_after_compact.py
+++ b/tests/test_reconcile_after_compact.py
@@ -1,0 +1,99 @@
+"""Reconcile and authority settle must see archived history (#647).
+
+Compaction moves the pre-anchor prefix into events_archive, but the
+probe-driven settle path folded only the live tail. An archived
+uncertain action crashed settle_run with LookupError, and authority
+probes ran on an empty payload. Both scans now use full history.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import shlex
+import sys
+from pathlib import Path
+
+from continuum.actions import ActionLedger
+from continuum.actions.authority import record_authority_consumed
+from continuum.cli import ExitCode, main
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.reconcilers import load_reconcilers, settle_authority, settle_run
+from continuum.storage import SQLiteStorage
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+def make_db(path: Path) -> str:
+    db = str(path / "rec647.db")
+    with SQLiteStorage(db) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    return db
+
+
+def compact(db: str) -> None:
+    code, _, err = run("--db", db, "compact", "run_1", "--force")
+    assert code == ExitCode.OK, err
+    with SQLiteStorage(db) as store:
+        assert store.read_archived_events("run_1")
+
+
+def registry(tmp_path: Path, entries: dict[str, str]) -> Path:
+    p = tmp_path / "reconcilers.json"
+    p.write_text(
+        json.dumps({"probes": {k: {"command": v, "timeout": 10} for k, v in entries.items()}})
+    )
+    return p
+
+
+def test_settle_run_settles_archived_action(tmp_path: Path) -> None:
+    db = make_db(tmp_path)
+    with SQLiteStorage(db) as store:
+        ActionLedger(store, "run_1").claim("send_invoice", {}, key="invoice:1")
+    compact(db)
+    probes = load_reconcilers(registry(tmp_path, {"send_invoice": "echo occurred=true"}))
+    report = settle_run(SQLiteStorage(db), "run_1", probes)
+    assert report.settled == 1
+    assert report.settled_true
+    with SQLiteStorage(db) as store:
+        assert store.verify_events("run_1").ok
+
+
+def test_cli_reconcile_settles_archived_action(tmp_path: Path) -> None:
+    db = make_db(tmp_path)
+    with SQLiteStorage(db) as store:
+        ActionLedger(store, "run_1").claim("send_invoice", {}, key="invoice:2")
+    compact(db)
+    cfg = registry(tmp_path, {"send_invoice": "echo occurred=true"})
+    code, out, err = run("--db", db, "--json", "reconcile", "run_1", "--config", str(cfg))
+    assert code == ExitCode.OK, err
+    assert json.loads(out)["settled_total"] == 1
+
+
+def test_settle_authority_keeps_consumption_context_after_compact(tmp_path: Path) -> None:
+    db = make_db(tmp_path)
+    with SQLiteStorage(db) as store:
+        record_authority_consumed(store, "run_1", "tok-9", via_action_id="action_probe")
+    compact(db)
+    probe = tmp_path / "authority_probe.py"
+    probe.write_text(
+        "import json, sys\n"
+        "payload = json.load(sys.stdin)\n"
+        "assert payload.get('via_action_id') == 'action_probe', payload\n"
+        "assert payload.get('consumer_run_id') == 'run_1', payload\n"
+        "print('valid=true')\n"
+    )
+    command = f"{shlex.quote(sys.executable)} {shlex.quote(str(probe))}"
+    probes = {"tok-9": {"command": command, "timeout": 10}}
+    with SQLiteStorage(db) as store:
+        report = settle_authority(store, "run_1", "tok-9", probes, dry_run=True)
+    assert report.valid is True, report.detail
+    assert report.settled is False
+    with SQLiteStorage(db) as store:
+        assert store.verify_events("run_1").ok

--- a/tests/test_reconcile_after_compact.py
+++ b/tests/test_reconcile_after_compact.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import io
 import json
-import shlex
 import sys
 from pathlib import Path
 
@@ -89,7 +88,9 @@ def test_settle_authority_keeps_consumption_context_after_compact(tmp_path: Path
         "assert payload.get('consumer_run_id') == 'run_1', payload\n"
         "print('valid=true')\n"
     )
-    command = f"{shlex.quote(sys.executable)} {shlex.quote(str(probe))}"
+    # Double quotes, not shlex.quote: the probe runs through the platform
+    # shell, and cmd.exe does not strip POSIX single quotes (Windows CI).
+    command = f'"{sys.executable}" "{probe}"'
     probes = {"tok-9": {"command": command, "timeout": 10}}
     with SQLiteStorage(db) as store:
         report = settle_authority(store, "run_1", "tok-9", probes, dry_run=True)


### PR DESCRIPTION
## Description

Compaction moves the pre-anchor prefix into events_archive, but the probe-driven settle path folded only the live tail. An archived uncertain action crashed reconcile --auto with LookupError, and authority probes ran on an empty payload. Both scans now read full history, the same one-line family as #646.

## Related issues

Fixes #647

## Types of changes

- Type: bugfix

## Breaking changes

No. Previously crashing or degraded paths now behave as they do pre-compaction.

## How has this been tested?

Python 3.14, editable installation.

- New tests/test_reconcile_after_compact.py (3 tests): settle_run settles an archived action, CLI reconcile settles it end to end, and an asserting probe confirms settle_authority passes the full consumption payload after compact. All 3 fail on unpatched code.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,033 passed, 23 skipped.
- .venv/bin/ruff check src/ tests/ examples/: passed.
- .venv/bin/ruff format --check src/ tests/ examples/: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Changelog updated. CI has not yet run on this PR.

## Additional context

The library reconcile path in actions/reconciliation.py already folds the archive via _replay and is untouched. verify() passes after settle in all three tests.