### PR TITLE
feat(adapters): thin-adapter ledger writes carry external-agent provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,13 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- Thin-adapter ledger writes carry EXTERNAL_AGENT provenance (#612).
+  `ContinuumToolGuard` claims about framework-executed tools were recorded
+  `deterministic`, so agent-asserted effects laundered to trusted and derived
+  provenance hid the writer. `ActionLedger` accepts a `source` (default
+  unchanged) and the guard stamps `EXTERNAL_AGENT`, matching its docstring
+  and the OpenAI adapter. Denial records stay deterministic as ledger verdicts.
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -73,7 +73,7 @@ from continuum.budgets import (
 )
 from continuum.concurrency.lease import LeaseCoordinator
 from continuum.events import Event, EventType
-from continuum.models import Action, ActionStatus, ConsumedInputs, UnknownSideEffect, utcnow
+from continuum.models import Action, ActionStatus, ConsumedInputs, Origin, UnknownSideEffect, utcnow
 from continuum.security.hashing import stable_hash
 from continuum.storage.base import Storage
 
@@ -360,7 +360,17 @@ class ActionLedger:
         lease: LeaseCoordinator | None = None,
         holder_id: str | None = None,
         ttl: timedelta | None = None,
+        source: Origin = Origin.DETERMINISTIC,
     ) -> None:
+        """Bind this ledger to a run.
+
+        ``source`` stamps the action records this ledger writes
+        (issue #612): the writer, not the derivation. Callers whose
+        claims are asserted by an autonomous agent about its own work
+        pass ``Origin.EXTERNAL_AGENT`` so the validator holds the run
+        for review. Denial records stay ``DETERMINISTIC``: they are the
+        ledger's own verdicts, not caller assertions.
+        """
         if lease is not None and not holder_id:
             raise ValueError(
                 "holder_id is required when a lease is supplied: a shared default "
@@ -369,6 +379,7 @@ class ActionLedger:
             )
         self.storage = storage
         self.run_id = run_id
+        self._source = source
         self._lease = lease
         self._holder_id = holder_id or ""
         self._ttl = ttl
@@ -759,7 +770,7 @@ class ActionLedger:
             # rather than explicit key; keep forensic searchable.
             with suppress(Exception):
                 payload["rendered_key"] = str(action.arguments.get("record_key"))
-        self.storage.append_event(self.run_id, event_type, payload)
+        self.storage.append_event(self.run_id, event_type, payload, source=self._source)
         return action
 
     @_single_writer

--- a/src/continuum/adapters/thin.py
+++ b/src/continuum/adapters/thin.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from continuum.models import Origin
+
 __all__ = [
     "crewai_available",
     "pydantic_ai_available",
@@ -69,11 +71,20 @@ class ContinuumToolGuard:
         *,
         key_fn: Callable[[str, dict[str, Any]], str] | None = None,
         external_id_fn: Callable[[Any], str | None] | None = None,
+        source: Origin = Origin.EXTERNAL_AGENT,
     ) -> None:
+        """Bind the guard to a run.
+
+        ``source`` stamps the ledger writes (issue #612): a framework
+        executing tools asserts facts about its own work, so the
+        default is ``EXTERNAL_AGENT`` and the run is held for review
+        like any agent-reported work.
+        """
         self._storage = storage
         self._run_id = run_id
         self._key_fn = key_fn
         self._external_id_fn = external_id_fn
+        self._source = source
         self._ledger: Any | None = None
         self._seq = 0
         self._inflight: dict[int, str] = {}
@@ -83,7 +94,7 @@ class ContinuumToolGuard:
         if self._ledger is None:
             from continuum.actions import ActionLedger
 
-            self._ledger = ActionLedger(self._storage, self._run_id)
+            self._ledger = ActionLedger(self._storage, self._run_id, source=self._source)
         return self._ledger
 
     def _args_dict(self, args: Any) -> dict[str, Any]:

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -179,10 +179,12 @@ class Origin(StrEnum):
     """
 
     DETERMINISTIC = "deterministic"
-    """Recorded by trusted local code: the CLI, or an adapter called in-process.
+    """Recorded by trusted local code: the CLI, or CONTINUUM's own in-process
+    orchestration (serve loop, replay guard, benchmarks).
 
     Not a claim that the fact is *correct* — only that it was not asserted by an
-    autonomous agent reporting on itself.
+    autonomous agent reporting on itself. Framework adapters that execute tools
+    on an agent's behalf record EXTERNAL_AGENT instead (issue #612).
     """
 
     HUMAN = "human"

