### PR TITLE
style: remove em dashes from tests, examples, scripts, checkpoint context

### DIFF
--- a/examples/context_compaction.py
+++ b/examples/context_compaction.py
@@ -4,7 +4,7 @@
 
 An agent processes a long sequence of items over many turns. Its context
 window fills up, the platform compacts it, and the full conversation
-history is gone. What survives is CONTINUUM's semantic checkpoint — and
+history is gone. What survives is CONTINUUM's semantic checkpoint, and
 from that alone it reconstructs a bounded recovery context sufficient to
 continue the task.
 
@@ -214,7 +214,7 @@ def simulate_transcript(state: SemanticState) -> str:
         )
         if i % 50 == 0 and i > 0:
             lines.append(
-                f"Assistant: Progress update — {i} papers done. "
+                f"Assistant: Progress update, {i} papers done. "
                 f"Current trend: hypothesis X broadly supported but "
                 f"effect size varies. {state.progress.total - i} remaining."
             )
@@ -254,7 +254,7 @@ def main() -> int:
     say(f"    Checkpoint version: v{checkpoint.version}")
     say()
 
-    heading("2. The context window fills up — platform compacts the transcript")
+    heading("2. The context window fills up, platform compacts the transcript")
     transcript = simulate_transcript(state)
     transcript_chars = len(transcript)
     transcript_tokens = estimate_tokens(transcript)
@@ -263,7 +263,7 @@ def main() -> int:
     say(f"      characters:         {transcript_chars:,}")
     say(f"      est. tokens (heuristic, chars/4): {transcript_tokens:,}")
     say()
-    say("    [compaction occurs — full conversation history is discarded]")
+    say("    [compaction occurs, full conversation history is discarded]")
     say("    [the LLM can no longer see any previous turn, tool call, or reasoning]")
     say()
 
@@ -332,7 +332,7 @@ def main() -> int:
         say("    The semantic checkpoint carried everything that matters;")
         say("    the transcript carried everything that doesn't need to survive.")
     else:
-        say("    RESULT: Recovery blocked — see rationale above.")
+        say("    RESULT: Recovery blocked, see rationale above.")
 
     say()
     say(f"    Database: {db_path}")

--- a/examples/crash_recovery_agent.py
+++ b/examples/crash_recovery_agent.py
@@ -2,8 +2,8 @@
 
     python examples/crash_recovery_agent.py
 
-An agent analysing 1,000 documents is killed mid-run with os._exit(9) —
-no cleanup, no flush. While it is down, the dataset it depends on moves from
+An agent analysing 1,000 documents is killed mid-run with os._exit(9).
+No cleanup, no flush. While it is down, the dataset it depends on moves from
 v3 to v4. It restarts and must work out what, if anything, it can trust.
 
 Nothing here is simulated: a real process really dies, a real side effect is

--- a/examples/model_switch.py
+++ b/examples/model_switch.py
@@ -214,7 +214,7 @@ def main() -> int:
     say()
 
     heading("2. Model A becomes unavailable")
-    say(f"    [{MODEL_A} API returns 503 — capacity exhausted]")
+    say(f"    [{MODEL_A} API returns 503, capacity exhausted]")
     say("    [The agent must switch models to continue]")
     say()
 
@@ -232,7 +232,7 @@ def main() -> int:
     say(f"    Reason: {outcome_same.report.reason}")
     say()
 
