### PR TITLE
docs: risk policy operator guide with verified runs

### DIFF
--- a/docs/guides/risk-policy.md
+++ b/docs/guides/risk-policy.md
@@ -1,0 +1,95 @@
+# Risk policy: teaching recovery which signals matter
+
+Some failures are visible in state (stale evidence, uncertain actions) and some
+arrive as signals from outside: a monitor reporting a latency anomaly, a judge
+flagging a duplicated side effect, a rollout guard crying meltdown. Risk policy
+maps those signal names to recovery modes so the engine weighs them alongside
+everything else, with the most cautious proposal winning regardless of order.
+
+## The moving parts
+
+- `RISK_OBSERVED` events carry `trigger`, `score`, `detail` (plus optional
+  `episode_id` / `step_id`). They are hash-chained and stamped
+  `EXTERNAL_MONITOR`: a witness, never an authority, so a risk signal alone
+  cannot certify a run.
+- `risk-policy.json` (default `.continuum/risk-policy.json`, copy
+  `examples/risk-policy.json` to start) maps trigger names to modes:
+  `replan`, `wait`, `repair_and_resume`, `rollback`, `abort`, `request_human`,
+  or `annotate` for watch-without-action. Unknown triggers and `annotate`
+  propose nothing.
+- At assess time the engine evaluates every recorded trigger against the
+  policy, takes the most severe resulting mode, and names the winning event
+  ids in the contract's `triggering_risks` field.
+- Ingestion is fail-open: a malformed payload returns `False` and is dropped,
+  never blocking the run. Scores default to `0.0`, details truncate at 512
+  chars.
+
+## Try it
+
+```bash
+export DB=/tmp/risk-demo/g.db
+continuum --db $DB start risk-demo --goal "risk walkthrough"
+```
+
+Ingest one signal (in production a monitor posts these; here we post directly):
+
+```bash
+python - <<'EOF'
+from continuum.models import Run
+from continuum.events import EventType
+from continuum.storage import SQLiteStorage
+from continuum.recovery.risk import ingest_risk_json_line
+with SQLiteStorage("/tmp/risk-demo/g.db") as store:
+    print(ingest_risk_json_line(store, "risk-demo", '{"trigger": "meltdown", "score": 0.9}'))
+    print(ingest_risk_json_line(store, "risk-demo", "not json"))
+EOF
+```
+
+```text
+True
+False
+```
+
+Assess the run:
+
+```bash
+continuum --db $DB --json resume risk-demo | python -c \
+  "import json,sys; d = json.load(sys.stdin); print(d['mode'], d['safe'], len(d['contract']['triggering_risks']))"
+```
+
+```text
+rollback False 1
+```
+
+The `meltdown` trigger maps to `rollback` in the default policy, so the run
+proposes rollback and is unsafe to resume hands-free. Garbage ingestion
+returned `False` and changed nothing.
+
+## Writing policy
+
+Copy the example and edit the mapping; unknown trigger names are ignored until
+a signal arrives bearing them, so extra keys are harmless but dead:
+
+```json
+{
+  "loop": "replan",
+  "error_cascade": "wait",
+  "meltdown": "rollback",
+  "governance_decay": "request_human"
+}
+```
+
+A file that is not a JSON object, or a value outside the mode set plus
+`annotate`, fails validation at load. To preview a custom file without
+installing it, load it explicitly (`load_risk_policy(path)`) or point the
+working directory at it; assessment reads `.continuum/risk-policy.json` and
+falls back to the built-in default when absent.
+
+## Rules worth knowing
+
+- Severity decides, not arrival order: of all recorded triggers, the one
+  mapping to the most severe mode wins, and ties accumulate event ids.
+- `annotate` is deliberately silent: it records interest without proposing a
+  mode, for signals you want visible in history but not yet acting.
+- Risk never certifies: a signal can only escalate toward caution, and
+  `EXTERNAL_MONITOR` provenance keeps it from counting as verification.

--- a/docs/guides/risk-policy.md
+++ b/docs/guides/risk-policy.md
@@ -35,8 +35,6 @@ Ingest one signal (in production a monitor posts these; here we post directly):
 
 ```bash
 python - <<'EOF'
-from continuum.models import Run
-from continuum.events import EventType
 from continuum.storage import SQLiteStorage
 from continuum.recovery.risk import ingest_risk_json_line
 with SQLiteStorage("/tmp/risk-demo/g.db") as store:

--- a/docs/recovery_walkthrough.md
+++ b/docs/recovery_walkthrough.md
@@ -69,7 +69,9 @@ Next permitted action: reconcile_action:action_0243135b37757b236f1dfd7bf386ec83
 The contract is immutable and hash-chained. Its Phase 1 fields carry the
 decision's justification: `reason` is the threaded rationale and `evidence`
 names what drove it. Whatever resumes this run has one permitted next action,
-and it is the reconciliation, not the retry.
+and it is the reconciliation, not the retry. When outside signals drive the
+verdict, the contract names them in `triggering_risks`; that flow is walked
+through in `docs/guides/risk-policy.md`.
 
 ```
 == 3. the sealed contract explains itself (Phase 1 fields) ==


### PR DESCRIPTION
## Description

#640 operator guide: new docs/guides/risk-policy.md covering the risk-policy.json format (with reference to examples/risk-policy.json), how RISK_OBSERVED events with EXTERNAL_MONITOR provenance flow into the recovery decision, and what triggering risks look like in the contract. Every command was run verbatim against a fresh database (ingest true/false, assess rollback unsafe with 1 triggering risk). Linked from the contract section of docs/recovery_walkthrough.md.

## Related issues

Fixes #640

## Types of changes

- Type: docs

## Breaking changes

No. Documentation only.

## How has this been tested?

- Full walkthrough re-executed verbatim in a fresh directory; transcripts match, including exit codes and the deterministic metric line. One flag-order bug in my own draft (global --json placement) was caught by this verification and fixed.
- markdownlint-cli2 on both touched files: 0 new issues (one pre-existing MD040 pair in recovery_walkthrough.md, untouched).
- No em dashes introduced.
- CI runs the full gate.

## Checklist

Docs only, linked from the walkthrough. CI has not yet run on this PR.