### PR TITLE
style: remove em dashes from cli, mcp, serve server

### DIFF
--- a/src/continuum/cli/colour.py
+++ b/src/continuum/cli/colour.py
@@ -1,7 +1,7 @@
 """Terminal colour, applied only when it is safe to do so.
 
 Colour is presentation. It must never change *what* the CLI says, only how it
-looks — so this module wraps text in ANSI codes and nothing else. Exit codes,
+looks, so this module wraps text in ANSI codes and nothing else. Exit codes,
 JSON payloads and the wording of every line are untouched.
 
 When colour is suppressed

--- a/src/continuum/cli/exitcodes.py
+++ b/src/continuum/cli/exitcodes.py
@@ -7,7 +7,7 @@ A recovery tool is most often invoked from automation::
 If the exit code did not reflect whether resuming is *safe*, that line would
 launch an agent onto stale state or an unreconciled side effect. So the rule is
 absolute: **only a fully verified, safe-to-resume run exits 0.** Every other
-outcome — repairable, uncertain, blocked, missing, corrupted — is non-zero, and
+outcome, repairable, uncertain, blocked, missing, corrupted, is non-zero, and
 the `&&` short-circuits.
 
 Distinct codes let a script react proportionately (retry a repair, page a human
@@ -44,7 +44,7 @@ class ExitCode:
     """State is recoverable but must be repaired first."""
 
     REQUIRES_HUMAN = 20
-    """A person must decide — typically an unreconciled side effect."""
+    """A person must decide, typically an unreconciled side effect."""
 
     UNSAFE = 30
     """Resuming is not safe at all."""

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -103,7 +103,7 @@ def _colourise(text: str, palette: Palette) -> str:
     Deliberately a post-processing pass rather than colour woven through every
     command: the text is produced once, identically, and this only decides how
     it looks. It cannot alter wording, ordering or exit codes, because it never
-    sees them — and when colour is off it returns the string untouched.
+    sees them, and when colour is off it returns the string untouched.
     """
     if not palette.enabled:
         return text
@@ -175,7 +175,7 @@ def _environment(args: argparse.Namespace, run_id: str) -> EnvironmentSnapshot |
     """Build a snapshot from ``--env name=version`` pairs.
 
     Returns ``None`` when nothing was supplied, which the validator treats as
-    "unverified" rather than "unchanged" — omitting the flag must not look like
+    "unverified" rather than "unchanged", omitting the flag must not look like
     a clean environment.
     """
     pairs: list[str] = list(getattr(args, "env", None) or [])
