### PR TITLE
style: remove em dashes from adapters, recovery, state

### DIFF
--- a/src/continuum/adapters/generic.py
+++ b/src/continuum/adapters/generic.py
@@ -173,7 +173,7 @@ class GenericAgentAdapter(AgentAdapter):
         call does not prove the side effect failed to occur: a timeout or a
         dropped connection means the request may already have landed. Recording
         it as a definite failure would remove it from ``ledger.pending()``, hide
-        it from reconciliation, and let a later retry duplicate the effect —
+        it from reconciliation, and let a later retry duplicate the effect,
         exactly the hazard the ledger exists to prevent.
 
         There is no exception type in this layer that reliably proves nothing

--- a/src/continuum/adapters/langgraph.py
+++ b/src/continuum/adapters/langgraph.py
@@ -3,7 +3,7 @@
 Integrates CONTINUUM's durability, checkpointing, action ledger, and recovery
 with LangGraph's graph-based agent runtime.
 
-The adapter is optional — ``langgraph`` is not installed by default. Import
+The adapter is optional, ``langgraph`` is not installed by default. Import
 this module only after installing the ``langgraph`` extra.
 
 Usage
@@ -29,15 +29,15 @@ Usage
 Design
 ------
 LangGraph manages its own state via its checkpointer. CONTINUUM's role here is
-to add *semantic durability* — the action ledger prevents duplicate side effects
+to add *semantic durability*, the action ledger prevents duplicate side effects
 across graph invocations, and the recovery engine validates that resumed state
 is still consistent with the environment.
 
 The adapter does NOT replace LangGraph's checkpointer. The two serve different
 purposes:
 
-* **LangGraph checkpointer** — full state snapshots for graph resumption.
-* **CONTINUUM** — verified semantic state with environment validation and
+* **LangGraph checkpointer**, full state snapshots for graph resumption.
+* **CONTINUUM**, verified semantic state with environment validation and
   exactly-once side effect guarantees.
 """
 
@@ -192,7 +192,7 @@ class LangGraphAgentAdapter(GenericAgentAdapter):
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorator that wraps a LangGraph tool with action ledger interception.
 
-        The wrapped function will be idempotent across graph invocations —
+        The wrapped function will be idempotent across graph invocations:
         if the action already completed, the cached result is returned without
         re-executing the tool.
 
@@ -268,7 +268,7 @@ class LangGraphAgentAdapter(GenericAgentAdapter):
 
         Add this node to your graph at points where you want durable semantic
         state. It reads the run ID from state, projects semantic state, and
-        writes a checkpoint — then returns state unchanged so the graph can
+        writes a checkpoint, then returns state unchanged so the graph can
         continue.
 
         Parameters
@@ -280,7 +280,7 @@ class LangGraphAgentAdapter(GenericAgentAdapter):
         Returns
         -------
         dict
-            State updates (empty dict — this node is side-effect only on
+            State updates (empty dict, this node is side-effect only on
             CONTINUUM's storage).
 
         Example

--- a/src/continuum/adapters/openai.py
+++ b/src/continuum/adapters/openai.py
@@ -3,7 +3,7 @@
 Integrates CONTINUUM's durability, checkpointing, action ledger, and recovery
 with the OpenAI Agents SDK (``openai-agents`` package).
 
-The adapter is optional — ``openai-agents`` is not installed by default. Import
+The adapter is optional, ``openai-agents`` is not installed by default. Import
 this module only after installing the ``openai`` extra.
 
 Usage
@@ -37,10 +37,10 @@ Usage
 Design
 ------
 The OpenAI Agents SDK uses:
-- **ToolContext** (auto-injected) — we use it to carry run metadata
-- **RunHooks** — lifecycle callbacks we implement for checkpointing
-- **RunContextWrapper.context** — our custom ``ContinuumContext`` carries the run ID
-- **function_tool** — we wrap these with action ledger interception
+- **ToolContext** (auto-injected), we use it to carry run metadata
+- **RunHooks**, lifecycle callbacks we implement for checkpointing
+- **RunContextWrapper.context**, our custom ``ContinuumContext`` carries the run ID
+- **function_tool**, we wrap these with action ledger interception
 
 CONTINUUM does NOT replace the SDK's session/compaction mechanisms. It adds:
 - Idempotent side effects via the action ledger

--- a/src/continuum/recovery/contract.py
+++ b/src/continuum/recovery/contract.py
@@ -2,7 +2,7 @@
 
 A contract is the machine-readable answer to "what am I allowed to do now?".
 It names what was verified, what was invalidated, what must happen before
-normal work resumes, and — critically — the *single* next permitted action.
+normal work resumes, and, critically, the *single* next permitted action.
 
 One action, not a set. If a contract listed everything currently allowed, an
 agent could pick the convenient one and skip reconciling the side effect it was
@@ -12,7 +12,7 @@ and the ordering meaningful.
 Contracts are deterministic: the same state, environment and ledger always
 produce a byte-identical contract. That is what makes them auditable, diffable
 and safe to compare in tests. They are sealed with an integrity hash for the
-same reason checkpoints are — a contract that could be edited between issue and
+same reason checkpoints are, a contract that could be edited between issue and
 enforcement would gate nothing.
 """
 

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -1,16 +1,16 @@
-"""Deciding how — and whether — a run may resume.
+"""Deciding how, and whether, a run may resume.
 
 The engine reduces three independent signals to one decision:
 
