### PR TITLE
feat(bench): plan-aware resume scenario with duplicate-work metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Plan-aware bench scenario reports zero duplicate work (#468).**
+  `plan_aware_resume_skips_completed_units` starts a 5-unit linear plan via
+  `PLAN_UPSERT`, completes 2 units, reprojects from the log as a post-crash
+  resume would, and asserts units 1-2 never re-execute while 3-5 remain,
+  recording the duplicate count in the report metrics. It runs in CI through
+  the parametrized phase-6 suite.
+
 - **`examples/demo.ipynb`, the crash-recovery walkthrough as a notebook (#283).**
   The lowest-friction way to watch a recovery was `docker run`, which still wants
   a daemon; this wants a browser. Colab and Binder badges in the Quick Start

--- a/src/continuum/benchmark/phase6/scenarios.py
+++ b/src/continuum/benchmark/phase6/scenarios.py
@@ -282,6 +282,52 @@ def scenario_human_verdict_honored(ctx: ScenarioContext) -> None:
     assert ledger.pending_gate("run_1") is None
 
 
+def scenario_plan_aware_resume_skips_completed_units(ctx: ScenarioContext) -> None:
+    """Plan-aware resume does zero duplicate work for completed units (#468).
+
+    Starts a 5-unit linear plan via PLAN_UPSERT, completes 2 units, then
+    reprojects from the log the way a post-crash resume would. Units 1-2
+    must not be re-executed while 3-5 remain. Mirrors examples/plan_milestones.py.
+    """
+    from continuum.state.semantic import project
+
+    store = _new_store()
+    units = [
+        {
+            "id": f"u{i}",
+            "title": f"milestone {i}",
+            "status": "pending",
+            "depends_on": [f"u{i - 1}"] if i > 1 else [],
+        }
+        for i in range(1, 6)
+    ]
+    store.append_event("run_1", EventType.PLAN_UPSERT, {"plan_id": "p1", "units": units})
+    store.append_event(
+        "run_1",
+        EventType.PLAN_UPSERT,
+        {
+            "plan_id": "p1",
+            "units": [
+                {"id": "u1", "title": "milestone 1", "status": "done", "depends_on": []},
+                {
+                    "id": "u2",
+                    "title": "milestone 2",
+                    "status": "done",
+                    "depends_on": ["u1"],
+                },
+            ],
+        },
+    )
+    # Post-crash resume reads the log fresh rather than trusting memory.
+    resumed = project("run_1", store.read_events("run_1"))
+    remaining = [u.step_id for u in resumed.plan if u.status.value != "completed"]
+    assert remaining == ["u3", "u4", "u5"], remaining
+    duplicates = [u for u in remaining if u in ("u1", "u2")]
+    ctx.metrics["duplicate_completed_units"] = len(duplicates)
+    ctx.metrics["remaining_units"] = remaining
+    assert not duplicates, f"completed units would re-execute: {duplicates}"
+
+
 def scenario_transient_network_failure_on_install(ctx: ScenarioContext) -> None:
     store = _new_store()
     store.append_event(
@@ -310,4 +356,5 @@ ALL_SCENARIOS: list[tuple[str, ScenarioFn]] = [
     ("missing_dependency_graph_fallback", scenario_missing_dependency_graph_fallback),
     ("human_verdict_honored", scenario_human_verdict_honored),
     ("transient_network_failure_on_install", scenario_transient_network_failure_on_install),
+    ("plan_aware_resume_skips_completed_units", scenario_plan_aware_resume_skips_completed_units),
 ]

--- a/src/continuum/benchmark/phase6/scenarios.py
+++ b/src/continuum/benchmark/phase6/scenarios.py
@@ -319,10 +319,14 @@ def scenario_plan_aware_resume_skips_completed_units(ctx: ScenarioContext) -> No
         },
     )
     # Post-crash resume reads the log fresh rather than trusting memory.
+    # Both lists derive from the full projected plan in one pass: the metric
+    # must be able to fire on its own, not inherit an already-filtered list.
     resumed = project("run_1", store.read_events("run_1"))
+    completed = [u.step_id for u in resumed.plan if u.status.value == "completed"]
     remaining = [u.step_id for u in resumed.plan if u.status.value != "completed"]
     assert remaining == ["u3", "u4", "u5"], remaining
-    duplicates = [u for u in remaining if u in ("u1", "u2")]
+    scheduled = set(remaining)
+    duplicates = [c for c in completed if c in scheduled]
     ctx.metrics["duplicate_completed_units"] = len(duplicates)
     ctx.metrics["remaining_units"] = remaining
     assert not duplicates, f"completed units would re-execute: {duplicates}"


### PR DESCRIPTION
## Description

Closes the bench gate #312 left open (#468): a plan-aware scenario in the phase-6 harness that starts a 5-unit linear plan via PLAN_UPSERT, completes 2 units, reprojects from the log as a post-crash resume would, and asserts units 1-2 never re-execute while 3-5 remain. The duplicate count and remaining units land in the report metrics. Registering in ALL_SCENARIOS enrolls it in the parametrized CI suite automatically. Mirrors examples/plan_milestones.py.

## Related issues

Fixes #468
Refs #312, refs #550

## Types of changes

- Type: feature

## Breaking changes

No. Additive scenario plus metrics; no substrate change.

## How has this been tested?

Python 3.14, editable installation.

- tests/test_phase6.py: 17 passed (16 before, plus the new scenario).
- Direct harness run reports pass with duplicate_completed_units 0 and remaining u3-u5.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,031 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

Scenario registered and covered by the existing parametrized suite. Changelog updated. CI has not yet run on this PR.