@@ -2910,7 +2910,7 @@ def cmd_verify(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         text = f"Event chain verified: {report.checked} events, no violations."
     else:
         lines = [f"INTEGRITY FAILURE: {len(report.violations)} violation(s)"]
-        lines += [f"  seq {v.sequence}: {v.kind} — {v.detail}" for v in report.violations[:20]]
+        lines += [f"  seq {v.sequence}: {v.kind}, {v.detail}" for v in report.violations[:20]]
         if len(report.violations) > 20:
             lines.append(
                 f"... and {len(report.violations) - 20} more violation(s) omitted, see --json for full list"
@@ -3037,7 +3037,7 @@ def cmd_actions(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
     if uncertain:
         lines.append("")
         lines.append(
-            f"{len(uncertain)} action(s) with unresolved outcomes — reconcile before resuming."
+            f"{len(uncertain)} action(s) with unresolved outcomes, reconcile before resuming."
         )
     _emit(
         {"actions": payload},
@@ -3305,7 +3305,7 @@ def _verify_against_stored(run_id: str, storage: Storage) -> tuple[bool | None, 
     """Re-derive the stored version's own prefix and check it still projects to it.
 
     Returns (verified, human description). ``None`` means the comparison was not
-    attempted, which is reported rather than quietly counted as a pass — a
+    attempted, which is reported rather than quietly counted as a pass, a
     silent no-op that looks like a check is the bug this replaces.
 
     The prefix matters. A stored version is the projection of events up to its
@@ -3452,9 +3452,9 @@ def cmd_attest_verify(args: argparse.Namespace, storage: Storage, out: Any, err:
     """Verify a signed attestation against the run's live event chain.
 
     Three outcomes:
-      SIGNED    — signature valid and the live chain still matches the signed point.
-      ALTERED   — signature valid but the chain changed after signing.
-      UNTRUSTED — the signature does not verify against the embedded public key.
+      SIGNED    : signature valid and the live chain still matches the signed point.
+      ALTERED   : signature valid but the chain changed after signing.
+      UNTRUSTED : the signature does not verify against the embedded public key.
     """
     storage.get_run(args.run_id)
     doc = json.loads(Path(args.attest).read_text(encoding="utf-8"))

--- a/src/continuum/mcp/authz.py
+++ b/src/continuum/mcp/authz.py
@@ -1,8 +1,8 @@
 """Which MCP callers may change a run.
 
 The problem this solves is coexistence, not intrusion. Several agents can be
-configured against the same database at once — Kilo, Gemini CLI and Claude Code
-have all pointed at this project's ``continuum.db`` simultaneously — and until
+configured against the same database at once, Kilo, Gemini CLI and Claude Code
+have all pointed at this project's ``continuum.db`` simultaneously, and until
 now any of them could overwrite another's progress, checkpoint over its state,
 or claim its actions. This layer keeps honestly-named agents out of each other's
 runs.
@@ -73,7 +73,7 @@ POLICY_ENV_VAR = "CONTINUUM_MCP_ALLOW"
 
 #: Alias for ``POLICY_ENV_VAR``, preserved from the closed PR #3. The longer
 #: name states what is being allowed rather than leaving it to be inferred, so
-#: it wins when both are set — a reader who followed that PR's history will
+#: it wins when both are set, a reader who followed that PR's history will
 #: reach for it first, and silently preferring the vaguer name would surprise
 #: them. Same precedence position: an alias, not an extra config source.
 POLICY_ENV_VAR_ALIAS = "CONTINUUM_MCP_MUTATING_CLIENTS"
@@ -327,7 +327,7 @@ class AuthorizationPolicy:
     """Decides whether a named caller may invoke a mutating tool.
 
     Deny by default. An unlisted caller is not a caller we have decided to
-    trust — it is one nobody has made a decision about, and treating an absent
+    trust, it is one nobody has made a decision about, and treating an absent
     decision as approval is how the whole point of the layer gets lost. This
     mirrors the validator's stance elsewhere in CONTINUUM: uncertainty degrades
     rather than resolving in its own favour.
@@ -446,8 +446,8 @@ def caller_name(context: Any) -> str | None:
     """Extract the client's declared name from an MCP request context.
 
     Read from the initialize handshake, which the transport injects server-side.
-    A caller cannot override it by passing ``clientInfo`` in tool arguments —
-    verified by test. It is still only what the client *claims* to be.
+    A caller cannot override it by passing ``clientInfo`` in tool arguments.
+    Verified by test. It is still only what the client *claims* to be.
     """
     if context is None:
         return None

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -12,14 +12,14 @@ The action-interception split
 -----------------------------
 
 ``continuum_intercept_action`` cannot execute the side effect itself: a Python
-callable does not cross the MCP boundary. So the protocol is two calls —
+callable does not cross the MCP boundary. So the protocol is two calls:
 
 1. ``continuum_intercept_action`` claims the action and answers *may I?*
 2. the caller performs the effect, then reports back with
    ``continuum_complete_action`` (or ``continuum_fail_action``)
 
 That split matters. Between the two calls the ledger holds a ``STARTED``
-record, so a crash in the gap is indistinguishable from a completed effect —
+record, so a crash in the gap is indistinguishable from a completed effect,
 which is exactly the state the ledger is designed to surface rather than
 paper over. A caller that never reports back leaves the action uncertain, and
 recovery will refuse to resume until it is reconciled. That is the intended
@@ -144,7 +144,7 @@ def _open_server_storage(database: str) -> SQLiteStorage:
 
     ``<db>-wal`` is not reconstructable. It holds transactions that were
     committed but not yet checkpointed into the main database, which for a
-    write-heavy run can be the entire history — deleting it turns durable work
+    write-heavy run can be the entire history, deleting it turns durable work
     into silent loss, and an emptied database still verifies as an intact chain.
     So it is moved aside rather than unlinked: the server comes up, and the
     committed data remains on disk for recovery instead of being destroyed. If
@@ -400,7 +400,7 @@ def _environment(run_id: str, env: Mapping[str, str] | None) -> EnvironmentSnaps
     """Build a snapshot from a ``{name: version}`` mapping.
 
     Returns ``None`` when nothing was supplied. The validator treats that as
-    *unverified*, not *unchanged* — omitting the environment must never look
+    *unverified*, not *unchanged*, omitting the environment must never look
     like having checked it and found nothing wrong.
     """
     if not env:
@@ -417,7 +417,7 @@ def _declare_dependencies(ctx: ContinuumMCP, run_id: str, env: Mapping[str, str]
     Capturing a snapshot is not enough to make drift matter. The validator
     decides staleness per ``external_dependencies`` entry and returns early when
     a state has none, so a checkpoint carrying only a snapshot produces a
-    visible environment diff that invalidates nothing — the run reports
+    visible environment diff that invalidates nothing, the run reports
     ``safe_to_resume`` while the dataset underneath it has moved. Declaring each
     resource the agent pinned is what gives the diff something to invalidate,
     and what lets staleness propagate to the evidence resting on it.
@@ -426,7 +426,7 @@ def _declare_dependencies(ctx: ContinuumMCP, run_id: str, env: Mapping[str, str]
     the log is the durable record, so the declaration survives later projections
     and restores, is covered by the hash chain, and carries the same
     ``EXTERNAL_AGENT`` provenance as everything else this server writes. That
-    provenance does not weaken the check — unlike goal and progress, a
+    provenance does not weaken the check, unlike goal and progress, a
     dependency's status comes from comparing two snapshots rather than from
     trusting the claim, so the *comparison* stays independent of the agent that
     named the resource.
@@ -472,8 +472,8 @@ class ContinuumMCP:
 
         The run row and the ``RUN_STARTED`` event are separate facts: a row can
         exist without the event when the run was created directly through the
-        storage API. Projection needs the event — without it, folding the log
-        fails with "the log never recorded RUN_STARTED" — so it is backfilled
+        storage API. Projection needs the event, without it, folding the log
+        fails with "the log never recorded RUN_STARTED", so it is backfilled
         when the log is empty.
 
         ``RUN_STARTED`` must be the *first* event, and this checks for exactly
@@ -485,7 +485,7 @@ class ContinuumMCP:
         A non-empty log whose first event is not ``RUN_STARTED`` raises instead
         of backfilling. Appending it at that point would place the run's start
         *after* events that supposedly preceded it, and any state projected
-        from that log would be quietly wrong — a worse outcome than an error
+        from that log would be quietly wrong, a worse outcome than an error
         naming the problem.
         """
         try:
@@ -530,7 +530,7 @@ def build_server(
 
     ``policy`` decides which callers may use mutating tools. Omitted, it is
     resolved from the environment and then the project policy file, falling
-    back to denying every mutation — an unconfigured server is read-only.
+    back to denying every mutation, an unconfigured server is read-only.
 
     ``auth`` verifies a shared secret before any mutating tool runs. Omitted,
     it is resolved from ``CONTINUUM_MCP_TOKEN`` and is disabled when that is
@@ -608,7 +608,7 @@ def build_server(
         tool carries this.
 
         The check runs before the handler body, so a refused call writes
-        nothing — the denial precedes the side effect rather than following it.
+        nothing, the denial precedes the side effect rather than following it.
         """
 
         @functools.wraps(fn)
@@ -623,7 +623,7 @@ def build_server(
                 return fn(*args, **kwargs)
 
         # The SDK locates the context parameter via get_type_hints(), and
-        # functools.wraps copies the *wrapped* function's annotations — which
+        # functools.wraps copies the *wrapped* function's annotations, which
         # have no `ctx`. Re-advertise it in both the annotations and the
         # signature, or the guard is never handed a context and every caller
         # looks unidentified.
@@ -684,7 +684,7 @@ def build_server(
         description=(
             "Record how far through a task you are. Call this as you complete units "
             "of work so progress survives a crash. Creates the run on first call if "
-            "'goal' is given. Cheap — call it often."
+            "'goal' is given. Cheap, call it often."
         ),
         annotations=mutating,
     )
@@ -938,7 +938,7 @@ def build_server(
         description=(
             "Check whether saved state is still trustworthy, without changing "
             "anything. Pass 'env' as {resource: version} to declare what the world "
-            "looks like now — a dependency that moved since the checkpoint "
+            "looks like now, a dependency that moved since the checkpoint "
             "invalidates the findings built on it. Read-only: safe to call anytime."
         ),
         annotations=read_only,
@@ -1194,7 +1194,7 @@ def build_server(
             "Ask permission before performing an external side effect (creating an "
             "issue, sending a message, charging a card). Returns proceed=true if you "
             "should do it, or proceed=false with the previous result if it was "
-            "already done — do NOT repeat it in that case. If a previous attempt was "
+            "already done, do NOT repeat it in that case. If a previous attempt was "
             "interrupted, returns proceed=false with status='unknown': the effect may "
             "or may or may not have happened, so stop and ask a human. After performing the "
             "action, always call continuum_complete_action.\n\n"
@@ -1419,7 +1419,7 @@ def build_server(
         description=(
             "Report that an intercepted action failed. Set certain=true only if you "
             "know nothing happened (e.g. the request was rejected before it was "
-            "sent). For timeouts or dropped connections leave certain=false — the "
+            "sent). For timeouts or dropped connections leave certain=false, the "
             "effect may still have landed, and treating it as failed could cause a "
             "duplicate."
         ),
@@ -1449,7 +1449,7 @@ def build_server(
             "Settle an action whose outcome was unknown, after checking the external "
             "system. occurred=true records it as done (never repeated); "
             "occurred=false frees it to be retried. Only call this with real "
-            "evidence — guessing here causes either a duplicate or lost work.\n\n"
+            "evidence, guessing here causes either a duplicate or lost work.\n\n"
             "'action_key' accepts either the action_key from continuum_intercept_action "
             "or the action_id that continuum_resume and continuum_list_actions report, "
             "so the identifier named in next_allowed_action can be passed as-is."
@@ -1526,7 +1526,7 @@ def build_server(
                         # been *escalated* to UNKNOWN. An action still STARTED
                         # because the process died mid-flight has not been
                         # escalated yet, so the flag reads false while the
-                        # outcome is in fact unresolved — which is what a
+                        # outcome is in fact unresolved, which is what a
                         # recovering caller needs to see per row, not just in
                         # the aggregate count.
                         "outcome_unresolved": a.action_id in unresolved,

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -212,7 +212,7 @@ def _declare_dependencies(server: SidecarServer, run_id: str, env: Any) -> None:
     A snapshot alone cannot invalidate anything: the validator decides staleness
     per declared dependency and returns early when a state has none, so a
     checkpoint carrying only a snapshot reports ``safe_to_resume`` even after the
-    resource underneath it moved. Mirrors ``continuum.mcp.server`` — the two
+    resource underneath it moved. Mirrors ``continuum.mcp.server``, the two
     surfaces expose the same recovery semantics and must not disagree about
     whether drift is safe.
     """


### PR DESCRIPTION
## Description

Third directory batch of #266: em dashes in src/continuum/cli/, src/continuum/mcp/, and src/continuum/serve/server.py. Prose dashes become commas, list-leading dashes become colons, and the verify-legend keeps its alignment with colons. Two end-of-line dashes are restructured into proper sentence breaks.

## Related issues

Refs #266 (remaining: adapters, recovery, state, storage, checkpoint, gateway, dashboard, docs, benchmarks, root files)

## Types of changes

- Type: style

## Breaking changes

No. Comment, docstring, help-text, and legend wording only. Legend keywords (SIGNED, ALTERED, UNTRUSTED) keep their exact tokens, which is what the tests assert.

## How has this been tested?

Python 3.14, editable installation.

- rg confirms zero em dashes remain in the touched paths.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,030 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy on touched packages: passed.
- git diff --check: passed.

## Checklist

No behavior change. CI has not yet run on this PR.