-* validation statuses (Phase 5) — is the state still true?
-* the action ledger (Phase 6) — did an external effect land?
-* checkpoint integrity (Phases 3–4) — is the record itself sound?
+* validation statuses (Phase 5), is the state still true?
+* the action ledger (Phase 6), did an external effect land?
+* checkpoint integrity (Phases 3–4), is the record itself sound?
 
 The decision rule
 -----------------
 
 **The most cautious applicable signal wins.** Not the first one evaluated, not
-the most common — the most cautious. Each signal proposes a mode; the engine
+the most common, the most cautious. Each signal proposes a mode; the engine
 takes the maximum on a severity ordering:
 
     RESUME < REPAIR_AND_RESUME < WAIT < REQUEST_HUMAN < ROLLBACK < ABORT
@@ -18,7 +18,7 @@ takes the maximum on a severity ordering:
 Order-independence matters because these signals genuinely co-occur. A run can
 have a stale dataset *and* an uncertain side effect at once. If the engine
 returned whichever it noticed first, the same situation would recover
-differently depending on iteration order — and the unsafe answer would win
+differently depending on iteration order, and the unsafe answer would win
 roughly half the time. Taking the maximum makes the outcome deterministic and
 always errs toward caution.
 
@@ -28,7 +28,7 @@ What the engine does not do
 It does not execute repairs, mutate the run, or contact anything external. It
 reads state and returns a decision plus a contract. Keeping it free of side
 effects means a recovery decision can be computed, logged and reviewed without
-committing to it — which is what makes ``continuum validate`` safe to run
+committing to it, which is what makes ``continuum validate`` safe to run
 against a live database.
 """
 
@@ -596,7 +596,7 @@ class RecoveryEngine:
 
         if not validation.safe:
             # Count only what actually needs repair. Reporting every status
-            # would include the VALID ones and overstate the damage — a run
+            # would include the VALID ones and overstate the damage, a run
             # with two verified components and one stale one would claim three
             # need repair. The decision itself is unaffected; the operator
             # reading the rationale is not.

--- a/src/continuum/recovery/planner.py
+++ b/src/continuum/recovery/planner.py
@@ -7,7 +7,7 @@ Ordering is not cosmetic. Reconciling an uncertain side effect must come before
 any new work, because until the ledger knows whether that GitHub issue exists,
 the agent cannot safely act on the assumption that it does or does not.
 Similarly, a stale dependency must be re-pinned before the findings derived from
-it are re-derived — repairing in the wrong order produces work that is stale the
+it are re-derived, repairing in the wrong order produces work that is stale the
 moment it completes.
 
 Steps are declarative. The planner does not execute anything; it produces the
@@ -158,7 +158,7 @@ def _step_for(entry: ComponentValidationEntry, *, strict_unknown: bool = True) -
                 reason=entry.detail,
                 # An unverifiable resource normally needs a person, because
                 # nobody knows what is true. Callers who opted into tolerating
-                # uncertainty get an automatic step instead — the policy has to
+                # uncertainty get an automatic step instead, the policy has to
                 # hold here too, or the setting would be silently ignored.
                 requires_human=entry.status is StateStatus.UNKNOWN and strict_unknown,
             )
@@ -215,7 +215,7 @@ def plan_repairs(
 
     Steps are deduplicated by identity and sorted so that prerequisites precede
     the work that depends on them. Sorting is stable and total, so the same
-    inputs always yield the same plan — a contract that varied between runs
+    inputs always yield the same plan, a contract that varied between runs
     would be impossible to audit.
 
     ``unprojectable`` is ``(sequence, event_type, reason)`` for a log whose fold

--- a/src/continuum/state/diff.py
+++ b/src/continuum/state/diff.py
@@ -3,8 +3,8 @@
 The diff is *semantic*, not textual: it compares identified components by their
 IDs, so reordering a list produces no diff while invalidating a decision does.
 
-Output is deterministic — entries are emitted in a fixed component order and
-sorted by ID within each component — because the diff feeds `continuum diff`,
+Output is deterministic, entries are emitted in a fixed component order and
+sorted by ID within each component, because the diff feeds `continuum diff`,
 recovery contracts and benchmark scoring, all of which need stable output.
 """
 

--- a/src/continuum/state/extractor.py
+++ b/src/continuum/state/extractor.py
@@ -5,7 +5,7 @@ into semantic state. The deterministic extractor is the default and the only
 one required: it folds the event log and calls nothing external.
 
 The optional LLM extractor exists for state that was never recorded structurally
-— free-text reasoning a framework did not emit as events. It is constrained by
+, free-text reasoning a framework did not emit as events. It is constrained by
 design:
 
 * It runs only when explicitly enabled and given a callable; there is no
