### PR TITLE
docs: backfill changelog for probe, liveness-risk, reconciler, bench merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **External probe for consumed authorities via reconcilers.json (#557).**
+  `reconcile --authority <id>` runs the configured authority probe with the
+  recorded consumption payload on stdin; `valid=true` appends
+  `AUTHORITY_RECONCILED` and clears the consumed mark, `valid=false` keeps it
+  blocked, and anything else leaves it blocked. Covered by
+  `tests/test_authority_probe.py`, including the negative test that a restore
+  does not resurrect.
+
+- **Liveness watchdog and risk-informed recovery (#302, #303).**
+  Cadence contracts drive `continuum watch`, which appends
+  `LIVENESS_SILENCE_DETECTED` on breach and `LIVENESS_RECOVERED` on recovery
+  (webhook delivery is fail-open); `RISK_OBSERVED` ingestion maps through
+  `.continuum/risk-policy.json` with risks arriving as `EXTERNAL_MONITOR`
+  witnesses, and the contract carries a `triggering_risks` section. Covered
+  by the liveness, risk, and watch suites.
+
+- **Reconciler registry accepts documented shapes and refuses bool timeouts (#322).**
+  Probe entries require a command and a positive numeric timeout; a boolean
+  timeout is refused rather than read as seconds. The registry shape and the
+  default timeout are pinned by `tests/test_reconcilers.py`.
+
+- **Bench harness records byte counts, revalidation calls, and resume tokens (#568).**
+  Per-strategy counters flow into the shared report envelope, covered by
+  `tests/test_benchmark_counters.py`.
+
 - **`examples/demo.ipynb`, the crash-recovery walkthrough as a notebook (#283).**
   The lowest-friction way to watch a recovery was `docker run`, which still wants
   a daemon; this wants a browser. Colab and Binder badges in the Quick Start


### PR DESCRIPTION
## Description

#631 backfill: four user-visible merges with no Unreleased entry get one each, written from the implementation: the reconcilers.json authority probe (#557), the liveness watchdog plus risk policy stack (#302, #303), the registry shape and bool-timeout guard (#322), and the bench harness counters (#568). Each entry states the contract and names its covering test file, in the #609 style.

## Related issues

Refs #631

## Types of changes

- Type: docs

## Breaking changes

No. Changelog only.

## How has this been tested?

- Each claim checked against the merged code (probe stdin contract, watch docstring, timeout guard predicate, bench envelope).
- markdownlint-cli2 on CHANGELOG.md: 0 issues.
- CI runs the full gate.

## Checklist

Docs only. CI has not yet run on this PR.