-    heading("4. Recovery with Model B — CONTINUUM detects the switch")
+    heading("4. Recovery with Model B, CONTINUUM detects the switch")
     say(f"    Now validating with expected_model={MODEL_B}...")
     engine = RecoveryEngine(storage)
     decision = engine.assess(
@@ -284,7 +284,7 @@ def main() -> int:
         say("    RESULT: Recovery correctly BLOCKED until Model B revalidates")
         say("    the model-specific assumptions recorded under Model A.")
     else:
-        say("    RESULT: Recovery permitted — but model-specific state is marked")
+        say("    RESULT: Recovery permitted, but model-specific state is marked")
         say("    for review, not silently trusted.")
 
     say()

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -3,7 +3,7 @@
 
     python scripts/mcp_smoke.py
 
-Starts the real server as a subprocess and speaks raw JSON-RPC to it — no test
+Starts the real server as a subprocess and speaks raw JSON-RPC to it, no test
 harness, no in-process shortcut. Every frame sent and received is printed as it
 happens, so what you see is the wire, not a summary of it.
 
@@ -79,7 +79,7 @@ class MCPClient:
         env["CONTINUUM_DB"] = db_path
         # Mutating tools deny unlisted callers by default, so the demo grants
         # itself access the same way a real deployment would. Without this the
-        # server is read-only and step 2 onward is refused — which is the
+        # server is read-only and step 2 onward is refused, which is the
         # intended posture for an unconfigured server, not a bug.
         env["CONTINUUM_MCP_ALLOW"] = "mcp-smoke"
         src = Path(__file__).resolve().parents[1] / "src"
@@ -164,7 +164,7 @@ def main() -> int:
         if stale.exists():
             stale.unlink()
 
-    print(paint("CONTINUUM MCP — live stdio smoke test", BOLD))
+    print(paint("CONTINUUM MCP, live stdio smoke test", BOLD))
     print(paint(f"database: {DB_PATH} (fresh)", DIM))
     print(paint(f"server:   {sys.executable} -m continuum.mcp", DIM))
 
@@ -198,7 +198,7 @@ def main() -> int:
             print(paint(f"      [{marker}] {tool['name']}", DIM), flush=True)
 
         # 2 -- checkpoint a fresh run ------------------------------------ #
-        banner("2", "continuum_checkpoint — fresh run")
+        banner("2", "continuum_checkpoint, fresh run")
         payload = client.call_tool(
             "continuum_record_progress",
             {"run_id": run_id, "completed": 0, "total": 10, "goal": "Demo the MCP server live"},
@@ -211,7 +211,7 @@ def main() -> int:
         note(f"checkpoint v{payload.get('version')} sealed", GREEN)
 
         # 3 -- record progress ------------------------------------------- #
-        banner("3", "continuum_record_progress — 1..5 of 10")
+        banner("3", "continuum_record_progress, 1..5 of 10")
         for completed in range(1, 6):
             payload = client.call_tool(
                 "continuum_record_progress",
@@ -220,14 +220,14 @@ def main() -> int:
             show(payload)
 
         # 4 -- intercept an external action ------------------------------ #
-        banner("4", "continuum_intercept_action — first attempt")
+        banner("4", "continuum_intercept_action, first attempt")
         first = client.call_tool(
             "continuum_intercept_action",
             {"run_id": run_id, "action_type": "send_email", "arguments": action_args},
         )
         show(first)
         if first.get("proceed") is True:
-            note("proceed=true — nothing has claimed this action yet", GREEN)
+            note("proceed=true, nothing has claimed this action yet", GREEN)
         else:
             failures.append("first interception should have granted proceed=true")
             note("proceed was not true", RED)
@@ -250,7 +250,7 @@ def main() -> int:
         show(payload)
 
         # 6 -- the same action again ------------------------------------- #
-        banner("6", "continuum_intercept_action — SAME action, again")
+        banner("6", "continuum_intercept_action, SAME action, again")
         note("This is the whole point of the ledger.", "")
         second = client.call_tool(
             "continuum_intercept_action",
@@ -259,7 +259,7 @@ def main() -> int:
         show(second)
 
         if second.get("proceed") is False and second.get("external_id") == "msg_7781":
-            note("proceed=FALSE — the email is NOT sent twice", GREEN)
+            note("proceed=FALSE, the email is NOT sent twice", GREEN)
             note(f"previous result returned instead: {second.get('previous_result')}", GREEN)
         else:
             failures.append("duplicate interception was not refused")
@@ -279,8 +279,8 @@ def main() -> int:
             print(paint(f"    {line}", ""), flush=True)
 
         # Expectation changed when event provenance landed. Everything written
-        # through MCP is tagged EXTERNAL_AGENT — an agent's unverified report
-        # about its own work — so the run is deliberately NOT certified as
+        # through MCP is tagged EXTERNAL_AGENT, an agent's unverified report
+        # about its own work, so the run is deliberately NOT certified as
         # resumable on that basis alone. It previously returned mode=resume,
         # which meant an agent could fabricate progress and have CONTINUUM
         # confirm it was safe to continue. Requiring review is the fix, not a
@@ -289,14 +289,14 @@ def main() -> int:
         mode = decision.get("mode")
         uncertain = decision.get("uncertain_actions") or []
         if mode != "resume" and not uncertain:
-            note(f"mode={mode} — agent-reported state requires review (expected)", GREEN)
+            note(f"mode={mode}, agent-reported state requires review (expected)", GREEN)
             note("no uncertain side effects: the ledger itself is clean", GREEN)
         elif uncertain:
             failures.append(f"unexpected uncertain actions: {uncertain}")
             note(f"uncertain actions outstanding: {uncertain}", RED)
         else:
             failures.append("agent self-reported state was certified as resumable")
-            note(f"mode={mode} — self-reported state should not be 'resume'", RED)
+            note(f"mode={mode}, self-reported state should not be 'resume'", RED)
 
         banner("9", "ledger contents")
         show(client.call_tool("continuum_list_actions", {"run_id": run_id}))

--- a/src/continuum/checkpoint/context.py
+++ b/src/continuum/checkpoint/context.py
@@ -1,6 +1,6 @@
 """Bounded recovery context.
 
-When an agent resumes, it needs to be told what it was doing — but handing it
+When an agent resumes, it needs to be told what it was doing, but handing it
 the transcript defeats the purpose. This module renders the *minimum sufficient
 context*: what the goal is, what is verified, what is no longer trustworthy, and
 what it is allowed to do next.
@@ -52,7 +52,7 @@ _NEVER_DROPPED = frozenset(
     {
         "CURRENT GOAL",
         "VERIFIED PROGRESS",
-        "STALE STATE — DO NOT RELY ON",
+        "STALE STATE: DO NOT RELY ON",
     }
 )
 
@@ -184,7 +184,7 @@ def _stale_section(state: SemanticState) -> ContextSection:
     if dangling:
         lines.append(f"evidence cited but unavailable: {', '.join(dangling)}")
 
-    return ContextSection("STALE STATE — DO NOT RELY ON", tuple(lines), priority=2)
+    return ContextSection("STALE STATE: DO NOT RELY ON", tuple(lines), priority=2)
 
 
 def _review_section(state: SemanticState) -> ContextSection:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@
 
 Present so ``from tests.mcp_helpers import ...`` resolves regardless of how
 pytest is invoked. Without it the import works only when the repository root
-happens to land on ``sys.path`` — true when running ``pytest`` from the project
+happens to land on ``sys.path``, true when running ``pytest`` from the project
 directory, false in CI, which failed with ``ModuleNotFoundError: No module
 named 'tests'`` on all three Python versions.
 """

--- a/tests/mcp_helpers.py
+++ b/tests/mcp_helpers.py
@@ -25,8 +25,8 @@ class _Session:
 class FakeContext:
     """Stands in for an MCP request context with a declared client identity.
 
-    Mirrors the real shape the transport injects — ``session.client_params
-    .client_info.name`` — which is read from the initialize handshake and
+    Mirrors the real shape the transport injects, ``session.client_params
+    .client_info.name``, which is read from the initialize handshake and
     cannot be set by a tool argument. ``auth_token`` populates the handshake's
     ``_meta.authToken`` so authentication can be exercised without a live
     transport.

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -196,7 +196,7 @@ def test_an_unknown_action_reports_the_key_needed_to_reconcile_it(
 
 def test_an_interrupted_action_refuses_to_silently_retry(ledger: ActionLedger) -> None:
     """Crash between claim and complete: the effect may or may not have landed."""
-    ledger.claim("github.create_issue", ISSUE)  # never completed — process died
+    ledger.claim("github.create_issue", ISSUE)  # never completed, process died
 
     with pytest.raises(UnknownSideEffect, match="may or may not have occurred"):
         ledger.claim("github.create_issue", ISSUE)
@@ -603,7 +603,7 @@ def test_an_explicit_key_lets_a_repeat_be_a_genuine_second_action(
     """Argument hashing cannot express "this repeat is intentional".
 
     Two identical reminders are two sends, not one. Without an explicit key the
-    second is silently deduplicated away — failing closed, but still wrong.
+    second is silently deduplicated away, failing closed, but still wrong.
     """
     args = {"to": "x@y.z", "body": "Standup in 5"}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@
 
 ``continuum resume "$RUN" && ./start-agent.sh`` is the line these tests exist to
 protect. If an unsafe run ever exits 0, an agent gets launched onto stale state
-or an unreconciled side effect — so the exit code is treated as a safety
+or an unreconciled side effect, so the exit code is treated as a safety
 guarantee, not a formatting detail.
 """
 
@@ -193,7 +193,7 @@ def test_no_command_reports_success_for_a_run_that_does_not_exist(
     """A typo'd run name must never look like a clean bill of health.
 
     An empty run has a trivially valid (empty) event chain and no recorded
-    actions, so `verify` and `actions` would happily exit 0 — letting
+    actions, so `verify` and `actions` would happily exit 0, letting
     `continuum verify $TYPO && deploy` succeed against a name nobody has ever
     written to. Mutating commands owe the same distinction: `checkpoint`
     diagnosed a missing run as a projection error until issue #202.

--- a/tests/test_cli_colour.py
+++ b/tests/test_cli_colour.py
@@ -114,7 +114,7 @@ def test_emit_routes_json_around_the_colouriser_even_with_a_live_palette() -> No
 
     JSON is protected twice: the palette is disabled for --json, *and* _emit
     never passes the JSON branch through the colouriser. Either alone suffices,
-    so this asserts the lower layer directly — otherwise a refactor could drop
+    so this asserts the lower layer directly, otherwise a refactor could drop
     it while the upper guard masked the loss.
     """
     from continuum.cli.main import _emit

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -257,6 +257,6 @@ def test_composite_chains_without_double_applying_events() -> None:
     )
     state = composite.extract(context(log))
 
-    assert state.progress.completed == 1  # not 2 — events folded exactly once
+    assert state.progress.completed == 1  # not 2, events folded exactly once
     assert {w.task_id for w in state.pending_work} == {"t_llm"}
     assert state.decision("d1") is not None

--- a/tests/test_interchange_evidence.py
+++ b/tests/test_interchange_evidence.py
@@ -82,7 +82,7 @@ def test_truncation_is_detectable() -> None:
         _make_run(store)
         primitives = export_evidence(store, "run_1")
         assert verify_export(primitives) is True
-        # Drop a middle line — sequence and prev_hash break
+        # Drop a middle line, sequence and prev_hash break
         truncated = primitives[:2] + primitives[3:]
         assert verify_export(truncated) is False
         # Tail truncation is detectable by length and final hash mismatch

--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -6,7 +6,7 @@ asking "is this safe to resume?" should never require permission.
 
 This is authorization by declared identity, not authentication. ``clientInfo``
 is asserted by the client at handshake and never verified, so these tests prove
-that honestly-named agents are kept apart — not that a hostile one is stopped.
+that honestly-named agents are kept apart, not that a hostile one is stopped.
 """
 
 from __future__ import annotations
@@ -311,7 +311,7 @@ async def test_read_only_tools_stay_open_to_anyone(
     """Asking "is this safe to resume?" must never require permission.
 
     A stranger denied read access could not even discover why its writes are
-    failing, and the information disclosed — a run's goal and progress — is
+    failing, and the information disclosed, a run's goal and progress, is
     already readable by anyone holding the database file.
     """
     await seed(server)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -60,7 +60,7 @@ def _no_confirm_token(monkeypatch: pytest.MonkeyPatch) -> None:
 def server_ctx() -> Iterator[tuple[Any, Any]]:
     """A server whose caller is authorized to mutate.
 
-    These tests cover tool behaviour, not the authorization layer — that lives
+    These tests cover tool behaviour, not the authorization layer, that lives
     in test_mcp_authz.py. Without an explicit policy the server denies every
     mutation, and a policy failure here would look like a logic bug.
     """
@@ -269,7 +269,7 @@ async def test_a_rejected_progress_call_writes_nothing_at_all(
     """A rejected call must not even create the run (issue #203).
 
     The counter checks used to run after `ensure_run`, so a typo'd or hostile
-    call left a goal-bearing run row and a RUN_STARTED event behind — facts no
+    call left a goal-bearing run row and a RUN_STARTED event behind, facts no
     tool can delete. Validation now precedes creation, matching the guard's
     own rule that a refusal writes nothing.
     """
@@ -545,7 +545,7 @@ async def test_validate_flags_a_changed_dependency(server_ctx: tuple[Any, Any]) 
 # The test above declares the dependency by appending an event straight to
 # storage, which no MCP client can do. Checkpointing with ``env`` used to record
 # a snapshot and nothing else, and the validator returns early for a state with
-# no declared dependencies — so drift was rendered in ``environment_changes``
+# no declared dependencies, so drift was rendered in ``environment_changes``
 # while the verdict stayed ``safe``, which is precisely "reported as verified
 # when it is not". These drive the whole path through the tools.
 
@@ -579,7 +579,7 @@ async def test_drift_in_an_env_declared_dependency_blocks_resume(
     """A moved dataset must stop the run even once the self-report is confirmed.
 
     Confirming clears the REQUIRES_REVIEW on goal and progress, so nothing else
-    is left to mask the environment check — if the verdict were still ``safe``
+    is left to mask the environment check, if the verdict were still ``safe``
     the agent would resume on top of data that changed underneath it.
     """
     server, _ = server_ctx
@@ -734,7 +734,7 @@ async def test_deterministic_state_still_resumes_cleanly(
     """The provenance check must not block genuinely verified state.
 
     Written through the storage API directly (as the CLI or an in-process
-    adapter would), the same run resumes cleanly — proving the gate keys on
+    adapter would), the same run resumes cleanly, proving the gate keys on
     *who asserted it*, not on some blanket refusal.
     """
     server, ctx = server_ctx
@@ -1748,7 +1748,7 @@ def test_server_startup_never_deletes_the_write_ahead_log(tmp_path: Any) -> None
     """A blocking ``-wal`` is quarantined, not destroyed.
 
     Deleting it would turn committed transactions into silent loss, and an
-    emptied database still verifies as an intact chain — the failure would look
+    emptied database still verifies as an intact chain, the failure would look
     like success. The bytes must survive somewhere recoverable.
     """
     path = str(tmp_path / "agent.db")
@@ -2119,7 +2119,7 @@ async def test_a_log_not_beginning_with_run_started_is_refused(
     If some other writer appends before RUN_STARTED, inserting the start event
     afterwards would place the run's beginning *after* events that supposedly
     preceded it. The resulting projection would be wrong in a way nothing
-    downstream can detect, so this raises instead — naming the problem beats
+    downstream can detect, so this raises instead, naming the problem beats
     silently producing bad state.
     """
     from continuum.mcp.server import MalformedRunLog

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -128,7 +128,7 @@ def test_progress_stays_tainted_once_an_agent_contributes(store: SQLiteStorage) 
     """Progress is cumulative, so the weakest contributor wins.
 
     A trusted event appended after an agent's self-report does not launder the
-    running total — the agent's contribution is still inside it.
+    running total, the agent's contribution is still inside it.
     """
     store.create_run(Run(run_id="r", goal="g"))
     store.append_event("r", EventType.RUN_STARTED, {"goal": "g", "total": 100})

--- a/tests/test_recovery_context.py
+++ b/tests/test_recovery_context.py
@@ -65,7 +65,7 @@ def test_stale_state_is_surfaced_not_buried() -> None:
         )
     )
     rendered = context.render()
-    assert "STALE STATE — DO NOT RELY ON" in rendered
+    assert "STALE STATE: DO NOT RELY ON" in rendered
     assert "decision_12" in rendered
     assert "dataset changed" in rendered
     assert "dependency dataset" in rendered
@@ -220,9 +220,9 @@ def test_stale_state_survives_a_tight_budget_even_with_a_next_action() -> None:
     )
     context = build_recovery_context(stale, token_budget=60, next_action="reconcile_action:x")
     assert "STALE STATE" in context.render()
-    assert "STALE STATE — DO NOT RELY ON" not in context.dropped_sections
+    assert "STALE STATE: DO NOT RELY ON" not in context.dropped_sections
     titles = [section.title for section in context.sections]
-    assert "STALE STATE — DO NOT RELY ON" in titles
+    assert "STALE STATE: DO NOT RELY ON" in titles
     assert "CURRENT GOAL" in titles
     assert "VERIFIED PROGRESS" in titles
 
@@ -249,9 +249,9 @@ def test_the_protected_sections_are_never_dropped_across_budgets() -> None:
                 next_action=next_action,
                 environment_changes=("data pipeline redeployed",),
             )
