### PR TITLE
feat(notify): signed fail-open webhook delivery primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,12 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- Shared signed webhook delivery primitive for human notification (#305).
+  `continuum.recovery.notify` posts JSON with an HMAC-SHA256 signature when
+  `CONTINUUM_WEBHOOK_SECRET` is set and plain JSON otherwise, always
+  fail-open. The liveness watch webhook path now routes through it with
+  identical wire behavior when unconfigured.
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- Shared signed webhook delivery primitive for human notification (#305).
+  `continuum.recovery.notify` posts JSON with an HMAC-SHA256 signature when
+  `CONTINUUM_WEBHOOK_SECRET` is set and plain JSON otherwise, always
+  fail-open. The liveness watch webhook path now routes through it with
+  identical wire behavior when unconfigured.
+
 - **`examples/demo.ipynb`, the crash-recovery walkthrough as a notebook (#283).**
   The lowest-friction way to watch a recovery was `docker run`, which still wants
   a daemon; this wants a browser. Colab and Binder badges in the Quick Start
@@ -165,12 +171,6 @@ All notable changes to this project are documented here. The format follows
   held for review the way an MCP-reported one is. Docs-only, no runtime change.
 
 ### Fixed
-
-- Shared signed webhook delivery primitive for human notification (#305).
-  `continuum.recovery.notify` posts JSON with an HMAC-SHA256 signature when
-  `CONTINUUM_WEBHOOK_SECRET` is set and plain JSON otherwise, always
-  fail-open. The liveness watch webhook path now routes through it with
-  identical wire behavior when unconfigured.
 
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1093,19 +1093,11 @@ def cmd_watch(args: argparse.Namespace, storage: Storage, out: Any, err: Any) ->
         else f"Liveness ok for {run_id}: {advisory.get('silence_seconds')}"
     )
     if breached and on_breach == "webhook" and webhook_url:
-        try:
-            import json as _json
-            import urllib.request
+        from continuum.recovery.notify import post_webhook
 
-            data = _json.dumps(payload).encode("utf-8")
-            req = urllib.request.Request(
-                webhook_url, data=data, headers={"Content-Type": "application/json"}, method="POST"
-            )
-            with urllib.request.urlopen(req, timeout=5):
-                pass
-        except Exception as exc:
-            # Fail-open delivery, like dashboard token path
-            print(f"warning: webhook delivery failed: {exc}", file=err)
+        # Fail-open delivery, like dashboard token path
+        if not post_webhook(webhook_url, payload):
+            print("warning: webhook delivery failed", file=err)
     # Emit result
     _emit(
         payload,

--- a/src/continuum/recovery/notify.py
+++ b/src/continuum/recovery/notify.py
@@ -57,15 +57,17 @@ def post_webhook(
     import urllib.request
 
     secret = secret if secret is not None else os.environ.get(SECRET_ENV_VAR)
-    data = json.dumps(payload).encode("utf-8")
-    headers = {"Content-Type": "application/json"}
-    if secret:
-        headers[SIGNATURE_HEADER] = signature(data, secret)
-    request = urllib.request.Request(url, data=data, headers=headers, method="POST")
     try:
+        data = json.dumps(payload).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        if secret:
+            headers[SIGNATURE_HEADER] = signature(data, secret)
+        request = urllib.request.Request(url, data=data, headers=headers, method="POST")
         with urllib.request.urlopen(request, timeout=timeout) as response:
             return bool(200 <= response.status < 300)
-    except (urllib.error.URLError, OSError, ValueError, http.client.HTTPException):
+    except (urllib.error.URLError, OSError, ValueError, TypeError, http.client.HTTPException):
+        # TypeError covers non-serializable payloads: serialization is inside
+        # the boundary so a bad payload fails open like a bad network.
         # HTTPException covers malformed status lines and truncated bodies,
         # which urlopen lets through unwrapped: all still fail open.
         return False

--- a/src/continuum/recovery/notify.py
+++ b/src/continuum/recovery/notify.py
@@ -1,0 +1,68 @@
+"""Signed outbound webhooks for human notification (issue #305).
+
+A blocked run is only useful if a human learns about it. This module is the
+shared delivery primitive behind notification paths (liveness watch today,
+request_human tomorrow): JSON POST, fail-open, with an HMAC-SHA256 signature
+when the operator configures ``CONTINUUM_WEBHOOK_SECRET``. The signature lets
+the receiver trust the notification came from CONTINUUM and not from the very
+agent being reported on, the same discipline as ``CONTINUUM_MCP_CONFIRM_TOKEN``.
+
+Without a secret the wire format is unchanged (plain JSON POST), so existing
+receivers keep working. Delivery failure never raises: it returns False and
+the caller decides how loudly to note it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+from typing import Any
+
+SECRET_ENV_VAR = "CONTINUUM_WEBHOOK_SECRET"
+SIGNATURE_HEADER = "X-Continuum-Signature"
+_SIGNATURE_PREFIX = "sha256="
+
+
+def signature(payload: bytes, secret: str) -> str:
+    """HMAC-SHA256 hex signature for a payload, with the header prefix."""
+    digest = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+    return f"{_SIGNATURE_PREFIX}{digest}"
+
+
+def verify_signature(payload: bytes, secret: str, header: str | None) -> bool:
+    """True when ``header`` is the valid signature for ``payload``."""
+    if not header or not header.startswith(_SIGNATURE_PREFIX):
+        return False
+    expected = signature(payload, secret)
+    return hmac.compare_digest(expected, header)
+
+
+def post_webhook(
+    url: str,
+    payload: dict[str, Any],
+    *,
+    secret: str | None = None,
+    timeout: float = 5.0,
+) -> bool:
+    """POST payload as JSON, signed when ``secret`` is set. Fail-open.
+
+    Returns True when the receiver answered 2xx, False for any failure
+    (unreachable, non-2xx, timeout). Never raises: notification failure
+    must never flip a recovery verdict.
+    """
+    import urllib.error
+    import urllib.request
+
+    secret = secret if secret is not None else os.environ.get(SECRET_ENV_VAR)
+    data = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if secret:
+        headers[SIGNATURE_HEADER] = signature(data, secret)
+    request = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return bool(200 <= response.status < 300)
+    except (urllib.error.URLError, OSError, ValueError):
+        return False

--- a/src/continuum/recovery/notify.py
+++ b/src/continuum/recovery/notify.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import http.client
 import json
 import os
 from typing import Any
@@ -64,5 +65,7 @@ def post_webhook(
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             return bool(200 <= response.status < 300)
-    except (urllib.error.URLError, OSError, ValueError):
+    except (urllib.error.URLError, OSError, ValueError, http.client.HTTPException):
+        # HTTPException covers malformed status lines and truncated bodies,
+        # which urlopen lets through unwrapped: all still fail open.
         return False

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -86,3 +86,32 @@ def test_secret_env_var_signs(monkeypatch) -> None:  # type: ignore[no-untyped-d
     finally:
         server.shutdown()
         monkeypatch.undo()
+
+
+def test_malformed_status_line_still_fails_open() -> None:
+    """Response framing errors must not escape post_webhook (#674 review)."""
+    import socket
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+    stop = threading.Event()
+
+    def garble() -> None:
+        conn, _ = listener.accept()
+        with conn:
+            conn.settimeout(5)
+            try:
+                conn.recv(65536)
+            except OSError:
+                return
+            conn.sendall(b"NOTHTTP garbage\r\n\r\n")
+
+    thread = threading.Thread(target=garble, daemon=True)
+    thread.start()
+    try:
+        assert post_webhook(f"http://127.0.0.1:{port}/hook", {"run_id": "r1"}) is False
+    finally:
+        stop.set()
+        listener.close()

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,88 @@
+"""Signed webhook delivery primitive (issue #305, unit 1)."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import http.server
+import json
+import threading
+
+from continuum.recovery.notify import (
+    SIGNATURE_HEADER,
+    post_webhook,
+    signature,
+    verify_signature,
+)
+
+
+def test_signature_known_answer() -> None:
+    expected = "sha256=" + hmac.new(b"s3cret", b'{"a":1}', hashlib.sha256).hexdigest()
+    assert signature(b'{"a":1}', "s3cret") == expected
+
+
+def test_verify_accepts_and_rejects() -> None:
+    payload = b'{"run_id": "r1"}'
+    header = signature(payload, "s3cret")
+    assert verify_signature(payload, "s3cret", header) is True
+    assert verify_signature(payload, "wrong", header) is False
+    assert verify_signature(payload, "s3cret", None) is False
+    assert verify_signature(payload, "s3cret", "bogus") is False
+
+
+def _receiver(captured: dict, status: int = 200):
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length", 0))
+            captured["body"] = self.rfile.read(length)
+            captured["signature"] = self.headers.get(SIGNATURE_HEADER)
+            self.send_response(status)
+            self.end_headers()
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+def test_signed_post_delivers_and_verifies() -> None:
+    captured: dict = {}
+    server = _receiver(captured)
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/hook"
+        assert post_webhook(url, {"run_id": "r1"}, secret="s3cret") is True
+        assert json.loads(captured["body"]) == {"run_id": "r1"}
+        assert verify_signature(captured["body"], "s3cret", captured["signature"]) is True
+    finally:
+        server.shutdown()
+
+
+def test_unsigned_post_keeps_plain_format() -> None:
+    captured: dict = {}
+    server = _receiver(captured)
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/hook"
+        assert post_webhook(url, {"run_id": "r1"}, secret=None) is True
+        assert captured["signature"] is None
+    finally:
+        server.shutdown()
+
+
+def test_delivery_failure_returns_false(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("CONTINUUM_WEBHOOK_SECRET", raising=False)
+    assert post_webhook("http://127.0.0.1:1/hook", {"run_id": "r1"}, timeout=0.2) is False
+
+
+def test_secret_env_var_signs(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict = {}
+    server = _receiver(captured)
+    try:
+        monkeypatch.setenv("CONTINUUM_WEBHOOK_SECRET", "env-secret")
+        url = f"http://127.0.0.1:{server.server_port}/hook"
+        assert post_webhook(url, {"run_id": "r1"}) is True
+        assert verify_signature(captured["body"], "env-secret", captured["signature"]) is True
+    finally:
+        server.shutdown()
+        monkeypatch.undo()

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -59,7 +59,8 @@ def test_signed_post_delivers_and_verifies() -> None:
         server.shutdown()
 
 
-def test_unsigned_post_keeps_plain_format() -> None:
+def test_unsigned_post_keeps_plain_format(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("CONTINUUM_WEBHOOK_SECRET", raising=False)
     captured: dict = {}
     server = _receiver(captured)
     try:
@@ -86,6 +87,11 @@ def test_secret_env_var_signs(monkeypatch) -> None:  # type: ignore[no-untyped-d
     finally:
         server.shutdown()
         monkeypatch.undo()
+
+
+def test_non_serializable_payload_fails_open() -> None:
+    """Serialization happens inside the fail-open boundary (#674 review)."""
+    assert post_webhook("http://127.0.0.1:1/hook", {"bad": object()}, timeout=0.2) is False
 
 
 def test_malformed_status_line_still_fails_open() -> None:


### PR DESCRIPTION
## Description

First unit of #305: a shared delivery primitive in continuum.recovery.notify. JSON POST with HMAC-SHA256 signature (X-Continuum-Signature) when CONTINUUM_WEBHOOK_SECRET is set, plain JSON otherwise, always fail-open with a boolean return so notification failure can never flip a recovery verdict. The liveness watch webhook path now routes through it with identical wire behavior when unconfigured. Registry file, dedup, dead-letter event, and request_human hookup stay follow-ups.

## Related issues

Refs #305 (unit 1 of the proposed solution)

## Types of changes

- Type: feature

## Breaking changes

No. New module plus a behavior-identical reroute of one call site.

## How has this been tested?

Python 3.14, editable installation.

- New tests/test_notify.py (6 tests): HMAC known-answer, verify accept/reject, live loopback delivery with signature verification, unsigned plain format, refused-connection fail-open, env-var secret.
- Existing liveness suites pass through the rerouted path.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,036 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy src/continuum: passed, 122 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Changelog updated. CI has not yet run on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Webhook notifications can now include HMAC-SHA256 signatures when a signing secret is configured.
  - Added support for verifying webhook signatures.
  - Liveness watch notifications use the shared webhook delivery behavior.

- **Reliability**
  - Webhook delivery continues without interrupting monitoring when delivery fails.
  - Existing plain JSON webhook behavior is preserved when no signing secret is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->