### PR TITLE
perf(storage): merge archive and live streams in linear time

### DIFF
--- a/src/continuum/storage/base.py
+++ b/src/continuum/storage/base.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
+from heapq import merge
 from types import TracebackType
 from typing import Any, ClassVar
 
@@ -152,7 +153,10 @@ class Storage(ABC):
             return live
         if not live:
             return archived
-        return tuple(sorted([*archived, *live], key=lambda e: e.sequence))
+        # Both streams arrive sequence-ordered, so merge linearly instead of
+        # re-sorting: full-history folds on long compacted runs pay O(n).
+        # merge is stable, matching sorted() for equal sequences.
+        return tuple(merge(archived, live, key=lambda e: e.sequence))
 
     def foreign_action(self, key: str, *, exclude_run: str) -> Action | None:
         """Newest action recorded under ``key`` outside ``exclude_run``.

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -346,3 +346,18 @@ def test_anchor_event_is_non_projecting(db: str) -> None:
     assert not report.ignored_types, (
         "EVENT_LOG_ANCHORED must be declared non-projecting, not silently ignored"
     )
+
+
+def test_read_all_events_merges_in_sequence_order(db: str) -> None:
+    """Full history stays sequence-ordered across the archive boundary (#650 review)."""
+    with SQLiteStorage(db) as store:
+        for i in range(3):
+            store.append_event("run_1", EventType.WORK_COMPLETED, {"n": i})
+        store.compact_run("run_1")
+        for i in range(3, 6):
+            store.append_event("run_1", EventType.WORK_COMPLETED, {"n": i})
+        full = store.read_all_events("run_1")
+    seqs = [e.sequence for e in full]
+    assert seqs == sorted(seqs)
+    assert len(seqs) == len(set(seqs))
+    assert [e.payload["n"] for e in full if e.type is EventType.WORK_COMPLETED] == list(range(6))


### PR DESCRIPTION
## Description

Answers the performance thread on #650: read_all_events sorted the concatenated archive plus live tail on every call, so each full-history fold on a long compacted run paid O(n log n) per invocation. Both streams arrive sequence-ordered from their queries, so heapq.merge folds them in O(n). heapq.merge is stable, matching sorted for equal sequences, and the compact-twice ordering test pins sequence order plus uniqueness across the boundary.

## Related issues

Refs #650 (performance follow-up; correctness fix stays untouched)

## Types of changes

- Type: performance

## Breaking changes

No. Identical output ordering, linear instead of linearithmic.

## How has this been tested?

Python 3.14, editable installation.

- New test_read_all_events_merges_in_sequence_order: compact plus tail appends, then asserts global order, uniqueness, and payload order.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,031 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

No behavior change by construction (same order, cheaper). CI has not yet run on this PR.