### PR TITLE
docs: add notebook zero-setup rows to Spanish README

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -66,9 +66,11 @@ Rutas sin configuración (sin clonar, sin instalar, sin publicar nada):
 | Usar la CLI a través de Docker | `docker run --rm ghcr.io/cyrax321/continuum continuum --help` |
 | Ejecutar la CLI sin clonar | `uvx --from git+https://github.com/Cyrax321/CONTINUUM.git continuum --help` |
 | Windows PowerShell (desde un clon) | `powershell -ExecutionPolicy Bypass -File .\try-it.ps1` o `powershell -ExecutionPolicy Bypass -File .\try-it.ps1 cli --help` |
+| Ver la misma recuperación en un cuaderno | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Cyrax321/CONTINUUM/blob/main/examples/demo.ipynb) |
+| El mismo cuaderno, en Binder | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Cyrax321/CONTINUUM/HEAD?labpath=examples%2Fdemo.ipynb) |
 | Entorno de desarrollo completo en el navegador | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Cyrax321/CONTINUUM?quickstart=1) |
 
-La imagen Docker se publica en GHCR por CI en cada push a `main` y en cada etiqueta de release (`.github/workflows/docker-publish.yml`). El Codespace se define en `.devcontainer/`.
+La imagen Docker se publica en GHCR por CI en cada push a `main` y en cada etiqueta de release (`.github/workflows/docker-publish.yml`). El Codespace se define en `.devcontainer/`. El cuaderno es [examples/demo.ipynb](examples/demo.ipynb): su primera celda instala CONTINUUM solo cuando falla la importación, así que el mismo archivo funciona en Colab, en Binder y desde un clon.
 
 ```bash
 git clone https://github.com/Cyrax321/CONTINUUM.git


### PR DESCRIPTION
## Description

#635 follow-up: the Colab and Binder zero-setup rows plus the notebook sentence from #610 never reached the Spanish translation. Adds both rows in the same table position (after PowerShell, before Codespaces) with translated labels, identical badge links, and the translated notebook sentence after the table.

## Related issues

Fixes #635
Follows #610

## Types of changes

- Type: docs

## Breaking changes

No. Translation only.

## How has this been tested?

- Badge URLs diffed identical against the English rows.
- markdownlint-cli2 on README.es.md: 0 issues.
- rg confirms no em dashes introduced.
- CI runs the full gate.

## Checklist

Translation only, same position and links. CI has not yet run on this PR.