--- a/tests/test_adapters_thin.py
+++ b/tests/test_adapters_thin.py
@@ -219,3 +219,52 @@ async def test_pydantic_error_path_fails_the_action(db: str) -> None:
         ctx, "charge_card", {"customer": "c2"}, result=None, error="card declined"
     )
     assert last_action(db).status is ActionStatus.FAILED
+
+
+# --- provenance -------------------------------------------------------------------- #
+
+
+def test_guard_ledger_writes_carry_external_agent(db: str) -> None:
+    """Framework-asserted facts must not self-certify as deterministic (#612)."""
+    from continuum.models import Origin
+    from continuum.provenance_map import derived_provenance_for_events
+
+    with SQLiteStorage(db) as store:
+        guard = ContinuumToolGuard(store, "run_1")
+        guard.complete(guard.claim("notify.customer", {"order_id": "O-9"}))
+        action_events = [
+            e for e in store.read_events("run_1") if e.type is EventType.ACTION_RECORDED
+        ]
+    assert action_events, "guard must record action events"
+    assert {e.source for e in action_events} == {Origin.EXTERNAL_AGENT}
+    with SQLiteStorage(db) as store:
+        derived = derived_provenance_for_events(store.read_events("run_1"))
+    assert derived is Origin.EXTERNAL_AGENT
+
+
+def test_default_ledger_stays_deterministic(db: str) -> None:
+    """The new source parameter must not change existing writers (#612)."""
+    from continuum.actions import ActionLedger
+    from continuum.models import Origin
+
+    with SQLiteStorage(db) as store:
+        ActionLedger(store, "run_1").claim("x.do", {}, key="plain")
+        action_events = [
+            e for e in store.read_events("run_1") if e.type is EventType.ACTION_RECORDED
+        ]
+    assert action_events
+    assert {e.source for e in action_events} == {Origin.DETERMINISTIC}
+
+
+def test_guard_source_override_is_respected(db: str) -> None:
+    """Callers that own the facts can keep the deterministic stamp (#612)."""
+    from continuum.models import Origin
+
+    with SQLiteStorage(db) as store:
+        guard = ContinuumToolGuard(store, "run_1", source=Origin.DETERMINISTIC)
+        guard.complete(guard.claim("notify.customer", {"order_id": "O-9"}))
+        action_events = [
+            e for e in store.read_events("run_1") if e.type is EventType.ACTION_RECORDED
+        ]
+    assert action_events
+    assert {e.source for e in action_events} == {Origin.DETERMINISTIC}


### PR DESCRIPTION
## Description

Option A from #612: make the behavior match the docstring. ContinuumToolGuard claims about framework-executed tools were recorded deterministic, so agent-asserted effects laundered to trusted and derived provenance hid the writer. ActionLedger now accepts a source (default deterministic, used only for action records; denial records stay deterministic as ledger verdicts) and the guard stamps EXTERNAL_AGENT, matching its module docstring and the OpenAI adapter. The DETERMINISTIC enum doc is clarified so in-process framework execution is not misread as trusted local orchestration.

## Related issues

Fixes #612

## Types of changes

- Type: bugfix

## Breaking changes

No API break (new optional parameters). Behavior change scoped to thin-adapter runs: their action records now carry EXTERNAL_AGENT, so derived provenance reports the true writer. All other ledger writers keep byte-identical output.

## How has this been tested?

Python 3.14, editable installation.

- 3 new tests in tests/test_adapters_thin.py: guard writes carry EXTERNAL_AGENT with derived provenance to match, default ledger stays deterministic, source override respected. The 2 behavior tests fail on unpatched code.
- Reproduced the issue script before (all deterministic, derived deterministic) and after (action records external_agent, derived external_agent).
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,033 passed, 23 skipped.
- .venv/bin/ruff check src/ tests/ examples/: passed.
- .venv/bin/ruff format --check src/ tests/ examples/: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Changelog updated. CI has not yet run on this PR.

## Additional context

One honest boundary: the run-level human gate keys off goal and progress provenance, which still depends on who asserted those, so the issue's minimal repro script (operator-owned goal) still resumes. What changes is that framework-asserted effects can no longer launder to trusted anywhere derivations consume them. MCP and sidecar ledger construction still uses the default; widening that is a deliberate verdict change for every MCP run and is left as a follow-up, not smuggled in here.