### PR TITLE
docs: add missing subcommand rows to CLI reference table

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -47,6 +47,17 @@ continuum --json <command>                    # machine-readable output
 | `attest-verify <run_id> --attest <file>` | Verify a signed attestation against the live chain. |
 | `serve` | Run the Tier 0 newline-delimited JSON sidecar (no MCP dependency). |
 | `dashboard` | Serve the dashboard (presentation over run data). |
+| `export-evidence` | Export evidence as content-addressed JSON lines. Read-only. |
+| `forget` | Enumerate and tombstone memory records for a tenant. Mutates unless --dry-run. |
+| `health` | Advisory prefix-trust health check. Read-only. |
+| `impact` | Show downstream impact of an evidence item. Read-only. |
+| `merge` | Merge into a run at an anchor. Mutates storage. |
+| `precompact` | Checkpoint before context compaction (PreCompact hook). Mutates the run. |
+| `provenance` | Show provenance DAG. Read-only. |
+| `record-plan` | Record a structured plan upsert. Mutates storage. |
+| `restore` | Restore a run to an anchor checkpoint. Mutates storage. |
+| `rewind` | Rewind workspace and projection to a checkpoint. |
+| `watch` | Watch a run for liveness breach, optionally notify via webhook. |
 
 ## Examples
 

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -1,0 +1,22 @@
+"""Every CLI subcommand must have a row in the reference table (#632).
+
+The table in docs/api/cli.md drifted behind the parser twice (#360, #632).
+Rows carry usage syntax after the name, so the guard matches a backtick
+immediately before the name rather than a bare backticked word.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from continuum.cli.main import build_parser
+
+TABLE = Path(__file__).resolve().parents[1] / "docs" / "api" / "cli.md"
+
+
+def test_every_subcommand_has_a_table_row() -> None:
+    table = TABLE.read_text(encoding="utf-8")
+    subs = sorted(build_parser()._subparsers._group_actions[0].choices.keys())
+    assert subs, "parser exposes no subcommands"
+    missing = [name for name in subs if ("`" + name) not in table]
+    assert not missing, f"subcommands without a docs/api/cli.md row: {missing}"

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -1,12 +1,15 @@
 """Every CLI subcommand must have a row in the reference table (#632).
 
 The table in docs/api/cli.md drifted behind the parser twice (#360, #632).
-Rows carry usage syntax after the name, so the guard matches a backtick
-immediately before the name rather than a bare backticked word.
+Rows carry usage syntax after the name, so the guard anchors on Command-column
+row starts instead of bare substrings: prose mentions (`` `resume --json` ``)
+and prefix collisions (`` `attest `` matching `` `attest-keygen` ``) must not
+mask a deleted row.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from continuum.cli.main import build_parser
@@ -14,9 +17,13 @@ from continuum.cli.main import build_parser
 TABLE = Path(__file__).resolve().parents[1] / "docs" / "api" / "cli.md"
 
 
+def _row_pattern(name: str) -> "re.Pattern[str]":
+    return re.compile(r"^\|\s*`" + re.escape(name) + r"(?=[\s`|])", re.MULTILINE)
+
+
 def test_every_subcommand_has_a_table_row() -> None:
     table = TABLE.read_text(encoding="utf-8")
     subs = sorted(build_parser()._subparsers._group_actions[0].choices.keys())
     assert subs, "parser exposes no subcommands"
-    missing = [name for name in subs if ("`" + name) not in table]
+    missing = [name for name in subs if not _row_pattern(name).search(table)]
     assert not missing, f"subcommands without a docs/api/cli.md row: {missing}"

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -17,7 +17,7 @@ from continuum.cli.main import build_parser
 TABLE = Path(__file__).resolve().parents[1] / "docs" / "api" / "cli.md"
 
 
-def _row_pattern(name: str) -> "re.Pattern[str]":
+def _row_pattern(name: str) -> re.Pattern[str]:
     return re.compile(r"^\|\s*`" + re.escape(name) + r"(?=[\s`|])", re.MULTILINE)
 
 


### PR DESCRIPTION
## Description

#632 follow-up: the Commands table in docs/api/cli.md omits 11 shipped subcommands (export-evidence, forget, health, impact, merge, precompact, provenance, record-plan, restore, rewind, watch). Adds one row per command with purpose text matching --help, plus tests/test_cli_docs.py asserting every parser subcommand has a table row so this stops recurring (same durable-fix pattern as #630).

## Related issues

Fixes #632
Follows #360 and #363

## Types of changes

- Type: docs

## Breaking changes

No. Documentation only.

## How has this been tested?

- Guard passes on the completed table, fails when a row is removed, passes again after restore.
- .venv/bin/ruff check and format --check on the new test: passed.
- markdownlint-cli2 on docs/api/cli.md: 0 issues.
- CI runs the full gate.

## Checklist

Docs updated with --help wording. Guard test added. CI has not yet run on this PR.