### PR TITLE
test(gateway): smuggled body after malformed length is never dispatched

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -383,3 +383,37 @@ def test_compacted_consumed_authority_still_denies(db: str, gateway: str) -> Non
     status, body = post(gateway, "/v1/invoices", {"id": "new", "authority_id": "spent"})
     assert status == 403
     assert "spent" in body["reason"] and "consumed at seq" in body["reason"]
+
+
+@pytest.mark.parametrize("bad_length", ["abc", "-5"])
+def test_malformed_length_smuggled_body_is_never_dispatched(
+    db: str, gateway: str, bad_length: str
+) -> None:
+    """A refused body must not become the next request on a live socket (#611).
+
+    The refused head carries no trustable body boundary, so the gateway must
+    answer once and close. Whatever the client already wrote stays unread and
+    must never be parsed as a second request.
+    """
+    host, port = gateway.split(":")
+    smuggled = (
+        b"POST /v1/invoices HTTP/1.1\r\n"
+        b"Host: api.example.com\r\n"
+        b"Content-Length: 11\r\n"
+        b"\r\n"
+        b'{"id":"X1"}'
+    )
+    request = (
+        b"POST /v1/invoices HTTP/1.1\r\n"
+        b"Host: api.example.com\r\n"
+        b"Content-Length: " + bad_length.encode() + b"\r\n"
+        b"\r\n" + smuggled
+    )
+    with socket.create_connection((host, int(port)), timeout=10) as sock:
+        sock.sendall(request)
+        response = recv_until_close(sock)
+
+    assert response.count(b"HTTP/1.1") == 1
+    assert b"400 Bad Request" in response
+    assert b"Connection: close" in response
+    assert b"malformed Content-Length" in response


### PR DESCRIPTION
## Description

Regression test for #611: a refused head with an unparseable Content-Length carries no trustable body boundary, so the gateway must answer once and close. Sends malformed and negative Content-Length heads with a whole smuggled request as the body on one keep-alive socket and asserts exactly one response (400, Connection: close).

## Related issues

Refs #611 (the defect itself was fixed by the close-on-refusal in a72100e; this pins the attack end to end so it cannot regress silently)

## Types of changes

- Type: tests

## Breaking changes

No. Test-only, no runtime change.

## How has this been tested?

Python 3.14, editable installation.

- New test_malformed_length_smuggled_body_is_never_dispatched (malformed and negative lengths): passes on main.
- With the close_connection line temporarily removed the new test fails with 2 responses (smuggled request dispatched), then passes again after restore, so it pins the fix.
- tests/test_gateway.py: 20 passed.
- .venv/bin/ruff check and format --check on the touched file: passed.

## Checklist

Tests added for changed behavior. No changelog entry (test-only, no user-visible change). CI has not yet run on this PR.