### PR TITLE
style: remove em dashes from actions, models, events

### DIFF
--- a/src/continuum/__init__.py
+++ b/src/continuum/__init__.py
@@ -1,4 +1,4 @@
-"""CONTINUUM — verifiable semantic recovery layer for long-running AI agents.
+"""CONTINUUM, verifiable semantic recovery layer for long-running AI agents.
 
 Agents that can lose their context without losing their work.
 

--- a/src/continuum/actions/idempotency.py
+++ b/src/continuum/actions/idempotency.py
@@ -4,7 +4,7 @@ An idempotency key answers one question: has this exact operation already been
 performed? Get it wrong in one direction and the agent duplicates a side effect;
 wrong in the other and it refuses to do legitimate new work.
 
-The key is derived from the action type plus its arguments, canonically hashed —
+The key is derived from the action type plus its arguments, canonically hashed,
 so argument order never matters, but a changed value always does.
 
 Volatile arguments
@@ -17,7 +17,7 @@ new action. ``volatile`` names the fields to exclude.
 
 This is a sharp edge, so it is opt-in and explicit. Excluding a field that
 genuinely distinguishes two operations would collapse them into one and silently
-skip real work — the failure mode is quiet, which makes it worse than the noisy
+skip real work, the failure mode is quiet, which makes it worse than the noisy
 one. Nothing is excluded by default.
 """
 

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -16,14 +16,14 @@ The protocol
 
 A crash can land anywhere:
 
-* **before 1** — nothing happened. Retry is safe.
-* **between 1 and 2** — intent recorded, effect may or may not have occurred.
+* **before 1**, nothing happened. Retry is safe.
+* **between 1 and 2**, intent recorded, effect may or may not have occurred.
   On recovery the action is ``STARTED`` with no result: **the effect is of
   unknown status.** The ledger refuses to guess.
-* **between 2 and 3** — the effect definitely happened but was never recorded.
+* **between 2 and 3**, the effect definitely happened but was never recorded.
   Indistinguishable from the previous case *from the ledger alone*, which is
   precisely why it must not be resolved by assumption.
-* **after 3** — fully recorded. A repeat call returns the stored result.
+* **after 3**, fully recorded. A repeat call returns the stored result.
 
 Why not just retry?
 -------------------
@@ -32,7 +32,7 @@ Retrying an unrecorded action is only safe if the operation is naturally
 idempotent. Creating a GitHub issue, charging a card and sending an email are
 not. Retrying duplicates them; skipping may drop them. Neither default is
 correct, so the ledger raises ``UnknownSideEffect`` and requires the caller to
-supply a reconciler — usually a cheap read against the external system that can
+supply a reconciler, usually a cheap read against the external system that can
 answer "did this actually happen?".
 
 This is honest at-least-once with mandatory reconciliation, not exactly-once.
@@ -294,7 +294,7 @@ class ActionOutcome:
     """What a claim returned.
 
     ``fresh`` distinguishes "go ahead and perform this" from "already done,
-    here is the previous result" — the single most important bit for callers.
+    here is the previous result", the single most important bit for callers.
     """
 
     key: IdempotencyKey
@@ -1100,10 +1100,10 @@ class ActionLedger:
     def fail(self, key: str, error: str, *, certain: bool = True) -> Action:
         """Record that the effect did not happen.
 
-        ``certain=False`` is for failures where the effect may still have landed
-        — a timeout after the request was sent, for instance. Those become
-        ``UNKNOWN`` rather than ``FAILED``, because a timeout is not evidence of
-        absence.
+         ``certain=False`` is for failures where the effect may still have landed
+        , a timeout after the request was sent, for instance. Those become
+         ``UNKNOWN`` rather than ``FAILED``, because a timeout is not evidence of
+         absence.
         """
         key, existing = self._require(key)
         action = existing.model_copy(

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -1100,10 +1100,10 @@ class ActionLedger:
     def fail(self, key: str, error: str, *, certain: bool = True) -> Action:
         """Record that the effect did not happen.
 