-            assert "STALE STATE — DO NOT RELY ON" not in context.dropped_sections
+            assert "STALE STATE: DO NOT RELY ON" not in context.dropped_sections
             titles = [section.title for section in context.sections]
-            assert "STALE STATE — DO NOT RELY ON" in titles
+            assert "STALE STATE: DO NOT RELY ON" in titles
             assert "CURRENT GOAL" in titles
             assert "VERIFIED PROGRESS" in titles
 

--- a/tests/test_recovery_engine.py
+++ b/tests/test_recovery_engine.py
@@ -428,7 +428,7 @@ def test_assessment_changes_nothing(store: SQLiteStorage) -> None:
 def test_lenient_mode_still_never_resumes_over_an_uncertain_side_effect(
     store: SQLiteStorage,
 ) -> None:
-    """Tolerating uncertainty downgrades REQUEST_HUMAN to WAIT — not to RESUME.
+    """Tolerating uncertainty downgrades REQUEST_HUMAN to WAIT, not to RESUME.
 
     Opting out of strictness may change who resolves the doubt; it must never
     make an unresolved side effect look settled.

--- a/tests/test_rewind_dual_state.py
+++ b/tests/test_rewind_dual_state.py
@@ -1,4 +1,4 @@
-"""Atomic dual-state rewind (issue #292) — 6 acceptance criteria."""
+"""Atomic dual-state rewind (issue #292), 6 acceptance criteria."""
 
 from __future__ import annotations
 

