### PR TITLE
fix(watch): explicit max-silence override beats default scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,11 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- `watch --max-silence` override wins without an open claim (#670).
+  The override kept the default phase scopes, so the `otherwise` scope
+  (3600s) silently replaced the flag value. The override contract now
+  carries empty scopes and falls back to the requested seconds.
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/docs/guides/liveness-watch.md
+++ b/docs/guides/liveness-watch.md
@@ -1,0 +1,99 @@
+# Liveness watch: hearing silence as a signal
+
+A run that stops emitting events may be resting, or it may be wedged. The
+liveness stack turns that distinction into a contract: `.continuum/liveness.json`
+declares how long each phase may stay quiet, and `continuum watch` reports
+breach or quiet without ever gating or mutating beyond its two audit events.
+
+## The cadence contract
+
+```json
+{
+  "max_silence_seconds": 3600,
+  "phase_scopes": {"open_claim": 600, "otherwise": 3600}
+}
+```
+
+`max_silence_seconds` is the default threshold (one hour). `phase_scopes`
+overrides it per phase: while a tool claim is open the tighter `open_claim`
+scope applies, otherwise the `otherwise` scope. A partial file stays valid:
+any missing scope falls back to `max_silence_seconds`. With no file at all the
+built-in default above applies, so a fresh clone behaves sanely with nothing
+configured.
+
+## Watch a run
+
+```bash
+export DB=/tmp/live-demo/g.db
+continuum --db $DB start live-demo --goal "liveness walkthrough"
+```
+
+Wait past the threshold, then check. `--max-silence` overrides the contract
+for one invocation and always wins, even with no claim open:
+
+```bash
+continuum --db $DB watch live-demo --max-silence 1s
+```
+
+```text
+Liveness: BREACHED, silence 3.3s exceeds threshold 1s (phase otherwise). Advisory only.
+```
+
+Exit code 20: breach is advisory, never a gate. A breach appends one
+`LIVENESS_SILENCE_DETECTED` event (hash-chained, carrying silence, threshold,
+and phase) unless the last liveness event already says detected, so repeated
+checks do not spam the log. Check again inside the window and the run reports
+recovery the same way:
+
+```bash
+continuum --db $DB watch live-demo --max-silence 1h
+```
+
+```text
+Liveness ok for live-demo: 0.201496
+```
+
+Exit code 0. Because the previous check left a `DETECTED` marker, this check
+appends `LIVENESS_RECOVERED` and the pair brackets the silent interval in the
+log for audit.
+
+## Where else the advisory appears
+
+`continuum resume` appends the same liveness reading to its verdict,
+read-only:
+
+```bash
+continuum --db $DB resume live-demo
+```
+
+```text
+Next permitted action: continue
+
+Liveness: ok, silence 22.8s within threshold 3600s (phase otherwise).
+```
+
+`continuum health` stays scoped to the prefix-trust score; liveness lives
+with the commands that act on quiet.
+
+## Breach webhook
+
+For unattended runs, `--on-breach webhook` with `--webhook-url` POSTs the
+advisory as JSON instead of just exiting 20:
+
+```bash
+continuum --db $DB watch live-demo --max-silence 1s \
+  --on-breach webhook --webhook-url https://hooks.example.com/continuum
+```
+
+Delivery is fail-open like every notification path: a dead receiver prints a
+warning and never changes the verdict. Signed delivery with
+`CONTINUUM_WEBHOOK_SECRET` is covered by the shared notify primitive.
+
+## Rules worth knowing
+
+- Watch never gates: breach exits 20 and appends audit events, but resume
+  decisions stay with the recovery engine.
+- Silence is measured from the last event timestamp with an injected clock,
+  so the check is deterministic and testable, not wall-clock flaky.
+- A run with no events at all is never breached: there is no silence to
+  measure yet.

--- a/docs/guides/liveness-watch.md
+++ b/docs/guides/liveness-watch.md
@@ -86,8 +86,9 @@ continuum --db $DB watch live-demo --max-silence 1s \
 ```
 
 Delivery is fail-open like every notification path: a dead receiver prints a
-warning and never changes the verdict. Signed delivery with
-`CONTINUUM_WEBHOOK_SECRET` is covered by the shared notify primitive.
+warning and never changes the verdict. The POST carries the advisory as plain
+JSON; there is no authentication on the receiver side, so put the URL behind
+your own secret path or bearer check.
 
 ## Rules worth knowing
 

--- a/docs/recovery_walkthrough.md
+++ b/docs/recovery_walkthrough.md
@@ -137,6 +137,11 @@ Repairs required:
 Next permitted action: revalidate_dependency:dataset
 ```
 
+Live `resume` output also carries a liveness reading after the permitted
+action (`Liveness: ok/breached ...`); `continuum watch` evaluates it on
+demand with its own contract, walked through in
+docs/guides/liveness-watch.md.
+
 ## What just happened
 
 - No duplicate Slack message: the interrupted effect was reconciled by probe

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1021,7 +1021,9 @@ def cmd_watch(args: argparse.Namespace, storage: Storage, out: Any, err: Any) ->
 
         # Use override if provided, else load contract
         if override_threshold is not None:
-            contract = CadenceContract(max_silence_seconds=override_threshold)
+            # Empty scopes so the explicit operator value wins: otherwise the
+            # default otherwise scope (3600s) would silently override the flag (#670).
+            contract = CadenceContract(max_silence_seconds=override_threshold, phase_scopes={})
             # We need to compute advisory manually with override
             from datetime import UTC, datetime
 

--- a/tests/test_liveness_events.py
+++ b/tests/test_liveness_events.py
@@ -209,3 +209,35 @@ def test_contract_liveness_section(tmp_path: Path) -> None:
         assert "last_append_age" in decision.contract.liveness
         assert "breaches" in decision.contract.liveness
         assert "breached" in decision.contract.liveness
+
+
+def test_max_silence_override_wins_without_open_claim(tmp_path: Path) -> None:
+    """An explicit --max-silence beats the default otherwise scope (#670)."""
+    db = str(tmp_path / "watch_override.db")
+    with SQLiteStorage(db) as store:
+        run_id = "run_watch_override"
+        store.create_run_started(Run(run_id=run_id, goal="watch test"))
+        from continuum.events import Event
+
+        old_ts = datetime.now(UTC) - timedelta(seconds=30)
+        last_seq = store.last_sequence(run_id)
+        ev = Event(
+            run_id=run_id,
+            sequence=last_seq + 1,
+            type=EventType.TASK_UPDATED,
+            timestamp=old_ts,
+            payload={"completed": 1},
+            prev_hash=store.read_events(run_id)[-1].hash,
+        ).sealed()
+        store.append_sealed(ev)
+
+    out, err = io.StringIO(), io.StringIO()
+    code = main(
+        ["--db", db, "watch", run_id, "--max-silence", "5", "--on-breach", "exit"],
+        out=out,
+        err=err,
+    )
+    assert code == 20, out.getvalue()
+    with SQLiteStorage(db) as store:
+        types = [e.type for e in store.read_events(run_id)]
+        assert EventType.LIVENESS_SILENCE_DETECTED in types


### PR DESCRIPTION
## Description

continuum watch --max-silence built CadenceContract(max_silence_seconds=N) while keeping the default phase scopes, and threshold_for prefers scopes, so with no open claim the effective threshold was always 3600 regardless of the flag. The override contract now carries empty scopes and falls back to the requested seconds. File-loaded contracts keep scope precedence unchanged.

## Related issues

Fixes #670

## Types of changes

- Type: bugfix

## Breaking changes

No. The flag now does what it advertises; file-based contracts are untouched.

## How has this been tested?

Python 3.14, editable installation.

- New test_max_silence_override_wins_without_open_claim: backdated event plus --max-silence 5 breaches with exit 20 and appends LIVENESS_SILENCE_DETECTED. Fails on unpatched code.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,031 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Changelog updated. CI has not yet run on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `watch --max-silence` so the explicitly provided silence threshold is honored even when no claim is open.
  - Liveness breaches now correctly use the requested duration instead of the default 3600-second scope.

- **Documentation**
  - Added a guide covering liveness monitoring, breach behavior, audit events, and recovery.
  - Documented liveness readings included in live `resume` output.
  - Updated the changelog with the corrected `--max-silence` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->