-         ``certain=False`` is for failures where the effect may still have landed
-        , a timeout after the request was sent, for instance. Those become
-         ``UNKNOWN`` rather than ``FAILED``, because a timeout is not evidence of
-         absence.
+        ``certain=False`` is for failures where the effect may still have landed:
+        a timeout after the request was sent, for instance. Those become
+        ``UNKNOWN`` rather than ``FAILED``, because a timeout is not evidence of
+        absence.
         """
         key, existing = self._require(key)
         action = existing.model_copy(

--- a/src/continuum/actions/reconciliation.py
+++ b/src/continuum/actions/reconciliation.py
@@ -7,7 +7,7 @@ Strategies, and when each is defensible
 ---------------------------------------
 
 ``ProbeReconciler``
-    Ask the external system directly — search for the issue, look up the charge.
+    Ask the external system directly, search for the issue, look up the charge.
     The only strategy that produces evidence. Prefer it wherever a read exists.
 
 ``AssumeNotOccurredReconciler``
@@ -20,7 +20,7 @@ Strategies, and when each is defensible
     operation is not idempotent. Slow, and honest about it.
 
 There is deliberately no ``AssumeOccurred`` strategy. Assuming success without
-evidence silently drops work, and a dropped side effect is invisible — nothing
+evidence silently drops work, and a dropped side effect is invisible, nothing
 in the system will ever contradict it. Optimism is the one default that cannot
 be audited after the fact.
 """
@@ -66,7 +66,7 @@ class Reconciler(ABC):
         """Return a resolution, or ``None`` if this reconciler cannot decide.
 
         Returning ``None`` is a legitimate answer and leaves the action
-        uncertain — better than a confident wrong one.
+        uncertain, better than a confident wrong one.
         """
 
 
@@ -75,7 +75,7 @@ class ProbeReconciler(Reconciler):
 
     The probe receives the recorded action and returns a ``Resolution``, or
     ``None`` if it could not find out. A probe that raises is treated as "could
-    not find out" rather than as evidence of absence — an unreachable API tells
+    not find out" rather than as evidence of absence, an unreachable API tells
     you nothing about whether your earlier request landed.
     """
 
@@ -149,7 +149,7 @@ class ReconciliationReport:
         if self.resolved_failed:
             lines.append(f"confirmed as not performed: {', '.join(self.resolved_failed)}")
         if self.unresolved:
-            lines.append(f"STILL UNKNOWN — needs human review: {', '.join(self.unresolved)}")
+            lines.append(f"STILL UNKNOWN: needs human review: {', '.join(self.unresolved)}")
         return "\n".join(lines) or "nothing to reconcile"
 
 

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -196,7 +196,7 @@ class Event(BaseModel):
     Included in ``content()`` deliberately. A trust marker outside the hash
     could be edited without breaking verification, which would make it useless
     for the one job it has. The cost is that chains written before this field
-    existed no longer verify — accepted as a clean break rather than carrying a
+    existed no longer verify, accepted as a clean break rather than carrying a
     permanently-untrusted legacy tier.
     """
 
@@ -371,7 +371,7 @@ class EventLog:
         so an edited event is reported twice: ``TAMPERED_CONTENT`` on the event
         itself and ``BROKEN_CHAIN`` on its successor, whose link no longer
         matches. The walk then re-syncs, because untampered events remain
-        internally consistent — so the violation list localises damage instead
+        internally consistent, so the violation list localises damage instead
         of flooding.
 
         Trust is expressed separately by ``trusted_through``: only the prefix

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -2,7 +2,7 @@
 
 Phase 1 defines the *shape* of durable task state: enums, the semantic state
 tree, ledger records, environment snapshots, validation reports and recovery
-contracts. No storage or recovery logic lives here — these are pure data
+contracts. No storage or recovery logic lives here, these are pure data
 structures (mostly immutable) so they can be serialized, versioned, hashed and
 diffed without side effects.
 
@@ -12,7 +12,7 @@ Conventions
 * All IDs are stable strings (``run_..``, ``action_..``, ``finding_..``).
 * Enums are ``str`` subclasses so they serialize to readable JSON.
 * State-bearing models are frozen: mutations must produce a new version via
-  ``model_copy`` — the versioning phase builds on this property.
+  ``model_copy``, the versioning phase builds on this property.
 """
 
 from __future__ import annotations
@@ -170,7 +170,7 @@ class PlanStepStatus(StrEnum):
 
 
 class Origin(StrEnum):
-    """Who asserted a fact — decides how much it can be trusted.
+    """Who asserted a fact, decides how much it can be trusted.
 
     This describes the *writer*, not the derivation. Folding a fabricated event
     is still a faithful fold, so "the projection is reproducible" says nothing
@@ -181,7 +181,7 @@ class Origin(StrEnum):
     DETERMINISTIC = "deterministic"
     """Recorded by trusted local code: the CLI, or an adapter called in-process.
 
