### PR TITLE
docs: re-sync pytest counts and guard against drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -558,7 +558,7 @@ All notable changes to this project are documented here. The format follows
   Framework Integration documents the CrewAI/AutoGen/Pydantic-AI thin hooks
   and the gateway/OTel fallback seams; the Roadmap marks the dashboard and
   the enforced-durability work complete; test counts are current
-  (~1,918 collected, ~1,880 passed, ~38 skipped on a minimal env).
+  (~2,053 collected, ~2,030 passed, ~23 skipped on a minimal env).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
 
 - **Gateway hardening and docs refresh.** The enforcing proxy now refuses

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Verify:
 ```bash
 continuum --help                 # CLI entrypoint
 continuum-mcp --help             # MCP server entrypoint (needs [mcp] or [dev])
-pytest -q                        # ~1,918 collected, ~1,880 passed, ~38 skipped on a minimal env (exact counts vary)
+pytest -q                        # ~2,053 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
 ruff check src/ tests/ examples/ && ruff format --check src/ tests/ examples/
 mypy src/continuum               # the three gates CI enforces
 ```
@@ -232,7 +232,7 @@ CONTINUUM is verified against real LLM agents, live protocol boundaries, and har
 - **Third-party clients**: Gemini CLI and Kilo Code connected over stdio JSON-RPC against the live SQLite store, validating multi-agent co-existence and authorization isolation.
 - **Protocol compliance**: driven end to end with `@modelcontextprotocol/inspector --cli` across process deaths; mutating tools deny by default behind `CONTINUUM_MCP_MUTATING_CLIENTS`; external claims degrade to `REQUIRES_REVIEW` (`safe: false`).
 - **Self-healing**: hard-killed servers recover from orphaned SQLite `-wal`/`-shm` sidecars via single-retry cleanup at startup.
-- **Scale**: roughly 1,918 tests collected (~1,880 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
+- **Scale**: roughly 2,053 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
 - **Adversarial audit**: the full MCP surface was audited over the live protocol; three defects were found and fixed. Method and reproduction steps in [test.md](test.md).
 
 ## MCP Integration
@@ -398,7 +398,7 @@ Schema v6. SQLite is primary, Postgres is CI verified. One log, many projections
 
 ### Module map — one library, many surfaces
 
-CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~1,918 tests). All modules append to and replay one hash chained event log:
+CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~2,053 tests). All modules append to and replay one hash chained event log:
 
 | Module | Role |
 |:--|:--|

--- a/docs/CONTRIBUTING_ONBOARDING.md
+++ b/docs/CONTRIBUTING_ONBOARDING.md
@@ -26,8 +26,8 @@ Welcome. This guide gets you from clone to green tests without re-deriving conte
 
 Install once with `uv sync --extra dev` (or `pip install -e ".[dev]"`).
 
-- Run all tests: `uv run pytest` or `pytest -q`. Expect `~1,880 passed, ~38 skipped`
-  on main at this writing (`~1,918` collected).
+- Run all tests: `uv run pytest` or `pytest -q`. Expect `~2,030 passed, ~23 skipped`
+  on main at this writing (`~2,053` collected).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
   Skips are environmental (Postgres without `CONTINUUM_TEST_POSTGRES_DSN`, adapter tests without `langgraph` or `openai-agents`).
 - Run a single area: `uv run pytest tests/test_checkpoint_phase4.py -v`

