### PR TITLE
feat(provenance): validate finding caused_by on every append path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,13 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- FINDING_ADDED accepts caused_by causal links like decisions and actions (#597).
+  Findings derived from evidence link back under the same 32-id, 1-128-char
+  caps and unknown-id refusal, validated on every append path (memory log,
+  SQLite, Postgres) behind one shared CAUSED_BY_TYPES constant. The graph
+  fold already edges any node type, so finding-to-evidence edges appear with
+  no projection change. PLAN_UPSERT nodes stay a separate design question.
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -35,6 +35,7 @@ from continuum.security.hashing import make_id, stable_hash
 
 __all__ = [
     "EventType",
+    "CAUSED_BY_TYPES",
     "Event",
     "EventLog",
     "IntegrityViolation",
@@ -70,7 +71,7 @@ class EventType(StrEnum):
     # semantic state
     # DECISION_CREATED payload may include caused_by: list[str] (1-128 chars each, max 32,
     # default []). Unknown ids raise ValueError. Field is hash-covered and old events
-    # without it load as [].
+    # without it load as []. FINDING_ADDED accepts the same links (issue #597).
     DECISION_CREATED = "DECISION_CREATED"
     DECISION_INVALIDATED = "DECISION_INVALIDATED"
     EVIDENCE_ADDED = "EVIDENCE_ADDED"
@@ -144,6 +145,17 @@ class EventType(StrEnum):
 
     # memory governance (issue #304, #567): per-tenant tombstone for erasure
     MEMORY_TOMBSTONED = "MEMORY_TOMBSTONED"
+
+
+#: Event types whose payloads may carry ``caused_by`` causal links
+#: (issues #551, #597). Findings joined decisions and actions here:
+#: a finding derived from evidence links back to it under the same
+#: 32-id, 1-128-char caps and unknown-id refusal.
+CAUSED_BY_TYPES = (
+    EventType.DECISION_CREATED,
+    EventType.ACTION_RECORDED,
+    EventType.FINDING_ADDED,
+)
 
 
 class AppendOnlyViolation(RuntimeError):
@@ -286,7 +298,7 @@ class EventLog:
     ) -> Event:
         """Append an event and return the sealed (hashed) record."""
         chain = self._by_run.setdefault(run_id, [])
-        if type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED) and payload is not None:
+        if type in CAUSED_BY_TYPES and payload is not None:
             caused_by = payload.get("caused_by") if isinstance(payload, Mapping) else None
             if caused_by is not None:
                 if not isinstance(caused_by, list):

--- a/src/continuum/storage/postgres.py
+++ b/src/continuum/storage/postgres.py
@@ -32,7 +32,7 @@ from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from typing import Any
 
-from continuum.events import Event, EventType, IntegrityReport, IntegrityViolation
+from continuum.events import CAUSED_BY_TYPES, Event, EventType, IntegrityReport, IntegrityViolation
 from continuum.models import (
     Action,
     Origin,
@@ -427,7 +427,7 @@ class PostgresStorage(Storage):
         (compaction) reuse this instead of :meth:`append_event`, which would
         commit the marker in its own autocommit transaction.
         """
-        if type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED) and payload is not None:
+        if type in CAUSED_BY_TYPES and payload is not None:
             caused_by = payload.get("caused_by") if isinstance(payload, dict) else None
             if caused_by is not None:
                 if not isinstance(caused_by, list):
@@ -471,7 +471,7 @@ class PostgresStorage(Storage):
         return event
 
     def append_sealed(self, event: Event) -> Event:
-        if event.type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED):
+        if event.type in CAUSED_BY_TYPES:
             caused_by = event.payload.get("caused_by") if isinstance(event.payload, dict) else None
             if caused_by is not None:
                 if not isinstance(caused_by, list):
@@ -482,7 +482,7 @@ class PostgresStorage(Storage):
                     if not isinstance(cid, str) or not 1 <= len(cid) <= 128:
                         raise ValueError("caused_by entries must be 1-128 chars")
         with self._write():
-            if event.type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED):
+            if event.type in CAUSED_BY_TYPES:
                 caused_by = (
                     event.payload.get("caused_by") if isinstance(event.payload, dict) else None
                 )

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -31,7 +31,7 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from continuum.events import Event, EventType, IntegrityReport, IntegrityViolation
+from continuum.events import CAUSED_BY_TYPES, Event, EventType, IntegrityReport, IntegrityViolation
 from continuum.models import Action, Origin, Run, RunStatus, SemanticState, StateCheckpoint, utcnow
 from continuum.security.hashing import make_id
 from continuum.state.versioning import canonical_state_json, state_fingerprint
@@ -351,7 +351,7 @@ class SQLiteStorage(Storage):
         (compaction) reuse this instead of :meth:`append_event`, which would
         try to nest a second transaction.
         """
-        if type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED) and payload is not None:
+        if type in CAUSED_BY_TYPES and payload is not None:
             caused_by = payload.get("caused_by") if isinstance(payload, dict) else None
             if caused_by is not None:
                 if not isinstance(caused_by, list):
