### PR TITLE
fix(checkpoint): anchor over full history so runs compact repeatedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,11 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- Runs compact more than once: the anchor checkpoint folds full history (#648).
+  It read only the live tail, so after the first compaction RUN_STARTED lived
+  in the archive and the second compact died with ValueError: could not be
+  anchored. Checkpointing a compacted run works again.
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/src/continuum/checkpoint/manager.py
+++ b/src/continuum/checkpoint/manager.py
@@ -162,8 +162,13 @@ class CheckpointManager:
     # -- writing ---------------------------------------------------------- #
 
     def project_current(self, run_id: str) -> SemanticState:
-        """Fold the run's full event history into state."""
-        return project(run_id, self.storage.read_events(run_id))
+        """Fold the run's full event history into state.
+
+        Full history, not the live tail: after compaction RUN_STARTED and
+        other foundation events live in the archive, and projecting the
+        tail alone concludes the run never started (issue #648).
+        """
+        return project(run_id, self.storage.read_all_events(run_id))
 
     def checkpoint(
         self,

--- a/tests/test_compact_twice.py
+++ b/tests/test_compact_twice.py
@@ -1,0 +1,74 @@
+"""A run can be compacted more than once (#648).
+
+The anchor checkpoint folded only the live tail, so after the first
+compaction RUN_STARTED lived in the archive and the second compact died
+with ValueError: could not be anchored. project_current now folds full
+history, matching its own contract.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from continuum.actions import ActionLedger
+from continuum.checkpoint.manager import CheckpointManager
+from continuum.cli import ExitCode, main
+from continuum.models import Run
+from continuum.storage import SQLiteStorage
+
+
+def run_cli(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+def make_db(path: Path) -> str:
+    db = str(path / "compact2.db")
+    with SQLiteStorage(db) as store:
+        store.create_run_started(Run(run_id="run_1", goal="g"))
+    return db
+
+
+def do_work(db: str, key: str) -> None:
+    with SQLiteStorage(db) as store:
+        outcome = ActionLedger(store, "run_1").claim("refund", {}, key=key)
+        ActionLedger(store, "run_1").complete(outcome.key, external_id="e1", result={})
+
+
+def test_second_compact_succeeds_after_more_work(tmp_path: Path) -> None:
+    db = make_db(tmp_path)
+    do_work(db, "k1")
+    with SQLiteStorage(db) as store:
+        first = store.compact_run("run_1")
+        assert first["archived"] > 0
+    do_work(db, "k2")
+    with SQLiteStorage(db) as store:
+        second = store.compact_run("run_1")
+        assert second["archived"] > 0
+        assert store.verify_events("run_1").ok
+
+
+def test_checkpoint_works_after_compaction(tmp_path: Path) -> None:
+    db = make_db(tmp_path)
+    do_work(db, "k1")
+    with SQLiteStorage(db) as store:
+        store.compact_run("run_1")
+    with SQLiteStorage(db) as store:
+        checkpoint = CheckpointManager(store).checkpoint("run_1", reason="post-compact")
+    assert checkpoint.run_id == "run_1"
+    with SQLiteStorage(db) as store:
+        assert store.verify_events("run_1").ok
+
+
+def test_cli_compact_twice_end_to_end(tmp_path: Path) -> None:
+    db = make_db(tmp_path)
+    do_work(db, "k1")
+    code, _, err = run_cli("--db", db, "compact", "run_1", "--force")
+    assert code == ExitCode.OK, err
+    do_work(db, "k2")
+    code, _, err = run_cli("--db", db, "compact", "run_1", "--force")
+    assert code == ExitCode.OK, err
+    with SQLiteStorage(db) as store:
+        assert store.verify_events("run_1").ok


### PR DESCRIPTION
## Description

The anchor checkpoint folded only the live tail, so after the first compaction RUN_STARTED lived in the archive and any second compact died with ValueError: could not be anchored. project_current now folds full history, matching its own documented contract. This also repairs checkpoint, recovery anchors, and adapter projection on compacted runs, which share the same choke point.

## Related issues

Fixes #648

## Types of changes

- Type: bugfix

## Breaking changes

No. Runs without an archive fold identically (the archive read is empty). Compacted runs go from hard failure to working.

## How has this been tested?

Python 3.14, editable installation.

- New tests/test_compact_twice.py (3 tests): compact, work, compact succeeds with growing archives; checkpoint works after compaction; CLI compact twice end to end. All 3 fail on unpatched code. verify() passes throughout.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,033 passed, 23 skipped.
- .venv/bin/ruff check src/ tests/ examples/: passed.
- .venv/bin/ruff format --check src/ tests/ examples/: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Changelog updated. CI has not yet run on this PR.

## Additional context

The single-transaction archive marker behavior in compact_run is untouched. source_sequence semantics are unchanged: the archive predates the live tail, so the sorted full-history fold stays chronological.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeated run compaction so subsequent compactions correctly include the full event history.
  * Checkpointing now continues to work after a previous compaction.

* **Tests**
  * Added regression coverage for multiple compactions, post-compaction checkpointing, and repeated forced compaction through the command-line workflow.

* **Documentation**
  * Documented the behavior supporting repeated compaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->