-    Not a claim that the fact is *correct* — only that it was not asserted by an
+    Not a claim that the fact is *correct*, only that it was not asserted by an
     autonomous agent reporting on itself.
     """
 
@@ -209,7 +209,7 @@ class Origin(StrEnum):
     def self_certified(self) -> bool:
         """Whether this origin is an unverified self-report.
 
-        Such state is usable — it is often correct — but it cannot be the
+        Such state is usable, it is often correct, but it cannot be the
         grounds for declaring a run verified.
         """
         return self in (Origin.LLM, Origin.EXTERNAL_AGENT, Origin.IMPORTED)
@@ -702,7 +702,7 @@ class ModelState(BaseModel):
 class SemanticState(BaseModel):
     """The compact, durable representation of task state.
 
-    This is what survives crashes and context loss — NOT the transcript.
+    This is what survives crashes and context loss, NOT the transcript.
 
     A state is a *projection* of an event prefix. ``source_sequence`` records
     how far into the log the projection consumed, which makes the state
@@ -802,7 +802,7 @@ class SemanticState(BaseModel):
     def dangling_evidence(self) -> frozenset[str]:
         """Support cited by decisions or findings that the state cannot produce.
 
-        A decision may cite either raw evidence or a finding derived from it —
+        A decision may cite either raw evidence or a finding derived from it;
         both are legitimate provenance. Only references matching neither are
         dangling. Treating a cited finding as missing evidence would raise a
         false alarm on every well-formed reasoning chain, and false alarms are

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -2,7 +2,7 @@
 
 Phase 1 defines the *shape* of durable task state: enums, the semantic state
 tree, ledger records, environment snapshots, validation reports and recovery
-contracts. No storage or recovery logic lives here, these are pure data
+contracts. No storage or recovery logic lives here. These are pure data
 structures (mostly immutable) so they can be serialized, versioned, hashed and
 diffed without side effects.
 
@@ -12,7 +12,7 @@ Conventions
 * All IDs are stable strings (``run_..``, ``action_..``, ``finding_..``).
 * Enums are ``str`` subclasses so they serialize to readable JSON.
 * State-bearing models are frozen: mutations must produce a new version via
-  ``model_copy``, the versioning phase builds on this property.
+  ``model_copy``. The versioning phase builds on this property.
 """
 
 from __future__ import annotations
@@ -170,7 +170,7 @@ class PlanStepStatus(StrEnum):
 
 
 class Origin(StrEnum):
-    """Who asserted a fact, decides how much it can be trusted.
+    """The origin identifies who asserted a fact and decides how much it can be trusted.
 
     This describes the *writer*, not the derivation. Folding a fabricated event
     is still a faithful fold, so "the projection is reproducible" says nothing
@@ -209,7 +209,7 @@ class Origin(StrEnum):
     def self_certified(self) -> bool:
         """Whether this origin is an unverified self-report.
 
-        Such state is usable, it is often correct, but it cannot be the
+        Such state is usable. It is often correct, but it cannot be the
         grounds for declaring a run verified.
         """
         return self in (Origin.LLM, Origin.EXTERNAL_AGENT, Origin.IMPORTED)
@@ -802,8 +802,8 @@ class SemanticState(BaseModel):
     def dangling_evidence(self) -> frozenset[str]:
         """Support cited by decisions or findings that the state cannot produce.
 
-        A decision may cite either raw evidence or a finding derived from it;
-        both are legitimate provenance. Only references matching neither are
+        A decision may cite either raw evidence or a finding derived from it.
+        Both are legitimate provenance. Only references matching neither are
         dangling. Treating a cited finding as missing evidence would raise a
         false alarm on every well-formed reasoning chain, and false alarms are
         how real ones get ignored.


### PR DESCRIPTION
## Description

Second directory batch of #266: em dashes in src/continuum/actions/, models.py, events.py, __init__.py, plus the paired tests/test_reconciliation.py assertion. Prose dashes become commas; the rendered STILL UNKNOWN banner becomes STILL UNKNOWN: needs human review with its assertions updated in the same commit.

## Related issues

Refs #266 (remaining: rest of src/, docs, benchmarks, root files)

## Types of changes

- Type: style

## Breaking changes

No. Docstring, comment, and banner-text wording only.

## How has this been tested?

Python 3.14, editable installation.

- rg confirms zero em dashes remain in the touched paths.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,030 passed, 23 skipped.
- .venv/bin/ruff check and format --check src/ tests/ examples/: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

No behavior change. CI has not yet run on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated punctuation and formatting across module, class, and method documentation.
  * Clarified report text formatting without changing its meaning or behavior.
  * No functional, validation, data model, or control-flow changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->