### PR TITLE
style: remove em dashes from benchmarks

### DIFF
--- a/benchmarks/horizon/judge.py
+++ b/benchmarks/horizon/judge.py
@@ -87,7 +87,7 @@ def score_suite(results: list[JudgeResult]) -> dict[str, Any]:
     repair_needed = [r for r in results if r.repair_needed]
     repair_correct = sum(1 for r in repair_needed if r.repair_correct)
     repair_precision = round(repair_correct / len(repair_needed), 3) if repair_needed else 1.0
-    # Placeholders for the other three metrics — they are computed by the
+    # Placeholders for the other three metrics, they are computed by the
     # driver from actual storage/ledger state, not just judge labels.
     # For now, report 0 for duplicates and 1.0 for compression as the
     # horizon driver is focused on decision correctness; the full

--- a/benchmarks/horizon/scenarios.py
+++ b/benchmarks/horizon/scenarios.py
@@ -2,7 +2,7 @@
 
 Each scenario is constructed with a correct recovery mode label at
 construction time. Two independent labelings were performed and
-disagreements resolved before publication — see the resolution note
+disagreements resolved before publication, see the resolution note
 in the PR body.
 
 Scenarios force at least 100 reconstruction cycles via the simulated
@@ -33,18 +33,18 @@ class HorizonScenario:
 # - Author 1 (primary): labeled based on whether environment drift exists
 # - Author 2 (reviewer): labeled based on whether side effects are uncertain
 # Disagreements resolved:
-# - Scenario "steady_progress" — both labeled resume, no disagreement
-# - Scenario "quarterly_drift" — Author1 said repair, Author2 said request_human;
+# - Scenario "steady_progress", both labeled resume, no disagreement
+# - Scenario "quarterly_drift", Author1 said repair, Author2 said request_human;
 #   resolved to repair because drift is re-pinnable dependency, not uncertain side effect
-# - Scenario "budget_exhaustion" — both labeled request_human, no disagreement
-# - Scenario "compaction_stress" — both labeled resume, no disagreement
-# - Scenario "abort_condition" — Author1 said abort, Author2 said request_human;
+# - Scenario "budget_exhaustion", both labeled request_human, no disagreement
+# - Scenario "compaction_stress", both labeled resume, no disagreement
+# - Scenario "abort_condition", Author1 said abort, Author2 said request_human;
 #   resolved to abort because the run's goal is invalidated (decision invalidated), not just review
 
 HORIZON_SCENARIOS: list[HorizonScenario] = [
     HorizonScenario(
         name="steady_progress_year",
-        description="Year of steady progress, weekly compaction, no drift — should resume",
+        description="Year of steady progress, weekly compaction, no drift, should resume",
         correct_mode="resume",
         cycles=120,
         mutations=None,
@@ -52,7 +52,7 @@ HORIZON_SCENARIOS: list[HorizonScenario] = [
     ),
     HorizonScenario(
         name="quarterly_drift_year",
-        description="Dataset version drifts quarterly (every 30 cycles) — should repair",
+        description="Dataset version drifts quarterly (every 30 cycles), should repair",
         correct_mode="repair",
         cycles=120,
         mutations={30: {"dataset": "v2"}, 60: {"dataset": "v3"}, 90: {"dataset": "v4"}},
@@ -60,7 +60,7 @@ HORIZON_SCENARIOS: list[HorizonScenario] = [
     ),
     HorizonScenario(
         name="budget_exhaustion_year",
-        description="Many side effects exhaust retry budget — should request_human",
+        description="Many side effects exhaust retry budget, should request_human",
         correct_mode="request_human",
         cycles=120,
         mutations={10: {"budget": "exhausted"}},
@@ -68,7 +68,7 @@ HORIZON_SCENARIOS: list[HorizonScenario] = [
     ),
     HorizonScenario(
         name="compaction_stress_year",
-        description="Aggressive compaction every cycle — should still resume",
+        description="Aggressive compaction every cycle, should still resume",
         correct_mode="resume",
         cycles=150,
         mutations=None,
@@ -76,7 +76,7 @@ HORIZON_SCENARIOS: list[HorizonScenario] = [
     ),
     HorizonScenario(
         name="abort_condition_year",
-        description="Goal invalidated via decision invalidation — should abort",
+        description="Goal invalidated via decision invalidation, should abort",
         correct_mode="abort",
         cycles=120,
         mutations={60: {"goal": "invalidated"}},


### PR DESCRIPTION
## Description

Final directory batch of #266: em dashes in benchmarks/horizon/judge.py and scenarios.py. Comment and scenario-description wording only; no description string is asserted by tests (verified by grep over tests/).

## Related issues

Refs #266 (with this, every directory from the issue is covered across the batch PRs; the issue can close once they all merge)

## Types of changes

- Type: style

## Breaking changes

No. Comment and description-string wording only.

## How has this been tested?

- rg confirms zero em dashes remain in benchmarks/.
- py_compile on both files: clean.
- pytest horizon plus benchmark suites: 20 passed.
- CI runs the full gate.

## Checklist

No behavior change. CI has not yet run on this PR.