--- a/tests/test_storage_concurrency.py
+++ b/tests/test_storage_concurrency.py
@@ -6,7 +6,7 @@ overwrite each other.** One wins, the other is told it lost.
 
 These tests are the reason the engine takes an IMMEDIATE lock and keeps a
 UNIQUE constraint on ``(run_id, sequence)``. Without both, a race produces a
-forked chain that verifies clean — the worst possible failure, because it looks
+forked chain that verifies clean, the worst possible failure, because it looks
 correct.
 """
 


### PR DESCRIPTION
## Description

First directory batch of #266: 53 em dashes across 19 files in tests/, examples/, scripts/, and the one src string the tests pin (the STALE STATE banner in checkpoint/context.py, which becomes STALE STATE: DO NOT RELY ON with its assertions updated in the same commit). Prose dashes become commas; the single end-of-line dash becomes a full stop.

## Related issues

Refs #266 (remaining: src/, docs, benchmarks, root files; each gets its own PR)

## Types of changes

- Type: style

## Breaking changes

No. Comment, docstring, demo-output, and banner-text wording only. The banner text change is covered by its own asserting tests, which pass.

## How has this been tested?

Python 3.14, editable installation.

- rg confirms zero em dashes remain in the touched directories.
- pytest on all touched test files (recovery context, rewind, action ledger, CLI colour, provenance, recovery engine, storage concurrency): 208 passed.
- python -m py_compile on touched examples, scripts, and src file: clean.
- .venv/bin/ruff check and format --check on the touched paths: passed.
- Full suite plus mypy will run in CI.

## Checklist

No behavior change. CI has not yet run on this PR.