### PR TITLE
style: remove em dashes from storage, checkpoint, security, environment

### DIFF
--- a/src/continuum/checkpoint/context.py
+++ b/src/continuum/checkpoint/context.py
@@ -1,6 +1,6 @@
 """Bounded recovery context.
 
-When an agent resumes, it needs to be told what it was doing — but handing it
+When an agent resumes, it needs to be told what it was doing, but handing it
 the transcript defeats the purpose. This module renders the *minimum sufficient
 context*: what the goal is, what is verified, what is no longer trustworthy, and
 what it is allowed to do next.
@@ -52,7 +52,7 @@ _NEVER_DROPPED = frozenset(
     {
         "CURRENT GOAL",
         "VERIFIED PROGRESS",
-        "STALE STATE — DO NOT RELY ON",
+        "STALE STATE: DO NOT RELY ON",
     }
 )
 
@@ -184,7 +184,7 @@ def _stale_section(state: SemanticState) -> ContextSection:
     if dangling:
         lines.append(f"evidence cited but unavailable: {', '.join(dangling)}")
 
-    return ContextSection("STALE STATE — DO NOT RELY ON", tuple(lines), priority=2)
+    return ContextSection("STALE STATE: DO NOT RELY ON", tuple(lines), priority=2)
 
 
 def _review_section(state: SemanticState) -> ContextSection:

--- a/src/continuum/checkpoint/manager.py
+++ b/src/continuum/checkpoint/manager.py
@@ -7,11 +7,11 @@ integrity hash makes it the unit recovery trusts.
 Ordering matters here. The manager writes the version, then the checkpoint,
 then records ``STATE_CHECKPOINTED``. If the process dies partway:
 
-* died before the version was written — nothing is lost; the state is still
+* died before the version was written, nothing is lost; the state is still
   derivable from the events.
-* died after the version but before the checkpoint — a version exists with no
+* died after the version but before the checkpoint, a version exists with no
   checkpoint. Harmless: the next checkpoint reuses it.
-* died after the checkpoint but before the event — the checkpoint exists and is
+* died after the checkpoint but before the event, the checkpoint exists and is
   valid; the log simply lacks the annotation. ``restore`` reads checkpoints, not
   the annotation, so recovery is unaffected.
 
@@ -62,7 +62,7 @@ class RestoredRun:
     """What recovery gets back: verified state plus how stale it is.
 
     ``pending_events`` is the gap between the checkpoint and the end of the
-    log — work that happened after the last checkpoint. It is replayed onto the
+    log, work that happened after the last checkpoint. It is replayed onto the
     checkpoint rather than ignored, so a crash between checkpoints does not
     discard the work in between.
     """

--- a/src/continuum/checkpoint/policy.py
+++ b/src/continuum/checkpoint/policy.py
@@ -4,7 +4,7 @@ Checkpointing every turn is the obvious design and the wrong one: it costs an
 fsync per step and fills history with versions that mean nothing. Checkpointing
 too rarely loses work. A policy decides.
 
-Policies answer one question — ``should_checkpoint(...) -> Decision`` — and are
+Policies answer one question, ``should_checkpoint(...) -> Decision``, and are
 pure: same inputs, same answer, no clock reads hidden inside except the one
 passed in. That makes checkpoint timing testable instead of a source of
 flakiness.
@@ -166,7 +166,7 @@ class IntervalPolicy(CheckpointPolicy):
 class EventPolicy(CheckpointPolicy):
     """Checkpoint when particular event types appear.
 
-    Defaults to side effects and milestones — the events whose loss actually
+    Defaults to side effects and milestones, the events whose loss actually
     costs something.
     """
 
@@ -203,8 +203,8 @@ class SemanticPolicy(CheckpointPolicy):
 
     Progress alone does not qualify unless it crosses a stride: counting from
     3,400 to 3,401 is not worth an fsync, but losing 500 documents of work is.
-    Structural changes — a new or invalidated decision, a new finding, a changed
-    dependency, an approval, a model switch — always qualify, because they
+    Structural changes, a new or invalidated decision, a new finding, a changed
+    dependency, an approval, a model switch, always qualify, because they
     change what the agent is allowed to do next.
     """
 

--- a/src/continuum/environment/diff.py
+++ b/src/continuum/environment/diff.py
@@ -8,7 +8,7 @@ because they demand different responses:
 ``UNKNOWN``    we could not tell
 
 ``UNKNOWN`` is not a softer ``UNCHANGED``. A resource that could not be
-inspected — an API that timed out, a file that is now unreadable — must not be
+inspected, an API that timed out, a file that is now unreadable, must not be
 treated as intact just because nothing contradicted it. Recovery downgrades on
 uncertainty rather than assuming the best.
 """

--- a/src/continuum/environment/snapshot.py
+++ b/src/continuum/environment/snapshot.py
@@ -4,13 +4,13 @@ A checkpoint is only meaningful relative to an environment. "3,421 documents
 analysed" means nothing if the dataset was replaced afterwards. The snapshot is
 the fingerprint recovery compares against.
 
-Providers are pluggable because environments differ wildly — files, datasets,
+Providers are pluggable because environments differ wildly, files, datasets,
 git commits, API sessions, permissions. Each provider answers one question:
 *what does this resource look like right now?* CONTINUUM ships providers that
 need nothing but the standard library.
 
 Capture failures are recorded, not raised. If a resource cannot be inspected at
-recovery time — the API is down, the file is unreadable — that is itself a
+recovery time, the API is down, the file is unreadable, that is itself a
 finding: the resource becomes ``UNKNOWN`` rather than silently ``VALID``. An
 environment check that fails open would defeat the purpose of checking.
 """