@@ -395,7 +395,7 @@ class SQLiteStorage(Storage):
         return event
 
     def append_sealed(self, event: Event) -> Event:
-        if event.type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED):
+        if event.type in CAUSED_BY_TYPES:
             caused_by = event.payload.get("caused_by") if isinstance(event.payload, dict) else None
             if caused_by is not None:
                 if not isinstance(caused_by, list):
@@ -406,7 +406,7 @@ class SQLiteStorage(Storage):
                     if not isinstance(cid, str) or not 1 <= len(cid) <= 128:
                         raise ValueError("caused_by entries must be 1-128 chars")
         with self._write() as conn:
-            if event.type in (EventType.DECISION_CREATED, EventType.ACTION_RECORDED):
+            if event.type in CAUSED_BY_TYPES:
                 caused_by = (
                     event.payload.get("caused_by") if isinstance(event.payload, dict) else None
                 )

--- a/tests/test_provenance_caused_by.py
+++ b/tests/test_provenance_caused_by.py
@@ -177,3 +177,59 @@ def test_action_record_caused_by_round_trip() -> None:
     assert [e for e in events if e.type == EventType.ACTION_RECORDED][0].payload["caused_by"] == [
         ev.event_id
     ]
+
+
+def test_finding_caused_by_links_evidence_in_graph() -> None:
+    """FINDING_ADDED accepts caused_by and the graph gains the edge (#597)."""
+    from continuum.models import Run
+    from continuum.provenance.graph import build_provenance_graph
+
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_finding_links"
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    ev = storage.append_event(run_id, EventType.EVIDENCE_ADDED, {"evidence_id": "ev1"})
+    finding = storage.append_event(
+        run_id,
+        EventType.FINDING_ADDED,
+        {"finding_id": "f1", "claim": "c", "caused_by": [ev.event_id]},
+    )
+    assert finding.payload["caused_by"] == [ev.event_id]
+    graph = build_provenance_graph(storage.read_events(run_id))
+    assert ev.event_id in graph.edges
+    assert finding.event_id in graph.edges[ev.event_id]
+
+
+def test_finding_unknown_caused_by_raises() -> None:
+    """Unknown ids are refused for findings exactly as for decisions (#597)."""
+    from continuum.models import Run
+
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_finding_unknown"
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    with pytest.raises(ValueError, match="unknown caused_by"):
+        storage.append_event(
+            run_id,
+            EventType.FINDING_ADDED,
+            {"finding_id": "f1", "claim": "c", "caused_by": ["event_nope_1"]},
+        )
+
+
+def test_finding_caused_by_caps_are_enforced() -> None:
+    """The 32-id and 1-128-char caps apply to findings (#597)."""
+    from continuum.models import Run
+
+    storage = SQLiteStorage(":memory:")
+    run_id = "run_finding_caps"
+    storage.create_run(Run(run_id=run_id, goal="g"))
+    with pytest.raises(ValueError, match="at most 32"):
+        storage.append_event(
+            run_id,
+            EventType.FINDING_ADDED,
+            {"finding_id": "f1", "claim": "c", "caused_by": [f"e{i}" for i in range(33)]},
+        )
+    with pytest.raises(ValueError, match="1-128"):
+        storage.append_event(
+            run_id,
+            EventType.FINDING_ADDED,
+            {"finding_id": "f1", "claim": "c", "caused_by": ["x" * 129]},
+        )


### PR DESCRIPTION
## Description

Step 2 of #597 (findings half): FINDING_ADDED payloads accept caused_by causal links under the same 32-id, 1-128-char caps and unknown-id refusal as decisions and actions. One shared CAUSED_BY_TYPES constant in continuum.events replaces the repeated type tuples on all six validation sites (memory log, SQLite append plus sealed paths, Postgres equivalents). The graph fold already edges any node type, so finding-to-evidence edges appear with no projection change. PLAN_UPSERT nodes stay a separate design question, stated in the changelog.

## Related issues

Refs #597 (pagination landed in #654; Postgres live verification still open)

## Types of changes

- Type: feature

## Breaking changes

No. Additive validation: payloads that were silently accepted with dangling links are now refused, matching decision and action behavior since #551.

## How has this been tested?

Python 3.14, editable installation.

- 3 new tests: finding-to-evidence edge in the built graph, unknown-id refusal, caps enforcement. The refusal and caps tests fail on unpatched code.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,033 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Changelog updated. CI has not yet run on this PR. Postgres path changed identically but not run live locally; CI covers it.