@@ -106,7 +106,7 @@ LLMCallable = Callable[[ExtractionContext, SemanticState], LLMProposal]
 class LLMExtractor:
     """Optional enrichment layer over a base extractor.
 
-    ``llm`` is supplied by the caller — CONTINUUM has no provider dependency.
+    ``llm`` is supplied by the caller, CONTINUUM has no provider dependency.
     If it raises, extraction falls back to the deterministic result rather than
     failing the run: losing an optional enrichment must never cost a recovery.
     """

--- a/src/continuum/state/extractor.py
+++ b/src/continuum/state/extractor.py
@@ -4,8 +4,8 @@ An extractor turns a trajectory (the run's recorded events) plus an environment
 into semantic state. The deterministic extractor is the default and the only
 one required: it folds the event log and calls nothing external.
 
-The optional LLM extractor exists for state that was never recorded structurally
-, free-text reasoning a framework did not emit as events. It is constrained by
+The optional LLM extractor exists for state that was never recorded structurally:
+free-text reasoning a framework did not emit as events. It is constrained by
 design:
 
 * It runs only when explicitly enabled and given a callable; there is no

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -91,7 +91,7 @@ def _provenance(event: Event) -> Provenance:
     """Carry the event's own trust marker into the projected component.
 
     Previously this hardcoded ``DETERMINISTIC``, which was true of the *fold*
-    but said nothing about the event being folded — so an agent's self-report
+    but said nothing about the event being folded, so an agent's self-report
     projected as indistinguishable from a verified fact.
 
     For derived artifacts (issue #392) the payload may carry a stamped
@@ -291,7 +291,7 @@ class _Accumulator:
 
         # Re-derive `pending` whenever the caller moved `completed`/`failed`
         # without restating it. Keeping the old value would leave the counters
-        # summing past `total` and the update would be rejected — punishing a
+        # summing past `total` and the update would be rejected, punishing a
         # caller for omitting a field that had not changed.
         total = current["total"]
         if total is not None and "pending" not in payload:
@@ -865,7 +865,7 @@ def project(
 ) -> SemanticState:
     """Project a run's events into semantic state.
 
-    ``upto`` truncates the fold at a sequence number — the mechanism behind
+    ``upto`` truncates the fold at a sequence number, the mechanism behind
     ``continuum inspect --version`` and recovery from a partially trusted log.
 
     ``on_unprojectable`` forwards to :func:`project_incremental`: ``"raise"``
@@ -952,7 +952,7 @@ def account_pins_in_context(
             flag = None
         else:
             # If context was truncated, we cannot tell if the pin was in a
-            # dropped section — mark as unverifiable rather than absent
+            # dropped section, mark as unverifiable rather than absent
             if is_truncated:
                 # Heuristic: if the pin's marker would have been in a low-
                 # priority section that was dropped, mark unverifiable

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -5,7 +5,7 @@ trustworthy merely because it was persisted.** Before an agent resumes, every
 component is checked against the environment as it is *now*.
 
 Staleness propagates. If a dataset moves from v3 to v4, the dependency is not
-the only casualty — every finding whose evidence came from that dataset, and
+the only casualty, every finding whose evidence came from that dataset, and
 every decision resting on those findings, is now suspect. Marking only the
 dependency would leave the agent reasoning from conclusions it can no longer
 justify. Propagation walks:
@@ -17,8 +17,8 @@ Uncertainty degrades rather than resolves. An unverifiable resource yields
 resume. The system is allowed to say "I cannot tell"; it is not allowed to
 guess in its own favour.
 
-This module decides *status*. Choosing what to do about it — resume, repair,
-abort — is the recovery engine's job in Phase 7.
+This module decides *status*. Choosing what to do about it (resume, repair,
+abort) is the recovery engine's job in Phase 7.
 """
 
 from __future__ import annotations
@@ -58,7 +58,7 @@ __all__ = [
 #: reporting "safe to resume" while that is outstanding is precisely the false
 #: assurance this layer exists to prevent. The recovery engine already refused
 #: to resume in these cases via the repair plan, but the validator's own
-#: `safe_to_resume` disagreed with it — so anything reading the validation
+#: `safe_to_resume` disagreed with it, so anything reading the validation
 #: report directly got the wrong answer.
 _UNUSABLE = frozenset(
     {


### PR DESCRIPTION
## Description

Fourth directory batch of #266: em dashes in src/continuum/adapters/, src/continuum/recovery/, and src/continuum/state/. Prose dashes become commas; three end-of-line dashes are restructured into proper sentence breaks (colon, which-clause, parenthetical).

## Related issues

Refs #266 (remaining: storage, checkpoint, security, environment, docs, benchmarks, root files)

## Types of changes

- Type: style

## Breaking changes

No. Comment and docstring wording only.

## How has this been tested?

Python 3.14, editable installation.

- rg confirms zero em dashes remain in the touched paths.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,030 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy on touched packages (42 files): passed.
- git diff --check: passed.

## Checklist

No behavior change. CI has not yet run on this PR.