### PR TITLE
feat(cli): paginate provenance and impact listings display-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,11 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- Provenance listings paginate with --limit/--offset, display only (#597).
+  `continuum provenance` and `continuum impact` truncate the rendered nodes
+  (JSON carries nodes_total/nodes_hidden and downstream totals) while the
+  in-memory graph behind staleness stays whole. `--limit 0` is refused.
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -730,6 +730,28 @@ def cmd_events(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
     return ExitCode.OK
 
 
+def _page_bounds(
+    total: int, limit: int | None, offset: int, err: Any
+) -> tuple[int, int, int] | None:
+    """Validate --limit/--offset and return (start, end, hidden) for display paging.
+
+    Paging truncates display only; the underlying graph stays whole, so a
+    truncated listing can never change what staleness or validation conclude
+    (issues #321, #597). Returns None after reporting usage errors to err.
+    """
+    if limit is not None and limit < 1:
+        # Refuse rather than clamp: --limit 0 would print an empty-looking
+        # graph for a run that has nodes, which this listing must never do.
+        print(f"--limit must be 1 or more (got {limit})", file=err)
+        return None
+    if offset < 0:
+        print(f"--offset must be 0 or more (got {offset})", file=err)
+        return None
+    start = min(offset, total)
+    end = total if limit is None else min(total, start + limit)
+    return start, end, total - (end - start)
+
+
 def cmd_provenance(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Show provenance DAG with per-node Origin (issue #554). Read-only, compaction-aware."""
     storage.get_run(args.run_id)
@@ -748,22 +770,41 @@ def cmd_provenance(args: argparse.Namespace, storage: Storage, out: Any, err: An
         else:
             print(dot, file=out)
         return ExitCode.OK
+    ordered = sorted(graph.nodes.values(), key=lambda n: n.sequence)
+    page = _page_bounds(
+        len(ordered),
+        getattr(args, "limit", None),
+        getattr(args, "offset", None) or 0,
+        err,
+    )
+    if page is None:
+        return ExitCode.ERROR
+    start, end, hidden = page
+    shown = ordered[start:end]
     if getattr(args, "json", False):
         payload = graph.to_dict()
         payload["run_id"] = args.run_id
+        payload["nodes"] = payload["nodes"][start:end]
+        payload["nodes_total"] = len(ordered)
+        payload["nodes_hidden"] = hidden
         _emit(payload, "", as_json=True, stream=out)
         return ExitCode.OK
     lines = [
         f"run: {args.run_id}  (provenance DAG)",
         f"nodes: {len(graph.nodes)}  edges: {sum(len(v) for v in graph.edges.values())}",
     ]
-    for node in sorted(graph.nodes.values(), key=lambda n: n.sequence):
+    for node in shown:
         parents = graph.reverse_edges.get(node.event_id, [])
         children = graph.edges.get(node.event_id, [])
         parents_str = ",".join(p[:8] for p in parents) if parents else "-"
         children_str = ",".join(c[:8] for c in children) if children else "-"
         lines.append(
             f"  {node.sequence:>3}  {node.type.value:<18} {node.event_id[:8]}  origin={node.origin.value}  parents={parents_str}  children={children_str}  {node.label}"
+        )
+    if hidden:
+        lines.append(
+            f"  ... {hidden} of {len(ordered)} nodes hidden by paging; "
+            "run without --limit/--offset to see the whole graph"
         )
     _emit({}, "\n".join(lines), as_json=False, stream=out, palette=getattr(args, "_palette", None))
     return ExitCode.OK
@@ -782,6 +823,16 @@ def cmd_impact(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         events = storage.read_events(args.run_id)
     graph = build_provenance_graph(events)
     downstream = downstream_of(graph, evidence_id)
+    page = _page_bounds(
+        len(downstream),
+        getattr(args, "limit", None),
+        getattr(args, "offset", None) or 0,
+        err,
+    )
+    if page is None:
+        return ExitCode.ERROR
+    start, end, hidden = page
+    shown = downstream[start:end]
     if getattr(args, "json", False):
         payload = {
             "run_id": args.run_id,
@@ -794,8 +845,10 @@ def cmd_impact(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
                     "origin": n.origin.value,
                     "label": n.label,
                 }
-                for n in downstream
+                for n in shown
             ],
+            "downstream_total": len(downstream),
+            "downstream_hidden": hidden,
         }
         _emit(payload, "", as_json=True, stream=out)
         return ExitCode.OK
@@ -806,9 +859,14 @@ def cmd_impact(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         f"run: {args.run_id}  impact of {evidence_id!r}",
         f"downstream: {len(downstream)} node(s)",
     ]
-    for node in downstream:
+    for node in shown:
         lines.append(
             f"  {node.sequence:>3}  {node.type.value:<18} {node.event_id[:8]}  origin={node.origin.value}  {node.label}"
+        )
+    if hidden:
+        lines.append(
+            f"  ... {hidden} of {len(downstream)} nodes hidden by paging; "
+            "run without --limit/--offset to see the whole impact"
         )
     _emit({}, "\n".join(lines), as_json=False, stream=out, palette=getattr(args, "_palette", None))
     return ExitCode.OK
@@ -3608,12 +3666,28 @@ def build_parser() -> argparse.ArgumentParser:
     prov_parser.add_argument(
         "--dot", action="store_true", help="emit Graphviz DOT with per-node Origin color"
     )
+    prov_parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="show at most N nodes, display only; the graph behind staleness stays whole",
+    )
+    prov_parser.add_argument(
+        "--offset", type=int, default=0, help="skip the first M nodes in sequence order"
+    )
     impact = with_run(
         add("impact", cmd_impact, "Show downstream impact of an evidence item. Read-only.")
     )
     impact.add_argument(
         "--evidence", required=True, help="evidence event id or payload evidence_id"
     )
+    impact.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="show at most N downstream nodes, display only",
+    )
+    impact.add_argument("--offset", type=int, default=0, help="skip the first M downstream nodes")
 
     events = with_run(add("events", cmd_events, "List recorded events."))
     events.add_argument("--after", type=int, default=0)

--- a/tests/test_provenance_paging.py
+++ b/tests/test_provenance_paging.py
@@ -1,0 +1,136 @@
+"""Pagination for provenance listings (issue #597, step 1).
+
+--limit/--offset truncate display only. The in-memory graph behind staleness
+and validation is always whole, mirroring the tree --limit contract (#321).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from continuum.cli import ExitCode, main
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.storage import SQLiteStorage
+
+
+def run_cli(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+def seed_db(path: Path) -> str:
+    """A run with a 5-node chain: 2 evidence, 1 decision, 2 actions."""
+    db = str(path / "paging.db")
+    with SQLiteStorage(db) as store:
+        store.create_run_started(Run(run_id="run_1", goal="g"))
+        ev1 = store.append_event("run_1", EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
+        ev2 = store.append_event("run_1", EventType.EVIDENCE_ADDED, {"evidence_id": "ev2"})
+        dec = store.append_event(
+            "run_1",
+            EventType.DECISION_CREATED,
+            {"decision": "d", "decision_id": "dec1", "caused_by": [ev1.event_id]},
+        )
+        store.append_event(
+            "run_1",
+            EventType.ACTION_RECORDED,
+            {
+                "key": "k1",
+                "action_id": "a1",
+                "action_type": "send",
+                "status": "completed",
+                "action": {
+                    "action_id": "a1",
+                    "action_type": "send",
+                    "status": "completed",
+                    "arguments": {},
+                },
+                "caused_by": [dec.event_id],
+            },
+        )
+        store.append_event(
+            "run_1",
+            EventType.ACTION_RECORDED,
+            {
+                "key": "k2",
+                "action_id": "a2",
+                "action_type": "send",
+                "status": "completed",
+                "action": {
+                    "action_id": "a2",
+                    "action_type": "send",
+                    "status": "completed",
+                    "arguments": {},
+                },
+                "caused_by": [ev2.event_id],
+            },
+        )
+    return db
+
+
+def node_lines(out: str) -> list[str]:
+    return [
+        line for line in out.splitlines() if line.startswith("  ") and not line.startswith("  ...")
+    ]
+
+
+def test_provenance_limit_truncates_display_only(tmp_path: Path) -> None:
+    db = seed_db(tmp_path)
+    code, out, err = run_cli("--db", db, "provenance", "run_1", "--limit", "2")
+    assert code == ExitCode.OK, err
+    assert len(node_lines(out)) == 2
+    assert "hidden by paging" in out
+
+
+def test_provenance_offset_skips_from_the_front(tmp_path: Path) -> None:
+    db = seed_db(tmp_path)
+    _, full, _ = run_cli("--db", db, "provenance", "run_1")
+    code, out, err = run_cli("--db", db, "provenance", "run_1", "--offset", "2")
+    assert code == ExitCode.OK, err
+    assert len(node_lines(out)) == len(node_lines(full)) - 2
+
+
+def test_provenance_json_carries_totals(tmp_path: Path) -> None:
+    db = seed_db(tmp_path)
+    code, out, err = run_cli("--db", db, "--json", "provenance", "run_1", "--limit", "3")
+    assert code == ExitCode.OK, err
+    payload = json.loads(out)
+    assert payload["nodes_total"] == len(payload["nodes"]) + payload["nodes_hidden"]
+    assert len(payload["nodes"]) == 3
+    assert payload["nodes_hidden"] == payload["nodes_total"] - 3
+
+
+def test_provenance_limit_zero_is_refused(tmp_path: Path) -> None:
+    db = seed_db(tmp_path)
+    code, _, err = run_cli("--db", db, "provenance", "run_1", "--limit", "0")
+    assert code == ExitCode.ERROR
+    assert "--limit must be 1 or more" in err
+
+
+def test_impact_limit_and_json_totals(tmp_path: Path) -> None:
+    db = seed_db(tmp_path)
+    code, out, err = run_cli("--db", db, "impact", "run_1", "--evidence", "ev1", "--limit", "1")
+    assert code == ExitCode.OK, err
+    assert "hidden by paging" in out
+    code, out, err = run_cli(
+        "--db", db, "--json", "impact", "run_1", "--evidence", "ev1", "--limit", "1"
+    )
+    assert code == ExitCode.OK, err
+    payload = json.loads(out)
+    assert len(payload["downstream"]) == 1
+    assert payload["downstream_total"] == 1 + payload["downstream_hidden"]
+
+
+def test_no_flags_behaves_as_before(tmp_path: Path) -> None:
+    db = seed_db(tmp_path)
+    code, out, err = run_cli("--db", db, "provenance", "run_1")
+    assert code == ExitCode.OK, err
+    assert "hidden by paging" not in out
+    code, out, err = run_cli("--db", db, "--json", "provenance", "run_1")
+    assert code == ExitCode.OK, err
+    payload = json.loads(out)
+    assert payload["nodes_hidden"] == 0
+    assert payload["nodes_total"] == len(payload["nodes"])


### PR DESCRIPTION
## Description

Step 1 of #597: continuum provenance and continuum impact accept --limit and --offset. Paging truncates the rendered node lists only; the in-memory graph behind staleness and validation stays whole, mirroring the tree --limit contract (#321). JSON carries nodes_total/nodes_hidden (provenance) and downstream_total/downstream_hidden (impact). --limit 0 and negative --offset are refused rather than clamped. The --dot path keeps full fidelity.

## Related issues

Refs #597 (pagination step; caused_by extension and Postgres live test stay separate)

## Types of changes

- Type: feature

## Breaking changes

No. Default output is unchanged except additive JSON total fields.

## How has this been tested?

Python 3.14, editable installation.

- New tests/test_provenance_paging.py (6 tests): limit truncates with hidden line, offset skips from the front, JSON totals reconcile, limit 0 refused, impact limit plus JSON totals, unflagged output shape unchanged.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,036 passed, 23 skipped.
- .venv/bin/ruff check src/ tests/ examples/: passed.
- .venv/bin/ruff format --check src/ tests/ examples/: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Changelog updated. CI has not yet run on this PR.