--- a/tests/test_docs_counts.py
+++ b/tests/test_docs_counts.py
@@ -1,0 +1,64 @@
+"""Guard the documented pytest counts against silent drift (#630).
+
+README.md, docs/CONTRIBUTING_ONBOARDING.md, and CHANGELOG.md each state the
+collected total. The guard asserts the three files agree with each other and
+with a live ``pytest --collect-only`` within tolerance. Skips vary by
+environment, so only collected totals are compared, never passed/skipped
+splits. Regenerate the figures with ``pytest --collect-only -q; pytest -q``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COUNTED_FILES = (
+    ROOT / "README.md",
+    ROOT / "docs" / "CONTRIBUTING_ONBOARDING.md",
+    ROOT / "CHANGELOG.md",
+)
+# Small PRs move the total by a handful of tests; doc rot moves it by the
+# hundreds (#316: exact, #630: 135). Tolerance 30 splits the difference.
+TOLERANCE = 30
+
+_COLLECTED_RE = re.compile(r"~([\d,]+)`?\s+collected")
+
+
+def documented_total(path: Path) -> int:
+    matches = _COLLECTED_RE.findall(path.read_text(encoding="utf-8"))
+    assert matches, f"{path.name} states no ~N collected figure"
+    totals = {int(m.replace(",", "")) for m in matches}
+    assert len(totals) == 1, f"{path.name} states inconsistent figures: {sorted(totals)}"
+    return totals.pop()
+
+
+def live_total() -> int:
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-p", "no:cacheprovider"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=ROOT,
+    )
+    assert proc.returncode == 0, f"collect-only failed:\n{proc.stderr[-2000:]}"
+    match = re.search(r"(\d[\d,]*)\s+tests? collected", proc.stdout)
+    assert match, f"unparsable collect-only output:\n{proc.stdout[-500:]}"
+    return int(match.group(1).replace(",", ""))
+
+
+def test_documented_counts_agree() -> None:
+    totals = {f.name: documented_total(f) for f in COUNTED_FILES}
+    assert len(set(totals.values())) == 1, f"documented counts disagree: {totals}"
+
+
+def test_documented_count_matches_suite() -> None:
+    documented = documented_total(COUNTED_FILES[0])
+    live = live_total()
+    assert abs(live - documented) <= TOLERANCE, (
+        f"suite collects {live} tests but docs say ~{documented}: "
+        "re-sync README.md, docs/CONTRIBUTING_ONBOARDING.md, and CHANGELOG.md "
+        "(pytest --collect-only -q; pytest -q)"
+    )

--- a/tests/test_docs_counts.py
+++ b/tests/test_docs_counts.py
@@ -24,12 +24,20 @@ COUNTED_FILES = (
 # hundreds (#316: exact, #630: 135). Tolerance 30 splits the difference.
 TOLERANCE = 30
 
-_COLLECTED_RE = re.compile(r"~([\d,]+)`?\s+collected")
+# Every prose form the three files use for the collected total (#664 review):
+# "~2,053 collected", "roughly 2,053 tests collected", "~2,053 tests".
+# Passed/skipped figures are deliberately unmatched: they vary by environment.
+_COLLECTED_RES = (
+    re.compile(r"~([\d,]+)`?\s+collected"),
+    re.compile(r"roughly\s+([\d,]+)\s+tests\s+collected"),
+    re.compile(r"~([\d,]+)\s+tests\b"),
+)
 
 
 def documented_total(path: Path) -> int:
-    matches = _COLLECTED_RE.findall(path.read_text(encoding="utf-8"))
-    assert matches, f"{path.name} states no ~N collected figure"
+    text = path.read_text(encoding="utf-8")
+    matches = [m for rx in _COLLECTED_RES for m in rx.findall(text)]
+    assert matches, f"{path.name} states no collected-total figure"
     totals = {int(m.replace(",", "")) for m in matches}
     assert len(totals) == 1, f"{path.name} states inconsistent figures: {sorted(totals)}"
     return totals.pop()


### PR DESCRIPTION
## Description

Both halves of #630: re-syncs README.md, docs/CONTRIBUTING_ONBOARDING.md, and CHANGELOG.md from ~1,918 to the current 2,053 collected (2,030 passed, 23 skipped), keeping the regeneration comments intact, and adds tests/test_docs_counts.py, which asserts the three files agree with each other and with a live pytest --collect-only within a stated tolerance of 30. Only collected totals are compared since skips vary by environment.

## Related issues

Fixes #630
Follows #316 and #605

## Types of changes

- Type: docs

## Breaking changes

No. Documentation figures plus a new guard test.

## How has this been tested?

Python 3.14, editable installation.

- Guard passes on the synced tree (2 passed).
- Guard fails on a deliberately reverted figure (both tests fail), then passes again after restore.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,032 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- markdownlint-cli2 on README.md and CHANGELOG.md: 0 issues.
- git diff --check: passed.

## Checklist

Docs re-synced with the same honest wording. Guard test added. CI has not yet run on this PR.