--- a/src/continuum/security/hashing.py
+++ b/src/continuum/security/hashing.py
@@ -92,8 +92,8 @@ def stable_hash(value: Any, algorithm: str = "sha256") -> str:
 def make_id(prefix: str) -> str:
     """Random hex identifier with a human-readable prefix, e.g. ``run_8f3a...``.
 
-    Uses 16 bytes (128 bits) of cryptographic randomness — the same budget as
-    UUID v4 — so birthday-paradox collisions are negligible even at billions of
+    Uses 16 bytes (128 bits) of cryptographic randomness, the same budget as
+    UUID v4, so birthday-paradox collisions are negligible even at billions of
     IDs.
     """
     return f"{prefix}_{secrets.token_hex(16)}"

--- a/src/continuum/storage/base.py
+++ b/src/continuum/storage/base.py
@@ -58,7 +58,7 @@ class RunNotFound(StorageError, KeyError):
     Subclasses ``KeyError`` so ``except KeyError`` still catches it, but
     overrides ``__str__``: ``KeyError.__str__`` applies ``repr()`` to its
     message, which would surface to CLI users as ``"no such run: 'ghost'"``
-    — quoted twice.
+    (quoted twice).
     """
 
     def __init__(self, run_id: str) -> None:

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -3,20 +3,20 @@
 Chosen defaults and why
 -----------------------
 
-* **WAL journal mode** — readers never block the writer, so `continuum inspect`
+* **WAL journal mode**, readers never block the writer, so `continuum inspect`
   can read a run while the agent is still working.
-* **`synchronous=FULL`** — the whole point of this layer is surviving power
+* **`synchronous=FULL`**, the whole point of this layer is surviving power
   loss. `NORMAL` can lose the last commits on a WAL crash, which would silently
   reintroduce the duplicate-work problem CONTINUUM exists to prevent. The cost
   is an fsync per append; correctness wins.
-* **`foreign_keys=ON`** — events cannot reference a run that was never created.
-* **`IMMEDIATE` transactions for writes** — takes the write lock up front, so a
+* **`foreign_keys=ON`**, events cannot reference a run that was never created.
+* **`IMMEDIATE` transactions for writes**, takes the write lock up front, so a
   racing writer fails at BEGIN rather than halfway through a read-modify-write.
 
 Sequence allocation is done inside the write transaction with a UNIQUE
 constraint on ``(run_id, sequence)`` as the backstop. If two processes race,
 one commits and the other hits the constraint and is reported as a
-``ConcurrentWriteError`` — never a silent overwrite.
+``ConcurrentWriteError``, never a silent overwrite.
 """
 
 from __future__ import annotations
@@ -171,7 +171,7 @@ class SQLiteStorage(Storage):
             try:
                 conn.close()
             except sqlite3.ProgrammingError:
-                # Already closed — safe to call close() more than once.
+                # Already closed, safe to call close() more than once.
                 pass
             finally:
                 self._connection = None  # type: ignore[assignment]

--- a/tests/test_recovery_context.py
+++ b/tests/test_recovery_context.py
@@ -65,7 +65,7 @@ def test_stale_state_is_surfaced_not_buried() -> None:
         )
     )
     rendered = context.render()
-    assert "STALE STATE — DO NOT RELY ON" in rendered
+    assert "STALE STATE: DO NOT RELY ON" in rendered
     assert "decision_12" in rendered
     assert "dataset changed" in rendered
     assert "dependency dataset" in rendered
@@ -220,9 +220,9 @@ def test_stale_state_survives_a_tight_budget_even_with_a_next_action() -> None:
     )
     context = build_recovery_context(stale, token_budget=60, next_action="reconcile_action:x")
     assert "STALE STATE" in context.render()
-    assert "STALE STATE — DO NOT RELY ON" not in context.dropped_sections
+    assert "STALE STATE: DO NOT RELY ON" not in context.dropped_sections
     titles = [section.title for section in context.sections]
-    assert "STALE STATE — DO NOT RELY ON" in titles
+    assert "STALE STATE: DO NOT RELY ON" in titles
     assert "CURRENT GOAL" in titles
     assert "VERIFIED PROGRESS" in titles
 
@@ -249,9 +249,9 @@ def test_the_protected_sections_are_never_dropped_across_budgets() -> None:
                 next_action=next_action,
                 environment_changes=("data pipeline redeployed",),
             )
-            assert "STALE STATE — DO NOT RELY ON" not in context.dropped_sections
+            assert "STALE STATE: DO NOT RELY ON" not in context.dropped_sections
             titles = [section.title for section in context.sections]
-            assert "STALE STATE — DO NOT RELY ON" in titles
+            assert "STALE STATE: DO NOT RELY ON" in titles
             assert "CURRENT GOAL" in titles
             assert "VERIFIED PROGRESS" in titles
 


### PR DESCRIPTION
## Description

Fifth directory batch of #266: em dashes in src/continuum/storage/, checkpoint/, security/, and environment/, plus the paired tests/test_recovery_context.py assertions for the STALE STATE banner (colon form, identical to the #655 batch so the two merge cleanly).

## Related issues

Refs #266 (remaining: docs, benchmarks, root files)

## Types of changes

- Type: style

## Breaking changes

No. Comment, docstring, and banner-text wording only.

## How has this been tested?

Python 3.14, editable installation.

- rg confirms zero em dashes remain in the touched paths.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,030 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy on touched packages: passed.
- git diff --check: passed.

## Checklist

No behavior change. CI has not yet run on this PR.