### PR TITLE
feat(ledger): MCP and sidecar ledgers stamp external agent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+# The pre-commit ecosystem is deliberately not watched (#689). Dependabot
+# groups cannot cross ecosystems, so a pre-commit update would land as its own
+# PR bumping only .pre-commit-config.yaml, and the three-way ruff rev lockstep
+# (pyproject.toml, .pre-commit-config.yaml, CONTRIBUTING.md, enforced by
+# tests/test_precommit_config.py) would fail CI in that PR. Bump ruff in all
+# three places by hand in one PR.
 updates:
   - package-ecosystem: "pip"
     directory: "/"

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ demo-run/*
 
 # opencode local state
 .opencode/
+
+# Benchmark artifacts
+benchmarks/out/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "continuum-mcp": {
-      "command": "continuum-mcp",
+      "command": "${CLAUDE_PROJECT_DIR:-.}/.venv/bin/continuum-mcp",
       "args": ["--db", "continuum.db"],
       "env": {
         "CONTINUUM_MCP_MUTATING_CLIENTS": "claude-code"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Guidance for AI coding agents (and their operators) working in this repository.
 
 ## Commit and push conventions
 
-- No em dashes (—) anywhere in commit messages, code comments, or docs.
+- No em dashes (U+2014) anywhere in commit messages, code comments, or docs.
   Use commas, periods, or parentheses instead.
 - No AI attribution or fingerprints: no "Generated with [tool]", no AI
   co-author trailers, no comments naming an AI agent or tool. Commits and

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,7 +2,7 @@
 
 **Creator and Maintainer**
 
-* **Anandhu P Shaji** ([@Cyrax321](https://github.com/Cyrax321) · [LinkedIn](https://www.linkedin.com/in/anandhupshaji/)) — original design, architecture, and ongoing development. Maintains roadmap, releases, and direction.
+* **Anandhu P Shaji** ([@Cyrax321](https://github.com/Cyrax321) · [LinkedIn](https://www.linkedin.com/in/anandhupshaji/)): original design, architecture, and ongoing development. Maintains roadmap, releases, and direction.
 
 **Contributors**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,18 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **`reconcile --auto` settles archived actions and probes authorities with
+  full consumption context after compaction (#647).**
+  `ActionLedger.pending` folds archived plus live events, but
+  `reconcilers._key_for` folded only the live tail, so one action claimed
+  before a compaction aborted the whole settle report with `LookupError`;
+  `settle_authority` scanned only live events for the `AUTHORITY_CONSUMED`
+  row, silently handing the probe a bare `authority_id` payload without
+  `consumer_run_id`, `via_action_id`, or `sequence`. Both now read full
+  history via `read_all_events`, the same archive-aware pattern the library
+  reconciliation path already used. Covered by `tests/test_reconcilers.py`
+  and `tests/test_authority_probe.py`.
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -558,7 +558,7 @@ All notable changes to this project are documented here. The format follows
   Framework Integration documents the CrewAI/AutoGen/Pydantic-AI thin hooks
   and the gateway/OTel fallback seams; the Roadmap marks the dashboard and
   the enforced-durability work complete; test counts are current
-  (~1,918 collected, ~1,880 passed, ~38 skipped on a minimal env).
+  (~2,053 collected, ~2,030 passed, ~23 skipped on a minimal env).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
 
 - **Gateway hardening and docs refresh.** The enforcing proxy now refuses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **External probe for consumed authorities via reconcilers.json (#557).**
+  `reconcile --authority <id>` runs the configured authority probe with the
+  recorded consumption payload on stdin; `valid=true` appends
+  `AUTHORITY_RECONCILED` and clears the consumed mark, `valid=false` keeps it
+  blocked, and anything else leaves it blocked. Covered by
+  `tests/test_authority_probe.py`, including the negative test that a restore
+  does not resurrect.
+
+- **Liveness watchdog and risk-informed recovery (#302, #303).**
+  Cadence contracts drive `continuum watch`, which appends
+  `LIVENESS_SILENCE_DETECTED` on breach and `LIVENESS_RECOVERED` on recovery
+  (webhook delivery is fail-open); `RISK_OBSERVED` ingestion maps through
+  `.continuum/risk-policy.json` with risks arriving as `EXTERNAL_MONITOR`
+  witnesses, and the contract carries a `triggering_risks` section. Covered
+  by the liveness, risk, and watch suites.
+
+- **Reconciler registry accepts documented shapes and refuses bool timeouts (#322).**
+  Probe entries require a command and a positive numeric timeout; a boolean
+  timeout is refused rather than read as seconds. The registry shape and the
+  default timeout are pinned by `tests/test_reconcilers.py`.
+
+- **Bench harness records byte counts, revalidation calls, and resume tokens (#568).**
+  Per-strategy counters flow into the shared report envelope, covered by
+  `tests/test_benchmark_counters.py`.
+
 - **`examples/demo.ipynb`, the crash-recovery walkthrough as a notebook (#283).**
   The lowest-friction way to watch a recovery was `docker run`, which still wants
   a daemon; this wants a browser. Colab and Binder badges in the Quick Start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -607,7 +607,7 @@ All notable changes to this project are documented here. The format follows
   Framework Integration documents the CrewAI/AutoGen/Pydantic-AI thin hooks
   and the gateway/OTel fallback seams; the Roadmap marks the dashboard and
   the enforced-durability work complete; test counts are current
-  (~2,089 collected, ~2,030 passed, ~23 skipped on a minimal env).
+  (~2,122 collected, ~2,030 passed, ~23 skipped on a minimal env).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
 
 - **Gateway hardening and docs refresh.** The enforcing proxy now refuses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,9 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- The missing-MCP-extra subprocess test now imports the working tree even when
+  CONTINUUM is not installed or an older copy is installed (#810).
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Documented three-file ruff rev lockstep (#689).** CONTRIBUTING.md now
+  names all three places the ruff version lives (the `ruff==` pin in
+  `pyproject.toml`, `rev` in `.pre-commit-config.yaml`, and the `rev` quoted
+  in CONTRIBUTING.md itself) and the test that enforces them; the pin test's
+  failure message says "version skew, not a broken test" and lists the three
+  files to bump, so a dependabot PR that trips it (#627) is readable as
+  drift. The pre-commit ecosystem's absence from dependabot is recorded in a
+  comment there and pinned by a test: its updates cannot be grouped with pip
+  bumps and would break the lockstep in their own PR.
+
 - **External probe for consumed authorities via reconcilers.json (#557).**
   `reconcile --authority <id>` runs the configured authority probe with the
   recorded consumption payload on stdin; `valid=true` appends

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -593,7 +593,7 @@ All notable changes to this project are documented here. The format follows
   Framework Integration documents the CrewAI/AutoGen/Pydantic-AI thin hooks
   and the gateway/OTel fallback seams; the Roadmap marks the dashboard and
   the enforced-durability work complete; test counts are current
-  (~2,053 collected, ~2,030 passed, ~23 skipped on a minimal env).
+  (~2,089 collected, ~2,030 passed, ~23 skipped on a minimal env).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
 
 - **Gateway hardening and docs refresh.** The enforcing proxy now refuses

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,10 +148,19 @@ To run it manually against all files:
 pre-commit run --all-files
 ```
 
-If you bump the `ruff==` pin in `pyproject.toml`, bump `rev` in
-`.pre-commit-config.yaml` to the matching `vX.Y.Z` tag in the same PR. A hook
-running a different ruff than CI is how a locally formatted file still fails
-`ruff format --check` on the PR.
+The ruff version lives in three places that must move together in one PR.
+`tests/test_precommit_config.py` fails any PR where they drift, which is how a
+dependabot `pip` bump surfaces (as a red test, not a version skew, so read a
+failure there as drift before anything else):
+
+1. the `ruff==` pin in the `dev` extra of `pyproject.toml`,
+2. `rev:` in `.pre-commit-config.yaml`, and
+3. the `rev:` quoted in the yaml block above. This file is itself one of the
+   pins, which is easy to miss because you are editing prose, not
+   configuration.
+
+A hook running a different ruff than CI is how a locally formatted file still
+fails `ruff format --check` on the PR.
 
 **Note on mypy:** mypy is intentionally not included in this pre-commit setup.
 Pre-commit hooks run in isolated environments without the project's installed

--- a/README.es.md
+++ b/README.es.md
@@ -66,9 +66,11 @@ Rutas sin configuración (sin clonar, sin instalar, sin publicar nada):
 | Usar la CLI a través de Docker | `docker run --rm ghcr.io/cyrax321/continuum continuum --help` |
 | Ejecutar la CLI sin clonar | `uvx --from git+https://github.com/Cyrax321/CONTINUUM.git continuum --help` |
 | Windows PowerShell (desde un clon) | `powershell -ExecutionPolicy Bypass -File .\try-it.ps1` o `powershell -ExecutionPolicy Bypass -File .\try-it.ps1 cli --help` |
+| Ver la misma recuperación en un cuaderno | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Cyrax321/CONTINUUM/blob/main/examples/demo.ipynb) |
+| El mismo cuaderno, en Binder | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Cyrax321/CONTINUUM/HEAD?labpath=examples%2Fdemo.ipynb) |
 | Entorno de desarrollo completo en el navegador | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Cyrax321/CONTINUUM?quickstart=1) |
 
-La imagen Docker se publica en GHCR por CI en cada push a `main` y en cada etiqueta de release (`.github/workflows/docker-publish.yml`). El Codespace se define en `.devcontainer/`.
+La imagen Docker se publica en GHCR por CI en cada push a `main` y en cada etiqueta de release (`.github/workflows/docker-publish.yml`). El Codespace se define en `.devcontainer/`. El cuaderno es [examples/demo.ipynb](examples/demo.ipynb): su primera celda instala CONTINUUM solo cuando falla la importación, así que el mismo archivo funciona en Colab, en Binder y desde un clon.
 
 ```bash
 git clone https://github.com/Cyrax321/CONTINUUM.git

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Verify:
 ```bash
 continuum --help                 # CLI entrypoint
 continuum-mcp --help             # MCP server entrypoint (needs [mcp] or [dev])
-pytest -q                        # ~2,089 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
+pytest -q                        # ~2,122 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
 ruff check src/ tests/ examples/ && ruff format --check src/ tests/ examples/
 mypy src/continuum               # the three gates CI enforces
 ```
@@ -232,7 +232,7 @@ CONTINUUM is verified against real LLM agents, live protocol boundaries, and har
 - **Third-party clients**: Gemini CLI and Kilo Code connected over stdio JSON-RPC against the live SQLite store, validating multi-agent co-existence and authorization isolation.
 - **Protocol compliance**: driven end to end with `@modelcontextprotocol/inspector --cli` across process deaths; mutating tools deny by default behind `CONTINUUM_MCP_MUTATING_CLIENTS`; external claims degrade to `REQUIRES_REVIEW` (`safe: false`).
 - **Self-healing**: hard-killed servers recover from orphaned SQLite `-wal`/`-shm` sidecars via single-retry cleanup at startup.
-- **Scale**: roughly 2,089 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
+- **Scale**: roughly 2,122 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
 - **Adversarial audit**: the full MCP surface was audited over the live protocol; three defects were found and fixed. Method and reproduction steps in [test.md](test.md).
 
 ## MCP Integration
@@ -398,7 +398,7 @@ Schema v6. SQLite is primary, Postgres is CI verified. One log, many projections
 
 ### Module map: one library, many surfaces
 
-CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~2,089 tests). All modules append to and replay one hash chained event log:
+CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (155 test files, ~2,122 tests). All modules append to and replay one hash chained event log:
 
 | Module | Role |
 |:--|:--|

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ CONTINUUM asks a narrower, harder question: can an agent resume from a compact s
 
 ## Quick Start
 
-Published to PyPI as `continuum-agent` 0.1.0 — `pip install continuum-agent` (`pip install continuum-agent==0.1.0` to pin). Release tags additionally ship built wheels attached to [GitHub Releases](https://github.com/Cyrax321/CONTINUUM/releases).
+Published to PyPI as `continuum-agent` 0.1.0: `pip install continuum-agent` (`pip install continuum-agent==0.1.0` to pin). Release tags additionally ship built wheels attached to [GitHub Releases](https://github.com/Cyrax321/CONTINUUM/releases).
 
 Zero-setup paths (no clone, no install, nothing published anywhere):
 
 | Path | How |
 |:--|:--|
-| Install from PyPI | `pip install continuum-agent==0.1.0` — then `continuum --help` |
+| Install from PyPI | `pip install continuum-agent==0.1.0`, then `continuum --help` |
 | Watch crash recovery happen end to end | `docker run --rm ghcr.io/cyrax321/continuum` |
 | Use the CLI through Docker | `docker run --rm ghcr.io/cyrax321/continuum continuum --help` |
 | Run the CLI without cloning | `uvx --from git+https://github.com/Cyrax321/CONTINUUM.git continuum --help` |
@@ -303,7 +303,7 @@ The deep reference for each concept lives in [references/concepts.md](references
 
 CONTINUUM is organised around one invariant: **every fact carries its origin, and trust is earned, never assumed.** Why this matters for a startup: an agent that runs for weeks must not lose work when its context is lost, and it must not waste tokens, cost, or fire a tool twice.
 
-### System at a glance — universal adapter, one log, any harness
+### System at a glance: universal adapter, one log, any harness
 
 Any harness plugs into the same hash chained log. The same run can be written by Claude Code, resumed by LangGraph, inspected by the CLI, and approved on the dashboard. No framework cooperation is required.
 
@@ -333,13 +333,13 @@ Any harness plugs into the same hash chained log. The same run can be written by
 |:--|:--|:--|
 | 1 In-process | `GenericAgentAdapter.intercept_action(...)` and `wrap_tool(key_fn=...)` on LangChain, LangGraph, OpenAI Agents SDK | Python frameworks, trusted writes |
 | 2 MCP server | `continuum-mcp` 12 tools over stdio (`continuum_record_progress`, `continuum_intercept_action`, `continuum_complete_action`, etc.) | Any MCP capable client, 3 read only + 8 mutating, allowlist `CONTINUUM_MCP_MUTATING_CLIENTS` |
-| 3 CLI lifecycle hooks | `continuum hooks install claude-code --with-gate` also `gemini` and `codex` | Coding CLIs: `SessionStart briefing`, `PostToolUse observe`, `PreToolUse gate` — no CLAUDE.md needed |
+| 3 CLI lifecycle hooks | `continuum hooks install claude-code --with-gate` also `gemini` and `codex` | Coding CLIs: `SessionStart briefing`, `PostToolUse observe`, `PreToolUse gate`; no CLAUDE.md needed |
 | 4 Enforcing HTTP gateway | `continuum gateway --port 8765` with `.continuum/gateway.json` | Any language, any outbound HTTP must have a claim, gateway settles from real status code |
 | 5 OpenTelemetry bridge | `make_span_processor(storage)` | Any traced app, spans become `TOOL_COMPLETED` evidence |
 
 Thin hook surfaces for CrewAI, AutoGen, Pydantic AI live in `adapters/thin.py` with no SDK required.
 
-### Enforcement pipeline — why no duplicate and no invalid call
+### Enforcement pipeline: why no duplicate and no invalid call
 
 The gate to observe pipeline closes the gap at the harness boundary. This is what saves tokens and cost and blocks invalid tool calls.
 
@@ -361,12 +361,12 @@ agent performs effect
 continuum_complete_action  (settled from reality, not from report)
     |
     v
-ledger marked COMPLETED — next replay returns cached result, not a second fire
+ledger marked COMPLETED: next replay returns cached result, not a second fire
 ```
 
 Unknown host is denied fail closed, not an open relay. Shell `Bash/curl` is the documented v1 blind spot.
 
-### Recovery decision tree — weeks until done, correct and exactly
+### Recovery decision tree: weeks until done, correct and exactly
 
 The engine takes the most cautious signal, so safety never loses to convenience.
 
@@ -379,7 +379,7 @@ Every `continuum resume` returns a sealed contract with: recovery status and `sa
 ### Why this saves tokens, cost, and invalid calls
 
 * **Tokens:** Semantic checkpoint stores `Goal + Plan + Progress` not a transcript dump. Briefing serves only verified state plus a 4096 cap reasoning summary, not the error tail that self conditioning shows degrades the next session. Informed retry `recovery/summary.py` injects an engine authored summary, not raw history.
-* **Cost:** Ledger `action_index` refuses duplicate side effects even under argument drift like relative vs absolute paths (`invoice:INV-001` stable key) — so same API is not paid twice after a resume. Budgets `budgets.py` cap retry storms at claim time. `continuum benchmark` prints `0 duplicates` for continuum vs `50` for naive.
+* **Cost:** Ledger `action_index` refuses duplicate side effects even under argument drift like relative vs absolute paths (`invoice:INV-001` stable key), so the same API is not paid twice after a resume. Budgets `budgets.py` cap retry storms at claim time. `continuum benchmark` prints `0 duplicates` for continuum vs `50` for naive.
 * **Invalid calls:** Gate and gateway and `replayguard` `langgraph_protected_node` block unclaimed or replayed tool calls before they fire. Pinning `pinning.py` surfaces prompt or tool drift on resume.
 
 ### Storage architecture
@@ -392,25 +392,25 @@ Schema v6. SQLite is primary, Postgres is CI verified. One log, many projections
 | `runs` | Run metadata with `parent_run_id` for multi agent |
 | `versions` | SemanticState snapshots per checkpoint |
 | `checkpoints` | Sealed checkpoint records with `RECOVERY` anchors |
-| `action_index` | Cross run idempotency projection (schema v3+) — indexed reads, not full scans |
-| `events_archive` | Compacted prefix storage (schema v5+) — `continuum compact` bounds live log for weeks |
-| `lg_checkpoints` / `lg_writes` | LangGraph native persistence (schema v4+) — `make_continuum_checkpointer(storage)` |
+| `action_index` | Cross run idempotency projection (schema v3+): indexed reads, not full scans |
+| `events_archive` | Compacted prefix storage (schema v5+): `continuum compact` bounds live log for weeks |
+| `lg_checkpoints` / `lg_writes` | LangGraph native persistence (schema v4+): `make_continuum_checkpointer(storage)` |
 
-### Module map — one library, many surfaces
+### Module map: one library, many surfaces
 
 CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~2,053 tests). All modules append to and replay one hash chained event log:
 
 | Module | Role |
 |:--|:--|
 | `events.py` | Append only, hash chained event log and `verify() trusted_through` |
-| `state/` | Projection `project()`, validation, extraction — staleness propagation |
+| `state/` | Projection `project()`, validation, extraction: staleness propagation |
 | `storage/` | `SQLiteStorage` v6, `postgres.py`, `migrations.py`, `actionindex.py` |
 | `actions/` | Idempotent ledger `claim/complete/reconcile`, `idempotency.py` key + canonicalization + token fallback, consumed grant tracking `GRANT_DENIED` |
 | `checkpoint/` | Policy driven checkpoints `manager.py` `policy.py` with `RECOVERY` anchors and `prune` |
 | `recovery/` | Engine, planner, sealed contract `contract.py`, `guidance` `human_steps`, `observations` disk checked, `family` rollup, `fork` semantics, `summary` informed retry |
 | `gate.py` | Pre tool use enforcement: allow or deny against ledger claims |
 | `gateway.py` | Enforcing HTTP proxy: claim before fire for outbound requests |
-| `replayguard.py` | Portable guard: `evaluate, protected_call, langgraph_protected_node` — closes ACRFence replay hazard |
+| `replayguard.py` | Portable guard: `evaluate, protected_call, langgraph_protected_node`: closes ACRFence replay hazard |
 | `hooks.py` `clienthooks.py` | Shared checkpoint hooks and installer profiles `claude-code gemini codex` |
 | `budgets.py` | Retry budget registry and evaluation per action type |
 | `pinning.py` | Version pinning normalisation and drift detection on resume |
@@ -420,9 +420,9 @@ CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite 
 | `mcp/` | 12 stdio tools plus authz `authz.py` token auth, allowlist, confirmation token |
 | `serve/` | Sidecar stdio JSON wire + HTTP `CONTINUUM_SERVE_TOKEN` |
 | `dashboard/` | Web dashboard `app.py` `hitl.py` with HITL buttons confirm/reconcile/complete, prefix trust advisory, pins |
-| `cli/` | 38 argparse commands, exit codes as verdict — `runs, start, inspect, resume, verify, health, tree, benchmark, attest, dashboard` |
+| `cli/` | 38 argparse commands, exit codes as verdict: `runs, start, inspect, resume, verify, health, tree, benchmark, attest, dashboard` |
 | `otel.py` | OpenTelemetry span processor bridge |
-| `benchmark/` | CONTINUUM-Bench harness — 5 crash scenarios + argument drift + 12 scenario recovery suite |
+| `benchmark/` | CONTINUUM-Bench harness: 5 crash scenarios + argument drift + 12 scenario recovery suite |
 
 ### Honest limitations
 
@@ -433,7 +433,7 @@ CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite 
 - Large payload offloading (#254) not yet implemented
 - Weeks scale benchmark with token cost table lands in #550 board (#568 to #570)
 
-Full reference in [references/architecture.md](references/architecture.md). And the months plane that builds on this — provenance causal graph, authority resurrection, admissibility, liveness — is pinned as board #550 with 20 sub issues #551 to #570.
+Full reference in [references/architecture.md](references/architecture.md). And the months plane that builds on this (provenance causal graph, authority resurrection, admissibility, liveness) is pinned as board #550 with 20 sub issues #551 to #570.
 
 ## API and CLI
 
@@ -541,7 +541,7 @@ If CONTINUUM helps your agents recover reliably, consider sponsoring to support 
 </p>
 
 <p align="center">
-  <a href="https://github.com/sponsors/Cyrax321">Become a sponsor</a> — GitHub Sponsors, or add FUNDING.yml custom link if you prefer another platform.
+  <a href="https://github.com/sponsors/Cyrax321">Become a sponsor</a>: GitHub Sponsors, or add FUNDING.yml custom link if you prefer another platform.
 </p>
 
 ## License

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Verify:
 ```bash
 continuum --help                 # CLI entrypoint
 continuum-mcp --help             # MCP server entrypoint (needs [mcp] or [dev])
-pytest -q                        # ~1,918 collected, ~1,880 passed, ~38 skipped on a minimal env (exact counts vary)
+pytest -q                        # ~2,053 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
 ruff check src/ tests/ examples/ && ruff format --check src/ tests/ examples/
 mypy src/continuum               # the three gates CI enforces
 ```
@@ -232,7 +232,7 @@ CONTINUUM is verified against real LLM agents, live protocol boundaries, and har
 - **Third-party clients**: Gemini CLI and Kilo Code connected over stdio JSON-RPC against the live SQLite store, validating multi-agent co-existence and authorization isolation.
 - **Protocol compliance**: driven end to end with `@modelcontextprotocol/inspector --cli` across process deaths; mutating tools deny by default behind `CONTINUUM_MCP_MUTATING_CLIENTS`; external claims degrade to `REQUIRES_REVIEW` (`safe: false`).
 - **Self-healing**: hard-killed servers recover from orphaned SQLite `-wal`/`-shm` sidecars via single-retry cleanup at startup.
-- **Scale**: roughly 1,918 tests collected (~1,880 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
+- **Scale**: roughly 2,053 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
 - **Adversarial audit**: the full MCP surface was audited over the live protocol; three defects were found and fixed. Method and reproduction steps in [test.md](test.md).
 
 ## MCP Integration
@@ -398,7 +398,7 @@ Schema v6. SQLite is primary, Postgres is CI verified. One log, many projections
 
 ### Module map — one library, many surfaces
 
-CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~1,918 tests). All modules append to and replay one hash chained event log:
+CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~2,053 tests). All modules append to and replay one hash chained event log:
 
 | Module | Role |
 |:--|:--|

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Verify:
 ```bash
 continuum --help                 # CLI entrypoint
 continuum-mcp --help             # MCP server entrypoint (needs [mcp] or [dev])
-pytest -q                        # ~2,053 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
+pytest -q                        # ~2,089 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
 ruff check src/ tests/ examples/ && ruff format --check src/ tests/ examples/
 mypy src/continuum               # the three gates CI enforces
 ```
@@ -232,7 +232,7 @@ CONTINUUM is verified against real LLM agents, live protocol boundaries, and har
 - **Third-party clients**: Gemini CLI and Kilo Code connected over stdio JSON-RPC against the live SQLite store, validating multi-agent co-existence and authorization isolation.
 - **Protocol compliance**: driven end to end with `@modelcontextprotocol/inspector --cli` across process deaths; mutating tools deny by default behind `CONTINUUM_MCP_MUTATING_CLIENTS`; external claims degrade to `REQUIRES_REVIEW` (`safe: false`).
 - **Self-healing**: hard-killed servers recover from orphaned SQLite `-wal`/`-shm` sidecars via single-retry cleanup at startup.
-- **Scale**: roughly 2,053 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
+- **Scale**: roughly 2,089 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
 - **Adversarial audit**: the full MCP surface was audited over the live protocol; three defects were found and fixed. Method and reproduction steps in [test.md](test.md).
 
 ## MCP Integration
@@ -398,7 +398,7 @@ Schema v6. SQLite is primary, Postgres is CI verified. One log, many projections
 
 ### Module map: one library, many surfaces
 
-CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~2,053 tests). All modules append to and replay one hash chained event log:
+CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~2,089 tests). All modules append to and replay one hash chained event log:
 
 | Module | Role |
 |:--|:--|

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,3 +26,13 @@ The script:
 
 The deliverable for #6 is the captured sequence plus the deviations noted in the
 issue, not a passing unit test.
+
+## Hook-path speedup micro-benchmark
+
+`speedup_demo.py` measures checkpoint/ledger machinery cost with no LLM: five
+per-section sync checkpoints versus one async checkpoint at the end, then prints
+the wall-clock ratio.
+
+```bash
+PYTHONPATH=src python benchmarks/speedup_demo.py
+```

--- a/benchmarks/graph_build_overhead.py
+++ b/benchmarks/graph_build_overhead.py
@@ -10,6 +10,7 @@ See issue #111.
 
 from __future__ import annotations
 
+import argparse
 import tempfile
 import time
 from pathlib import Path
@@ -23,7 +24,26 @@ def _make_repo(root: Path, n_files: int) -> None:
         f.write_text("import os\nimport sys\nimport numpy\nimport pandas\n", encoding="utf-8")
 
 
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``benchmarks/graph_build_overhead.py`` argument parser.
+
+    Only ``--help`` is recognised; anything else fails with exit code 2
+    (argparse convention) instead of silently launching the measurement
+    (issue #773).
+    """
+    return argparse.ArgumentParser(
+        prog="python benchmarks/graph_build_overhead.py",
+        description=(
+            "Micro-benchmark for source DependencyGraph build time over a "
+            "synthetic repository. Reports timings for several sizes; makes "
+            "no claim about caching or production scale."
+        ),
+        epilog="With no arguments, runs the measurement for 50, 100, and 200 files.",
+    )
+
+
 def main() -> None:
+    build_parser().parse_args()
     print("Source DependencyGraph build overhead (synthetic fixture, no caching claim)")
     for n in (50, 100, 200):
         with tempfile.TemporaryDirectory() as tmp:

--- a/benchmarks/horizon/judge.py
+++ b/benchmarks/horizon/judge.py
@@ -87,7 +87,7 @@ def score_suite(results: list[JudgeResult]) -> dict[str, Any]:
     repair_needed = [r for r in results if r.repair_needed]
     repair_correct = sum(1 for r in repair_needed if r.repair_correct)
     repair_precision = round(repair_correct / len(repair_needed), 3) if repair_needed else 1.0
-    # Placeholders for the other three metrics — they are computed by the
+    # Placeholders for the other three metrics: they are computed by the
     # driver from actual storage/ledger state, not just judge labels.
     # For now, report 0 for duplicates and 1.0 for compression as the
     # horizon driver is focused on decision correctness; the full

--- a/benchmarks/horizon/scenarios.py
+++ b/benchmarks/horizon/scenarios.py
@@ -2,7 +2,7 @@
 
 Each scenario is constructed with a correct recovery mode label at
 construction time. Two independent labelings were performed and
-disagreements resolved before publication — see the resolution note
+disagreements resolved before publication. See the resolution note
 in the PR body.
 
 Scenarios force at least 100 reconstruction cycles via the simulated
@@ -33,18 +33,18 @@ class HorizonScenario:
 # - Author 1 (primary): labeled based on whether environment drift exists
 # - Author 2 (reviewer): labeled based on whether side effects are uncertain
 # Disagreements resolved:
-# - Scenario "steady_progress" — both labeled resume, no disagreement
-# - Scenario "quarterly_drift" — Author1 said repair, Author2 said request_human;
+# - Scenario "steady_progress": both labeled resume, no disagreement
+# - Scenario "quarterly_drift": Author1 said repair, Author2 said request_human;
 #   resolved to repair because drift is re-pinnable dependency, not uncertain side effect
-# - Scenario "budget_exhaustion" — both labeled request_human, no disagreement
-# - Scenario "compaction_stress" — both labeled resume, no disagreement
-# - Scenario "abort_condition" — Author1 said abort, Author2 said request_human;
+# - Scenario "budget_exhaustion": both labeled request_human, no disagreement
+# - Scenario "compaction_stress": both labeled resume, no disagreement
+# - Scenario "abort_condition": Author1 said abort, Author2 said request_human;
 #   resolved to abort because the run's goal is invalidated (decision invalidated), not just review
 
 HORIZON_SCENARIOS: list[HorizonScenario] = [
     HorizonScenario(
         name="steady_progress_year",
-        description="Year of steady progress, weekly compaction, no drift — should resume",
+        description="Year of steady progress, weekly compaction, no drift: should resume",
         correct_mode="resume",
         cycles=120,
         mutations=None,
@@ -52,7 +52,7 @@ HORIZON_SCENARIOS: list[HorizonScenario] = [
     ),
     HorizonScenario(
         name="quarterly_drift_year",
-        description="Dataset version drifts quarterly (every 30 cycles) — should repair",
+        description="Dataset version drifts quarterly (every 30 cycles): should repair",
         correct_mode="repair",
         cycles=120,
         mutations={30: {"dataset": "v2"}, 60: {"dataset": "v3"}, 90: {"dataset": "v4"}},
@@ -60,7 +60,7 @@ HORIZON_SCENARIOS: list[HorizonScenario] = [
     ),
     HorizonScenario(
         name="budget_exhaustion_year",
-        description="Many side effects exhaust retry budget — should request_human",
+        description="Many side effects exhaust retry budget: should request_human",
         correct_mode="request_human",
         cycles=120,
         mutations={10: {"budget": "exhausted"}},
@@ -68,7 +68,7 @@ HORIZON_SCENARIOS: list[HorizonScenario] = [
     ),
     HorizonScenario(
         name="compaction_stress_year",
-        description="Aggressive compaction every cycle — should still resume",
+        description="Aggressive compaction every cycle: should still resume",
         correct_mode="resume",
         cycles=150,
         mutations=None,
@@ -76,7 +76,7 @@ HORIZON_SCENARIOS: list[HorizonScenario] = [
     ),
     HorizonScenario(
         name="abort_condition_year",
-        description="Goal invalidated via decision invalidation — should abort",
+        description="Goal invalidated via decision invalidation: should abort",
         correct_mode="abort",
         cycles=120,
         mutations={60: {"goal": "invalidated"}},

--- a/benchmarks/localized_repair.py
+++ b/benchmarks/localized_repair.py
@@ -12,6 +12,8 @@ issue #106.
 
 from __future__ import annotations
 
+import argparse
+
 from continuum.checkpoint import CheckpointManager
 from continuum.environment import StaticProvider, capture
 from continuum.events import EventType
@@ -66,7 +68,27 @@ def _preserved(decision) -> int:
     return sum(1 for it in items if it.status.value == "valid")
 
 
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``benchmarks/localized_repair.py`` argument parser.
+
+    Only ``--help`` is recognised; anything else fails with exit code 2
+    (argparse convention) instead of silently launching the measurement
+    (issue #773).
+    """
+    return argparse.ArgumentParser(
+        prog="python benchmarks/localized_repair.py",
+        description=(
+            "Synthetic localized-repair measurement: compare how many state "
+            "items stay VALID under a scoped recovery assessment versus a "
+            "naive global reset. Runs against an in-memory store; no external "
+            "world claims."
+        ),
+        epilog="With no arguments, runs the measurement and prints the summary.",
+    )
+
+
 def main() -> None:
+    build_parser().parse_args()
     storage = _build()
     engine = RecoveryEngine(storage)
 

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,7 +1,7 @@
 """Run the Phase 6 recovery-correctness scenario suite and emit a report.
 
 Usage:
-    uv run python benchmarks/run.py
+    uv run python benchmarks/run.py [--list]
 
 Writes ``benchmarks/out/report.json`` and ``benchmarks/out/report.md``. The run
 is reproducible: scenarios build their own in-memory state, so the output can be
@@ -25,6 +25,7 @@ Continuum bench byte counts (issue #568, #293a):
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 from pathlib import Path
@@ -197,7 +198,49 @@ def _append_continuum_bench(out_dir: str | Path) -> None:
         print("continuum bench: unexpected report shape, skipping merge")
 
 
+_SUITES: dict[str, str] = {
+    "phase6": "recovery-correctness scenarios -> out/report.{json,md}",
+    "continuum-bench": "crash-recovery byte counts -> merged into out/report.json",
+    "fault-injection": "chaos suite (#397) -> out/fault_injection_report.{json,md}",
+    "horizon": (
+        "horizon-scale suite (#398) -> out/horizon_report.{json,md}; "
+        "also regenerates the README bench table"
+    ),
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``benchmarks/run.py`` argument parser.
+
+    Only ``--help`` and ``--list`` are recognised; anything else fails with
+    exit code 2 (argparse convention, matching ``src/continuum/cli/main.py``)
+    instead of silently launching the full multi-minute suite (issue #682).
+    """
+    parser = argparse.ArgumentParser(
+        prog="python benchmarks/run.py",
+        description=(
+            "Run the full benchmark suite: Phase 6 recovery-correctness scenarios, "
+            "the CONTINUUM crash-recovery byte-count bench, the fault-injection "
+            "chaos suite, and the horizon-scale suite. Takes minutes and writes "
+            "reports under benchmarks/out/."
+        ),
+        epilog="With no arguments, runs every suite in order and writes all reports.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="print the suites this runner executes and where each report lands, then exit.",
+    )
+    return parser
+
+
 def main() -> None:
+    args = build_parser().parse_args()
+    if args.list:
+        for name, what in _SUITES.items():
+            print(f"{name}: {what}")
+        return
+
     report = run_benchmark(scenarios.ALL_SCENARIOS)
     out_dir = os.path.join(os.path.dirname(__file__), "out")
     os.makedirs(out_dir, exist_ok=True)

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -199,11 +199,11 @@ def _append_continuum_bench(out_dir: str | Path) -> None:
 
 
 _SUITES: dict[str, str] = {
-    "phase6": "recovery-correctness scenarios -> out/report.{json,md}",
-    "continuum-bench": "crash-recovery byte counts -> merged into out/report.json",
-    "fault-injection": "chaos suite (#397) -> out/fault_injection_report.{json,md}",
+    "phase6": "recovery-correctness scenarios -> benchmarks/out/report.{json,md}",
+    "continuum-bench": "crash-recovery byte counts -> merged into benchmarks/out/report.json",
+    "fault-injection": "chaos suite (#397) -> benchmarks/out/fault_injection_report.{json,md}",
     "horizon": (
-        "horizon-scale suite (#398) -> out/horizon_report.{json,md}; "
+        "horizon-scale suite (#398) -> benchmarks/out/horizon_report.{json,md}; "
         "also regenerates the README bench table"
     ),
 }

--- a/docs/CONTRIBUTING_ONBOARDING.md
+++ b/docs/CONTRIBUTING_ONBOARDING.md
@@ -26,8 +26,8 @@ Welcome. This guide gets you from clone to green tests without re-deriving conte
 
 Install once with `uv sync --extra dev` (or `pip install -e ".[dev]"`).
 
-- Run all tests: `uv run pytest` or `pytest -q`. Expect `~1,880 passed, ~38 skipped`
-  on main at this writing (`~1,918` collected).
+- Run all tests: `uv run pytest` or `pytest -q`. Expect `~2,030 passed, ~23 skipped`
+  on main at this writing (`~2,053` collected).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
   Skips are environmental (Postgres without `CONTINUUM_TEST_POSTGRES_DSN`, adapter tests without `langgraph` or `openai-agents`).
 - Run a single area: `uv run pytest tests/test_checkpoint_phase4.py -v`

--- a/docs/CONTRIBUTING_ONBOARDING.md
+++ b/docs/CONTRIBUTING_ONBOARDING.md
@@ -27,7 +27,7 @@ Welcome. This guide gets you from clone to green tests without re-deriving conte
 Install once with `uv sync --extra dev` (or `pip install -e ".[dev]"`).
 
 - Run all tests: `uv run pytest` or `pytest -q`. Expect `~2,030 passed, ~23 skipped`
-  on main at this writing (`~2,089` collected).
+  on main at this writing (`~2,122` collected).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
   Skips are environmental (Postgres without `CONTINUUM_TEST_POSTGRES_DSN`, adapter tests without `langgraph` or `openai-agents`).
 - Run a single area: `uv run pytest tests/test_checkpoint_phase4.py -v`

--- a/docs/CONTRIBUTING_ONBOARDING.md
+++ b/docs/CONTRIBUTING_ONBOARDING.md
@@ -27,7 +27,7 @@ Welcome. This guide gets you from clone to green tests without re-deriving conte
 Install once with `uv sync --extra dev` (or `pip install -e ".[dev]"`).
 
 - Run all tests: `uv run pytest` or `pytest -q`. Expect `~2,030 passed, ~23 skipped`
-  on main at this writing (`~2,053` collected).
+  on main at this writing (`~2,089` collected).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
   Skips are environmental (Postgres without `CONTINUUM_TEST_POSTGRES_DSN`, adapter tests without `langgraph` or `openai-agents`).
 - Run a single area: `uv run pytest tests/test_checkpoint_phase4.py -v`

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -3,36 +3,36 @@
 Every term here is used in issues and in code. Definitions point to the implementation so they can be verified, not inferred.
 
 - **Anchor**  
-  A checkpoint or ledger entry that must survive cleanup and compaction. In code a checkpoint with `trigger == CheckpointTrigger.RECOVERY` (`src/continuum/checkpoint/policy.py:62`) and a ledger entry with `anchor == True` (`src/continuum/recovery/ledger.py:89`) are anchors. `CheckpointManager.prune` and `RecoveryLedger.compact` keep anchors while dropping older ephemeral entries. See `src/continuum/recovery/cleanup.py:1` for the cleanup rule that preserves referenced anchors.
+  A checkpoint or ledger entry that must survive cleanup and compaction. In code a checkpoint with `trigger == CheckpointTrigger.RECOVERY` (`src/continuum/checkpoint/policy.py:62`) and a ledger entry with `anchor == True` (`src/continuum/recovery/ledger.py:88`) are anchors. `CheckpointManager.prune` and `RecoveryLedger.compact` keep anchors while dropping older ephemeral entries. See `src/continuum/recovery/cleanup.py:20` for the cleanup rule that preserves referenced anchors.
 
 - **Lease**  
-  A short lived, per run ownership claim that prevents two recoveries from acting as authority at once. Implemented in `src/continuum/concurrency/lease.py:1`. The recovery ledger can be constructed with a `LeaseCoordinator` (`src/continuum/recovery/ledger.py:209`) so `append_decision` and `record_attempt` acquire the lease for the run. `Phase 4` added the `RECOVERY` trigger to `CheckpointTrigger` and the `StateCheckpoint.reason` field so a lease protected anchor can be created atomically via `CheckpointManager.checkpoint_on_recovery`.
+  A short lived, per run ownership claim that prevents two recoveries from acting as authority at once. Implemented by `LeaseCoordinator` in `src/continuum/concurrency/lease.py:58`. The recovery ledger can be constructed with a `LeaseCoordinator` (`src/continuum/recovery/ledger.py:208`) so `append_decision` and `record_attempt` acquire the lease for the run. `Phase 4` added the `RECOVERY` trigger to `CheckpointTrigger` and the `StateCheckpoint.reason` field so a lease protected anchor can be created atomically via `CheckpointManager.checkpoint_on_recovery`.
 
 - **Contract**  
-  The machine readable verdict `RecoveryContract` (`src/continuum/models.py:555`) sealed by hash. It carries `recovery_status`, `checkpoint_version`, `verified` and `invalidated` lists, `required_actions`, a single `next_allowed_action`, plus the Phase 1 fields `evidence` and `reason`. Built in `src/continuum/recovery/contract.py:1` and surfaced by `RecoveryEngine.assess`. The contract is the single permitted next step. Rendering is in `src/continuum/recovery/contract.py`.
+  The machine readable verdict `RecoveryContract` (`src/continuum/models.py:1060`) sealed by hash. It carries `recovery_status`, `checkpoint_version`, `verified` and `invalidated` lists, `required_actions`, a single `next_allowed_action`, plus the Phase 1 fields `evidence` and `reason`. Built by `build_contract` in `src/continuum/recovery/contract.py:83` and surfaced by `RecoveryEngine.assess`. The contract is the single permitted next step. Rendering is in `src/continuum/recovery/contract.py`.
 
 - **Provenance**  
-  The three orthogonal axes that trace a fact back to its origin: `Origin` (who asserted it, `src/continuum/models.py:163`), `TrustLevel` (how verified it is, `src/continuum/security/provenance.py:1`), and `StateStatus` (what validity state it is in, `src/continuum/models.py:199`). `src/continuum/provenance_map.py:1` projects these onto `CanonicalProvenance` without deleting the source enums. `ProvenanceView` carries all three source values alongside the canonical labels.
+  The three orthogonal axes that trace a fact back to its origin: `Origin` (who asserted it, `src/continuum/models.py:172`), `TrustLevel` (how verified it is, `src/continuum/security/provenance.py:19`), and `StateStatus` (what validity state it is in, `src/continuum/models.py:94`). `src/continuum/provenance_map.py:60` projects these onto `CanonicalProvenance` without deleting the source enums. `ProvenanceView` carries all three source values alongside the canonical labels.
 
 - **Checkpoint**  
-  A sealed `StateCheckpoint` (`src/continuum/models.py:601`) bundling the projected `SemanticState` at a version, the event cursor it covers, and the `EnvironmentSnapshot` it was verified against. Created in `src/continuum/checkpoint/manager.py:160` via `checkpoint`, restored via `restore` which replays events recorded after the checkpoint. The checkpoint policy that decides when to write lives in `src/continuum/checkpoint/policy.py:1`.
+  A sealed `StateCheckpoint` (`src/continuum/models.py:1133`) bundling the projected `SemanticState` at a version, the event cursor it covers, and the `EnvironmentSnapshot` it was verified against. Created in `src/continuum/checkpoint/manager.py:168` via `checkpoint`, restored via `restore` which replays events recorded after the checkpoint. The checkpoint policy that decides when to write lives in `src/continuum/checkpoint/policy.py:52`.
 
 - **EnvironmentSnapshot**  
-  A capture of the current external world for a run (`src/continuum/models.py:555` nearby). Each `EnvResource` (`src/continuum/models.py:605`) records a named resource and its version or checksum. Comparison of a checkpoint environment and a live environment drives `EnvironmentDiff` and the validator's staleness propagation.
+  A capture of the current external world for a run (`src/continuum/models.py:1024`). Each `EnvResource` (`src/continuum/models.py:1014`) records a named resource and its version or checksum. Comparison of a checkpoint environment and a live environment drives `EnvironmentDiff` and the validator's staleness propagation.
 
 - **Validation**  
-  `StateValidator` in `src/continuum/state/validator.py:1` decides per component whether the checkpointed state is still true against the live environment. Staleness propagates `dependency -> evidence -> finding -> decision`. This propagation is mirrored by the `DependencyGraph` in `src/continuum/recovery/impact.py:1` for localized repair.
+  `StateValidator` in `src/continuum/state/validator.py:218` decides per component whether the checkpointed state is still true against the live environment. Staleness propagates `dependency -> evidence -> finding -> decision`. This propagation is mirrored by the `DependencyGraph` in `src/continuum/recovery/impact.py:47` for localized repair.
 
 - **Ledger**  
   The append only, tamper evident `RecoveryLedger` (`src/continuum/recovery/ledger.py:205`) over a `LedgerBackend` (memory or JSONL file). Entries are hash chained from `GENESIS`. `verify` reports the last trusted index. `record_attempt` tracks retry counts and writes an anchored `human_required` gate when a threshold is reached. `compact` drops a prefix while re sealing the chain. Reconciliation (`reconcile`) detects drift between the ledger chain and the live state version.
 
 - **Repair plan**  
-  `RepairPlan` in `src/continuum/recovery/planner.py:1` listing ordered `RepairStep`s derived from validation statuses and uncertain actions (`plan_repairs`). Steps are ordered so inputs are re-derived before consumers.
+  `RepairPlan` in `src/continuum/recovery/planner.py:111` listing ordered `RepairStep`s derived from validation statuses and uncertain actions (`plan_repairs`). Steps are ordered so inputs are re-derived before consumers.
 
 - **Adapter action**  
-  `AdapterAction` (`src/continuum/adapters/actions.py:1`) is the uniform `name + params + dep_scope` operation that every adapter emits. `AdapterResult` carries the outcome. `run_action` is the facade over `AgentAdapter.intercept_action` where the ledger provides idempotency and the telemetry hook (`on_event`, issue 162) can observe each execution.
+  `AdapterAction` (`src/continuum/adapters/actions.py:24`) is the uniform `name + params + dep_scope` operation that every adapter emits. `AdapterResult` carries the outcome. `run_action` is the facade over `AgentAdapter.intercept_action` where the ledger provides idempotency and the telemetry hook (`on_event`, issue 162) can observe each execution.
 
 - **Telemetry**  
-  Optional observer callback `on_event` on `run_action` (`src/continuum/adapters/actions.py:55`). Disabled by default. Receives `(AdapterAction, AdapterResult)` for every execution, whether completed or failed. A raising observer is suppressed so observability cannot break the action it observes.
+  Optional observer callback `on_event` on `run_action` (`src/continuum/adapters/actions.py:53`). Disabled by default. Receives `(AdapterAction, AdapterResult)` for every execution, whether completed or failed. A raising observer is suppressed so observability cannot break the action it observes.
 
 Reference from the master plan: these terms appear throughout `docs/CONTINUUM_MASTER_PLAN.md` and `docs/ARCHITECTURE_EVOLUTION.md`. The walkthrough in `docs/recovery_walkthrough.md` shows them interacting in one concrete failure.

--- a/docs/TESTING_MCP.md
+++ b/docs/TESTING_MCP.md
@@ -1,6 +1,6 @@
 # CONTINUUM MCP test report
 
-Adversarial verification of the CONTINUUM MCP server: all 11 registered tools,
+Adversarial verification of the CONTINUUM MCP server: all 12 registered tools,
 their failure modes, and the guarantees that must not move.
 
 - **Date:** 2026-08-24
@@ -16,7 +16,7 @@ their failure modes, and the guarantees that must not move.
 | `python -m pytest` | 1361 passed, 24 skipped, stable across consecutive runs |
 | `ruff check` / `ruff format --check` | clean on every changed file |
 | `mypy src` | 25 errors, identical to baseline (missing stubs for the optional `mcp` extra and `cryptography`) |
-| In-process audit, all 11 tools | 23 of 23 assertions passed |
+| In-process audit, all 12 tools | 23 of 23 assertions passed |
 | Adversarial probe round 2 | 14 of 14 assertions passed |
 | Adversarial probe round 3 | 14 of 16, both failures diagnosed (one probe bug, one real finding) |
 | Live MCP audit through the running server | all fixes confirmed present |
@@ -48,12 +48,13 @@ fix carries a test that fails without it.
 
 ## Tool coverage
 
-All 11 tools were exercised. None was covered by inspection alone.
+All 12 tools were exercised. None was covered by inspection alone.
 
 | Tool | Exercised with |
 |---|---|
 | `continuum_record_progress` | valid, `completed > total`, negative counters, blank and whitespace `run_id`, unicode goal |
 | `continuum_record_summary` | full structured payload, 20 KB oversized note |
+| `continuum_record_plan` | valid upsert on an existing run, blank `plan_id`, empty `units`, duplicate unit `id`, invalid status |
 | `continuum_checkpoint` | with and without `env`, unknown run, version increment |
 | `continuum_validate` | no `env`, matching `env`, drifted `env`, `expected_model`, unknown run |
 | `continuum_resume` | by id, no id (active-run path), unknown run, `expected_model`, both guidance branches |

--- a/docs/about.html
+++ b/docs/about.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CONTINUUM — About</title>
+  <title>CONTINUUM: About</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&family=Caveat:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -142,6 +142,8 @@ per-client notes for Gemini and Codex):
   (`^Bash$|^shell$`).
 - **`SessionStart` (`briefing`)**: runs `continuum briefing` to inject the active
   run id, goal, progress, and recovery next steps at session start or resume.
+  For a ready-made out-of-band alternative that prints `continuum --json resume`
+  (no model turn), see [`scripts/session_start_resume.sh`](../../scripts/session_start_resume.sh).
 - **`PreCompact` (`precompact`)**: runs `continuum precompact` to seal a
   checkpoint before context compaction discards unverified transcript state
   (configured by default on clients with a compaction event, such as Claude Code).

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -47,6 +47,17 @@ continuum --json <command>                    # machine-readable output
 | `attest-verify <run_id> --attest <file>` | Verify a signed attestation against the live chain. |
 | `serve` | Run the Tier 0 newline-delimited JSON sidecar (no MCP dependency). |
 | `dashboard` | Serve the dashboard (presentation over run data). |
+| `export-evidence` | Export evidence as content-addressed JSON lines. Read-only. |
+| `forget` | Enumerate and tombstone memory records for a tenant. Mutates unless --dry-run. |
+| `health` | Advisory prefix-trust health check. Read-only. |
+| `impact` | Show downstream impact of an evidence item. Read-only. |
+| `merge` | Merge into a run at an anchor. Mutates storage. |
+| `precompact` | Checkpoint before context compaction (PreCompact hook). Mutates the run. |
+| `provenance` | Show provenance DAG. Read-only. |
+| `record-plan` | Record a structured plan upsert. Mutates storage. |
+| `restore` | Restore a run to an anchor checkpoint. Mutates storage. |
+| `rewind` | Rewind workspace and projection to a checkpoint. |
+| `watch` | Watch a run for liveness breach, optionally notify via webhook. |
 
 ## Examples
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -4,6 +4,12 @@ The `continuum` command is the command-line surface, also usable in scripts. Exi
 codes are a safety contract: only a verified-safe run exits `0`, so
 `continuum resume "$RUN" && ./start-agent.sh` cannot launch onto stale state.
 
+Typing bare `continuum` at an interactive terminal opens the full-screen
+dashboard on its landing splash (issue #782); piped or non-terminal output,
+`--json`, and platforms without curses print the help text instead, so scripts
+that run `continuum` blind never find a curses screen where they expected
+usage text.
+
 ```bash
 continuum <command> [args]                    # storage defaults to ./continuum.db
 continuum --db <url-or-path> <command>        # storage URL or path (default: continuum.db)
@@ -47,6 +53,7 @@ continuum --json <command>                    # machine-readable output
 | `attest-verify <run_id> --attest <file>` | Verify a signed attestation against the live chain. |
 | `serve` | Run the Tier 0 newline-delimited JSON sidecar (no MCP dependency). |
 | `dashboard` | Serve the dashboard (presentation over run data). |
+| `tui [--refresh <seconds>]` | Full-screen terminal dashboard: monitor and control runs, read-only until an action is confirmed (`q` quits). |
 | `export-evidence` | Export evidence as content-addressed JSON lines. Read-only. |
 | `forget` | Enumerate and tombstone memory records for a tenant. Mutates unless --dry-run. |
 | `health` | Advisory prefix-trust health check. Read-only. |

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -127,27 +127,59 @@ was wrong (issue #322).
 ## hooks
 
 `continuum hooks install` writes host-side observation hooks into agent
-settings files (for example `.claude/settings.json` or `.gemini/settings.json`).
-The installed `observe` command is baked in at install time and may take one of
-two shapes:
+settings files (for example `.claude/settings.json`, `.gemini/settings.json`, or
+`.codex/hooks.json`).
+
+By default, `hooks install` configures up to three entries (depending on the
+client profile):
+
+- **`PostToolUse` (`observe`)**: intercepts file modifications (matching
+  `Write|Edit|MultiEdit|NotebookEdit`) and runs `continuum observe` to record
+  file writes as `TOOL_COMPLETED` events with path, size, and sha256 hash.
+- **`SessionStart` (`briefing`)**: runs `continuum briefing` to inject the active
+  run id, goal, progress, and recovery next steps at session start or resume.
+- **`PreCompact` (`precompact`)**: runs `continuum precompact` to seal a
+  checkpoint before context compaction discards unverified transcript state
+  (configured by default on clients with a compaction event, such as Claude Code).
+
+When `--with-gate` is passed, an additional entry is installed:
+
+- **`PreToolUse` (`gate`)**: intercepts all tool calls (`*`) and runs
+  `continuum gate` to deny unregistered or unclaimed side effects before they fire.
+
+### Flags
+
+- **`--db <path>`**: bakes a specific database path into each hook command (for
+  example `continuum --db /abs/path.db observe`), ensuring hook processes running
+  from the project root resolve the intended database without ambiguity.
+- **`--with-gate`**: installs the `PreToolUse` gate hook in addition to the default
+  hooks.
+- **`--no-precompact`**: skips installing the `PreCompact` checkpoint hook, and
+  removes one if an earlier install wrote it.
+- **`--settings <path>`**: writes to a custom settings file path instead of the
+  default location determined by the client profile.
+
+The installed commands are baked in at install time and take one of two shapes:
 
 - **`continuum` on PATH**: an absolute path to the resolved executable, for
   example `/usr/local/bin/continuum observe`.
 - **Editable / interpreter-only installs**: `/path/to/python -m continuum.cli observe`
   when no `continuum` executable is found on PATH.
 
-If you pass `--db`, that path is baked into the command too (for example
-`continuum --db /abs/path.db observe`), because hook processes run with the
-project root as cwd and the default database path would otherwise be ambiguous.
-
-To see what was installed, inspect the settings file after install:
+To inspect what was installed, view the target settings file:
 
 ```bash
-continuum hooks install claude-code --db /tmp/test.db
+continuum hooks install claude-code --db /tmp/test.db --with-gate
 cat .claude/settings.json
 ```
 
-If the command looks unexpected after moving a virtualenv, re-run the
-same install command for that host, including the original `--db` value
-when one was used (for example `continuum hooks install claude-code --db /tmp/test.db`);
-it rewrites the baked command path without changing the database target.
+If the command paths become stale after moving a virtualenv or interpreter,
+re-running `continuum hooks install` updates the baked command paths while preserving
+existing targets.
+
+To remove all installed CONTINUUM hooks from a client settings file:
+
+```bash
+continuum hooks remove claude-code
+```
+

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -91,6 +91,9 @@ with per-pin status (`present`, `absent`, `unverifiable`), grace deadline, and
 flagged set. Flagged pins render prominently in human text as `[!!]` lines
 coloured on TTY and plain when piped, byte-identical modulo colour (issue #419).
 
+The authority-probe flow (`--authority`, verdicts, unblocking) is walked through
+in `docs/guides/authority-probes.md`.
+
 `reconcile <run_id>` reads its probe registry from `.continuum/reconcilers.json`
 unless `--config <path>` names another file, and each probe's `timeout` is in
 seconds and optional:

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -131,11 +131,15 @@ settings files (for example `.claude/settings.json`, `.gemini/settings.json`, or
 `.codex/hooks.json`).
 
 By default, `hooks install` configures up to three entries (depending on the
-client profile):
+client profile; event names and matchers below are Claude Code's, see the
+per-client notes for Gemini and Codex):
 
 - **`PostToolUse` (`observe`)**: intercepts file modifications (matching
-  `Write|Edit|MultiEdit|NotebookEdit`) and runs `continuum observe` to record
-  file writes as `TOOL_COMPLETED` events with path, size, and sha256 hash.
+  `Write|Edit|MultiEdit|NotebookEdit` on Claude Code) and runs
+  `continuum observe` to record file writes as `TOOL_COMPLETED` events with
+  path, size, and sha256 hash. Gemini uses the `AfterTool` event with the
+  `write_file|replace` matcher, and Codex observes shell calls only
+  (`^Bash$|^shell$`).
 - **`SessionStart` (`briefing`)**: runs `continuum briefing` to inject the active
   run id, goal, progress, and recovery next steps at session start or resume.
 - **`PreCompact` (`precompact`)**: runs `continuum precompact` to seal a
@@ -144,8 +148,10 @@ client profile):
 
 When `--with-gate` is passed, an additional entry is installed:
 
-- **`PreToolUse` (`gate`)**: intercepts all tool calls (`*`) and runs
-  `continuum gate` to deny unregistered or unclaimed side effects before they fire.
+- **`PreToolUse` (`gate`)**: intercepts tool calls and runs `continuum gate`
+  to deny unregistered or unclaimed side effects before they fire. The matcher
+  is client specific: `*` on Claude Code, `.*` on Gemini (`BeforeTool`), and
+  `^Bash$|^shell$` on Codex, which only sees shell calls.
 
 ### Flags
 

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,4 +1,4 @@
-// CONTINUUM — Interactive Application Logic
+// CONTINUUM: Interactive Application Logic
 
 document.addEventListener('DOMContentLoaded', () => {
   initSimulator();

--- a/docs/guides/authority-probes.md
+++ b/docs/guides/authority-probes.md
@@ -1,0 +1,134 @@
+# Authority probes: re-validating a consumed credential
+
+A consumed single-use authority stays blocked until something outside the log
+says otherwise. An authority probe is that something: an operator-configured
+command that checks the real world (approval dashboard, credential issuer,
+outbox) and prints a verdict. `continuum reconcile --authority <id>` runs the
+probe and, on a clear answer, settles the block by appending
+`AUTHORITY_RECONCILED`. This guide pairs with the registry reference in
+`docs/api/cli.md` (the `reconcile` section documents the file shape, timeouts,
+and the bool-timeout refusal); what follows is the authority half end to end.
+
+## Prerequisites
+
+- `continuum-agent` installed and a run to work in. The demo below uses a
+  throwaway database so nothing touches your real runs.
+
+## 1. Register the probe
+
+Probes live in `reconcilers.json` (default `.continuum/reconcilers.json`,
+override with `--config`). Authority entries are keyed by authority id, action
+entries by action type; the two namespaces share one file:
+
+```json
+{
+  "probes": {
+    "approval-7": {"command": "/opt/probes/check-approval", "timeout": 10}
+  }
+}
+```
+
+When the probe runs, CONTINUUM writes the recorded consumption as JSON to its
+stdin: `authority_id`, `consumer_run_id`, `via_action_id`, `consumed_at`, and
+`sequence`. A probe that needs no context can ignore stdin entirely. For this
+walkthrough any command printing a verdict will do:
+
+```bash
+export DB=/tmp/probe-demo/g.db
+continuum --db $DB start probe-demo --goal "demo approvals"
+```
+
+In production your integration records the consumption when it spends the
+credential; here we record one directly so there is something to probe:
+
+```bash
+python - <<'EOF'
+from continuum.actions.authority import record_authority_consumed
+from continuum.storage import SQLiteStorage
+with SQLiteStorage("/tmp/probe-demo/g.db") as store:
+    record_authority_consumed(store, "probe-demo", "approval-7", via_action_id="action_first")
+EOF
+```
+
+```json
+{"probes": {"approval-7": {"command": "echo valid=true", "timeout": 10}}}
+```
+
+## 2. Read the three verdicts
+
+The probe's final stdout line decides. `valid=true` (or JSON `{"valid": true}`)
+unblocks, `valid=false` keeps the block, anything else (including empty output)
+is unknown and keeps the block, and a crashing or timing-out probe is an error
+rather than an answer. Nothing about the verdict is guessed.
+
+Dry-run first to see the answer without writing:
+
+```bash
+continuum --db $DB reconcile probe-demo --authority approval-7 \
+  --config reconcilers.json --dry-run
+```
+
+```text
+authority 'approval-7' still valid, reconciled and unblocked
+detail:
+dry run: nothing was written
+```
+
+Then for real (exit code 0):
+
+```bash
+continuum --db $DB reconcile probe-demo --authority approval-7 \
+  --config reconcilers.json
+```
+
+```text
+authority 'approval-7' still valid, reconciled and unblocked
+detail:
+```
+
+A probe that answers `valid=false` keeps the block and exits 20:
+
+```text
+authority 'approval-7' not valid, remains blocked
+detail:
+```
+
+A probe that cannot tell (`echo maybe`) also exits 20, saying so explicitly:
+
+```text
+authority 'approval-7' probe could not determine validity
+detail: authority probe could not determine validity from output 'maybe'
+```
+
+Machine readers get the same report as JSON (`settled` tells whether the log
+moved):
+
+```json
+{
+  "authority_id": "approval-7",
+  "detail": "",
+  "dry_run": false,
+  "run_id": "probe-demo",
+  "settled": true,
+  "valid": true
+}
+```
+
+## 3. What unblocking writes
+
+A `true` verdict appends one `AUTHORITY_RECONCILED` event carrying the id, the
+verdict, and the probe detail, and clears the consumed mark: the next
+`collect_consumed_authorities` fold no longer contains the id, so the gate
+stops refusing it for prior consumption. A `false` or unknown verdict writes
+nothing. Reconciliation never invents validity; it only records what the probe
+said, with the probe's words in the payload for audit.
+
+## Rules worth knowing
+
+- Exit code is 0 only when the authority is confirmed still valid. Every other
+  outcome exits 20 (`REQUIRES_HUMAN`), including dry runs that answered
+  anything but true.
+- Probes run with a timeout in seconds (default 10); a timeout is an error,
+  not an unknown, and settles nothing.
+- The gate keeps refusing the id until the reconciled event lands; restart
+  semantics do not resurrect (pinned by `tests/test_authority_probe.py`).

--- a/docs/guides/authority-probes.md
+++ b/docs/guides/authority-probes.md
@@ -34,6 +34,7 @@ stdin: `authority_id`, `consumer_run_id`, `via_action_id`, `consumed_at`, and
 walkthrough any command printing a verdict will do:
 
 ```bash
+mkdir -p /tmp/probe-demo
 export DB=/tmp/probe-demo/g.db
 continuum --db $DB start probe-demo --goal "demo approvals"
 ```

--- a/docs/guides/authority-probes.md
+++ b/docs/guides/authority-probes.md
@@ -51,8 +51,12 @@ with SQLiteStorage("/tmp/probe-demo/g.db") as store:
 EOF
 ```
 
-```json
+Write that config to disk where the later commands expect it:
+
+```bash
+cat > reconcilers.json <<'EOF'
 {"probes": {"approval-7": {"command": "echo valid=true", "timeout": 10}}}
+EOF
 ```
 
 ## 2. Read the three verdicts

--- a/docs/guides/bring-your-own-dashboard.md
+++ b/docs/guides/bring-your-own-dashboard.md
@@ -12,12 +12,12 @@ Your dashboard is presentation. CONTINUUM stays the substrate. That separation i
 
 ## Substrates consumed
 
-### 1. Resume contract (`continuum resume --json`)
+### 1. Resume contract (`continuum --json resume`)
 
 Shell:
 
 ```bash
-continuum resume my-task --json | python -m json.tool
+continuum --json resume my-task | python -m json.tool
 ```
 
 Python:
@@ -139,7 +139,7 @@ For an external verifier that holds only the attestation file:
 ```bash
 continuum attest-keygen --out signer.pem --pub signer.pem.pub
 continuum attest my-task --key signer.pem --out my-task.attest.json
-continuum attest-verify my-task --attest my-task.attest.json --json | python -m json.tool
+continuum --json attest-verify my-task --attest my-task.attest.json | python -m json.tool
 ```
 
 Verdicts are `SIGNED`, `ALTERED`, or `UNTRUSTED` and appear in both human text and JSON.
@@ -251,7 +251,7 @@ print("claimed", out.key)
 PY
 
 # SIGKILL simulation done, now ask the dashboard substrate what it should show
-continuum --db /tmp/byod-demo.db resume dashboard-demo --json | python -m json.tool | head -n 60
+continuum --db /tmp/byod-demo.db --json resume dashboard-demo | python -m json.tool | head -n 60
 continuum --db /tmp/byod-demo.db export-evidence dashboard-demo | wc -l
 continuum --db /tmp/byod-demo.db verify dashboard-demo
 ```
@@ -285,7 +285,7 @@ Measured from a fresh checkout:
 
 1. `uv pip install -e ".[dev]"` (about 40s)
 2. `continuum start my-task --goal "trial"` (1s)
-3. `python dashboard_minimal.py` (or `continuum resume my-task --json` from any UI) (1s)
+3. `python dashboard_minimal.py` (or `continuum --json resume my-task` from any UI) (1s)
 4. Simulate kill, re-poll `GET /api/run/my-task/resume` and see `request_human` (under 1s)
 5. Reconcile, re-poll, see `resume` (under 1s)
 

--- a/docs/guides/bring-your-own-dashboard.md
+++ b/docs/guides/bring-your-own-dashboard.md
@@ -107,10 +107,10 @@ ok = verify_export(primitives)
 
 Each line in the export is one of four neutral primitives:
 
-- `transition` — every event appended to the log
-- `observation` — validations and diffs
-- `relation` — dependency edges
-- `checkpoint` — sealed checkpoints
+- `transition`: every event appended to the log
+- `observation`: validations and diffs
+- `relation`: dependency edges
+- `checkpoint`: sealed checkpoints
 
 Every primitive is content-addressed:
 
@@ -149,7 +149,7 @@ Verdicts are `SIGNED`, `ALTERED`, or `UNTRUSTED` and appear in both human text a
 A 60-line Python example you can drop in and adapt. It polls the live store, renders the contract, and streams evidence.
 
 ```python
-# dashboard_minimal.py — polling example, adapt to your framework
+# dashboard_minimal.py: polling example, adapt to your framework
 import json
 from pathlib import Path
 from flask import Flask, jsonify, render_template_string
@@ -163,7 +163,7 @@ app = Flask(__name__)
 TEMPLATE = """
 <!doctype html>
 <title>CONTINUUM dashboard</title>
-<h1>Run {{run_id}} — {{mode}} (safe={{safe}})</h1>
+<h1>Run {{run_id}}: {{mode}} (safe={{safe}})</h1>
 <p>Goal: {{goal}}</p>
 <p>Progress: {{completed}} / {{total or '?'}} completed</p>
 <h2>Contract</h2>

--- a/docs/guides/embed-claude-code.md
+++ b/docs/guides/embed-claude-code.md
@@ -34,7 +34,7 @@ Expected hooks installed:
 Verify without starting Claude Code:
 
 ```bash
-continuum briefing --json | python -m json.tool
+continuum --json briefing | python -m json.tool
 ```
 
 With no active run you get a silent exit (no DB open, no latency). With an interrupted run you get a banner similar to:
@@ -44,10 +44,10 @@ With no active run you get a silent exit (no DB open, no latency). With an inter
   "active_run": "my-task",
   "mode": "resume",
   "safe": true,
-  "context": "Interrupted run my-task – resume pending\n  run: continuum resume my-task --json\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)",
+  "context": "Interrupted run my-task – resume pending\n  run: continuum --json resume my-task\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)",
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
-    "additionalContext": "Interrupted run my-task – resume pending\n  run: continuum resume my-task --json\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)"
+    "additionalContext": "Interrupted run my-task – resume pending\n  run: continuum --json resume my-task\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)"
   }
 }
 ```
@@ -68,7 +68,7 @@ Fast path keeps cold starts under a second: if `.continuum/resume.json` does not
 To consume the JSON resume contract directly inside an agent turn, use:
 
 ```bash
-continuum resume my-task --json | python -m json.tool
+continuum --json resume my-task | python -m json.tool
 ```
 
 Key fields:
@@ -101,7 +101,7 @@ Claude Code fires `PreCompact` before context compaction. Use it to force a chec
 `continuum hooks install claude-code` wires this for you: the `PreCompact` entry runs `continuum precompact`, which resolves the active run itself, seals a checkpoint with trigger `context_pressure`, and writes both snapshots below. Pass `--no-precompact` to keep the managed entry off the event, which also takes out one an earlier install wrote, and `continuum hooks remove claude-code` takes it out again with the rest.
 
 ```bash
-continuum precompact --json   # what the hook runs; safe to try by hand
+continuum --json precompact   # what the hook runs; safe to try by hand
 ```
 
 It never fails its host: with no active run it exits 0 with nothing sealed, and a snapshot it cannot write is reported in `failures` while the checkpoint stands.
@@ -117,7 +117,7 @@ If you want to pin one run instead of following the active one, the hand-written
         "hooks": [
           {
             "type": "command",
-            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum resume my-task --json > .continuum/precompact-resume.json; continuum verify my-task --json > .continuum/precompact-verify.json"
+            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum --json resume my-task > .continuum/precompact-resume.json; continuum --json verify my-task > .continuum/precompact-verify.json"
           }
         ]
       }
@@ -144,7 +144,7 @@ What this gives:
 Constraint verification: if your run pins constraints by digest (see below), `resume --json` surfaces `pinning_drift` when the current environment pins differ from the recorded set. A non-empty drift does not block resume, it is informational. Check it in PreCompact:
 
 ```bash
-continuum resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' --json | python -c "import json,sys; j=json.load(sys.stdin); print(j['pinning_drift'])"
+continuum --json resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' | python -c "import json,sys; j=json.load(sys.stdin); print(j['pinning_drift'])"
 ```
 
 If you need to record constraint pins at run start (hash-only, plaintext never stored):
@@ -180,7 +180,7 @@ With `--with-gate`, every tool call checks `.continuum/gate.json`:
 
 Unclaimed effects are denied before they fire (exit 2, message fed back to the model):
 
-```
+```text
 [!!] deny: slack.notify is gated and has no claim for key notify:O-9; call continuum_intercept_action first
 ```
 
@@ -199,7 +199,7 @@ If you prefer to hand-edit instead of running `hooks install`:
         "hooks": [
           {
             "type": "command",
-            "command": "continuum briefing --json"
+            "command": "continuum --json briefing"
           }
         ]
       }
@@ -232,7 +232,7 @@ If you prefer to hand-edit instead of running `hooks install`:
         "hooks": [
           {
             "type": "command",
-            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum resume my-task --json > .continuum/precompact-resume.json"
+            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum --json resume my-task > .continuum/precompact-resume.json"
           }
         ]
       }
@@ -272,7 +272,7 @@ PY
 # (the ledger STILL holds the claim as STARTED; no cleanup ran)
 
 # fresh session resumes (new process, same DB, no prompt needed)
-continuum --db /tmp/embed-claude-demo.db resume hardkill-demo --json | python -m json.tool
+continuum --db /tmp/embed-claude-demo.db --json resume hardkill-demo | python -m json.tool
 echo "exit code: $?"
 ```
 
@@ -310,7 +310,7 @@ Exit code 0 means launch is safe.
 
 Real hard-kill with `os._exit(9)` (subprocess, no cleanup) also verified:
 
-```
+```text
 CLAIMED da7942fd0ff97d66197da9ab8c6623e4aeb4db60489fb5857c6a95b067bcd2c9 fresh=True
 exit code: 9
 mode=request_human safe=False reason=1 external side effect(s) have unknown outcomes
@@ -325,7 +325,7 @@ A newcomer with only this guide should have crash recovery inside ten minutes. S
 3. `continuum hooks install claude-code` (1s)
 4. Do any work (write a file, claim an action via adapter, checkpoint)
 5. `kill -9` the agent (or `os._exit(9)` in the example) (instant)
-6. New shell: `continuum resume my-task --json` shows correct mode and next steps (under 1s)
+6. New shell: `continuum --json resume my-task` shows correct mode and next steps (under 1s)
 
 Gap list as of this doc (honest): LangChain/LangGraph/Codex adapters require their optional dependency (`pip install "continuum-agent[langchain]"` etc.) which adds install time but stays inside ten minutes on a warm cache. No gap found for generic adapter path.
 
@@ -335,7 +335,7 @@ Gap list as of this doc (honest): LangChain/LangGraph/Codex adapters require the
 - Hook writes stale command path after moving a virtualenv: re-run `continuum hooks install claude-code` (reports `updated` and rewrites the command).
 - `CONNECTION_CLOSED` from MCP: see `docs/api/mcp.md` troubleshooting; hook path issues, not CONTINUUM.
 - PreCompact never fires: confirm your Claude Code version supports the event, then confirm the entry is actually there. `hooks install` writes it by default (PostToolUse, SessionStart, PreCompact, and PreToolUse only under `--with-gate`), so a missing entry means the install ran with `--no-precompact` or predates #449; re-run `continuum hooks install claude-code` and look for `precompact` in the output.
-- Resume still `request_human` after reconcile: run `continuum actions my-task --json` to confirm no STARTED/UNKNOWN remains, then `continuum resume` again.
+- Resume still `request_human` after reconcile: run `continuum --json actions my-task` to confirm no STARTED/UNKNOWN remains, then `continuum resume` again.
 
 ## See also
 

--- a/docs/guides/embed-claude-code.md
+++ b/docs/guides/embed-claude-code.md
@@ -34,7 +34,7 @@ Expected hooks installed:
 Verify without starting Claude Code:
 
 ```bash
-continuum briefing --json | python -m json.tool
+continuum --json briefing | python -m json.tool
 ```
 
 With no active run you get a silent exit (no DB open, no latency). With an interrupted run you get a banner similar to:
@@ -44,10 +44,10 @@ With no active run you get a silent exit (no DB open, no latency). With an inter
   "active_run": "my-task",
   "mode": "resume",
   "safe": true,
-  "context": "Interrupted run my-task – resume pending\n  run: continuum resume my-task --json\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)",
+  "context": "Interrupted run my-task – resume pending\n  run: continuum --json resume my-task\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)",
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
-    "additionalContext": "Interrupted run my-task – resume pending\n  run: continuum resume my-task --json\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)"
+    "additionalContext": "Interrupted run my-task – resume pending\n  run: continuum --json resume my-task\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)"
   }
 }
 ```
@@ -68,7 +68,7 @@ Fast path keeps cold starts under a second: if `.continuum/resume.json` does not
 To consume the JSON resume contract directly inside an agent turn, use:
 
 ```bash
-continuum resume my-task --json | python -m json.tool
+continuum --json resume my-task | python -m json.tool
 ```
 
 Key fields:
@@ -101,7 +101,7 @@ Claude Code fires `PreCompact` before context compaction. Use it to force a chec
 `continuum hooks install claude-code` wires this for you: the `PreCompact` entry runs `continuum precompact`, which resolves the active run itself, seals a checkpoint with trigger `context_pressure`, and writes both snapshots below. Pass `--no-precompact` to keep the managed entry off the event, which also takes out one an earlier install wrote, and `continuum hooks remove claude-code` takes it out again with the rest.
 
 ```bash
-continuum precompact --json   # what the hook runs; safe to try by hand
+continuum --json precompact   # what the hook runs; safe to try by hand
 ```
 
 It never fails its host: with no active run it exits 0 with nothing sealed, and a snapshot it cannot write is reported in `failures` while the checkpoint stands.
@@ -117,7 +117,7 @@ If you want to pin one run instead of following the active one, the hand-written
         "hooks": [
           {
             "type": "command",
-            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum resume my-task --json > .continuum/precompact-resume.json; continuum verify my-task --json > .continuum/precompact-verify.json"
+            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum --json resume my-task > .continuum/precompact-resume.json; continuum --json verify my-task > .continuum/precompact-verify.json"
           }
         ]
       }
@@ -141,10 +141,10 @@ What this gives:
 - `.continuum/precompact-resume.json` with the recovery decision as of that checkpoint (inspect `contract.verified` and `contract.invalidated`)
 - `.continuum/precompact-verify.json` proving the chain is intact up to the checkpoint
 
-Constraint verification: if your run pins constraints by digest (see below), `resume --json` surfaces `pinning_drift` when the current environment pins differ from the recorded set. A non-empty drift does not block resume, it is informational. Check it in PreCompact:
+Constraint verification: if your run pins constraints by digest (see below), `--json resume` surfaces `pinning_drift` when the current environment pins differ from the recorded set. A non-empty drift does not block resume, it is informational. Check it in PreCompact:
 
 ```bash
-continuum resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' --json | python -c "import json,sys; j=json.load(sys.stdin); print(j['pinning_drift'])"
+continuum --json resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' | python -c "import json,sys; j=json.load(sys.stdin); print(j['pinning_drift'])"
 ```
 
 If you need to record constraint pins at run start (hash-only, plaintext never stored):
@@ -199,7 +199,7 @@ If you prefer to hand-edit instead of running `hooks install`:
         "hooks": [
           {
             "type": "command",
-            "command": "continuum briefing --json"
+            "command": "continuum --json briefing"
           }
         ]
       }
@@ -232,7 +232,7 @@ If you prefer to hand-edit instead of running `hooks install`:
         "hooks": [
           {
             "type": "command",
-            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum resume my-task --json > .continuum/precompact-resume.json"
+            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum --json resume my-task > .continuum/precompact-resume.json"
           }
         ]
       }
@@ -272,7 +272,7 @@ PY
 # (the ledger STILL holds the claim as STARTED; no cleanup ran)
 
 # fresh session resumes (new process, same DB, no prompt needed)
-continuum --db /tmp/embed-claude-demo.db resume hardkill-demo --json | python -m json.tool
+continuum --db /tmp/embed-claude-demo.db --json resume hardkill-demo | python -m json.tool
 echo "exit code: $?"
 ```
 
@@ -295,7 +295,7 @@ Expected contract (real output from this repo, ids vary per run):
 
 Exit code is 20 (`REQUIRES_HUMAN`), not 0, so a guarded launch stops. Resolve by reconciling or, if the effect indeed never landed, retrying with a budget-aware claim, then `continuum resume` returns `resume` with `safe: true`.
 
-With a clean run (no uncertain actions), the same `resume --json` reports:
+With a clean run (no uncertain actions), the same `--json resume` reports:
 
 ```json
 {
@@ -325,7 +325,7 @@ A newcomer with only this guide should have crash recovery inside ten minutes. S
 3. `continuum hooks install claude-code` (1s)
 4. Do any work (write a file, claim an action via adapter, checkpoint)
 5. `kill -9` the agent (or `os._exit(9)` in the example) (instant)
-6. New shell: `continuum resume my-task --json` shows correct mode and next steps (under 1s)
+6. New shell: `continuum --json resume my-task` shows correct mode and next steps (under 1s)
 
 Gap list as of this doc (honest): LangChain/LangGraph/Codex adapters require their optional dependency (`pip install "continuum-agent[langchain]"` etc.) which adds install time but stays inside ten minutes on a warm cache. No gap found for generic adapter path.
 
@@ -335,7 +335,7 @@ Gap list as of this doc (honest): LangChain/LangGraph/Codex adapters require the
 - Hook writes stale command path after moving a virtualenv: re-run `continuum hooks install claude-code` (reports `updated` and rewrites the command).
 - `CONNECTION_CLOSED` from MCP: see `docs/api/mcp.md` troubleshooting; hook path issues, not CONTINUUM.
 - PreCompact never fires: confirm your Claude Code version supports the event, then confirm the entry is actually there. `hooks install` writes it by default (PostToolUse, SessionStart, PreCompact, and PreToolUse only under `--with-gate`), so a missing entry means the install ran with `--no-precompact` or predates #449; re-run `continuum hooks install claude-code` and look for `precompact` in the output.
-- Resume still `request_human` after reconcile: run `continuum actions my-task --json` to confirm no STARTED/UNKNOWN remains, then `continuum resume` again.
+- Resume still `request_human` after reconcile: run `continuum --json actions my-task` to confirm no STARTED/UNKNOWN remains, then `continuum resume` again.
 
 ## See also
 

--- a/docs/guides/embed-codex.md
+++ b/docs/guides/embed-codex.md
@@ -58,8 +58,8 @@ Expected entries in `.codex/hooks.json`:
 Manual verification without starting Codex:
 
 ```bash
-continuum briefing --json | python -m json.tool
-continuum resume my-task --json | python -m json.tool
+continuum --json briefing | python -m json.tool
+continuum --json resume my-task | python -m json.tool
 ```
 
 As with Claude Code, `briefing` exits 0 with no output when no interrupted run exists (checked via `.continuum/resume.json` before any DB open), so cold starts stay fast.
@@ -72,10 +72,10 @@ Same behavior as the Claude Code recipe: banner when `.continuum/resume.json` ex
 
 ```
 Interrupted run my-task – resume pending
-  run: continuum resume my-task --json
+  run: continuum --json resume my-task
 ```
 
-Example `resume --json` contract while safe:
+Example `--json resume` contract while safe:
 
 ```json
 {
@@ -137,7 +137,7 @@ Codex does not yet expose a PreCompact-equivalent event. Mirror the Claude Code 
 ```bash
 # append to your agent loop or as a stop hook
 continuum checkpoint my-task --reason "periodic" || true
-continuum resume my-task --json > .continuum/precompact-resume.json
+continuum --json resume my-task > .continuum/precompact-resume.json
 ```
 
 Or use the tiny glue script:
@@ -161,7 +161,7 @@ If you prefer to hand-edit rather than running `hooks install`:
         "hooks": [
           {
             "type": "command",
-            "command": "continuum briefing --json"
+            "command": "continuum --json briefing"
           }
         ]
       }
@@ -213,7 +213,7 @@ store.append_event("my-task", EventType.CONSTRAINT_PINNED, ConstraintPinned(cons
 Check drift on resume:
 
 ```bash
-continuum resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' --json | python -m json.tool | grep pinning_drift -A3
+continuum --json resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' | python -m json.tool | grep pinning_drift -A3
 ```
 
 Non-empty drift is surfaced as informational lines in the resume text and as `pinning_drift` in JSON. It does not block resume, it is the verification layer.
@@ -243,7 +243,7 @@ PY
 
 # SIGKILL simulation: no cleanup runs, ledger stays STARTED
 
-continuum --db /tmp/embed-codex-demo.db resume hardkill-codex --json | python -m json.tool
+continuum --db /tmp/embed-codex-demo.db --json resume hardkill-codex | python -m json.tool
 echo "exit code: $?"
 ```
 
@@ -264,7 +264,7 @@ Expected (real output from this repo, ids vary per run):
 }
 ```
 
-Exit code 20 (`REQUIRES_HUMAN`). After `continuum reconcile` or manual reconcile settling the claim, a fresh `continuum resume hardkill-codex --json` reports `resume` with `safe: true` and exit 0.
+Exit code 20 (`REQUIRES_HUMAN`). After `continuum reconcile` or manual reconcile settling the claim, a fresh `continuum --json resume hardkill-codex` reports `resume` with `safe: true` and exit 0.
 
 Clean-run case (no uncertain actions) stays `resume` / `safe: true` and exit 0, identical to the Claude Code path.
 
@@ -279,7 +279,7 @@ Measured from a fresh `git clone`:
 3. `continuum hooks install codex --with-gate` (1s)
 4. Do work, claim an action, checkpoint (any adapter or raw events)
 5. `kill -9` (instant)
-6. `continuum resume my-task --json` shows `request_human` with reconciliate step when uncertain, `resume` when clean (under 1s)
+6. `continuum --json resume my-task` shows `request_human` with reconciliate step when uncertain, `resume` when clean (under 1s)
 
 Gap list: Codex file writes via `apply_patch` are not hook-traversed and therefore not observed unless routed through `Bash`/`shell`. That is a Codex hook scope limit, not a CONTINUUM missing glue, and the workaround (write via shell) is copy-paste. No gap for Bash-mediated runs. If a future Codex release expands hook traversal, this line becomes stale and should be deleted.
 

--- a/docs/guides/embed-codex.md
+++ b/docs/guides/embed-codex.md
@@ -31,7 +31,7 @@ continuum hooks install codex --with-gate
 
 If the flag is absent the install prints:
 
-```
+```text
 note: 'codex_hooks' was not found in ~/.codex/config.toml; add '[features]
 codex_hooks = true', then restart Codex.
 ```
@@ -58,8 +58,8 @@ Expected entries in `.codex/hooks.json`:
 Manual verification without starting Codex:
 
 ```bash
-continuum briefing --json | python -m json.tool
-continuum resume my-task --json | python -m json.tool
+continuum --json briefing | python -m json.tool
+continuum --json resume my-task | python -m json.tool
 ```
 
 As with Claude Code, `briefing` exits 0 with no output when no interrupted run exists (checked via `.continuum/resume.json` before any DB open), so cold starts stay fast.
@@ -70,9 +70,9 @@ As with Claude Code, `briefing` exits 0 with no output when no interrupted run e
 
 Same behavior as the Claude Code recipe: banner when `.continuum/resume.json` exists, full `RecoveryEngine.assess` otherwise. The banner before compaction looks like:
 
-```
+```text
 Interrupted run my-task – resume pending
-  run: continuum resume my-task --json
+  run: continuum --json resume my-task
 ```
 
 Example `resume --json` contract while safe:
@@ -114,7 +114,7 @@ If you cannot route through Bash, the durability alternative is `continuum obser
 
 With `--with-gate`, Codex shell calls are denied before they fire when unclaimed:
 
-```
+```text
 [!!] deny: slack.notify is gated and has no claim for key notify:O-9
 ```
 
@@ -137,7 +137,7 @@ Codex does not yet expose a PreCompact-equivalent event. Mirror the Claude Code 
 ```bash
 # append to your agent loop or as a stop hook
 continuum checkpoint my-task --reason "periodic" || true
-continuum resume my-task --json > .continuum/precompact-resume.json
+continuum --json resume my-task > .continuum/precompact-resume.json
 ```
 
 Or use the tiny glue script:
@@ -161,7 +161,7 @@ If you prefer to hand-edit rather than running `hooks install`:
         "hooks": [
           {
             "type": "command",
-            "command": "continuum briefing --json"
+            "command": "continuum --json briefing"
           }
         ]
       }
@@ -213,7 +213,7 @@ store.append_event("my-task", EventType.CONSTRAINT_PINNED, ConstraintPinned(cons
 Check drift on resume:
 
 ```bash
-continuum resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' --json | python -m json.tool | grep pinning_drift -A3
+continuum --json resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' | python -m json.tool | grep pinning_drift -A3
 ```
 
 Non-empty drift is surfaced as informational lines in the resume text and as `pinning_drift` in JSON. It does not block resume, it is the verification layer.
@@ -243,7 +243,7 @@ PY
 
 # SIGKILL simulation: no cleanup runs, ledger stays STARTED
 
-continuum --db /tmp/embed-codex-demo.db resume hardkill-codex --json | python -m json.tool
+continuum --db /tmp/embed-codex-demo.db --json resume hardkill-codex | python -m json.tool
 echo "exit code: $?"
 ```
 
@@ -264,7 +264,7 @@ Expected (real output from this repo, ids vary per run):
 }
 ```
 
-Exit code 20 (`REQUIRES_HUMAN`). After `continuum reconcile` or manual reconcile settling the claim, a fresh `continuum resume hardkill-codex --json` reports `resume` with `safe: true` and exit 0.
+Exit code 20 (`REQUIRES_HUMAN`). After `continuum reconcile` or manual reconcile settling the claim, a fresh `continuum --json resume hardkill-codex` reports `resume` with `safe: true` and exit 0.
 
 Clean-run case (no uncertain actions) stays `resume` / `safe: true` and exit 0, identical to the Claude Code path.
 
@@ -279,7 +279,7 @@ Measured from a fresh `git clone`:
 3. `continuum hooks install codex --with-gate` (1s)
 4. Do work, claim an action, checkpoint (any adapter or raw events)
 5. `kill -9` (instant)
-6. `continuum resume my-task --json` shows `request_human` with reconciliate step when uncertain, `resume` when clean (under 1s)
+6. `continuum --json resume my-task` shows `request_human` with reconciliate step when uncertain, `resume` when clean (under 1s)
 
 Gap list: Codex file writes via `apply_patch` are not hook-traversed and therefore not observed unless routed through `Bash`/`shell`. That is a Codex hook scope limit, not a CONTINUUM missing glue, and the workaround (write via shell) is copy-paste. No gap for Bash-mediated runs. If a future Codex release expands hook traversal, this line becomes stale and should be deleted.
 

--- a/docs/guides/risk-policy.md
+++ b/docs/guides/risk-policy.md
@@ -1,0 +1,95 @@
+# Risk policy: teaching recovery which signals matter
+
+Some failures are visible in state (stale evidence, uncertain actions) and some
+arrive as signals from outside: a monitor reporting a latency anomaly, a judge
+flagging a duplicated side effect, a rollout guard crying meltdown. Risk policy
+maps those signal names to recovery modes so the engine weighs them alongside
+everything else, with the most cautious proposal winning regardless of order.
+
+## The moving parts
+
+- `RISK_OBSERVED` events carry `trigger`, `score`, `detail` (plus optional
+  `episode_id` / `step_id`). They are hash-chained and stamped
+  `EXTERNAL_MONITOR`: a witness, never an authority, so a risk signal alone
+  cannot certify a run.
+- `risk-policy.json` (default `.continuum/risk-policy.json`, copy
+  `examples/risk-policy.json` to start) maps trigger names to modes:
+  `replan`, `wait`, `repair_and_resume`, `rollback`, `abort`, `request_human`,
+  or `annotate` for watch-without-action. Unknown triggers and `annotate`
+  propose nothing.
+- At assess time the engine evaluates every recorded trigger against the
+  policy, takes the most severe resulting mode, and names the winning event
+  ids in the contract's `triggering_risks` field.
+- Ingestion is fail-open: a malformed payload returns `False` and is dropped,
+  never blocking the run. Scores default to `0.0`, details truncate at 512
+  chars.
+
+## Try it
+
+```bash
+export DB=/tmp/risk-demo/g.db
+continuum --db $DB start risk-demo --goal "risk walkthrough"
+```
+
+Ingest one signal (in production a monitor posts these; here we post directly):
+
+```bash
+python - <<'EOF'
+from continuum.models import Run
+from continuum.events import EventType
+from continuum.storage import SQLiteStorage
+from continuum.recovery.risk import ingest_risk_json_line
+with SQLiteStorage("/tmp/risk-demo/g.db") as store:
+    print(ingest_risk_json_line(store, "risk-demo", '{"trigger": "meltdown", "score": 0.9}'))
+    print(ingest_risk_json_line(store, "risk-demo", "not json"))
+EOF
+```
+
+```text
+True
+False
+```
+
+Assess the run:
+
+```bash
+continuum --db $DB --json resume risk-demo | python -c \
+  "import json,sys; d = json.load(sys.stdin); print(d['mode'], d['safe'], len(d['contract']['triggering_risks']))"
+```
+
+```text
+rollback False 1
+```
+
+The `meltdown` trigger maps to `rollback` in the default policy, so the run
+proposes rollback and is unsafe to resume hands-free. Garbage ingestion
+returned `False` and changed nothing.
+
+## Writing policy
+
+Copy the example and edit the mapping; unknown trigger names are ignored until
+a signal arrives bearing them, so extra keys are harmless but dead:
+
+```json
+{
+  "loop": "replan",
+  "error_cascade": "wait",
+  "meltdown": "rollback",
+  "governance_decay": "request_human"
+}
+```
+
+A file that is not a JSON object, or a value outside the mode set plus
+`annotate`, fails validation at load. To preview a custom file without
+installing it, load it explicitly (`load_risk_policy(path)`) or point the
+working directory at it; assessment reads `.continuum/risk-policy.json` and
+falls back to the built-in default when absent.
+
+## Rules worth knowing
+
+- Severity decides, not arrival order: of all recorded triggers, the one
+  mapping to the most severe mode wins, and ties accumulate event ids.
+- `annotate` is deliberately silent: it records interest without proposing a
+  mode, for signals you want visible in history but not yet acting.
+- Risk never certifies: a signal can only escalate toward caution, and
+  `EXTERNAL_MONITOR` provenance keeps it from counting as verification.

--- a/docs/guides/risk-policy.md
+++ b/docs/guides/risk-policy.md
@@ -35,8 +35,6 @@ Ingest one signal (in production a monitor posts these; here we post directly):
 
 ```bash
 python - <<'EOF'
-from continuum.models import Run
-from continuum.events import EventType
 from continuum.storage import SQLiteStorage
 from continuum.recovery.risk import ingest_risk_json_line
 with SQLiteStorage("/tmp/risk-demo/g.db") as store:

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -6,7 +6,7 @@ Copy-paste recipes for wiring CONTINUUM into your harness and for consuming it a
 
 - **[Claude Code: SessionStart + PreCompact](claude-code.md)** – three hook entries, all installed by `continuum hooks install claude-code` (PostToolUse `observe`, SessionStart `briefing`, PreCompact `precompact`). Pairs with the instant-detection work in #394 (`.continuum/resume.json` fast path, scoped confirm, slim subset).
 - **[Codex: SessionStart, plus a copy-paste PreCompact (Bash-only)](codex.md)** – two hook entries from `continuum hooks install codex` (PostToolUse `observe`, SessionStart `briefing`), the `[features] codex_hooks = true` flag, Bash-only limitation documented, same hard-kill test as Claude Code. Codex publishes no compaction event, so unlike Claude Code there is no PreCompact hook for the installer to write; that section of the recipe reuses SessionStart and you paste it yourself.
-- **[Bring your own dashboard](control-plane.md)** – poll `continuum resume --json` and `continuum export-evidence` as the verification substrate; your UI owns orchestration, CONTINUUM owns `safe` and the sealed contract.
+- **[Bring your own dashboard](control-plane.md)** – poll `continuum --json resume` and `continuum export-evidence` as the verification substrate; your UI owns orchestration, CONTINUUM owns `safe` and the sealed contract.
 
 ## Adapter funnel
 
@@ -16,11 +16,11 @@ Copy-paste recipes for wiring CONTINUUM into your harness and for consuming it a
 
 - `docs/recipes/` (new, 4 pages, all docs-first, no CLI table overlapping #363)
 - `docs/api/adapters.md`: added four one-paragraph crash-recovery pointers (Generic, LangGraph, LangChain, OpenAI) – 12 lines total, no CLI table
-- No new runtime code; the glue was already on `main` (`continuum hooks install`, `continuum briefing`, `continuum resume --json`, `continuum export-evidence`)
+- No new runtime code; the glue was already on `main` (`continuum hooks install`, `continuum briefing`, `continuum --json resume`, `continuum export-evidence`)
 
 ## How these were tested
 
-Every recipe has a **Hard-kill test** section that is not a mock: it starts a run, claims a side effect, hard-kills the process with `os._exit(9)` mid-action, then in a fresh process runs the hook command (`continuum briefing` or `continuum resume --json`) and asserts `REQUEST_HUMAN` with one uncertain action and `safe:false`. The silent path (no `resume.json`, no active run) is also tested: the hook exits 0 with no output and no DB open. Timings above are wall-clock on a darwin Python 3.13 SSD box, measured with `time`.
+Every recipe has a **Hard-kill test** section that is not a mock: it starts a run, claims a side effect, hard-kills the process with `os._exit(9)` mid-action, then in a fresh process runs the hook command (`continuum briefing` or `continuum --json resume`) and asserts `REQUEST_HUMAN` with one uncertain action and `safe:false`. The silent path (no `resume.json`, no active run) is also tested: the hook exits 0 with no output and no DB open. Timings above are wall-clock on a darwin Python 3.13 SSD box, measured with `time`.
 
 ## Ten-minute metric (honest)
 

--- a/docs/recipes/claude-code.md
+++ b/docs/recipes/claude-code.md
@@ -45,7 +45,7 @@ instead if you want the compaction boundary to report without writing:
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum briefing --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json briefing"
           }
         ]
       }
@@ -67,7 +67,7 @@ For an explicit `resume --json` variant (pairs with #394):
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum resume --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json resume"
           }
         ]
       }
@@ -78,7 +78,7 @@ For an explicit `resume --json` variant (pairs with #394):
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum resume --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json resume"
           }
         ]
       }
@@ -114,7 +114,7 @@ Measured: briefing silent 0.01 ms, resume 0.05 ms with resume.json, well under 1
 
 ## Constraint verification
 
-`continuum resume --json` includes `pins` from `SemanticState`. The PreCompact hook sees the same contract.
+`continuum --json resume` includes `pins` from `SemanticState`. The PreCompact hook sees the same contract.
 
 ## Troubleshooting
 

--- a/docs/recipes/claude-code.md
+++ b/docs/recipes/claude-code.md
@@ -45,7 +45,7 @@ instead if you want the compaction boundary to report without writing:
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum briefing --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json briefing"
           }
         ]
       }
@@ -56,7 +56,7 @@ instead if you want the compaction boundary to report without writing:
 
 Replace `/absolute/path/to/.venv/bin/continuum` with `which continuum`.
 
-For an explicit `resume --json` variant (pairs with #394):
+For an explicit `--json resume` variant (pairs with #394):
 
 ```json
 {
@@ -67,7 +67,7 @@ For an explicit `resume --json` variant (pairs with #394):
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum resume --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json resume"
           }
         ]
       }
@@ -78,7 +78,7 @@ For an explicit `resume --json` variant (pairs with #394):
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum resume --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json resume"
           }
         ]
       }
@@ -114,7 +114,7 @@ Measured: briefing silent 0.01 ms, resume 0.05 ms with resume.json, well under 1
 
 ## Constraint verification
 
-`continuum resume --json` includes `pins` from `SemanticState`. The PreCompact hook sees the same contract.
+`continuum --json resume` includes `pins` from `SemanticState`. The PreCompact hook sees the same contract.
 
 ## Troubleshooting
 

--- a/docs/recipes/codex.md
+++ b/docs/recipes/codex.md
@@ -47,7 +47,7 @@ cat .codex/hooks.json | python -m json.tool
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum resume --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json resume"
           }
         ]
       }

--- a/docs/recovery_walkthrough.md
+++ b/docs/recovery_walkthrough.md
@@ -69,7 +69,9 @@ Next permitted action: reconcile_action:action_0243135b37757b236f1dfd7bf386ec83
 The contract is immutable and hash-chained. Its Phase 1 fields carry the
 decision's justification: `reason` is the threaded rationale and `evidence`
 names what drove it. Whatever resumes this run has one permitted next action,
-and it is the reconciliation, not the retry.
+and it is the reconciliation, not the retry. When outside signals drive the
+verdict, the contract names them in `triggering_risks`; that flow is walked
+through in `docs/guides/risk-policy.md`.
 
 ```
 == 3. the sealed contract explains itself (Phase 1 fields) ==

--- a/docs/research/instant_detection.md
+++ b/docs/research/instant_detection.md
@@ -1,5 +1,7 @@
 # Instant Autonomous Detection
 
+> **Shipped.** Both halves landed and issue #83 is closed. The `SessionStart` briefing hook runs on session start (#394), and `.continuum/resume.json` is precomputed on every checkpoint in `src/continuum/checkpoint/manager.py` (#394 fast path). This note is kept for historical context.
+
 A Claude Code session only acts after the user sends a message, so detection costs a user message plus a model inference plus an MCP round trip. There is no autonomous session start trigger today.
 
 ## Proposal

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,4 +1,4 @@
-/* CONTINUUM — Complete Stylesheet */
+/* CONTINUUM: Complete Stylesheet */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&family=Caveat:wght@400;500;600;700&family=Anton&display=swap');
 
 :root {
@@ -55,7 +55,7 @@ body { background: var(--bg); color: var(--text); font-family: 'Inter', system-u
   overflow: visible;
 }
 
-/* Cloud A — Upper Left: cute cloud with motion */
+/* Cloud A, Upper Left: cute cloud with motion */
 .cloud-a {
   width: 340px;
   height: 140px;
@@ -156,7 +156,7 @@ body { background: var(--bg); color: var(--text); font-family: 'Inter', system-u
   75% { transform: translate(-18px, 12px); }
 }
 
-/* Cloud B — Upper Right */
+/* Cloud B, Upper Right */
 .cloud-b {
   width: 380px;
   height: 150px;
@@ -167,7 +167,7 @@ body { background: var(--bg); color: var(--text); font-family: 'Inter', system-u
   filter: brightness(1.1);
 }
 
-/* Cloud C — Mid Right */
+/* Cloud C, Mid Right */
 .cloud-c {
   width: 280px;
   height: 110px;
@@ -178,7 +178,7 @@ body { background: var(--bg); color: var(--text); font-family: 'Inter', system-u
   filter: brightness(1.1);
 }
 
-/* Cloud D — Lower Left/Mid */
+/* Cloud D, Lower Left/Mid */
 .cloud-d {
   width: 250px;
   height: 105px;
@@ -189,7 +189,7 @@ body { background: var(--bg); color: var(--text); font-family: 'Inter', system-u
   filter: brightness(1.1);
 }
 
-/* Cloud E — Lower Left */
+/* Cloud E, Lower Left */
 .cloud-e {
   width: 280px;
   height: 115px;
@@ -200,7 +200,7 @@ body { background: var(--bg); color: var(--text); font-family: 'Inter', system-u
   filter: brightness(1.1);
 }
 
-/* Cloud F — Upper Left back */
+/* Cloud F, Upper Left back */
 .cloud-f {
   width: 300px;
   height: 120px;

--- a/docs/why-switch.html
+++ b/docs/why-switch.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CONTINUUM — Why Teams Switch</title>
+  <title>CONTINUUM: Why Teams Switch</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&family=Caveat:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/examples/context_compaction.py
+++ b/examples/context_compaction.py
@@ -4,7 +4,7 @@
 
 An agent processes a long sequence of items over many turns. Its context
 window fills up, the platform compacts it, and the full conversation
-history is gone. What survives is CONTINUUM's semantic checkpoint — and
+history is gone. What survives is CONTINUUM's semantic checkpoint, and
 from that alone it reconstructs a bounded recovery context sufficient to
 continue the task.
 
@@ -214,7 +214,7 @@ def simulate_transcript(state: SemanticState) -> str:
         )
         if i % 50 == 0 and i > 0:
             lines.append(
-                f"Assistant: Progress update — {i} papers done. "
+                f"Assistant: Progress update: {i} papers done. "
                 f"Current trend: hypothesis X broadly supported but "
                 f"effect size varies. {state.progress.total - i} remaining."
             )
@@ -254,7 +254,7 @@ def main() -> int:
     say(f"    Checkpoint version: v{checkpoint.version}")
     say()
 
-    heading("2. The context window fills up — platform compacts the transcript")
+    heading("2. The context window fills up; platform compacts the transcript")
     transcript = simulate_transcript(state)
     transcript_chars = len(transcript)
     transcript_tokens = estimate_tokens(transcript)
@@ -263,7 +263,7 @@ def main() -> int:
     say(f"      characters:         {transcript_chars:,}")
     say(f"      est. tokens (heuristic, chars/4): {transcript_tokens:,}")
     say()
-    say("    [compaction occurs — full conversation history is discarded]")
+    say("    [compaction occurs; full conversation history is discarded]")
     say("    [the LLM can no longer see any previous turn, tool call, or reasoning]")
     say()
 
@@ -332,7 +332,7 @@ def main() -> int:
         say("    The semantic checkpoint carried everything that matters;")
         say("    the transcript carried everything that doesn't need to survive.")
     else:
-        say("    RESULT: Recovery blocked — see rationale above.")
+        say("    RESULT: Recovery blocked; see rationale above.")
 
     say()
     say(f"    Database: {db_path}")

--- a/examples/crash_recovery_agent.py
+++ b/examples/crash_recovery_agent.py
@@ -2,7 +2,7 @@
 
     python examples/crash_recovery_agent.py
 
-An agent analysing 1,000 documents is killed mid-run with os._exit(9) —
+An agent analysing 1,000 documents is killed mid-run with os._exit(9):
 no cleanup, no flush. While it is down, the dataset it depends on moves from
 v3 to v4. It restarts and must work out what, if anything, it can trust.
 

--- a/examples/model_switch.py
+++ b/examples/model_switch.py
@@ -214,7 +214,7 @@ def main() -> int:
     say()
 
     heading("2. Model A becomes unavailable")
-    say(f"    [{MODEL_A} API returns 503 — capacity exhausted]")
+    say(f"    [{MODEL_A} API returns 503: capacity exhausted]")
     say("    [The agent must switch models to continue]")
     say()
 
@@ -232,7 +232,7 @@ def main() -> int:
     say(f"    Reason: {outcome_same.report.reason}")
     say()
 
-    heading("4. Recovery with Model B — CONTINUUM detects the switch")
+    heading("4. Recovery with Model B: CONTINUUM detects the switch")
     say(f"    Now validating with expected_model={MODEL_B}...")
     engine = RecoveryEngine(storage)
     decision = engine.assess(
@@ -284,7 +284,7 @@ def main() -> int:
         say("    RESULT: Recovery correctly BLOCKED until Model B revalidates")
         say("    the model-specific assumptions recorded under Model A.")
     else:
-        say("    RESULT: Recovery permitted — but model-specific state is marked")
+        say("    RESULT: Recovery permitted, but model-specific state is marked")
         say("    for review, not silently trusted.")
 
     say()

--- a/references/architecture-spec.md
+++ b/references/architecture-spec.md
@@ -77,12 +77,13 @@ Thin wrappers that translate a framework's native loop into CONTINUUM calls.
 These are optional. An agent can also call the SDK or MCP server directly.
 
 ### 3.3 MCP server (stdio, deny by default)
-A Model Context Protocol server exposing 11 tools. It is read-only by default.
+A Model Context Protocol server exposing 12 tools. It is read-only by default.
 - Read-only tools (3): continuum_validate, continuum_resume,
   continuum_list_actions.
-- Mutating tools (8): continuum_record_progress, continuum_checkpoint,
-  continuum_record_summary, continuum_confirm, continuum_intercept_action,
-  continuum_complete_action, continuum_fail_action, continuum_reconcile_action.
+- Mutating tools (9): continuum_record_progress, continuum_checkpoint,
+  continuum_record_summary, continuum_record_plan, continuum_confirm,
+  continuum_intercept_action, continuum_complete_action, continuum_fail_action,
+  continuum_reconcile_action.
 (Every MCP tool name is prefixed with "continuum_" so it never collides
 with a host tool's own tool names.)
 An auth gate restricts mutating tools to an allowlist. The primary
@@ -264,7 +265,7 @@ Third tier: one large container labeled "CONTINUUM SDK". Inside it, a 3x3 grid:
   Row 2: State Engine, Checkpoint Manager, Environment
   Row 3: Validator, Recovery Engine, Security
   Place a pill at the top-right of the SDK container: "MCP server: deny by
-  default, 11 tools (3 read-only, 8 mutating)".
+  default, 12 tools (3 read-only, 9 mutating)".
 Fourth tier: two boxes side by side: "Durable Storage (SQLite, WAL)" and
   "External Systems (GitHub, email, APIs)".
 Bottom tier: one centered box "Resume (bounded recovery context)".

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -183,11 +183,11 @@ newer than that checkpoint is inverted from the hash-chained evidence log.
 continuum rewind <run_id> --to <checkpoint> [--force] [--dry-run]
 ```
 
-* **Deterministic revert set** — from ``TOOL_COMPLETED`` events, not model judgment.
-* **Digest-verified** — current file digest must match the last observed digest after the checkpoint; on mismatch the file is reported as a conflict and left untouched.
-* **Fail-closed** — external edits since the checkpoint surface as conflicts; nothing is clobbered silently.
-* **Snapshot-backed** — file content for each observed digest is stored under ``.continuum/file-snapshots/<sha256>`` at observation time, so the bytes for any past digest are recoverable. Large or unreadable files (>10 MiB) are reported as unrecoverable.
-* **Validated** — after reverting files, revalidation is run against the rewound world before issuing a resume verdict.
+* **Deterministic revert set**: from ``TOOL_COMPLETED`` events, not model judgment.
+* **Digest-verified**: current file digest must match the last observed digest after the checkpoint; on mismatch the file is reported as a conflict and left untouched.
+* **Fail-closed**: external edits since the checkpoint surface as conflicts; nothing is clobbered silently.
+* **Snapshot-backed**: file content for each observed digest is stored under ``.continuum/file-snapshots/<sha256>`` at observation time, so the bytes for any past digest are recoverable. Large or unreadable files (>10 MiB) are reported as unrecoverable.
+* **Validated**: after reverting files, revalidation is run against the rewound world before issuing a resume verdict.
 
 Untracked-file writes (created after checkpoint) are deleted; tracked-file writes are restored from the snapshot for the digest at checkpoint, or listed as unrecoverable when no snapshot exists.
 

--- a/references/testing.md
+++ b/references/testing.md
@@ -8,13 +8,17 @@ need nothing but this repository; higher levels need the named tool.
 
 ```bash
 pip install -e ".[dev]"
-python -m pytest            # ~1224 passed, 13 skipped in under 30s
-ruff check src tests        # lint
-ruff format --check src tests
-mypy src                    # strict type check
+pytest --tb=short -q --cov=continuum --cov-report=xml --cov-report=term-missing
+ruff check src/ tests/ examples/        # lint
+ruff format --check src/ tests/ examples/
+mypy src/continuum                     # strict type check
 ```
 
-What those 1200+ tests cover without any SDK or network: event-chain
+On the current main branch, collection reports approximately 2,058 tests; the
+exact count and pass/skip totals vary with Python version, platform, optional
+dependencies, and external services.
+
+What those 2,000+ tests cover without any SDK or network: event-chain
 integrity and tamper detection, semantic projection, checkpoint policy and
 restore, ledger claim/dedup/fail/reconcile (including cross-run unscoped
 claims through the action index), validator staleness propagation, recovery

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -3,7 +3,7 @@
 
     python scripts/mcp_smoke.py
 
-Starts the real server as a subprocess and speaks raw JSON-RPC to it — no test
+Starts the real server as a subprocess and speaks raw JSON-RPC to it: no test
 harness, no in-process shortcut. Every frame sent and received is printed as it
 happens, so what you see is the wire, not a summary of it.
 
@@ -79,7 +79,7 @@ class MCPClient:
         env["CONTINUUM_DB"] = db_path
         # Mutating tools deny unlisted callers by default, so the demo grants
         # itself access the same way a real deployment would. Without this the
-        # server is read-only and step 2 onward is refused — which is the
+        # server is read-only and step 2 onward is refused, which is the
         # intended posture for an unconfigured server, not a bug.
         env["CONTINUUM_MCP_ALLOW"] = "mcp-smoke"
         src = Path(__file__).resolve().parents[1] / "src"
@@ -164,7 +164,7 @@ def main() -> int:
         if stale.exists():
             stale.unlink()
 
-    print(paint("CONTINUUM MCP — live stdio smoke test", BOLD))
+    print(paint("CONTINUUM MCP: live stdio smoke test", BOLD))
     print(paint(f"database: {DB_PATH} (fresh)", DIM))
     print(paint(f"server:   {sys.executable} -m continuum.mcp", DIM))
 
@@ -198,7 +198,7 @@ def main() -> int:
             print(paint(f"      [{marker}] {tool['name']}", DIM), flush=True)
 
         # 2 -- checkpoint a fresh run ------------------------------------ #
-        banner("2", "continuum_checkpoint — fresh run")
+        banner("2", "continuum_checkpoint: fresh run")
         payload = client.call_tool(
             "continuum_record_progress",
             {"run_id": run_id, "completed": 0, "total": 10, "goal": "Demo the MCP server live"},
@@ -211,7 +211,7 @@ def main() -> int:
         note(f"checkpoint v{payload.get('version')} sealed", GREEN)
 
         # 3 -- record progress ------------------------------------------- #
-        banner("3", "continuum_record_progress — 1..5 of 10")
+        banner("3", "continuum_record_progress: 1..5 of 10")
         for completed in range(1, 6):
             payload = client.call_tool(
                 "continuum_record_progress",
@@ -220,14 +220,14 @@ def main() -> int:
             show(payload)
 
         # 4 -- intercept an external action ------------------------------ #
-        banner("4", "continuum_intercept_action — first attempt")
+        banner("4", "continuum_intercept_action: first attempt")
         first = client.call_tool(
             "continuum_intercept_action",
             {"run_id": run_id, "action_type": "send_email", "arguments": action_args},
         )
         show(first)
         if first.get("proceed") is True:
-            note("proceed=true — nothing has claimed this action yet", GREEN)
+            note("proceed=true: nothing has claimed this action yet", GREEN)
         else:
             failures.append("first interception should have granted proceed=true")
             note("proceed was not true", RED)
@@ -250,7 +250,7 @@ def main() -> int:
         show(payload)
 
         # 6 -- the same action again ------------------------------------- #
-        banner("6", "continuum_intercept_action — SAME action, again")
+        banner("6", "continuum_intercept_action: SAME action, again")
         note("This is the whole point of the ledger.", "")
         second = client.call_tool(
             "continuum_intercept_action",
@@ -259,7 +259,7 @@ def main() -> int:
         show(second)
 
         if second.get("proceed") is False and second.get("external_id") == "msg_7781":
-            note("proceed=FALSE — the email is NOT sent twice", GREEN)
+            note("proceed=FALSE: the email is NOT sent twice", GREEN)
             note(f"previous result returned instead: {second.get('previous_result')}", GREEN)
         else:
             failures.append("duplicate interception was not refused")
@@ -279,8 +279,8 @@ def main() -> int:
             print(paint(f"    {line}", ""), flush=True)
 
         # Expectation changed when event provenance landed. Everything written
-        # through MCP is tagged EXTERNAL_AGENT — an agent's unverified report
-        # about its own work — so the run is deliberately NOT certified as
+        # through MCP is tagged EXTERNAL_AGENT (an agent's unverified report
+        # about its own work) so the run is deliberately NOT certified as
         # resumable on that basis alone. It previously returned mode=resume,
         # which meant an agent could fabricate progress and have CONTINUUM
         # confirm it was safe to continue. Requiring review is the fix, not a
@@ -289,14 +289,14 @@ def main() -> int:
         mode = decision.get("mode")
         uncertain = decision.get("uncertain_actions") or []
         if mode != "resume" and not uncertain:
-            note(f"mode={mode} — agent-reported state requires review (expected)", GREEN)
+            note(f"mode={mode}: agent-reported state requires review (expected)", GREEN)
             note("no uncertain side effects: the ledger itself is clean", GREEN)
         elif uncertain:
             failures.append(f"unexpected uncertain actions: {uncertain}")
             note(f"uncertain actions outstanding: {uncertain}", RED)
         else:
             failures.append("agent self-reported state was certified as resumable")
-            note(f"mode={mode} — self-reported state should not be 'resume'", RED)
+            note(f"mode={mode}: self-reported state should not be 'resume'", RED)
 
         banner("9", "ledger contents")
         show(client.call_tool("continuum_list_actions", {"run_id": run_id}))

--- a/scripts/session_start_resume.sh
+++ b/scripts/session_start_resume.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # SessionStart hook that runs continuum resume out of band without a model turn.
 # Install as a Claude Code SessionStart hook to make detection instant.
+# Global flags such as --json must precede the subcommand (issue #774).
 set -e
 if command -v continuum >/dev/null 2>&1; then
-  continuum resume --json 2>/dev/null | head -c 2000
+  continuum --json resume 2>/dev/null | head -c 2000
 fi

--- a/src/continuum/__init__.py
+++ b/src/continuum/__init__.py
@@ -1,4 +1,4 @@
-"""CONTINUUM — verifiable semantic recovery layer for long-running AI agents.
+"""CONTINUUM: verifiable semantic recovery layer for long-running AI agents.
 
 Agents that can lose their context without losing their work.
 

--- a/src/continuum/actions/idempotency.py
+++ b/src/continuum/actions/idempotency.py
@@ -4,7 +4,7 @@ An idempotency key answers one question: has this exact operation already been
 performed? Get it wrong in one direction and the agent duplicates a side effect;
 wrong in the other and it refuses to do legitimate new work.
 
-The key is derived from the action type plus its arguments, canonically hashed —
+The key is derived from the action type plus its arguments, canonically hashed,
 so argument order never matters, but a changed value always does.
 
 Volatile arguments
@@ -17,7 +17,7 @@ new action. ``volatile`` names the fields to exclude.
 
 This is a sharp edge, so it is opt-in and explicit. Excluding a field that
 genuinely distinguishes two operations would collapse them into one and silently
-skip real work — the failure mode is quiet, which makes it worse than the noisy
+skip real work. The failure mode is quiet, which makes it worse than the noisy
 one. Nothing is excluded by default.
 """
 

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -16,14 +16,14 @@ The protocol
 
 A crash can land anywhere:
 
-* **before 1** — nothing happened. Retry is safe.
-* **between 1 and 2** — intent recorded, effect may or may not have occurred.
+* **before 1**: nothing happened. Retry is safe.
+* **between 1 and 2**: intent recorded, effect may or may not have occurred.
   On recovery the action is ``STARTED`` with no result: **the effect is of
   unknown status.** The ledger refuses to guess.
-* **between 2 and 3** — the effect definitely happened but was never recorded.
+* **between 2 and 3**: the effect definitely happened but was never recorded.
   Indistinguishable from the previous case *from the ledger alone*, which is
   precisely why it must not be resolved by assumption.
-* **after 3** — fully recorded. A repeat call returns the stored result.
+* **after 3**: fully recorded. A repeat call returns the stored result.
 
 Why not just retry?
 -------------------
@@ -32,7 +32,7 @@ Retrying an unrecorded action is only safe if the operation is naturally
 idempotent. Creating a GitHub issue, charging a card and sending an email are
 not. Retrying duplicates them; skipping may drop them. Neither default is
 correct, so the ledger raises ``UnknownSideEffect`` and requires the caller to
-supply a reconciler — usually a cheap read against the external system that can
+supply a reconciler, usually a cheap read against the external system that can
 answer "did this actually happen?".
 
 This is honest at-least-once with mandatory reconciliation, not exactly-once.
@@ -294,7 +294,7 @@ class ActionOutcome:
     """What a claim returned.
 
     ``fresh`` distinguishes "go ahead and perform this" from "already done,
-    here is the previous result" — the single most important bit for callers.
+    here is the previous result"; the single most important bit for callers.
     """
 
     key: IdempotencyKey
@@ -1100,8 +1100,8 @@ class ActionLedger:
     def fail(self, key: str, error: str, *, certain: bool = True) -> Action:
         """Record that the effect did not happen.
 
-        ``certain=False`` is for failures where the effect may still have landed
-        — a timeout after the request was sent, for instance. Those become
+        ``certain=False`` is for failures where the effect may still have landed,
+        a timeout after the request was sent for instance. Those become
         ``UNKNOWN`` rather than ``FAILED``, because a timeout is not evidence of
         absence.
         """

--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -1104,8 +1104,27 @@ class ActionLedger:
         a timeout after the request was sent for instance. Those become
         ``UNKNOWN`` rather than ``FAILED``, because a timeout is not evidence of
         absence.
+
+        Only in-flight statuses settle here (issue #733). Re-reporting a
+        ``FAILED`` action is allowed, because a caller repeating itself after a
+        dropped response is not asserting anything new. Every other status is
+        refused, mirroring :meth:`complete` (issue #366): a late ``fail`` on a
+        ``COMPLETED`` action used to flip it to ``FAILED`` while its recorded
+        result stayed on the books, which reopened the key and let the next
+        claim re-fire a side effect that had already happened. ``UNKNOWN`` is
+        refused for the same reason ``complete`` refuses it: resolving an
+        uncertain outcome is a correction that needs evidence, which is what
+        :meth:`reconcile` records.
         """
         key, existing = self._require(key)
+        if existing.status not in (ActionStatus.STARTED, ActionStatus.FAILED):
+            raise LedgerError(
+                f"action {existing.action_type!r} is {existing.status.value}, not in flight, so "
+                f"failing it would erase a recorded outcome. If a check confirmed "
+                f"the effect did not happen, call reconcile(occurred=False) "
+                f"(continuum_reconcile_action over MCP), which records the evidence "
+                f"and the note alongside the correction."
+            )
         action = existing.model_copy(
             update={
                 "status": ActionStatus.FAILED if certain else ActionStatus.UNKNOWN,

--- a/src/continuum/actions/reconciliation.py
+++ b/src/continuum/actions/reconciliation.py
@@ -7,7 +7,7 @@ Strategies, and when each is defensible
 ---------------------------------------
 
 ``ProbeReconciler``
-    Ask the external system directly — search for the issue, look up the charge.
+    Ask the external system directly: search for the issue, look up the charge.
     The only strategy that produces evidence. Prefer it wherever a read exists.
 
 ``AssumeNotOccurredReconciler``
@@ -20,7 +20,7 @@ Strategies, and when each is defensible
     operation is not idempotent. Slow, and honest about it.
 
 There is deliberately no ``AssumeOccurred`` strategy. Assuming success without
-evidence silently drops work, and a dropped side effect is invisible — nothing
+evidence silently drops work, and a dropped side effect is invisible: nothing
 in the system will ever contradict it. Optimism is the one default that cannot
 be audited after the fact.
 """
@@ -66,7 +66,7 @@ class Reconciler(ABC):
         """Return a resolution, or ``None`` if this reconciler cannot decide.
 
         Returning ``None`` is a legitimate answer and leaves the action
-        uncertain — better than a confident wrong one.
+        uncertain, which is better than a confident wrong one.
         """
 
 
@@ -75,7 +75,7 @@ class ProbeReconciler(Reconciler):
 
     The probe receives the recorded action and returns a ``Resolution``, or
     ``None`` if it could not find out. A probe that raises is treated as "could
-    not find out" rather than as evidence of absence — an unreachable API tells
+    not find out" rather than as evidence of absence: an unreachable API tells
     you nothing about whether your earlier request landed.
     """
 
@@ -149,7 +149,7 @@ class ReconciliationReport:
         if self.resolved_failed:
             lines.append(f"confirmed as not performed: {', '.join(self.resolved_failed)}")
         if self.unresolved:
-            lines.append(f"STILL UNKNOWN — needs human review: {', '.join(self.unresolved)}")
+            lines.append(f"STILL UNKNOWN (needs human review): {', '.join(self.unresolved)}")
         return "\n".join(lines) or "nothing to reconcile"
 
 

--- a/src/continuum/adapters/generic.py
+++ b/src/continuum/adapters/generic.py
@@ -173,7 +173,7 @@ class GenericAgentAdapter(AgentAdapter):
         call does not prove the side effect failed to occur: a timeout or a
         dropped connection means the request may already have landed. Recording
         it as a definite failure would remove it from ``ledger.pending()``, hide
-        it from reconciliation, and let a later retry duplicate the effect —
+        it from reconciliation, and let a later retry duplicate the effect,
         exactly the hazard the ledger exists to prevent.
 
         There is no exception type in this layer that reliably proves nothing

--- a/src/continuum/adapters/langgraph.py
+++ b/src/continuum/adapters/langgraph.py
@@ -3,7 +3,7 @@
 Integrates CONTINUUM's durability, checkpointing, action ledger, and recovery
 with LangGraph's graph-based agent runtime.
 
-The adapter is optional — ``langgraph`` is not installed by default. Import
+The adapter is optional: ``langgraph`` is not installed by default. Import
 this module only after installing the ``langgraph`` extra.
 
 Usage
@@ -29,15 +29,15 @@ Usage
 Design
 ------
 LangGraph manages its own state via its checkpointer. CONTINUUM's role here is
-to add *semantic durability* — the action ledger prevents duplicate side effects
+to add *semantic durability*: the action ledger prevents duplicate side effects
 across graph invocations, and the recovery engine validates that resumed state
 is still consistent with the environment.
 
 The adapter does NOT replace LangGraph's checkpointer. The two serve different
 purposes:
 
-* **LangGraph checkpointer** — full state snapshots for graph resumption.
-* **CONTINUUM** — verified semantic state with environment validation and
+* **LangGraph checkpointer**: full state snapshots for graph resumption.
+* **CONTINUUM**: verified semantic state with environment validation and
   exactly-once side effect guarantees.
 """
 
@@ -192,8 +192,8 @@ class LangGraphAgentAdapter(GenericAgentAdapter):
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Decorator that wraps a LangGraph tool with action ledger interception.
 
-        The wrapped function will be idempotent across graph invocations —
-        if the action already completed, the cached result is returned without
+        The wrapped function will be idempotent across graph invocations. If
+        the action already completed, the cached result is returned without
         re-executing the tool.
 
         Parameters
@@ -268,7 +268,7 @@ class LangGraphAgentAdapter(GenericAgentAdapter):
 
         Add this node to your graph at points where you want durable semantic
         state. It reads the run ID from state, projects semantic state, and
-        writes a checkpoint — then returns state unchanged so the graph can
+        writes a checkpoint, then returns state unchanged so the graph can
         continue.
 
         Parameters
@@ -280,7 +280,7 @@ class LangGraphAgentAdapter(GenericAgentAdapter):
         Returns
         -------
         dict
-            State updates (empty dict — this node is side-effect only on
+            State updates (empty dict, since this node is side-effect only on
             CONTINUUM's storage).
 
         Example

--- a/src/continuum/adapters/openai.py
+++ b/src/continuum/adapters/openai.py
@@ -3,7 +3,7 @@
 Integrates CONTINUUM's durability, checkpointing, action ledger, and recovery
 with the OpenAI Agents SDK (``openai-agents`` package).
 
-The adapter is optional — ``openai-agents`` is not installed by default. Import
+The adapter is optional: ``openai-agents`` is not installed by default. Import
 this module only after installing the ``openai`` extra.
 
 Usage
@@ -37,10 +37,10 @@ Usage
 Design
 ------
 The OpenAI Agents SDK uses:
-- **ToolContext** (auto-injected) — we use it to carry run metadata
-- **RunHooks** — lifecycle callbacks we implement for checkpointing
-- **RunContextWrapper.context** — our custom ``ContinuumContext`` carries the run ID
-- **function_tool** — we wrap these with action ledger interception
+- **ToolContext** (auto-injected): we use it to carry run metadata
+- **RunHooks**: lifecycle callbacks we implement for checkpointing
+- **RunContextWrapper.context**: our custom ``ContinuumContext`` carries the run ID
+- **function_tool**: we wrap these with action ledger interception
 
 CONTINUUM does NOT replace the SDK's session/compaction mechanisms. It adds:
 - Idempotent side effects via the action ledger

--- a/src/continuum/checkpoint/context.py
+++ b/src/continuum/checkpoint/context.py
@@ -1,6 +1,6 @@
 """Bounded recovery context.
 
-When an agent resumes, it needs to be told what it was doing — but handing it
+When an agent resumes, it needs to be told what it was doing, but handing it
 the transcript defeats the purpose. This module renders the *minimum sufficient
 context*: what the goal is, what is verified, what is no longer trustworthy, and
 what it is allowed to do next.
@@ -52,7 +52,7 @@ _NEVER_DROPPED = frozenset(
     {
         "CURRENT GOAL",
         "VERIFIED PROGRESS",
-        "STALE STATE — DO NOT RELY ON",
+        "STALE STATE: DO NOT RELY ON",
     }
 )
 
@@ -184,7 +184,7 @@ def _stale_section(state: SemanticState) -> ContextSection:
     if dangling:
         lines.append(f"evidence cited but unavailable: {', '.join(dangling)}")
 
-    return ContextSection("STALE STATE — DO NOT RELY ON", tuple(lines), priority=2)
+    return ContextSection("STALE STATE: DO NOT RELY ON", tuple(lines), priority=2)
 
 
 def _review_section(state: SemanticState) -> ContextSection:

--- a/src/continuum/checkpoint/manager.py
+++ b/src/continuum/checkpoint/manager.py
@@ -7,11 +7,11 @@ integrity hash makes it the unit recovery trusts.
 Ordering matters here. The manager writes the version, then the checkpoint,
 then records ``STATE_CHECKPOINTED``. If the process dies partway:
 
-* died before the version was written — nothing is lost; the state is still
+* died before the version was written: nothing is lost; the state is still
   derivable from the events.
-* died after the version but before the checkpoint — a version exists with no
+* died after the version but before the checkpoint: a version exists with no
   checkpoint. Harmless: the next checkpoint reuses it.
-* died after the checkpoint but before the event — the checkpoint exists and is
+* died after the checkpoint but before the event: the checkpoint exists and is
   valid; the log simply lacks the annotation. ``restore`` reads checkpoints, not
   the annotation, so recovery is unaffected.
 
@@ -62,7 +62,7 @@ class RestoredRun:
     """What recovery gets back: verified state plus how stale it is.
 
     ``pending_events`` is the gap between the checkpoint and the end of the
-    log — work that happened after the last checkpoint. It is replayed onto the
+    log: work that happened after the last checkpoint. It is replayed onto the
     checkpoint rather than ignored, so a crash between checkpoints does not
     discard the work in between.
     """

--- a/src/continuum/checkpoint/policy.py
+++ b/src/continuum/checkpoint/policy.py
@@ -4,7 +4,7 @@ Checkpointing every turn is the obvious design and the wrong one: it costs an
 fsync per step and fills history with versions that mean nothing. Checkpointing
 too rarely loses work. A policy decides.
 
-Policies answer one question — ``should_checkpoint(...) -> Decision`` — and are
+Policies answer one question (``should_checkpoint(...) -> Decision``) and are
 pure: same inputs, same answer, no clock reads hidden inside except the one
 passed in. That makes checkpoint timing testable instead of a source of
 flakiness.
@@ -166,7 +166,7 @@ class IntervalPolicy(CheckpointPolicy):
 class EventPolicy(CheckpointPolicy):
     """Checkpoint when particular event types appear.
 
-    Defaults to side effects and milestones — the events whose loss actually
+    Defaults to side effects and milestones, the events whose loss actually
     costs something.
     """
 
@@ -203,8 +203,8 @@ class SemanticPolicy(CheckpointPolicy):
 
     Progress alone does not qualify unless it crosses a stride: counting from
     3,400 to 3,401 is not worth an fsync, but losing 500 documents of work is.
-    Structural changes — a new or invalidated decision, a new finding, a changed
-    dependency, an approval, a model switch — always qualify, because they
+    Structural changes (a new or invalidated decision, a new finding, a changed
+    dependency, an approval, a model switch) always qualify, because they
     change what the agent is allowed to do next.
     """
 

--- a/src/continuum/cli/colour.py
+++ b/src/continuum/cli/colour.py
@@ -1,7 +1,7 @@
 """Terminal colour, applied only when it is safe to do so.
 
 Colour is presentation. It must never change *what* the CLI says, only how it
-looks — so this module wraps text in ANSI codes and nothing else. Exit codes,
+looks, so this module wraps text in ANSI codes and nothing else. Exit codes,
 JSON payloads and the wording of every line are untouched.
 
 When colour is suppressed

--- a/src/continuum/cli/exitcodes.py
+++ b/src/continuum/cli/exitcodes.py
@@ -7,7 +7,7 @@ A recovery tool is most often invoked from automation::
 If the exit code did not reflect whether resuming is *safe*, that line would
 launch an agent onto stale state or an unreconciled side effect. So the rule is
 absolute: **only a fully verified, safe-to-resume run exits 0.** Every other
-outcome — repairable, uncertain, blocked, missing, corrupted — is non-zero, and
+outcome (repairable, uncertain, blocked, missing, corrupted) is non-zero, and
 the `&&` short-circuits.
 
 Distinct codes let a script react proportionately (retry a repair, page a human
@@ -44,7 +44,7 @@ class ExitCode:
     """State is recoverable but must be repaired first."""
 
     REQUIRES_HUMAN = 20
-    """A person must decide — typically an unreconciled side effect."""
+    """A person must decide, typically an unreconciled side effect."""
 
     UNSAFE = 30
     """Resuming is not safe at all."""

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -4028,6 +4028,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="bind address (default: 127.0.0.1; 0.0.0.0 exposes recovery data).",
     )
 
+    def cmd_tui(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+        """Open the full-screen terminal dashboard (issue #782), q quits.
+
+        Read-only until an action is confirmed: browsing and refreshing never
+        write, and every mutating verb shows its exact write in the footer and
+        waits for a further y before performing it. Refuses rather than
+        half-rendering when curses is unavailable or stdout is not a TTY.
+        """
+        from continuum.tui import run_tui
+
+        return run_tui(storage, refresh_seconds=args.refresh, err=err)
+
+    tui = add(
+        "tui",
+        cmd_tui,
+        "Full-screen terminal dashboard: monitor and control runs (q quits).",
+    )
+    tui.add_argument(
+        "--refresh",
+        type=float,
+        default=0.0,
+        help="auto-refresh interval in seconds (default: 0, refresh on demand with r).",
+    )
+
     watch = with_run(
         add("watch", cmd_watch, "Watch a run for liveness breach, optionally notify via webhook.")
     )
@@ -4059,6 +4083,48 @@ def build_parser() -> argparse.ArgumentParser:
 # --------------------------------------------------------------------------- #
 
 
+def _bare_invocation(
+    parser: argparse.ArgumentParser, args: argparse.Namespace, out: Any, err: Any
+) -> int:
+    """`continuum` with no subcommand: open the TUI, or print help.
+
+    The interactive path is what an operator typing bare `continuum` at a
+    shell expects (issue #782): the full-screen dashboard with its landing
+    splash. Piped output, `--json` and platforms without curses keep the
+    help text unchanged: a script that runs `continuum` blind must never
+    find a curses screen where it expected usage text.
+    """
+    interactive = not args.json and _stream_is_a_tty(out) and _curses_available()
+    if not interactive:
+        parser.print_help(file=out)
+        return ExitCode.OK
+    from continuum.tui import run_tui
+
+    try:
+        storage = open_storage(args.db)
+    except (StorageError, ValueError, NotImplementedError, RuntimeError) as exc:
+        print(f"error: {exc}", file=err)
+        return ExitCode.ERROR
+    except sqlite3.Error as exc:
+        print(f"error: cannot open storage at '{args.db}': {exc}", file=err)
+        return ExitCode.ERROR
+    try:
+        return run_tui(storage, err=err)
+    finally:
+        storage.close()
+
+
+def _stream_is_a_tty(out: Any) -> bool:
+    isatty = getattr(out, "isatty", None)
+    return callable(isatty) and bool(isatty())
+
+
+def _curses_available() -> bool:
+    from importlib.util import find_spec
+
+    return find_spec("curses") is not None
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
@@ -4079,8 +4145,7 @@ def main(
         Palette(False) if args.json else Palette.for_stream(out, force=getattr(args, "color", None))
     )
     if getattr(args, "func", None) is None:
-        parser.print_help(file=out)
-        return ExitCode.OK
+        return _bare_invocation(parser, args, out, err)
 
     # hooks never touches a run, so it must not create an empty database as a
     # side effect of editing a settings file.

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1225,7 +1225,16 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
     text = decision.render()
     if family_blocked and decision.mode.value == "resume":
         # House rule: the most cautious signal wins (#243). A clean parent
-        # with an unsafe child is presented as request_human.
+        # with an unsafe child is presented as request_human on every surface:
+        # this text, the JSON payload and the exit code. The engine's per-run
+        # verdict stays visible in the rationale, but it must not read as
+        # permission to continue (issue #741).
+        text = text.replace(
+            "Recovery decision: RESUME", "Recovery decision: REQUEST_HUMAN"
+        ).replace(
+            "Next permitted action: continue",
+            "Next permitted action: none (settle the children below first)",
+        )
         text += "\n\nFAMILY BLOCKED: children of this run are not resumable.\n" + "\n".join(
             f"  !! {r}" for r in family_rationale
         )
@@ -1259,12 +1268,18 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             print(f"error: --pinning: {exc}", file=err)
             return ExitCode.ERROR
 
-    presented_mode = (
-        "request_human"
-        if (family_blocked and decision.mode.value == "resume")
-        else decision.mode.value
+    # The same house rule, as a mode: what the exit code and the JSON report.
+    # Following the engine's per-run mode here let `resume "$PARENT" &&
+    # ./start-agent.sh` exit 0 onto a family holding an unreconciled side
+    # effect, breaking the only-a-verified-safe-run-exits-0 contract
+    # (issue #741).
+    effective_mode = (
+        RecoveryMode.REQUEST_HUMAN
+        if (family_blocked and decision.mode is RecoveryMode.RESUME)
+        else decision.mode
     )
-    presented_safe = decision.safe and not (family_blocked and decision.mode.value == "resume")
+    presented_mode = effective_mode.value
+    presented_safe = decision.safe and effective_mode is decision.mode
     # Advisory prefix-trust (issue #401): deterministic, read-only, never gates.
     try:
         from continuum.analysis.prefix_trust import trust_over_prefix
@@ -1311,7 +1326,7 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         palette=getattr(args, "_palette", None),
     )
 
-    if decision.mode is not RecoveryMode.RESUME and not args.repair:
+    if effective_mode is not RecoveryMode.RESUME and not args.repair:
         print(
             "\nRun with --repair to record the repair plan, or resolve the items above first.",
             file=err,
@@ -1339,7 +1354,7 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             file=err,
         )
 
-    return exit_code_for(decision.mode)
+    return exit_code_for(effective_mode)
 
 
 def cmd_confirm(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1408,7 +1408,10 @@ def cmd_budget(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         print(f"error: budget registry invalid: {exc}", file=err)
         return ExitCode.ERROR
 
-    events = storage.read_events(args.run_id)
+    # Archive-aware (issue #734): compaction moves attempts into the archive,
+    # so a live-tail-only count understates attempts and overstates remaining
+    # after every compaction.
+    events = storage.read_all_events(args.run_id)
     types_seen = sorted(
         {
             e.payload.get("action", {}).get("action_type")

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -103,7 +103,7 @@ def _colourise(text: str, palette: Palette) -> str:
     Deliberately a post-processing pass rather than colour woven through every
     command: the text is produced once, identically, and this only decides how
     it looks. It cannot alter wording, ordering or exit codes, because it never
-    sees them — and when colour is off it returns the string untouched.
+    sees them; and when colour is off it returns the string untouched.
     """
     if not palette.enabled:
         return text
@@ -175,7 +175,7 @@ def _environment(args: argparse.Namespace, run_id: str) -> EnvironmentSnapshot |
     """Build a snapshot from ``--env name=version`` pairs.
 
     Returns ``None`` when nothing was supplied, which the validator treats as
-    "unverified" rather than "unchanged" — omitting the flag must not look like
+    "unverified" rather than "unchanged": omitting the flag must not look like
     a clean environment.
     """
     pairs: list[str] = list(getattr(args, "env", None) or [])
@@ -2910,7 +2910,7 @@ def cmd_verify(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         text = f"Event chain verified: {report.checked} events, no violations."
     else:
         lines = [f"INTEGRITY FAILURE: {len(report.violations)} violation(s)"]
-        lines += [f"  seq {v.sequence}: {v.kind} — {v.detail}" for v in report.violations[:20]]
+        lines += [f"  seq {v.sequence}: {v.kind}: {v.detail}" for v in report.violations[:20]]
         if len(report.violations) > 20:
             lines.append(
                 f"... and {len(report.violations) - 20} more violation(s) omitted, see --json for full list"
@@ -3037,7 +3037,7 @@ def cmd_actions(args: argparse.Namespace, storage: Storage, out: Any, err: Any) 
     if uncertain:
         lines.append("")
         lines.append(
-            f"{len(uncertain)} action(s) with unresolved outcomes — reconcile before resuming."
+            f"{len(uncertain)} action(s) with unresolved outcomes: reconcile before resuming."
         )
     _emit(
         {"actions": payload},
@@ -3305,7 +3305,7 @@ def _verify_against_stored(run_id: str, storage: Storage) -> tuple[bool | None, 
     """Re-derive the stored version's own prefix and check it still projects to it.
 
     Returns (verified, human description). ``None`` means the comparison was not
-    attempted, which is reported rather than quietly counted as a pass — a
+    attempted, which is reported rather than quietly counted as a pass; a
     silent no-op that looks like a check is the bug this replaces.
 
     The prefix matters. A stored version is the projection of events up to its
@@ -3452,9 +3452,9 @@ def cmd_attest_verify(args: argparse.Namespace, storage: Storage, out: Any, err:
     """Verify a signed attestation against the run's live event chain.
 
     Three outcomes:
-      SIGNED    — signature valid and the live chain still matches the signed point.
-      ALTERED   — signature valid but the chain changed after signing.
-      UNTRUSTED — the signature does not verify against the embedded public key.
+      SIGNED    : signature valid and the live chain still matches the signed point.
+      ALTERED   : signature valid but the chain changed after signing.
+      UNTRUSTED : the signature does not verify against the embedded public key.
     """
     storage.get_run(args.run_id)
     doc = json.loads(Path(args.attest).read_text(encoding="utf-8"))

--- a/src/continuum/environment/diff.py
+++ b/src/continuum/environment/diff.py
@@ -159,6 +159,8 @@ def diff_environments(
             reason = str(
                 current.metadata.get("error")
                 or previous.metadata.get("error")
+                or current.metadata.get("skipped")
+                or previous.metadata.get("skipped")
                 or "resource could not be inspected"
             )
             deltas.append(

--- a/src/continuum/environment/diff.py
+++ b/src/continuum/environment/diff.py
@@ -8,7 +8,7 @@ because they demand different responses:
 ``UNKNOWN``    we could not tell
 
 ``UNKNOWN`` is not a softer ``UNCHANGED``. A resource that could not be
-inspected — an API that timed out, a file that is now unreadable — must not be
+inspected (an API that timed out, a file that is now unreadable) must not be
 treated as intact just because nothing contradicted it. Recovery downgrades on
 uncertainty rather than assuming the best.
 """

--- a/src/continuum/environment/snapshot.py
+++ b/src/continuum/environment/snapshot.py
@@ -4,13 +4,13 @@ A checkpoint is only meaningful relative to an environment. "3,421 documents
 analysed" means nothing if the dataset was replaced afterwards. The snapshot is
 the fingerprint recovery compares against.
 
-Providers are pluggable because environments differ wildly — files, datasets,
+Providers are pluggable because environments differ wildly: files, datasets,
 git commits, API sessions, permissions. Each provider answers one question:
 *what does this resource look like right now?* CONTINUUM ships providers that
 need nothing but the standard library.
 
 Capture failures are recorded, not raised. If a resource cannot be inspected at
-recovery time — the API is down, the file is unreadable — that is itself a
+recovery time (the API is down, the file is unreadable), that is itself a
 finding: the resource becomes ``UNKNOWN`` rather than silently ``VALID``. An
 environment check that fails open would defeat the purpose of checking.
 """

--- a/src/continuum/environment/snapshot.py
+++ b/src/continuum/environment/snapshot.py
@@ -125,10 +125,15 @@ class FileProvider(EnvironmentProvider):
             try:
                 stat = path.stat()
                 if self.max_bytes is not None and stat.st_size > self.max_bytes:
+                    # UNKNOWN_VERSION, not a synthetic "size:<n>" stamp: a size
+                    # is not an identity, but diff_environments compared the old
+                    # stamp as one, so a replaced file of the same byte size
+                    # verified as unchanged and the environment check failed
+                    # open (issue #738). The size stays in metadata.
                     captured[key] = EnvResource(
                         name=key,
                         kind="file",
-                        version=f"size:{stat.st_size}",
+                        version=UNKNOWN_VERSION,
                         metadata={"skipped": "larger than max_bytes", "size": stat.st_size},
                     )
                     continue

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -196,7 +196,7 @@ class Event(BaseModel):
     Included in ``content()`` deliberately. A trust marker outside the hash
     could be edited without breaking verification, which would make it useless
     for the one job it has. The cost is that chains written before this field
-    existed no longer verify — accepted as a clean break rather than carrying a
+    existed no longer verify, accepted as a clean break rather than carrying a
     permanently-untrusted legacy tier.
     """
 
@@ -371,7 +371,7 @@ class EventLog:
         so an edited event is reported twice: ``TAMPERED_CONTENT`` on the event
         itself and ``BROKEN_CHAIN`` on its successor, whose link no longer
         matches. The walk then re-syncs, because untampered events remain
-        internally consistent — so the violation list localises damage instead
+        internally consistent, so the violation list localises damage instead
         of flooding.
 
         Trust is expressed separately by ``trusted_through``: only the prefix

--- a/src/continuum/mcp/authz.py
+++ b/src/continuum/mcp/authz.py
@@ -1,8 +1,8 @@
 """Which MCP callers may change a run.
 
 The problem this solves is coexistence, not intrusion. Several agents can be
-configured against the same database at once — Kilo, Gemini CLI and Claude Code
-have all pointed at this project's ``continuum.db`` simultaneously — and until
+configured against the same database at once (Kilo, Gemini CLI and Claude Code
+have all pointed at this project's ``continuum.db`` simultaneously), and until
 now any of them could overwrite another's progress, checkpoint over its state,
 or claim its actions. This layer keeps honestly-named agents out of each other's
 runs.
@@ -73,7 +73,7 @@ POLICY_ENV_VAR = "CONTINUUM_MCP_ALLOW"
 
 #: Alias for ``POLICY_ENV_VAR``, preserved from the closed PR #3. The longer
 #: name states what is being allowed rather than leaving it to be inferred, so
-#: it wins when both are set — a reader who followed that PR's history will
+#: it wins when both are set: a reader who followed that PR's history will
 #: reach for it first, and silently preferring the vaguer name would surprise
 #: them. Same precedence position: an alias, not an extra config source.
 POLICY_ENV_VAR_ALIAS = "CONTINUUM_MCP_MUTATING_CLIENTS"
@@ -327,7 +327,7 @@ class AuthorizationPolicy:
     """Decides whether a named caller may invoke a mutating tool.
 
     Deny by default. An unlisted caller is not a caller we have decided to
-    trust — it is one nobody has made a decision about, and treating an absent
+    trust. It is one nobody has made a decision about, and treating an absent
     decision as approval is how the whole point of the layer gets lost. This
     mirrors the validator's stance elsewhere in CONTINUUM: uncertainty degrades
     rather than resolving in its own favour.
@@ -446,8 +446,8 @@ def caller_name(context: Any) -> str | None:
     """Extract the client's declared name from an MCP request context.
 
     Read from the initialize handshake, which the transport injects server-side.
-    A caller cannot override it by passing ``clientInfo`` in tool arguments —
-    verified by test. It is still only what the client *claims* to be.
+    A caller cannot override it by passing ``clientInfo`` in tool arguments
+    (verified by test). It is still only what the client *claims* to be.
     """
     if context is None:
         return None

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -28,7 +28,7 @@ behaviour, not a leak.
 The optional dependency
 -----------------------
 
-The ``mcp`` SDK is an optional extra, but ``pip install continuum`` installs
+The ``mcp`` SDK is an optional extra, but ``pip install continuum-agent`` installs
 the ``continuum-mcp`` console script regardless. So the entry point exists in
 environments where its dependency does not, and importing the SDK at module
 scope makes that combination fail with a bare ``ModuleNotFoundError``.
@@ -1609,7 +1609,7 @@ def main(argv: list[str] | None = None) -> int:
             raise
         print(
             f"error: the MCP server needs the optional 'mcp' dependency, which is "
-            f"not importable ({exc}). Install it with: pip install 'continuum[mcp]'",
+            f"not importable ({exc}). Install it with: pip install continuum-agent[mcp]",
             file=sys.stderr,
         )
         return 1

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -12,14 +12,14 @@ The action-interception split
 -----------------------------
 
 ``continuum_intercept_action`` cannot execute the side effect itself: a Python
-callable does not cross the MCP boundary. So the protocol is two calls —
+callable does not cross the MCP boundary. So the protocol is two calls:
 
 1. ``continuum_intercept_action`` claims the action and answers *may I?*
 2. the caller performs the effect, then reports back with
    ``continuum_complete_action`` (or ``continuum_fail_action``)
 
 That split matters. Between the two calls the ledger holds a ``STARTED``
-record, so a crash in the gap is indistinguishable from a completed effect —
+record, so a crash in the gap is indistinguishable from a completed effect,
 which is exactly the state the ledger is designed to surface rather than
 paper over. A caller that never reports back leaves the action uncertain, and
 recovery will refuse to resume until it is reconciled. That is the intended
@@ -144,7 +144,7 @@ def _open_server_storage(database: str) -> SQLiteStorage:
 
     ``<db>-wal`` is not reconstructable. It holds transactions that were
     committed but not yet checkpointed into the main database, which for a
-    write-heavy run can be the entire history — deleting it turns durable work
+    write-heavy run can be the entire history; deleting it turns durable work
     into silent loss, and an emptied database still verifies as an intact chain.
     So it is moved aside rather than unlinked: the server comes up, and the
     committed data remains on disk for recovery instead of being destroyed. If
@@ -400,7 +400,7 @@ def _environment(run_id: str, env: Mapping[str, str] | None) -> EnvironmentSnaps
     """Build a snapshot from a ``{name: version}`` mapping.
 
     Returns ``None`` when nothing was supplied. The validator treats that as
-    *unverified*, not *unchanged* — omitting the environment must never look
+    *unverified*, not *unchanged*: omitting the environment must never look
     like having checked it and found nothing wrong.
     """
     if not env:
@@ -417,7 +417,7 @@ def _declare_dependencies(ctx: ContinuumMCP, run_id: str, env: Mapping[str, str]
     Capturing a snapshot is not enough to make drift matter. The validator
     decides staleness per ``external_dependencies`` entry and returns early when
     a state has none, so a checkpoint carrying only a snapshot produces a
-    visible environment diff that invalidates nothing — the run reports
+    visible environment diff that invalidates nothing; the run reports
     ``safe_to_resume`` while the dataset underneath it has moved. Declaring each
     resource the agent pinned is what gives the diff something to invalidate,
     and what lets staleness propagate to the evidence resting on it.
@@ -426,7 +426,7 @@ def _declare_dependencies(ctx: ContinuumMCP, run_id: str, env: Mapping[str, str]
     the log is the durable record, so the declaration survives later projections
     and restores, is covered by the hash chain, and carries the same
     ``EXTERNAL_AGENT`` provenance as everything else this server writes. That
-    provenance does not weaken the check — unlike goal and progress, a
+    provenance does not weaken the check: unlike goal and progress, a
     dependency's status comes from comparing two snapshots rather than from
     trusting the claim, so the *comparison* stays independent of the agent that
     named the resource.
@@ -472,8 +472,8 @@ class ContinuumMCP:
 
         The run row and the ``RUN_STARTED`` event are separate facts: a row can
         exist without the event when the run was created directly through the
-        storage API. Projection needs the event — without it, folding the log
-        fails with "the log never recorded RUN_STARTED" — so it is backfilled
+        storage API. Projection needs the event; without it, folding the log
+        fails with "the log never recorded RUN_STARTED", so it is backfilled
         when the log is empty.
 
         ``RUN_STARTED`` must be the *first* event, and this checks for exactly
@@ -485,7 +485,7 @@ class ContinuumMCP:
         A non-empty log whose first event is not ``RUN_STARTED`` raises instead
         of backfilling. Appending it at that point would place the run's start
         *after* events that supposedly preceded it, and any state projected
-        from that log would be quietly wrong — a worse outcome than an error
+        from that log would be quietly wrong, a worse outcome than an error
         naming the problem.
         """
         try:
@@ -530,7 +530,7 @@ def build_server(
 
     ``policy`` decides which callers may use mutating tools. Omitted, it is
     resolved from the environment and then the project policy file, falling
-    back to denying every mutation — an unconfigured server is read-only.
+    back to denying every mutation: an unconfigured server is read-only.
 
     ``auth`` verifies a shared secret before any mutating tool runs. Omitted,
     it is resolved from ``CONTINUUM_MCP_TOKEN`` and is disabled when that is
@@ -608,7 +608,7 @@ def build_server(
         tool carries this.
 
         The check runs before the handler body, so a refused call writes
-        nothing — the denial precedes the side effect rather than following it.
+        nothing; the denial precedes the side effect rather than following it.
         """
 
         @functools.wraps(fn)
@@ -623,7 +623,7 @@ def build_server(
                 return fn(*args, **kwargs)
 
         # The SDK locates the context parameter via get_type_hints(), and
-        # functools.wraps copies the *wrapped* function's annotations — which
+        # functools.wraps copies the *wrapped* function's annotations, which
         # have no `ctx`. Re-advertise it in both the annotations and the
         # signature, or the guard is never handed a context and every caller
         # looks unidentified.
@@ -684,7 +684,7 @@ def build_server(
         description=(
             "Record how far through a task you are. Call this as you complete units "
             "of work so progress survives a crash. Creates the run on first call if "
-            "'goal' is given. Cheap — call it often."
+            "'goal' is given. Cheap: call it often."
         ),
         annotations=mutating,
     )
@@ -938,7 +938,7 @@ def build_server(
         description=(
             "Check whether saved state is still trustworthy, without changing "
             "anything. Pass 'env' as {resource: version} to declare what the world "
-            "looks like now — a dependency that moved since the checkpoint "
+            "looks like now; a dependency that moved since the checkpoint "
             "invalidates the findings built on it. Read-only: safe to call anytime."
         ),
         annotations=read_only,
@@ -1194,7 +1194,7 @@ def build_server(
             "Ask permission before performing an external side effect (creating an "
             "issue, sending a message, charging a card). Returns proceed=true if you "
             "should do it, or proceed=false with the previous result if it was "
-            "already done — do NOT repeat it in that case. If a previous attempt was "
+            "already done; do NOT repeat it in that case. If a previous attempt was "
             "interrupted, returns proceed=false with status='unknown': the effect may "
             "or may or may not have happened, so stop and ask a human. After performing the "
             "action, always call continuum_complete_action.\n\n"
@@ -1419,7 +1419,7 @@ def build_server(
         description=(
             "Report that an intercepted action failed. Set certain=true only if you "
             "know nothing happened (e.g. the request was rejected before it was "
-            "sent). For timeouts or dropped connections leave certain=false — the "
+            "sent). For timeouts or dropped connections leave certain=false: the "
             "effect may still have landed, and treating it as failed could cause a "
             "duplicate."
         ),
@@ -1449,7 +1449,7 @@ def build_server(
             "Settle an action whose outcome was unknown, after checking the external "
             "system. occurred=true records it as done (never repeated); "
             "occurred=false frees it to be retried. Only call this with real "
-            "evidence — guessing here causes either a duplicate or lost work.\n\n"
+            "evidence; guessing here causes either a duplicate or lost work.\n\n"
             "'action_key' accepts either the action_key from continuum_intercept_action "
             "or the action_id that continuum_resume and continuum_list_actions report, "
             "so the identifier named in next_allowed_action can be passed as-is."
@@ -1526,7 +1526,7 @@ def build_server(
                         # been *escalated* to UNKNOWN. An action still STARTED
                         # because the process died mid-flight has not been
                         # escalated yet, so the flag reads false while the
-                        # outcome is in fact unresolved — which is what a
+                        # outcome is in fact unresolved, which is what a
                         # recovering caller needs to see per row, not just in
                         # the aggregate count.
                         "outcome_unresolved": a.action_id in unresolved,

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -1276,7 +1276,10 @@ def build_server(
         )
 
         if not settled:
-            events = ctx.storage.read_events(run_id)
+            # Archive-aware (issue #734): attempts live in the event log, and
+            # compaction moves failed attempts into the archive. Counting only
+            # the live tail reset an exhausted budget after every compaction.
+            events = ctx.storage.read_all_events(run_id)
             # Counted per key, so the budget caps retries of *this* operation
             # rather than the run's distinct work of this type (issue #368).
             claim_key = str(

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -513,7 +513,9 @@ class ContinuumMCP:
         return run
 
     def ledger(self, run_id: str) -> ActionLedger:
-        return ActionLedger(self.storage, run_id)
+        # Remote agents report their own work, so their ledger writes carry
+        # EXTERNAL_AGENT like everything else this server writes (issue #653).
+        return ActionLedger(self.storage, run_id, source=AGENT_SOURCE)
 
 
 def build_server(

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -144,6 +144,7 @@ class Component(StrEnum):
     MODEL = "model"
     APPROVAL = "approval"
     ENVIRONMENT = "environment"
+    PIN = "pin"
 
 
 class DiffKind(StrEnum):

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -2,7 +2,7 @@
 
 Phase 1 defines the *shape* of durable task state: enums, the semantic state
 tree, ledger records, environment snapshots, validation reports and recovery
-contracts. No storage or recovery logic lives here — these are pure data
+contracts. No storage or recovery logic lives here: these are pure data
 structures (mostly immutable) so they can be serialized, versioned, hashed and
 diffed without side effects.
 
@@ -12,7 +12,7 @@ Conventions
 * All IDs are stable strings (``run_..``, ``action_..``, ``finding_..``).
 * Enums are ``str`` subclasses so they serialize to readable JSON.
 * State-bearing models are frozen: mutations must produce a new version via
-  ``model_copy`` — the versioning phase builds on this property.
+  ``model_copy``; the versioning phase builds on this property.
 """
 
 from __future__ import annotations
@@ -170,7 +170,7 @@ class PlanStepStatus(StrEnum):
 
 
 class Origin(StrEnum):
-    """Who asserted a fact — decides how much it can be trusted.
+    """Who asserted a fact, which decides how much it can be trusted.
 
     This describes the *writer*, not the derivation. Folding a fabricated event
     is still a faithful fold, so "the projection is reproducible" says nothing
@@ -181,7 +181,7 @@ class Origin(StrEnum):
     DETERMINISTIC = "deterministic"
     """Recorded by trusted local code: the CLI, or an adapter called in-process.
 
-    Not a claim that the fact is *correct* — only that it was not asserted by an
+    Not a claim that the fact is *correct*, only that it was not asserted by an
     autonomous agent reporting on itself.
     """
 
@@ -209,7 +209,7 @@ class Origin(StrEnum):
     def self_certified(self) -> bool:
         """Whether this origin is an unverified self-report.
 
-        Such state is usable — it is often correct — but it cannot be the
+        Such state is usable (it is often correct) but it cannot be the
         grounds for declaring a run verified.
         """
         return self in (Origin.LLM, Origin.EXTERNAL_AGENT, Origin.IMPORTED)
@@ -702,7 +702,7 @@ class ModelState(BaseModel):
 class SemanticState(BaseModel):
     """The compact, durable representation of task state.
 
-    This is what survives crashes and context loss — NOT the transcript.
+    This is what survives crashes and context loss, NOT the transcript.
 
     A state is a *projection* of an event prefix. ``source_sequence`` records
     how far into the log the projection consumed, which makes the state
@@ -802,7 +802,7 @@ class SemanticState(BaseModel):
     def dangling_evidence(self) -> frozenset[str]:
         """Support cited by decisions or findings that the state cannot produce.
 
-        A decision may cite either raw evidence or a finding derived from it —
+        A decision may cite either raw evidence or a finding derived from it;
         both are legitimate provenance. Only references matching neither are
         dangling. Treating a cited finding as missing evidence would raise a
         false alarm on every well-formed reasoning chain, and false alarms are

--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -917,6 +917,15 @@ class Action(BaseModel):
     consumed_inputs: ConsumedInputs = Field(default_factory=ConsumedInputs)
     """Commitment inputs consumed to produce this action (issue #295)."""
 
+    @field_validator("origin_digest")
+    @classmethod
+    def _origin_digest_is_sha256(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not _SHA256_PATTERN.fullmatch(value):
+            raise ValueError("origin_digest must be 64 lowercase hex characters")
+        return value
+
 
 class ActionRecordPayload(BaseModel):
     """Payload for ACTION_RECORDED (issue #551).
@@ -970,15 +979,6 @@ def validate_caused_by(caused_by: list[str] | None, known_ids: set[str] | None =
     if known_ids is not None:
         _validate_caused_by_known(caused_by, known_ids)
     return list(caused_by)
-
-    @field_validator("origin_digest")  # type: ignore[misc]
-    @classmethod
-    def _origin_digest_is_sha256(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
-        if not _SHA256_PATTERN.fullmatch(value):
-            raise ValueError("origin_digest must be 64 lowercase hex characters")
-        return value
 
 
 class UnknownSideEffect(RuntimeError):

--- a/src/continuum/reconcilers.py
+++ b/src/continuum/reconcilers.py
@@ -236,10 +236,14 @@ def _key_for(storage: Storage, run_id: str, action: Action) -> Any:
     The fold is keyed by derived idempotency key while the Action record does
     not carry it, so recover the key by matching action_id against the run's
     folded ledger.
+
+    Folds full history, not the live tail: pending actions claimed before a
+    compaction live on as archived events (issue #647), and a live-only fold
+    would make every one of them "vanish mid-reconcile" and abort settle_run.
     """
     from continuum.actions.ledger import fold_action_events
 
-    folded = fold_action_events(storage.read_events(run_id))
+    folded = fold_action_events(storage.read_all_events(run_id))
     for key, candidate in folded.items():
         if candidate.action_id == action.action_id:
             return key
@@ -339,7 +343,10 @@ def settle_authority(
     from continuum.models import Origin
 
     payload: dict[str, Any] = {"authority_id": authority_id}
-    for ev in reversed(list(storage.read_events(run_id))):
+    # Full history, not the live tail: the AUTHORITY_CONSUMED row can predate a
+    # compaction (issue #647), and a live-only scan would hand the probe a bare
+    # authority_id, silently dropping the consumption context.
+    for ev in reversed(list(storage.read_all_events(run_id))):
         if (
             ev.type is not None
             and str(ev.type) == "AUTHORITY_CONSUMED"

--- a/src/continuum/recovery/contract.py
+++ b/src/continuum/recovery/contract.py
@@ -2,7 +2,7 @@
 
 A contract is the machine-readable answer to "what am I allowed to do now?".
 It names what was verified, what was invalidated, what must happen before
-normal work resumes, and — critically — the *single* next permitted action.
+normal work resumes, and (critically) the *single* next permitted action.
 
 One action, not a set. If a contract listed everything currently allowed, an
 agent could pick the convenient one and skip reconciling the side effect it was
@@ -12,7 +12,7 @@ and the ordering meaningful.
 Contracts are deterministic: the same state, environment and ledger always
 produce a byte-identical contract. That is what makes them auditable, diffable
 and safe to compare in tests. They are sealed with an integrity hash for the
-same reason checkpoints are — a contract that could be edited between issue and
+same reason checkpoints are: a contract that could be edited between issue and
 enforcement would gate nothing.
 """
 

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -1,16 +1,16 @@
-"""Deciding how — and whether — a run may resume.
+"""Deciding how, and whether, a run may resume.
 
 The engine reduces three independent signals to one decision:
 
-* validation statuses (Phase 5) — is the state still true?
-* the action ledger (Phase 6) — did an external effect land?
-* checkpoint integrity (Phases 3–4) — is the record itself sound?
+* validation statuses (Phase 5): is the state still true?
+* the action ledger (Phase 6): did an external effect land?
+* checkpoint integrity (Phases 3–4): is the record itself sound?
 
 The decision rule
 -----------------
 
 **The most cautious applicable signal wins.** Not the first one evaluated, not
-the most common — the most cautious. Each signal proposes a mode; the engine
+the most common: the most cautious. Each signal proposes a mode; the engine
 takes the maximum on a severity ordering:
 
     RESUME < REPAIR_AND_RESUME < WAIT < REQUEST_HUMAN < ROLLBACK < ABORT
@@ -18,7 +18,7 @@ takes the maximum on a severity ordering:
 Order-independence matters because these signals genuinely co-occur. A run can
 have a stale dataset *and* an uncertain side effect at once. If the engine
 returned whichever it noticed first, the same situation would recover
-differently depending on iteration order — and the unsafe answer would win
+differently depending on iteration order, and the unsafe answer would win
 roughly half the time. Taking the maximum makes the outcome deterministic and
 always errs toward caution.
 
@@ -28,7 +28,7 @@ What the engine does not do
 It does not execute repairs, mutate the run, or contact anything external. It
 reads state and returns a decision plus a contract. Keeping it free of side
 effects means a recovery decision can be computed, logged and reviewed without
-committing to it — which is what makes ``continuum validate`` safe to run
+committing to it, which is what makes ``continuum validate`` safe to run
 against a live database.
 """
 
@@ -605,7 +605,7 @@ class RecoveryEngine:
 
         if not validation.safe:
             # Count only what actually needs repair. Reporting every status
-            # would include the VALID ones and overstate the damage — a run
+            # would include the VALID ones and overstate the damage: a run
             # with two verified components and one stale one would claim three
             # need repair. The decision itself is unaffected; the operator
             # reading the rationale is not.

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -229,8 +229,20 @@ class RecoveryEngine:
         # Scoped confirm (issue #394) narrows this to named components only;
         # the payload may carry "components" or "scope" as a list, a single
         # string, or be absent (legacy full confirm of both).
+        # The scan includes the archived prefix so compaction cannot silently
+        # discard a human's confirmation (same archive-blindness family as
+        # issue #553): without it, a confirmed run re-escalates to
+        # request_human after every compaction.
         confirmed_components: set[str] = set()
-        for _ev in self.storage.read_events(run_id):
+        # Both archive-aware scans below (confirmations and provenance) share
+        # this one fetch: read_all_events walks the archived prefix too, and
+        # re-walking it twice per assess() doubles the archive scan for no
+        # gain.
+        try:
+            archive_aware_events = self.storage.read_all_events(run_id)
+        except Exception:
+            archive_aware_events = self.storage.read_events(run_id)
+        for _ev in archive_aware_events:
             if _ev.type is not EventType.REVIEW_CONFIRMED:
                 continue
             # Only human confirmations clear self-certification; an agent
@@ -253,11 +265,8 @@ class RecoveryEngine:
             else:
                 confirmed_components.update(["goal", "progress"])
 
-        # Provenance N-hop staleness (issue #553): include archived events so compaction does not launder
-        try:
-            provenance_events = self.storage.read_all_events(run_id)
-        except Exception:
-            provenance_events = self.storage.read_events(run_id)
+        # Provenance N-hop staleness (issue #553): the shared archive-aware
+        # fetch above feeds the validator so compaction does not launder it.
         validation = self.validator.validate(
             restored.state,
             current_environment=current_environment,
@@ -266,7 +275,7 @@ class RecoveryEngine:
             expected_model=expected_model,
             confirmed=confirmed_components,
             scope=scope,
-            events=provenance_events,
+            events=archive_aware_events,
         )
 
         ledger = ActionLedger(self.storage, run_id)

--- a/src/continuum/recovery/ledger.py
+++ b/src/continuum/recovery/ledger.py
@@ -245,12 +245,18 @@ class RecoveryLedger:
         anchor: bool = False,
         note: str = "",
     ) -> RecoveryLedgerEntry:
-        prev = entries[-1].content_hash if entries else GENESIS
+        # Sequence and prev_hash must follow the highest-sequence entry, not
+        # the last position of the backend's load order: after compact() the
+        # survivors keep their original (sparse) sequences, so len(entries)
+        # would mint a colliding sequence that sorts before them, breaking
+        # the chain walk in verify() and the approval ordering in
+        # pending_gate().
+        head = max(entries, key=lambda e: e.sequence) if entries else None
         partial = RecoveryLedgerEntry(
             entry_id=make_id("ledger"),
             run_id=run_id,
-            sequence=len(entries),
-            prev_hash=prev,
+            sequence=head.sequence + 1 if head else 0,
+            prev_hash=head.content_hash if head else GENESIS,
             content_hash="",
             kind=kind.value,
             contract=contract,

--- a/src/continuum/recovery/planner.py
+++ b/src/continuum/recovery/planner.py
@@ -7,7 +7,7 @@ Ordering is not cosmetic. Reconciling an uncertain side effect must come before
 any new work, because until the ledger knows whether that GitHub issue exists,
 the agent cannot safely act on the assumption that it does or does not.
 Similarly, a stale dependency must be re-pinned before the findings derived from
-it are re-derived — repairing in the wrong order produces work that is stale the
+it are re-derived. Repairing in the wrong order produces work that is stale the
 moment it completes.
 
 Steps are declarative. The planner does not execute anything; it produces the
@@ -158,7 +158,7 @@ def _step_for(entry: ComponentValidationEntry, *, strict_unknown: bool = True) -
                 reason=entry.detail,
                 # An unverifiable resource normally needs a person, because
                 # nobody knows what is true. Callers who opted into tolerating
-                # uncertainty get an automatic step instead — the policy has to
+                # uncertainty get an automatic step instead: the policy has to
                 # hold here too, or the setting would be silently ignored.
                 requires_human=entry.status is StateStatus.UNKNOWN and strict_unknown,
             )
@@ -215,7 +215,7 @@ def plan_repairs(
 
     Steps are deduplicated by identity and sorted so that prerequisites precede
     the work that depends on them. Sorting is stable and total, so the same
-    inputs always yield the same plan — a contract that varied between runs
+    inputs always yield the same plan, since a contract that varied between runs
     would be impossible to audit.
 
     ``unprojectable`` is ``(sequence, event_type, reason)`` for a log whose fold

--- a/src/continuum/replayguard.py
+++ b/src/continuum/replayguard.py
@@ -28,7 +28,21 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
-__all__ = ["GuardKind", "GuardDecision", "evaluate", "protected_call", "langgraph_protected_node"]
+__all__ = [
+    "GuardKind",
+    "GuardDecision",
+    "RESULT_ENVELOPE_KEY",
+    "evaluate",
+    "protected_call",
+    "langgraph_protected_node",
+]
+
+# Journal envelope, same literal adapters.generic uses for the same reason
+# (issue #44): a stored result must be distinguishable from the caller's own
+# dict, or the replay path unwraps one member of it instead of the dict
+# (issue #736). Defined locally so the core stays importable without the
+# adapter stack.
+RESULT_ENVELOPE_KEY = "__return_value__"
 
 
 class GuardKind(StrEnum):
@@ -139,7 +153,16 @@ def protected_call(
         except Exception as exc:
             ledger.fail(key_to_use, str(exc), certain=False)
             raise
-        journal = result if isinstance(result, dict) else {"return": result}
+        # A non-dict has to be wrapped to be stored. So does any dict carrying
+        # the envelope key or the legacy "return" marker: the replay path below
+        # unwraps those, and storing a caller's own dict with such a key as-is
+        # would make replay return one member of it rather than the whole dict,
+        # so a completed operation would answer differently on its second call
+        # than on its first (issue #736).
+        needs_envelope = (
+            not isinstance(result, dict) or RESULT_ENVELOPE_KEY in result or "return" in result
+        )
+        journal = {RESULT_ENVELOPE_KEY: result} if needs_envelope else result
         ledger.complete(key_to_use, external_id=key, result=journal)
         return GuardKind.ALLOW, result
 
@@ -147,7 +170,15 @@ def protected_call(
         assert decision.key is not None
         cached_action = actions[decision.key]
         cached = cached_action.result
-        value = cached.get("return", cached) if isinstance(cached, dict) else cached
+        if isinstance(cached, dict) and RESULT_ENVELOPE_KEY in cached:
+            value = cached[RESULT_ENVELOPE_KEY]
+        elif isinstance(cached, dict) and set(cached) == {"return"}:
+            # Legacy journal from before the envelope: a non-dict result
+            # wrapped as {"return": ...}. The write path now envelopes any
+            # dict containing "return", so this shape is historical only.
+            value = cached["return"]
+        else:
+            value = cached
         return GuardKind.SKIP_DUPLICATE, value
 
     raise ReplayBlocked(decision)

--- a/src/continuum/replayguard.py
+++ b/src/continuum/replayguard.py
@@ -79,6 +79,7 @@ def evaluate(
         return GuardDecision(
             GuardKind.BLOCK_UNCERTAIN,
             f"{action_type!r} {rendered_key!r} has an unknown outcome; reconcile first",
+            key=key,
         )
     return GuardDecision(
         GuardKind.DENY_RECLAIM,

--- a/src/continuum/security/hashing.py
+++ b/src/continuum/security/hashing.py
@@ -92,8 +92,8 @@ def stable_hash(value: Any, algorithm: str = "sha256") -> str:
 def make_id(prefix: str) -> str:
     """Random hex identifier with a human-readable prefix, e.g. ``run_8f3a...``.
 
-    Uses 16 bytes (128 bits) of cryptographic randomness — the same budget as
-    UUID v4 — so birthday-paradox collisions are negligible even at billions of
+    Uses 16 bytes (128 bits) of cryptographic randomness, the same budget as
+    UUID v4, so birthday-paradox collisions are negligible even at billions of
     IDs.
     """
     return f"{prefix}_{secrets.token_hex(16)}"

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -270,7 +270,9 @@ class SidecarServer:
         return run
 
     def _ledger(self, run_id: str) -> ActionLedger:
-        return ActionLedger(self.storage, run_id)
+        # Sidecar callers report their own work, so ledger writes carry
+        # EXTERNAL_AGENT like everything else this server writes (issue #653).
+        return ActionLedger(self.storage, run_id, source=AGENT_SOURCE)
 
     def dispatch(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         """Authenticate, then route to the handler for ``method``.

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -212,7 +212,7 @@ def _declare_dependencies(server: SidecarServer, run_id: str, env: Any) -> None:
     A snapshot alone cannot invalidate anything: the validator decides staleness
     per declared dependency and returns early when a state has none, so a
     checkpoint carrying only a snapshot reports ``safe_to_resume`` even after the
-    resource underneath it moved. Mirrors ``continuum.mcp.server`` — the two
+    resource underneath it moved. Mirrors ``continuum.mcp.server``: the two
     surfaces expose the same recovery semantics and must not disagree about
     whether drift is safe.
     """

--- a/src/continuum/state/diff.py
+++ b/src/continuum/state/diff.py
@@ -203,6 +203,18 @@ def diff_states(before: SemanticState, after: SemanticState) -> StateDiff:
         describe=lambda d: f"{d.resource} {d.version or ''}".strip(),
         fields=("version", "checksum", "status", "kind"),
     )
+    # Pins are first-class state (issue #417): the active constraint set a
+    # resuming agent must honour. The semantic diff predates them, so a pin
+    # added or retracted between two states used to yield an empty diff and
+    # `continuum diff` reported "no semantic change" (issue #740).
+    entries += _compare_collection(
+        list(before.pins.values()),
+        list(after.pins.values()),
+        component=Component.PIN,
+        key=lambda p: p.constraint_id,
+        describe=lambda p: f"{p.constraint_id} {p.sha256[:12]}",
+        fields=("sha256", "status", "pinned_at"),
+    )
 
     before_model = before.model.model if before.model else None
     after_model = after.model.model if after.model else None

--- a/src/continuum/state/diff.py
+++ b/src/continuum/state/diff.py
@@ -3,8 +3,8 @@
 The diff is *semantic*, not textual: it compares identified components by their
 IDs, so reordering a list produces no diff while invalidating a decision does.
 
-Output is deterministic — entries are emitted in a fixed component order and
-sorted by ID within each component — because the diff feeds `continuum diff`,
+Output is deterministic (entries are emitted in a fixed component order and
+sorted by ID within each component) because the diff feeds `continuum diff`,
 recovery contracts and benchmark scoring, all of which need stable output.
 """
 

--- a/src/continuum/state/extractor.py
+++ b/src/continuum/state/extractor.py
@@ -4,9 +4,9 @@ An extractor turns a trajectory (the run's recorded events) plus an environment
 into semantic state. The deterministic extractor is the default and the only
 one required: it folds the event log and calls nothing external.
 
-The optional LLM extractor exists for state that was never recorded structurally
-— free-text reasoning a framework did not emit as events. It is constrained by
-design:
+The optional LLM extractor exists for state that was never recorded
+structurally: free-text reasoning a framework did not emit as events. It is
+constrained by design:
 
 * It runs only when explicitly enabled and given a callable; there is no
   provider SDK, no network default, no API key handling.
@@ -106,9 +106,10 @@ LLMCallable = Callable[[ExtractionContext, SemanticState], LLMProposal]
 class LLMExtractor:
     """Optional enrichment layer over a base extractor.
 
-    ``llm`` is supplied by the caller — CONTINUUM has no provider dependency.
-    If it raises, extraction falls back to the deterministic result rather than
-    failing the run: losing an optional enrichment must never cost a recovery.
+    ``llm`` is supplied by the caller, since CONTINUUM has no provider
+    dependency. If it raises, extraction falls back to the deterministic result
+    rather than failing the run: losing an optional enrichment must never cost a
+    recovery.
     """
 
     name = "llm"

--- a/src/continuum/state/extractor.py
+++ b/src/continuum/state/extractor.py
@@ -37,7 +37,7 @@ from continuum.models import (
     SemanticState,
     StateStatus,
 )
-from continuum.state.semantic import ProjectionReport, project_incremental
+from continuum.state.semantic import ProjectionReport, _as_str_list, project_incremental
 
 __all__ = [
     "ExtractionContext",
@@ -155,7 +155,7 @@ class LLMExtractor:
                     decision_id=decision_id,
                     decision=str(raw.get("decision", "")),
                     reason=str(raw.get("reason", "")),
-                    evidence=[str(e) for e in raw.get("evidence", [])],
+                    evidence=_as_str_list(raw.get("evidence")),
                     status=StateStatus.REQUIRES_REVIEW,
                     provenance=provenance,
                 )
@@ -173,7 +173,7 @@ class LLMExtractor:
                 Finding(
                     finding_id=finding_id,
                     claim=str(raw.get("claim", "")),
-                    evidence=[str(e) for e in raw.get("evidence", [])],
+                    evidence=_as_str_list(raw.get("evidence")),
                     confidence=min(max(confidence, 0.0), 1.0),
                     status=StateStatus.REQUIRES_REVIEW,
                     provenance=provenance,

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
 from continuum.events import Event, EventType
@@ -191,6 +191,18 @@ def _as_str_list(value: Any) -> list[str]:
     if isinstance(value, Iterable):
         return [str(v) for v in value]
     return [str(value)]
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Interpret a naive datetime as UTC; aware values pass through.
+
+    Event payloads are external input: an ``expires_at`` ISO string without a
+    UTC offset (``"2027-01-01"``) parses to a naive datetime, and everything
+    downstream compares against the tz-aware ``utcnow()``, which would raise
+    TypeError and brick validation for the run (issue #704). The project
+    convention is UTC everywhere, so a missing offset is read as UTC.
+    """
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value
 
 
 def _replace(items: list[Any], key: str, identifier: str, updated: Any) -> bool:
@@ -467,7 +479,9 @@ class _Accumulator:
                     if event.payload.get("granted_by") is not None
                     else None
                 ),
-                "expires_at": datetime.fromisoformat(str(expires_raw)) if expires_raw else None,
+                "expires_at": (
+                    _as_utc(datetime.fromisoformat(str(expires_raw))) if expires_raw else None
+                ),
                 "reason": (
                     str(event.payload["reason"])
                     if event.payload.get("reason") is not None

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -91,7 +91,7 @@ def _provenance(event: Event) -> Provenance:
     """Carry the event's own trust marker into the projected component.
 
     Previously this hardcoded ``DETERMINISTIC``, which was true of the *fold*
-    but said nothing about the event being folded — so an agent's self-report
+    but said nothing about the event being folded, so an agent's self-report
     projected as indistinguishable from a verified fact.
 
     For derived artifacts (issue #392) the payload may carry a stamped
@@ -303,7 +303,7 @@ class _Accumulator:
 
         # Re-derive `pending` whenever the caller moved `completed`/`failed`
         # without restating it. Keeping the old value would leave the counters
-        # summing past `total` and the update would be rejected — punishing a
+        # summing past `total` and the update would be rejected, punishing a
         # caller for omitting a field that had not changed.
         total = current["total"]
         if total is not None and "pending" not in payload:
@@ -879,7 +879,7 @@ def project(
 ) -> SemanticState:
     """Project a run's events into semantic state.
 
-    ``upto`` truncates the fold at a sequence number — the mechanism behind
+    ``upto`` truncates the fold at a sequence number: the mechanism behind
     ``continuum inspect --version`` and recovery from a partially trusted log.
 
     ``on_unprojectable`` forwards to :func:`project_incremental`: ``"raise"``
@@ -966,7 +966,7 @@ def account_pins_in_context(
             flag = None
         else:
             # If context was truncated, we cannot tell if the pin was in a
-            # dropped section — mark as unverifiable rather than absent
+            # dropped section; mark as unverifiable rather than absent
             if is_truncated:
                 # Heuristic: if the pin's marker would have been in a low-
                 # priority section that was dropped, mark unverifiable

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from datetime import UTC
 from typing import Any
 
 from continuum.environment.diff import EnvironmentDiff, ResourceChange, diff_environments
@@ -867,14 +868,21 @@ class StateValidator:
     def _check_approvals(state: SemanticState, entries: list[ComponentValidationEntry]) -> None:
         now = utcnow()
         for approval in state.approvals:
+            # A naive expires_at (persisted by versions before issue #704, or
+            # constructed directly) must grade, not raise: comparing it against
+            # the tz-aware `now` would TypeError and take down the whole
+            # validation pass. Read a missing offset as UTC, as the fold does.
+            expires_at = approval.expires_at
+            if expires_at is not None and expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=UTC)
             if approval.status is ApprovalStatus.REVOKED:
                 status, detail = StateStatus.INVALID, "approval was revoked"
             elif approval.status is ApprovalStatus.EXPIRED:
                 status, detail = StateStatus.EXPIRED, "approval expired"
-            elif approval.expires_at is not None and approval.expires_at <= now:
+            elif expires_at is not None and expires_at <= now:
                 status, detail = (
                     StateStatus.EXPIRED,
-                    f"expired at {approval.expires_at.isoformat()}",
+                    f"expired at {expires_at.isoformat()}",
                 )
             elif approval.status is ApprovalStatus.PENDING:
                 status, detail = StateStatus.REQUIRES_REVIEW, "approval never granted"

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -434,19 +434,44 @@ class StateValidator:
             else:
                 evidence.append(item)
 
+        # A finding's support may be evidence or another finding
+        # (`dangling_evidence` blesses citing finding ids), so taint has to
+        # cascade along finding-to-finding edges too, and the pass repeats
+        # until no new finding is affected: a finding can cite one listed
+        # after it, which a single ordered pass would miss (issue #739).
         tainted_findings: set[str] = set()
+        finding_details: dict[str, str] = {}
+        changed = True
+        while changed:
+            changed = False
+            for finding in state.findings:
+                if finding.finding_id in tainted_findings:
+                    continue
+                if finding.status is not StateStatus.VALID:
+                    continue
+                affected_evidence = sorted(set(finding.evidence) & tainted_evidence)
+                affected_findings = sorted(set(finding.evidence) & tainted_findings)
+                if not (affected_evidence or affected_findings):
+                    continue
+                changed = True
+                tainted_findings.add(finding.finding_id)
+                parts = []
+                if affected_evidence:
+                    parts.append(f"changed evidence: {', '.join(affected_evidence)}")
+                if affected_findings:
+                    parts.append(f"stale finding: {', '.join(affected_findings)}")
+                finding_details[finding.finding_id] = "; ".join(parts)
+
         findings = []
         for finding in state.findings:
-            affected = sorted(set(finding.evidence) & tainted_evidence)
-            if affected and finding.status is StateStatus.VALID:
-                tainted_findings.add(finding.finding_id)
+            if finding.finding_id in tainted_findings:
                 findings.append(finding.model_copy(update={"status": StateStatus.STALE}))
                 entries.append(
                     ComponentValidationEntry(
                         component=Component.FINDING,
                         component_id=finding.finding_id,
                         status=StateStatus.STALE,
-                        detail=f"rests on changed evidence: {', '.join(affected)}",
+                        detail=f"rests on {finding_details[finding.finding_id]}",
                     )
                 )
             else:

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -5,7 +5,7 @@ trustworthy merely because it was persisted.** Before an agent resumes, every
 component is checked against the environment as it is *now*.
 
 Staleness propagates. If a dataset moves from v3 to v4, the dependency is not
-the only casualty — every finding whose evidence came from that dataset, and
+the only casualty: every finding whose evidence came from that dataset, and
 every decision resting on those findings, is now suspect. Marking only the
 dependency would leave the agent reasoning from conclusions it can no longer
 justify. Propagation walks:
@@ -17,8 +17,8 @@ Uncertainty degrades rather than resolves. An unverifiable resource yields
 resume. The system is allowed to say "I cannot tell"; it is not allowed to
 guess in its own favour.
 
-This module decides *status*. Choosing what to do about it — resume, repair,
-abort — is the recovery engine's job in Phase 7.
+This module decides *status*. Choosing what to do about it (resume, repair,
+abort) is the recovery engine's job in Phase 7.
 """
 
 from __future__ import annotations
@@ -59,7 +59,7 @@ __all__ = [
 #: reporting "safe to resume" while that is outstanding is precisely the false
 #: assurance this layer exists to prevent. The recovery engine already refused
 #: to resume in these cases via the repair plan, but the validator's own
-#: `safe_to_resume` disagreed with it — so anything reading the validation
+#: `safe_to_resume` disagreed with it, so anything reading the validation
 #: report directly got the wrong answer.
 _UNUSABLE = frozenset(
     {

--- a/src/continuum/storage/base.py
+++ b/src/continuum/storage/base.py
@@ -57,8 +57,8 @@ class RunNotFound(StorageError, KeyError):
 
     Subclasses ``KeyError`` so ``except KeyError`` still catches it, but
     overrides ``__str__``: ``KeyError.__str__`` applies ``repr()`` to its
-    message, which would surface to CLI users as ``"no such run: 'ghost'"``
-    — quoted twice.
+    message, which would surface to CLI users as ``"no such run: 'ghost'"``,
+    quoted twice.
     """
 
     def __init__(self, run_id: str) -> None:

--- a/src/continuum/storage/postgres.py
+++ b/src/continuum/storage/postgres.py
@@ -170,7 +170,7 @@ def _require_psycopg() -> Any:
         import psycopg
     except ImportError as exc:  # pragma: no cover - depends on environment
         raise RuntimeError(
-            "PostgreSQL storage requires the 'psycopg' extra: pip install continuum[postgres]"
+            "PostgreSQL storage requires the 'psycopg' extra: pip install continuum-agent[postgres]"
         ) from exc
     return psycopg
 

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -3,20 +3,20 @@
 Chosen defaults and why
 -----------------------
 
-* **WAL journal mode** — readers never block the writer, so `continuum inspect`
+* **WAL journal mode**: readers never block the writer, so `continuum inspect`
   can read a run while the agent is still working.
-* **`synchronous=FULL`** — the whole point of this layer is surviving power
+* **`synchronous=FULL`**: the whole point of this layer is surviving power
   loss. `NORMAL` can lose the last commits on a WAL crash, which would silently
   reintroduce the duplicate-work problem CONTINUUM exists to prevent. The cost
   is an fsync per append; correctness wins.
-* **`foreign_keys=ON`** — events cannot reference a run that was never created.
-* **`IMMEDIATE` transactions for writes** — takes the write lock up front, so a
+* **`foreign_keys=ON`**: events cannot reference a run that was never created.
+* **`IMMEDIATE` transactions for writes**: takes the write lock up front, so a
   racing writer fails at BEGIN rather than halfway through a read-modify-write.
 
 Sequence allocation is done inside the write transaction with a UNIQUE
 constraint on ``(run_id, sequence)`` as the backstop. If two processes race,
 one commits and the other hits the constraint and is reported as a
-``ConcurrentWriteError`` — never a silent overwrite.
+``ConcurrentWriteError``, never a silent overwrite.
 """
 
 from __future__ import annotations
@@ -171,7 +171,7 @@ class SQLiteStorage(Storage):
             try:
                 conn.close()
             except sqlite3.ProgrammingError:
-                # Already closed — safe to call close() more than once.
+                # Already closed, and close() is safe to call more than once.
                 pass
             finally:
                 self._connection = None  # type: ignore[assignment]

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -478,6 +478,12 @@ class SQLiteStorage(Storage):
         crash in between leave an anchored live log whose prefix never
         reached the archive, so verify would trust a genesis that was never
         earned.
+
+        ``through_sequence`` must stay below the anchor marker's sequence:
+        the live log always retains its anchor, so a value at or above it is
+        rejected (issue #705) instead of silently deleting the anchor and
+        every live row, which would leave the next append minting a fresh
+        genesis and fork the hash chain away from the archive.
         """
         from continuum.checkpoint.manager import CheckpointManager
 
@@ -493,6 +499,14 @@ class SQLiteStorage(Storage):
         storage_version = lv
         if storage_version is None:
             raise ValueError(f"run {run_id!r} could not be anchored: no projectable state")
+        # The anchor marker is appended at the head of the log in the
+        # transaction below, so its sequence is the current head + 1.
+        anchor_sequence = self.last_sequence(run_id) + 1
+        if through_sequence is not None and through_sequence >= anchor_sequence:
+            raise ValueError(
+                f"through_sequence {through_sequence} would archive the anchor marker"
+                f" at sequence {anchor_sequence}: the live log must retain its anchor"
+            )
         through = (
             through_sequence
             if through_sequence is not None

--- a/src/continuum/tui/__init__.py
+++ b/src/continuum/tui/__init__.py
@@ -1,0 +1,13 @@
+"""Full-screen terminal dashboard (issue #782).
+
+A presentation layer over the same Storage, CheckpointManager and
+RecoveryEngine the CLI and the web dashboard use, built on the standard
+library curses module so the dependency-free rule for the CLI holds here
+too. :mod:`continuum.tui.model` is the pure, testable view model;
+:mod:`continuum.tui.app` holds the key-driven state machine and the thin
+curses driver.
+"""
+
+from continuum.tui.app import TuiApp, run_tui
+
+__all__ = ["TuiApp", "run_tui"]

--- a/src/continuum/tui/app.py
+++ b/src/continuum/tui/app.py
@@ -1,0 +1,522 @@
+"""The ``continuum tui`` driver: a full-screen terminal dashboard (issue #782).
+
+Two layers, deliberately separated:
+
+- :class:`TuiApp` is a pure state machine. Keys arrive as plain names
+  (``"up"``, ``"enter"``, ``"y"``) and rendering is a list of strings, so
+  every flow is testable without a terminal.
+- :func:`run_tui` is a thin curses driver that maps real key codes onto those
+  names and draws the lines. It contains no decisions of its own.
+
+House style: read-only until an action is confirmed. Every mutating verb
+lands in ``pending`` first, the footer shows exactly what will happen, and
+only a further ``y`` performs the write. Anything else cancels.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from collections.abc import Callable
+from typing import Any
+
+from continuum import __version__
+from continuum.cli.exitcodes import ExitCode
+from continuum.storage.base import Storage
+from continuum.tui import model
+from continuum.tui.model import RunRow
+
+__all__ = ["TuiApp", "run_tui"]
+
+#: The splash logo, hand-drawn in the ANSI Shadow style and joined at full
+#: glyph width so it fits a standard 80-column terminal (78 columns exactly).
+_LOGO_LINES = (
+    " ██████╗ ██████╗ ███╗   ██╗████████╗██╗███╗   ██╗██╗   ██╗██╗   ██╗███╗   ███╗",
+    "██╔════╝██╔═══██╗████╗  ██║╚══██╔══╝██║████╗  ██║██║   ██║██║   ██║████╗ ████║",
+    "██║     ██║   ██║██╔██╗ ██║   ██║   ██║██╔██╗ ██║██║   ██║██║   ██║██╔████╔██║",
+    "██║     ██║   ██║██║╚██╗██║   ██║   ██║██║╚██╗██║██║   ██║██║   ██║██║╚██╔╝██║",
+    "╚██████╗╚██████╔╝██║ ╚████║   ██║   ██║██║ ╚████║╚██████╔╝╚██████╔╝██║ ╚═╝ ██║",
+    " ╚═════╝ ╚═════╝ ╚═╝  ╚═══╝   ╚═╝   ╚═╝╚═╝  ╚═══╝ ╚═════╝  ╚═════╝ ╚═╝     ╚═╝",
+)
+_LOGO_WIDTH = max(len(line) for line in _LOGO_LINES)
+_LANDING_TAGLINE = "durable recovery for long-running agents"
+
+
+class TuiApp:
+    """State machine for the terminal dashboard.
+
+    The view is three-level: a landing splash (logo, version, run count),
+    then a runs index, then one run's detail with tabs (overview, recovery,
+    checkpoints, actions, events, family, budget). Table tabs carry a
+    selectable cursor; text tabs only scroll.
+    """
+
+    TABS = ("overview", "recovery", "checkpoints", "actions", "events", "family", "budget")
+    _TABLE_TABS = frozenset({"checkpoints", "actions", "events", "budget"})
+
+    def __init__(self, storage: Storage) -> None:
+        self.storage = storage
+        self.view = "landing"
+        self.width = 80  # the driver restamps this from the real screen each draw
+        self.tab = 0
+        self.index = 0  # selection in the runs index
+        self.cursor = -1  # selected body line in a table tab, -1 when none
+        self.scroll = 0
+        self.rows: list[RunRow] = []
+        self.lines: list[str] = []
+        self.pending: tuple[str, Callable[[], str]] | None = None
+        self.message = ""
+        self.show_help = False
+        self.refresh()
+
+    # ------------------------------------------------------------------ #
+    # data
+    # ------------------------------------------------------------------ #
+
+    def refresh(self) -> None:
+        """Reload the current view's data from storage. Read-only."""
+        if self.view in ("landing", "runs"):
+            # the landing screen shows the run count, and leaving it lands on
+            # the runs list, so both views read the same rows
+            self.rows = model.run_rows(self.storage)
+            self.cursor = -1  # the runs list marks its selection itself
+            if self.rows:
+                self.index = min(self.index, len(self.rows) - 1)
+        else:
+            self._refresh_detail()
+
+    def _run_id(self) -> str | None:
+        if 0 <= self.index < len(self.rows):
+            return self.rows[self.index].run_id
+        return None
+
+    def _refresh_detail(self) -> None:
+        run_id = self._run_id()
+        if run_id is None:
+            self.lines = ["No run selected. Press esc to go back to the runs list."]
+            self.cursor = -1
+            return
+        tab = self.TABS[self.tab]
+        self.cursor = -1
+        rows: list[Any]  # one of the model's table row types, per tab
+        if tab == "overview":
+            self.lines = model.overview_lines(self.storage, run_id)
+        elif tab == "recovery":
+            self.lines = model.recovery_lines(self.storage, run_id)
+        elif tab == "checkpoints":
+            rows = model.checkpoint_rows(self.storage, run_id)
+            self.lines = [f"{'CHECKPOINT':<12} {'VERSION':<9} {'TRIGGER':<10} COMPLETED"]
+            self.lines += [
+                f"{r.checkpoint_id[:10]:<12} v{r.version:<8} {r.trigger:<10} {r.completed}"
+                for r in rows
+            ] or ["No checkpoints recorded. Press c to force one."]
+            self.cursor = 1 if len(self.lines) > 1 else -1
+        elif tab == "actions":
+            rows = model.action_rows(self.storage, run_id)
+            self.lines = [f"{'STATUS':<16} {'TYPE':<24} {'EXTERNAL ID':<20} KEY"]
+            self.lines += [
+                (
+                    f"{'(!)' if r.uncertain else '   '} {r.status:<12} {r.action_type:<24} "
+                    f"{r.external_id[:18]:<20} {r.key[:24]}"
+                )
+                for r in rows
+            ] or ["No actions recorded."]
+            self.cursor = 1 if len(self.lines) > 1 else -1
+        elif tab == "events":
+            rows = model.event_rows(self.storage, run_id)
+            self.lines = [f"{'SEQ':>5}  {'TYPE':<26} PAYLOAD"]
+            self.lines += [f"{r.sequence:>5}  {r.type:<26} {r.summary}" for r in rows] or [
+                "No events."
+            ]
+            self.cursor = 1 if len(self.lines) > 1 else -1
+        elif tab == "family":
+            self.lines = model.family_lines(self.storage, run_id)
+        elif tab == "budget":
+            rows = model.budget_rows(self.storage, run_id)
+            self.lines = [f"{'ACTION TYPE':<28} {'ATTEMPTS':>8} {'MAX':>4} {'REMAINING':>10}"]
+            self.lines += [
+                f"{r.action_type:<28} {r.attempts:>8} {r.max_attempts:>4} {r.remaining:>10}"
+                for r in rows
+            ] or ["No budgets configured."]
+            self.cursor = 1 if len(self.lines) > 1 else -1
+        if self.scroll > max(0, len(self.lines) - 1):
+            self.scroll = 0
+
+    def _selected_action(self) -> model.ActionRow | None:
+        """The action row under the cursor, on the actions tab only."""
+        if self.view != "detail" or self.TABS[self.tab] != "actions" or self.cursor < 1:
+            return None
+        rows = model.action_rows(self.storage, self._run_id() or "")
+        offset = self.cursor - 1
+        if 0 <= offset < len(rows):
+            return rows[offset]
+        return None
+
+    # ------------------------------------------------------------------ #
+    # rendering
+    # ------------------------------------------------------------------ #
+
+    def header(self) -> str:
+        """The top line: where we are and what view is active."""
+        if self.view == "landing":
+            return ""
+        if self.view == "runs":
+            return "CONTINUUM  runs  (enter: open, r: refresh, ?: help, q: quit)"
+        run_id = self._run_id() or "-"
+        tab = self.TABS[self.tab]
+        return (
+            f"CONTINUUM  run {run_id}  "
+            f"[{self.tab + 1}/{len(self.TABS)} {tab}]  "
+            "(left/right or 1-7: tabs, esc: runs, r: refresh, q: quit)"
+        )
+
+    def _landing_lines(self) -> list[str]:
+        """The splash page: logo, version, how many runs the store holds."""
+
+        def center(text: str) -> str:
+            return " " * max(0, (self.width - len(text)) // 2) + text
+
+        if self.width >= _LOGO_WIDTH + 2:
+            art: list[str] = list(_LOGO_LINES)
+        else:  # too narrow for the logo: a banner that fits, not one that clips
+            art = ["C O N T I N U U M"]
+        runs_line = f"{len(self.rows)} run(s) recorded" if self.rows else "no runs recorded yet"
+        return (
+            [""]
+            + [center(line) for line in art]
+            + ["", ""]
+            + [center(_LANDING_TAGLINE), center(f"v{__version__}   {runs_line}")]
+            + ["", "", center("press any key to open the dashboard")]
+        )
+
+    def body_lines(self) -> list[str]:
+        """The body: the help overlay when asked for, the view otherwise."""
+        if self.show_help:
+            return list(_HELP_LINES)
+        if self.view == "landing":
+            return self._landing_lines()
+        if self.view == "runs":
+            if not self.rows:
+                return ['No runs recorded. Start one with: continuum start <id> --goal "..."']
+            lines = [f"{'RUN':<20} {'STATUS':<10} {'EVT':>5}  {'MODE':<14} {'SAFE':<7} GOAL"]
+            for i, row in enumerate(self.rows):
+                marker = ">" if i == self.index else " "
+                lines.append(
+                    f"{marker} {row.run_id:<19} {row.status:<10} {row.events:>5}  "
+                    f"{row.mode:<14} {row.safe:<7} {row.goal}"
+                )
+            return lines
+        marked = []
+        for i, line in enumerate(self.lines):
+            if self.cursor >= 0:
+                marked.append(("> " if i == self.cursor else "  ") + line)
+            else:
+                marked.append(line)
+        return marked
+
+    def footer(self) -> str:
+        """The bottom line: a pending confirmation outranks everything, and a
+        result message outranks the key hints. The hints are the longest text
+        here, so on an 80-column terminal they would otherwise clip the one
+        line the operator most needs to read."""
+        if self.pending is not None:
+            return f"{self.pending[0]}  [y = do it, anything else = cancel]"
+        if self.message:
+            return self.message
+        if self.show_help:
+            return "? hides help"
+        if self.view == "landing":
+            return "press any key to open the dashboard   q quits"
+        if self.view == "runs":
+            return "runs: enter open | r refresh | c checkpoint | x complete | y confirm"
+        return "1-7 tabs | esc back | y/n reconcile (actions tab) | c checkpoint | x complete"
+
+    # ------------------------------------------------------------------ #
+    # keys
+    # ------------------------------------------------------------------ #
+
+    def handle_key(self, key: str) -> bool:
+        """Apply one key. Returns False when the app should quit."""
+        if self.pending is not None:
+            self._resolve_pending(key)
+            return True
+        if key == "q":
+            return False
+        if self.view == "landing":
+            if key == "resize":  # a resize is not a keystroke: keep the splash
+                return True
+            # the splash promises "press any key", so any key (except q above)
+            # opens the dashboard; there is nothing else to do on this screen
+            self.view = "runs"
+            self.message = ""
+            self.scroll = 0
+            self.refresh()
+            return True
+        if key == "?":
+            self.show_help = not self.show_help
+            return True
+        if key == "r":
+            self.refresh()
+            return True
+        if self.show_help:
+            return True  # any other key just leaves help on screen
+
+        if self.view == "runs":
+            return self._handle_runs_key(key)
+        return self._handle_detail_key(key)
+
+    def _resolve_pending(self, key: str) -> None:
+        assert self.pending is not None
+        prompt, action = self.pending
+        if key == "y":
+            try:
+                self.message = action()
+            except Exception as exc:
+                self.message = f"error: {exc}"
+        else:
+            self.message = f"cancelled: {prompt.split('?')[0].strip()}"
+        self.pending = None
+        self.refresh()
+
+    def _handle_runs_key(self, key: str) -> bool:
+        if key in ("up", "k") and self.rows:
+            self.index = (self.index - 1) % len(self.rows)
+        elif key in ("down", "j") and self.rows:
+            self.index = (self.index + 1) % len(self.rows)
+        elif key in ("enter", "o", "right") and self.rows:
+            self.view = "detail"
+            self.tab = 0
+            self.scroll = 0
+            self.message = ""
+            self._refresh_detail()
+        elif key == "c":
+            self._queue_checkpoint()
+        elif key == "x":
+            self._queue_complete()
+        elif key == "y":
+            self._queue_confirm()
+        return True
+
+    def _handle_detail_key(self, key: str) -> bool:
+        tab = self.TABS[self.tab]
+        if key == "esc" or (key == "left" and tab == "overview"):
+            self.view = "runs"
+            self.scroll = 0
+            self.message = ""
+            self.refresh()
+        elif key in ("left", "h"):
+            self.tab = (self.tab - 1) % len(self.TABS)
+            self.scroll = 0
+            self._refresh_detail()
+        elif key in ("right", "l"):
+            self.tab = (self.tab + 1) % len(self.TABS)
+            self.scroll = 0
+            self._refresh_detail()
+        elif key.isdigit() and 1 <= int(key) <= len(self.TABS):
+            self.tab = int(key) - 1
+            self.scroll = 0
+            self._refresh_detail()
+        elif key in ("up", "k"):
+            self._move_selection(-1)
+        elif key in ("down", "j"):
+            self._move_selection(1)
+        elif key == "c":
+            self._queue_checkpoint()
+        elif key == "x":
+            self._queue_complete()
+        elif key == "y":
+            if tab == "actions":
+                self._queue_reconcile(occurred=True)
+            else:
+                self._queue_confirm()
+        elif key == "n":
+            if tab == "actions":
+                self._queue_reconcile(occurred=False)
+        return True
+
+    def _move_selection(self, delta: int) -> None:
+        """Move the cursor in table tabs, the scroll in text tabs."""
+        if self.cursor >= 0:
+            self.cursor = max(1, min(len(self.lines) - 1, self.cursor + delta))
+        else:
+            self.scroll = max(0, min(max(0, len(self.lines) - 1), self.scroll + delta))
+
+    def _queue_checkpoint(self) -> None:
+        run_id = self._run_id()
+        if run_id is None:
+            self.message = "no run selected"
+            return
+        self.pending = (
+            f"force a checkpoint on run {run_id} now?",
+            lambda: model.force_checkpoint(self.storage, run_id),
+        )
+
+    def _queue_complete(self) -> None:
+        run_id = self._run_id()
+        if run_id is None:
+            self.message = "no run selected"
+            return
+        self.pending = (
+            f"close run {run_id} as completed? (REVIEW_CONFIRMED + RUN_COMPLETED)",
+            lambda: model.complete_run(self.storage, run_id),
+        )
+
+    def _queue_confirm(self) -> None:
+        run_id = self._run_id()
+        if run_id is None:
+            self.message = "no run selected"
+            return
+        self.pending = (
+            f"confirm the self-reported goal and progress of run {run_id}? (REVIEW_CONFIRMED)",
+            lambda: model.confirm_state(self.storage, run_id),
+        )
+
+    def _queue_reconcile(self, *, occurred: bool) -> None:
+        run_id = self._run_id()
+        row = self._selected_action()
+        if run_id is None or row is None:
+            self.message = "select an action row first (cursor is on the actions list)"
+            return
+        if not row.uncertain:
+            self.message = f"{row.key[:24]} is {row.status}; only uncertain actions can be settled"
+            return
+        self.pending = (
+            f"settle {row.action_type} on run {run_id} as "
+            f"{'OCCURRED' if occurred else 'NOT OCCURRED'}? (ACTION_RECONCILED)",
+            lambda: model.reconcile_action(self.storage, run_id, row.key, occurred=occurred),
+        )
+
+
+_HELP_LINES = [
+    "CONTINUUM tui keys",
+    "",
+    "  q            quit                     r        refresh the view",
+    "  ?            toggle this help",
+    "",
+    "  runs list:   up/down or j/k move      enter/o  open the run",
+    "               y confirm state          c        force a checkpoint",
+    "               x complete the run",
+    "",
+    "  run detail:  left/right or 1-7 tabs   esc      back to the runs list",
+    "               up/down move or scroll   y        confirm state",
+    "               c force a checkpoint     x        complete the run",
+    "  actions tab: y settle as occurred     n        settle as not occurred",
+    "",
+    "  Every mutating key asks first: the footer shows the exact write and",
+    "  only a further y performs it. Anything else cancels. Reads never",
+    "  write: refreshing and browsing are always safe on a live run.",
+]
+
+
+# --------------------------------------------------------------------------- #
+# curses driver
+# --------------------------------------------------------------------------- #
+
+
+def _key_name(curses: Any, ch: int) -> str | None:
+    """Map one curses key code to the plain name TuiApp understands."""
+    special = {
+        curses.KEY_UP: "up",
+        curses.KEY_DOWN: "down",
+        curses.KEY_LEFT: "left",
+        curses.KEY_RIGHT: "right",
+        curses.KEY_ENTER: "enter",
+        curses.KEY_RESIZE: "resize",
+        curses.KEY_BACKSPACE: "esc",
+        10: "enter",
+        13: "enter",
+        27: "esc",
+    }
+    if ch in special:
+        return special[ch]
+    if 0 < ch < 256:
+        return chr(ch)
+    return None
+
+
+def _addline(screen: Any, y: int, x: int, text: str, attr: int = 0) -> None:
+    """Write one line, clipping to the screen. The bottom-right cell raises
+    on a full write, so failures are swallowed: a clipped dashboard beats a
+    dead one."""
+    with contextlib.suppress(Exception):
+        screen.addnstr(y, x, text, screen.getmaxyx()[1] - x - 1, attr)
+
+
+def _driver(curses: Any, screen: Any, app: TuiApp, refresh_seconds: float) -> int:
+    """Draw, wait for one key, repeat. Auto-refresh ticks arrive as -1."""
+    screen.keypad(True)
+    # terminals without a cursor control still render fine
+    with contextlib.suppress(Exception):
+        curses.curs_set(0)
+    screen.timeout(int(refresh_seconds * 1000) if refresh_seconds > 0 else -1)
+
+    while True:
+        screen.erase()
+        height, width = screen.getmaxyx()
+        app.width = width  # the landing screen centres the logo on this
+        _addline(screen, 0, 0, app.header(), curses.A_BOLD)
+        body = app.body_lines()
+        available = max(1, height - 3)
+        if app.cursor >= 0:  # keep the selected line inside the window
+            if app.cursor < app.scroll:
+                app.scroll = app.cursor
+            if app.cursor >= app.scroll + available:
+                app.scroll = app.cursor - available + 1
+        start = min(app.scroll, max(0, len(body) - available))
+        for row, line in enumerate(body[start : start + available], start=start):
+            attr = curses.A_REVERSE if row == app.cursor else 0
+            _addline(screen, row - start + 2, 0, line, attr)
+        _addline(screen, height - 1, 0, app.footer())
+        screen.refresh()
+
+        ch = screen.getch()
+        if ch == -1:  # refresh tick (or no key yet on a nonblocking screen)
+            app.refresh()
+            continue
+        key = _key_name(curses, ch)
+        if key is None:
+            continue
+        if not app.handle_key(key):
+            return ExitCode.OK
+
+
+def run_tui(storage: Storage, *, refresh_seconds: float = 0.0, err: Any = None) -> int:
+    """Open the full-screen dashboard; returns a process exit status.
+
+    Refuses rather than half-rendering when curses is unavailable or stdout
+    is not a terminal: the recovery data on screen deserves a whole screen,
+    and a mangled scrape of one is worse than a clear refusal pointing at
+    ``continuum dashboard``.
+    """
+    err = err if err is not None else sys.stderr
+    try:
+        import curses
+    except ImportError:
+        print(
+            "error: the curses module is not available on this platform; "
+            "use `continuum dashboard` for the browser dashboard",
+            file=err,
+        )
+        return ExitCode.ERROR
+    if not sys.stdout.isatty():
+        print(
+            "error: continuum tui needs an interactive terminal; stdout is not a TTY",
+            file=err,
+        )
+        return ExitCode.ERROR
+    try:
+        return _run(curses, storage, refresh_seconds)
+    except curses.error as exc:  # a terminal too small or too alien for curses
+        print("error: this terminal cannot run the tui:", exc, file=err)
+        print("use `continuum dashboard` for the browser dashboard", file=err)
+        return ExitCode.ERROR
+
+
+def _run(curses: Any, storage: Storage, refresh_seconds: float) -> int:
+    """Enter curses mode; the wrapper restores the terminal on the way out."""
+
+    def inner(screen: Any) -> int:
+        return _driver(curses, screen, TuiApp(storage), refresh_seconds)
+
+    result: int = curses.wrapper(inner)
+    return result

--- a/src/continuum/tui/model.py
+++ b/src/continuum/tui/model.py
@@ -1,0 +1,406 @@
+"""Pure view models for the terminal dashboard (issue #782).
+
+Everything here is plain data built from the same Storage, CheckpointManager
+and RecoveryEngine the CLI and the web dashboard use. There is deliberately
+no curses import: the driver in ``continuum.tui.app`` renders these rows, and
+the tests drive them without a terminal. The mutating verbs mirror the human
+CLI commands one for one, landing the same event types with the same
+Origin.HUMAN provenance, exactly like the dashboard HITL buttons (#242).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from continuum.actions import ActionLedger
+from continuum.actions.ledger import fold_action_events
+from continuum.budgets import (
+    DEFAULT_BUDGETS_PATH,
+    attempts_for_type,
+    evaluate_budget,
+    load_budgets,
+)
+from continuum.checkpoint import CheckpointManager
+from continuum.events import EventType
+from continuum.models import Action, ActionStatus, Origin, RunStatus, StateStatus
+from continuum.recovery import RecoveryEngine
+from continuum.recovery.family import children_of, roll_up_children
+from continuum.storage.base import Storage
+
+__all__ = [
+    "ActionRow",
+    "BudgetRow",
+    "CheckpointRow",
+    "EventRow",
+    "RunRow",
+    "action_rows",
+    "budget_rows",
+    "checkpoint_rows",
+    "complete_run",
+    "confirm_state",
+    "event_rows",
+    "family_lines",
+    "force_checkpoint",
+    "overview_lines",
+    "reconcile_action",
+    "recovery_lines",
+    "run_rows",
+]
+
+
+#: The statuses an operator may still settle from the keyboard, matching the
+#: set `continuum actions` flags and `pending_actions_with_keys` offers.
+UNCERTAIN_STATUSES = frozenset(
+    {ActionStatus.UNKNOWN, ActionStatus.STARTED, ActionStatus.REQUIRES_REVIEW}
+)
+
+
+@dataclass(frozen=True)
+class RunRow:
+    """One row of the runs list: what `runs` shows plus the recovery verdict."""
+
+    run_id: str
+    status: str
+    events: int
+    mode: str
+    safe: str
+    goal: str
+
+
+@dataclass(frozen=True)
+class CheckpointRow:
+    """One row of the checkpoint lineage, matching `history`."""
+
+    checkpoint_id: str
+    version: int
+    trigger: str
+    completed: int
+
+
+@dataclass(frozen=True)
+class ActionRow:
+    """One ledger action with the key a reconciliation would need."""
+
+    key: str
+    status: str
+    action_type: str
+    external_id: str
+    uncertain: bool
+
+
+@dataclass(frozen=True)
+class EventRow:
+    """One event of the log, archived prefix included after compaction."""
+
+    sequence: int
+    type: str
+    summary: str
+
+
+@dataclass(frozen=True)
+class BudgetRow:
+    """Retry-budget usage for one action type, matching `budget`."""
+
+    action_type: str
+    attempts: int
+    max_attempts: int
+    remaining: int
+
+
+def run_rows(storage: Storage) -> list[RunRow]:
+    """Assess every run for the index, mirroring the dashboard run table.
+
+    Each row assesses recovery independently and an assessment that raises is
+    shown as ``error: ...`` in that row rather than dropping the run: an
+    unreadable run must not hide from the operator watching the index.
+    """
+    rows: list[RunRow] = []
+    for run in storage.list_runs():
+        try:
+            decision = RecoveryEngine(storage).assess(run.run_id)
+            mode: str = decision.mode.value
+            safe: str = "yes" if decision.safe else "no"
+        except Exception as exc:  # presentation must not drop the run
+            mode, safe = f"error: {exc}", "unknown"
+        rows.append(
+            RunRow(
+                run_id=run.run_id,
+                status=run.status.value,
+                events=storage.last_sequence(run.run_id),
+                mode=mode,
+                safe=safe,
+                goal=run.goal,
+            )
+        )
+    return rows
+
+
+def overview_lines(storage: Storage, run_id: str) -> list[str]:
+    """The `inspect` view: semantic state, degraded folds included.
+
+    A run whose tail does not fold still answers, naming the break, because
+    the operator needs to see *that* before anything else.
+    """
+    state = CheckpointManager(storage).restore(run_id, on_unprojectable="degrade").state
+    lines = [
+        f"run:         {state.run_id}",
+        f"goal:        {state.goal.description} (v{state.goal.version})",
+        f"version:     v{state.version}  (events 1..{state.source_sequence})",
+        f"progress:    {state.progress.completed} completed, "
+        f"{state.progress.pending} pending, {state.progress.failed} failed",
+        f"decisions:   {len(state.decisions)} ({len(state.valid_decisions())} valid)",
+        f"findings:    {len(state.findings)}",
+        f"evidence:    {len(state.evidence)}",
+        f"pending:     {len(state.open_work())} task(s)",
+    ]
+    if state.plan:
+        lines.append(f"plan:        {len(state.plan)} unit(s)")
+        lines += [f"  - {p.step_id}: {p.description} [{p.status.value}]" for p in state.plan]
+    else:
+        lines.append("plan:        (none)")
+    if state.external_dependencies:
+        lines.append("dependencies:")
+        lines += [
+            f"  - {d.resource}: {d.version or 'unversioned'} [{d.status}]"
+            for d in state.external_dependencies
+        ]
+    if state.status is StateStatus.INVALID:
+        lines += [
+            "",
+            f"PROJECTION FAILURE: the log stops folding at sequence "
+            f"{state.unprojectable_at_sequence} ({state.unprojectable_event_type})",
+            f"  {state.unprojectable_reason}",
+            "  Figures cover events through the break only; `continuum verify` "
+            "reports the offending event.",
+        ]
+    return lines
+
+
+def _human_steps(decision: Any, run_id: str) -> list[str]:
+    """Executable next steps, mirroring the CLI's read-only probe of config."""
+    from continuum.gate import DEFAULT_GATE_CONFIG_PATH
+    from continuum.reconcilers import DEFAULT_RECONCILERS_PATH, load_reconcilers
+    from continuum.recovery.guidance import human_steps_for
+
+    try:
+        probed: list[str] = list(load_reconcilers(Path(DEFAULT_RECONCILERS_PATH)))
+    except Exception:
+        probed = []
+    return human_steps_for(
+        decision,
+        run_id=run_id,
+        probed_types=probed,
+        gate_configured=Path(DEFAULT_GATE_CONFIG_PATH).exists(),
+    )
+
+
+def recovery_lines(storage: Storage, run_id: str) -> list[str]:
+    """The `resume` view without --repair: verdict, family roll-up, advisories.
+
+    Read-only. The family section repeats the CLI's presentation: a parent may
+    not RESUME while any child is unsafe, and the most cautious signal wins.
+    """
+    decision = RecoveryEngine(storage).assess(run_id)
+    lines = decision.render().split("\n")
+    steps = _human_steps(decision, run_id)
+    if steps:
+        lines += ["", "Next steps:"] + [f"  {i}. {step}" for i, step in enumerate(steps, 1)]
+
+    child_statuses, family_blocked = roll_up_children(storage, run_id)
+    if family_blocked:
+        lines += [
+            "",
+            "FAMILY BLOCKED: children of this run are not resumable.",
+        ] + [
+            f"  !! child run {c.run_id} is {c.mode} (uncertain={c.uncertain_actions})"
+            for c in child_statuses
+            if not c.safe or c.mode != "resume"
+        ]
+
+    try:
+        from continuum.recovery.health import advisory_for_storage, advisory_text
+
+        lines += ["", advisory_text(advisory_for_storage(storage, run_id))]
+    except Exception:
+        pass
+    try:
+        from continuum.analysis.prefix_trust import trust_over_prefix
+
+        advisory = trust_over_prefix(decision.state)
+        breakdown = advisory.get("breakdown", {})
+        lines += [
+            f"Prefix trust: {advisory.get('trust_score', 1.0):.3f} "
+            f"(role={breakdown.get('role', 1.0):.3f} "
+            f"goal={breakdown.get('goal', 1.0):.3f} "
+            f"evidence={breakdown.get('evidence', 1.0):.3f})"
+        ]
+    except Exception:
+        pass
+    return lines
+
+
+def checkpoint_rows(storage: Storage, run_id: str) -> list[CheckpointRow]:
+    """The `history` view: one row per checkpoint, multiple per version kept."""
+    storage.get_run(run_id)  # raises RunNotFound rather than reading as "none yet"
+    rows: list[CheckpointRow] = []
+    for checkpoint in storage.list_checkpoints(run_id):
+        state = storage.get_version(run_id, checkpoint.version)
+        rows.append(
+            CheckpointRow(
+                checkpoint_id=checkpoint.checkpoint_id,
+                version=checkpoint.version,
+                trigger=checkpoint.trigger,
+                completed=state.progress.completed,
+            )
+        )
+    return rows
+
+
+def action_rows(storage: Storage, run_id: str) -> list[ActionRow]:
+    """The `actions` view, each row carrying the key a reconciliation needs.
+
+    Folded from the live log the same way the dashboard HITL buttons fold it,
+    so the key offered here is the key that would settle the action.
+    """
+    storage.get_run(run_id)
+    folded: dict[str, Action] = fold_action_events(storage.read_events(run_id))
+    return [
+        ActionRow(
+            key=key,
+            status=action.status.value,
+            action_type=action.action_type,
+            external_id=action.external_id or "-",
+            uncertain=action.status in UNCERTAIN_STATUSES,
+        )
+        for key, action in sorted(folded.items())
+    ]
+
+
+def event_rows(storage: Storage, run_id: str) -> list[EventRow]:
+    """The `events` view: archived prefix included, so a compacted run reads
+    the same as one that was never compacted (#532)."""
+    storage.get_run(run_id)
+    return [
+        EventRow(
+            sequence=event.sequence,
+            type=event.type.value,
+            summary=json.dumps(dict(event.payload), default=str),
+        )
+        for event in storage.read_all_events(run_id)
+    ]
+
+
+def family_lines(storage: Storage, run_id: str) -> list[str]:
+    """The `tree` view: the parent verdict and every child's, read-only."""
+    storage.get_run(run_id)
+    run = storage.get_run(run_id)
+    lines = [f"{run_id}  [{run.status.value}]  {run.goal[:60]}"]
+    children = children_of(storage, run_id)
+    if not children:
+        lines.append("  (no children)")
+    for child in children:
+        fork_mark = "[fork] " if str(child.metadata.get("fork", "")) == "true" else ""
+        try:
+            decision = RecoveryEngine(storage).assess(child.run_id)
+            mark = "ok " if decision.safe else "!! "
+            lines.append(
+                f"  {mark}{fork_mark}{child.run_id}  [{decision.mode.value}, "
+                f"uncertain={len(decision.uncertain_actions)}]  {child.goal[:44]}"
+            )
+        except Exception as exc:
+            lines.append(f"  !! {fork_mark}{child.run_id}  [assess error: {exc}]")
+    return lines
+
+
+def budget_rows(storage: Storage, run_id: str) -> list[BudgetRow]:
+    """The `budget` view, archive-aware: attempts are counted over the whole
+    log, so compaction does not hand a run a fresh budget (#734)."""
+    storage.get_run(run_id)
+    try:
+        raw = load_budgets(Path(DEFAULT_BUDGETS_PATH))
+    except Exception:
+        raw = {}
+    events = storage.read_all_events(run_id)
+    types_seen = sorted(
+        {
+            e.payload.get("action", {}).get("action_type")
+            for e in events
+            if e.type is EventType.ACTION_RECORDED and isinstance(e.payload.get("action"), dict)
+        }
+        | set((raw.get("action_types") or {}).keys())
+    )
+    rows: list[BudgetRow] = []
+    for action_type in types_seen:
+        used = attempts_for_type(events, action_type)
+        _, _, maximum = evaluate_budget(raw, action_type, 0)
+        rows.append(
+            BudgetRow(
+                action_type=action_type,
+                attempts=used,
+                max_attempts=maximum,
+                remaining=max(0, maximum - used),
+            )
+        )
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# control verbs (mutating; the app layer confirms before calling any of these)
+# --------------------------------------------------------------------------- #
+
+
+def force_checkpoint(storage: Storage, run_id: str) -> str:
+    """`checkpoint --trigger manual`: seal the current state now."""
+    checkpoint = CheckpointManager(storage).checkpoint(
+        run_id, trigger="manual", reason="forced from the tui"
+    )
+    return (
+        f"checkpoint {checkpoint.checkpoint_id} written at v{checkpoint.version} "
+        f"({checkpoint.state.progress.completed} completed)"
+    )
+
+
+def confirm_state(storage: Storage, run_id: str) -> str:
+    """`confirm`: REVIEW_CONFIRMED (Origin.HUMAN), clearing self-certification."""
+    storage.append_event(
+        run_id,
+        EventType.REVIEW_CONFIRMED,
+        {"components": ["goal", "progress"]},
+        source=Origin.HUMAN,
+    )
+    return "goal and progress confirmed (REVIEW_CONFIRMED)"
+
+
+def reconcile_action(storage: Storage, run_id: str, ledger_key: str, *, occurred: bool) -> str:
+    """Settle one uncertain side effect, the same ledger write the dashboard
+    HITL button and `continuum reconcile` perform."""
+    ActionLedger(storage, run_id).reconcile(
+        ledger_key, occurred=occurred, note="settled from the tui"
+    )
+    return f"reconciled {ledger_key[:16]}... occurred={occurred}"
+
+
+def complete_run(storage: Storage, run_id: str) -> str:
+    """`complete`: close the run from the keyboard, mirroring cmd_complete
+    (REVIEW_CONFIRMED plus RUN_COMPLETED, both Origin.HUMAN, and the run row
+    flips so finished work stops surfacing as the active run)."""
+    run = storage.get_run(run_id)
+    if run.status is RunStatus.COMPLETED:
+        return f"run {run_id} is already completed"
+    storage.append_event(
+        run_id,
+        EventType.REVIEW_CONFIRMED,
+        {"components": ["goal", "progress"]},
+        source=Origin.HUMAN,
+    )
+    storage.append_event(
+        run_id,
+        EventType.RUN_COMPLETED,
+        {"closed_by": "tui"},
+        source=Origin.HUMAN,
+    )
+    storage.update_run(run.touch(status=RunStatus.COMPLETED))
+    return f"run {run_id} completed"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@
 
 Present so ``from tests.mcp_helpers import ...`` resolves regardless of how
 pytest is invoked. Without it the import works only when the repository root
-happens to land on ``sys.path`` — true when running ``pytest`` from the project
+happens to land on ``sys.path``: true when running ``pytest`` from the project
 directory, false in CI, which failed with ``ModuleNotFoundError: No module
 named 'tests'`` on all three Python versions.
 """

--- a/tests/mcp_helpers.py
+++ b/tests/mcp_helpers.py
@@ -25,8 +25,8 @@ class _Session:
 class FakeContext:
     """Stands in for an MCP request context with a declared client identity.
 
-    Mirrors the real shape the transport injects — ``session.client_params
-    .client_info.name`` — which is read from the initialize handshake and
+    Mirrors the real shape the transport injects (``session.client_params
+    .client_info.name``), which is read from the initialize handshake and
     cannot be set by a tool argument. ``auth_token`` populates the handshake's
     ``_meta.authToken`` so authentication can be exercised without a live
     transport.

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -295,6 +295,81 @@ def test_complete_refuses_every_status_that_is_not_in_flight(
         ledger.complete(outcome.key, external_id="txn-1")
 
 
+@pytest.mark.parametrize(
+    ("settle", "expected_status"),
+    [
+        (lambda led, key: led.complete(key, external_id="txn-1"), "completed"),
+        (lambda led, key: led.compensate(key, note="refunded"), "compensated"),
+        (lambda led, key: led.flag_for_review(key, "amount looks wrong"), "requires_review"),
+    ],
+)
+def test_fail_refuses_every_status_that_is_not_in_flight(
+    ledger: ActionLedger,
+    settle: Any,
+    expected_status: str,
+) -> None:
+    """The mirror of complete's guard (issue #366) for fail (issue #733).
+
+    A COMPLETED action flipped to FAILED by a late report reopened the key and
+    let the next claim re-fire a side effect that had already happened. The
+    other settled statuses are corrections of outcomes already on record, which
+    belong to `reconcile`.
+    """
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    settle(ledger, outcome.key)
+
+    with pytest.raises(LedgerError, match=expected_status):
+        ledger.fail(outcome.key, "late failure report")
+
+
+def test_a_refused_fail_leaves_the_completed_outcome_settled(ledger: ActionLedger) -> None:
+    """The point of the guard: dedup must survive the refused late report.
+
+    The COMPLETED action keeps its receipt, stays out of pending(), and the
+    same claim remains a cache hit instead of re-opening as a fresh attempt.
+    """
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.complete(outcome.key, external_id="txn-1")
+
+    with pytest.raises(LedgerError, match="erase a recorded outcome"):
+        ledger.fail(outcome.key, "late timeout report")
+
+    still = ledger.get(str(outcome.key))
+    assert still is not None
+    assert still.status is ActionStatus.COMPLETED
+    assert still.external_id == "txn-1"
+    assert not ledger.pending()
+
+    retry = ledger.claim("payment.charge", {"amount": 100})
+    assert retry.fresh is False, "a refused fail must not reopen the key"
+
+
+def test_failing_an_already_failed_action_is_still_allowed(ledger: ActionLedger) -> None:
+    """A caller repeating a failure report after a dropped response asserts
+    nothing new (same allowance complete makes for COMPLETED, issue #366)."""
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.fail(outcome.key, "500 from upstream")
+
+    again = ledger.fail(outcome.key, "500 from upstream, re-reported")
+    assert again.status is ActionStatus.FAILED
+
+
+def test_fail_refuses_an_unknown_action_and_reconcile_remains_the_route(
+    ledger: ActionLedger,
+) -> None:
+    """An uncertain outcome cannot be resolved by assertion; the evidence
+    goes through `reconcile`, exactly as for complete (issue #366)."""
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.fail(outcome.key, "gateway timeout", certain=False)
+
+    with pytest.raises(LedgerError, match="unknown"):
+        ledger.fail(outcome.key, "definitely did not happen")
+
+    settled = ledger.reconcile(outcome.key, occurred=False, note="gateway has no trace of it")
+    assert settled.status is ActionStatus.FAILED
+    assert not ledger.pending()
+
+
 def test_completing_an_already_completed_action_is_still_allowed(
     ledger: ActionLedger,
 ) -> None:

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -196,7 +196,7 @@ def test_an_unknown_action_reports_the_key_needed_to_reconcile_it(
 
 def test_an_interrupted_action_refuses_to_silently_retry(ledger: ActionLedger) -> None:
     """Crash between claim and complete: the effect may or may not have landed."""
-    ledger.claim("github.create_issue", ISSUE)  # never completed — process died
+    ledger.claim("github.create_issue", ISSUE)  # never completed, process died
 
     with pytest.raises(UnknownSideEffect, match="may or may not have occurred"):
         ledger.claim("github.create_issue", ISSUE)
@@ -603,7 +603,7 @@ def test_an_explicit_key_lets_a_repeat_be_a_genuine_second_action(
     """Argument hashing cannot express "this repeat is intentional".
 
     Two identical reminders are two sends, not one. Without an explicit key the
-    second is silently deduplicated away — failing closed, but still wrong.
+    second is silently deduplicated away, failing closed, but still wrong.
     """
     args = {"to": "x@y.z", "body": "Standup in 5"}
 

--- a/tests/test_authority_probe.py
+++ b/tests/test_authority_probe.py
@@ -228,3 +228,40 @@ def test_authority_probe_no_probe_registered_leaves_blocked(tmp_path: pathlib.Pa
         assert "auth-no-probe" in consumed
     finally:
         storage.close()
+
+
+def test_probe_payload_keeps_consumption_context_after_compaction(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Post-compaction probes must still see how the authority was consumed (issue #647).
+
+    The AUTHORITY_CONSUMED row can predate a compaction. settle_authority used
+    to scan the live tail only, silently handing the probe a bare authority_id
+    payload with no consumer_run_id, via_action_id, or sequence.
+    """
+    storage = _storage()
+    try:
+        record_authority_consumed(storage, "run_1", "auth-compact-1", via_action_id="act-1")
+        storage.compact_run("run_1", through_sequence=storage.last_sequence("run_1"))
+        # Premise guard: the consumption row really is archived, not live.
+        live_types = [e.type for e in storage.read_events("run_1")]
+        assert EventType.AUTHORITY_CONSUMED not in live_types
+
+        payload_file = tmp_path / "payload.json"
+        # Single quotes inside the double-quoted -c argument survive both sh
+        # grouping and cmd's C-runtime unescaping (see _probe_command).
+        cmd = f"\"{sys.executable}\" -c \"import sys; open('{payload_file.as_posix()}', 'w').write(sys.stdin.read())\""
+        cfg = tmp_path / "reconcilers.json"
+        cfg.write_text(json.dumps({"probes": {"auth-compact-1": {"command": cmd, "timeout": 5}}}))
+        probes = load_reconcilers(cfg)
+        report = settle_authority(storage, "run_1", "auth-compact-1", probes)
+        assert report.settled is False  # prints no verdict line: stays unknown
+
+        received = json.loads(payload_file.read_text(encoding="utf-8"))
+        assert received["authority_id"] == "auth-compact-1"
+        assert received["consumer_run_id"] == "run_1"
+        assert received["via_action_id"] == "act-1"
+        assert isinstance(received["sequence"], int)
+        assert received["consumed_at"]
+    finally:
+        storage.close()

--- a/tests/test_authority_probe.py
+++ b/tests/test_authority_probe.py
@@ -265,3 +265,35 @@ def test_probe_payload_keeps_consumption_context_after_compaction(
         assert received["consumed_at"]
     finally:
         storage.close()
+
+
+def test_probe_for_an_authority_that_was_never_consumed_settles_with_a_bare_id(
+    tmp_path: pathlib.Path,
+) -> None:
+    """No AUTHORITY_CONSUMED row at all: the scan exhausts and the probe still runs.
+
+    Covers the loop-exhaustion branch of the consumption scan (every other
+    test finds a row and breaks). The payload is intentionally bare: only
+    authority_id, with no consumption context to lose.
+    """
+    storage = _storage()
+    try:
+        cfg = tmp_path / "reconcilers.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "probes": {
+                        "auth-never-consumed": {
+                            "command": _probe_command('{"valid": true}'),
+                            "timeout": 5,
+                        }
+                    }
+                }
+            )
+        )
+        probes = load_reconcilers(cfg)
+        report = settle_authority(storage, "run_1", "auth-never-consumed", probes)
+        assert report.valid is True
+        assert report.settled is True
+    finally:
+        storage.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@
 
 ``continuum resume "$RUN" && ./start-agent.sh`` is the line these tests exist to
 protect. If an unsafe run ever exits 0, an agent gets launched onto stale state
-or an unreconciled side effect — so the exit code is treated as a safety
+or an unreconciled side effect, so the exit code is treated as a safety
 guarantee, not a formatting detail.
 """
 
@@ -193,7 +193,7 @@ def test_no_command_reports_success_for_a_run_that_does_not_exist(
     """A typo'd run name must never look like a clean bill of health.
 
     An empty run has a trivially valid (empty) event chain and no recorded
-    actions, so `verify` and `actions` would happily exit 0 — letting
+    actions, so `verify` and `actions` would happily exit 0, letting
     `continuum verify $TYPO && deploy` succeed against a name nobody has ever
     written to. Mutating commands owe the same distinction: `checkpoint`
     diagnosed a missing run as a projection error until issue #202.

--- a/tests/test_cli_colour.py
+++ b/tests/test_cli_colour.py
@@ -114,8 +114,8 @@ def test_emit_routes_json_around_the_colouriser_even_with_a_live_palette() -> No
 
     JSON is protected twice: the palette is disabled for --json, *and* _emit
     never passes the JSON branch through the colouriser. Either alone suffices,
-    so this asserts the lower layer directly — otherwise a refactor could drop
-    it while the upper guard masked the loss.
+    so this asserts the lower layer directly. Otherwise a refactor could drop it
+    while the upper guard masked the loss.
     """
     from continuum.cli.main import _emit
 

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -1,0 +1,22 @@
+"""Every CLI subcommand must have a row in the reference table (#632).
+
+The table in docs/api/cli.md drifted behind the parser twice (#360, #632).
+Rows carry usage syntax after the name, so the guard matches a backtick
+immediately before the name rather than a bare backticked word.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from continuum.cli.main import build_parser
+
+TABLE = Path(__file__).resolve().parents[1] / "docs" / "api" / "cli.md"
+
+
+def test_every_subcommand_has_a_table_row() -> None:
+    table = TABLE.read_text(encoding="utf-8")
+    subs = sorted(build_parser()._subparsers._group_actions[0].choices.keys())
+    assert subs, "parser exposes no subcommands"
+    missing = [name for name in subs if ("`" + name) not in table]
+    assert not missing, f"subcommands without a docs/api/cli.md row: {missing}"

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -1,12 +1,15 @@
 """Every CLI subcommand must have a row in the reference table (#632).
 
 The table in docs/api/cli.md drifted behind the parser twice (#360, #632).
-Rows carry usage syntax after the name, so the guard matches a backtick
-immediately before the name rather than a bare backticked word.
+Rows carry usage syntax after the name, so the guard anchors on Command-column
+row starts instead of bare substrings: prose mentions (`` `resume --json` ``)
+and prefix collisions (`` `attest `` matching `` `attest-keygen` ``) must not
+mask a deleted row.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from continuum.cli.main import build_parser
@@ -14,9 +17,13 @@ from continuum.cli.main import build_parser
 TABLE = Path(__file__).resolve().parents[1] / "docs" / "api" / "cli.md"
 
 
+def _row_pattern(name: str) -> "re.Pattern[str]":
+    return re.compile(r"^\|\s*`" + re.escape(name) + r"(?=[\s`|])", re.MULTILINE)
+
+
 def test_every_subcommand_has_a_table_row() -> None:
     table = TABLE.read_text(encoding="utf-8")
     subs = sorted(build_parser()._subparsers._group_actions[0].choices.keys())
     assert subs, "parser exposes no subcommands"
-    missing = [name for name in subs if ("`" + name) not in table]
+    missing = [name for name in subs if not _row_pattern(name).search(table)]
     assert not missing, f"subcommands without a docs/api/cli.md row: {missing}"

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -17,7 +17,7 @@ from continuum.cli.main import build_parser
 TABLE = Path(__file__).resolve().parents[1] / "docs" / "api" / "cli.md"
 
 
-def _row_pattern(name: str) -> "re.Pattern[str]":
+def _row_pattern(name: str) -> re.Pattern[str]:
     return re.compile(r"^\|\s*`" + re.escape(name) + r"(?=[\s`|])", re.MULTILINE)
 
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -346,3 +346,32 @@ def test_anchor_event_is_non_projecting(db: str) -> None:
     assert not report.ignored_types, (
         "EVENT_LOG_ANCHORED must be declared non-projecting, not silently ignored"
     )
+
+
+def test_compact_run_rejects_through_sequence_that_would_eat_the_anchor(db: str) -> None:
+    """Issue #705: through_sequence at or above the anchor's own sequence
+    must be rejected. Accepting it archived and deleted the anchor (and with
+    it the whole live log), so the next append minted a fresh genesis and
+    forked the hash chain away from the archive."""
+    for i in range(4):
+        work(db, i)
+    with SQLiteStorage(db) as store:
+        pre_live = len(store.read_events("run_1"))
+
+        with pytest.raises(ValueError, match="anchor"):
+            store.compact_run("run_1", through_sequence=10_000)
+
+        # The rejected call leaves a healthy, verifiable log behind: nothing
+        # was archived, only the forced checkpoint marker was appended.
+        report = store.verify_events("run_1")
+        assert report.ok, [v.kind for v in report.violations]
+        live = store.read_events("run_1")
+        assert len(live) == pre_live + 1
+        assert store.read_events("run_1")[0].sequence == 1, "live rows must not have moved"
+
+        # A bounded value below the anchor still compacts normally.
+        result = store.compact_run("run_1", through_sequence=1)
+        assert result["archived"] >= 1
+        assert any(e.type is EventType.EVENT_LOG_ANCHORED for e in store.read_events("run_1"))
+        report = store.verify_events("run_1")
+        assert report.ok, [v.kind for v in report.violations]

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -4,6 +4,7 @@ import pytest
 
 from continuum.models import (
     Component,
+    ConstraintPin,
     Decision,
     DiffKind,
     Evidence,
@@ -13,6 +14,7 @@ from continuum.models import (
     ModelState,
     PendingWork,
     Progress,
+    Provenance,
     SemanticState,
     StateStatus,
 )
@@ -53,6 +55,43 @@ def test_added_and_removed_components_are_reported() -> None:
     after = make_state(findings=[Finding(finding_id="f81", claim="new")])
     diff = diff_states(before, after)
     assert kinds(diff, Component.FINDING) == {DiffKind.ADDED, DiffKind.REMOVED}
+
+
+def test_pin_add_and_retract_are_reported() -> None:
+    """Pins are the active constraint set a resuming agent must honour.
+
+    The diff predates pins, so adding or retracting one used to yield an empty
+    diff and `continuum diff` said "no semantic change" (issue #740).
+    """
+    pin = ConstraintPin(
+        constraint_id="c1", sha256="a" * 64, status="active", provenance=Provenance()
+    )
+    added = diff_states(make_state(), make_state(pins={"c1": pin}))
+    assert kinds(added, Component.PIN) == {DiffKind.ADDED}
+
+    retracted = diff_states(make_state(pins={"c1": pin}), make_state())
+    assert kinds(retracted, Component.PIN) == {DiffKind.REMOVED}
+
+
+def test_a_pin_whose_digest_changes_is_reported() -> None:
+    """Same label, different constraint text: the digest is the identity."""
+    before = make_state(
+        pins={"c1": ConstraintPin(constraint_id="c1", sha256="a" * 64, provenance=Provenance())}
+    )
+    after = make_state(
+        pins={"c1": ConstraintPin(constraint_id="c1", sha256="b" * 64, provenance=Provenance())}
+    )
+    diff = diff_states(before, after)
+    assert kinds(diff, Component.PIN) == {DiffKind.CHANGED}
+
+
+def test_unchanged_pins_produce_no_entries() -> None:
+    pin = ConstraintPin(
+        constraint_id="c1", sha256="a" * 64, status="active", provenance=Provenance()
+    )
+    before = make_state(pins={"c1": pin})
+    after = make_state(pins={"c1": pin})
+    assert diff_states(before, after).entries == []
 
 
 def test_invalidation_is_distinguished_from_an_ordinary_change() -> None:

--- a/tests/test_docs_counts.py
+++ b/tests/test_docs_counts.py
@@ -1,0 +1,64 @@
+"""Guard the documented pytest counts against silent drift (#630).
+
+README.md, docs/CONTRIBUTING_ONBOARDING.md, and CHANGELOG.md each state the
+collected total. The guard asserts the three files agree with each other and
+with a live ``pytest --collect-only`` within tolerance. Skips vary by
+environment, so only collected totals are compared, never passed/skipped
+splits. Regenerate the figures with ``pytest --collect-only -q; pytest -q``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COUNTED_FILES = (
+    ROOT / "README.md",
+    ROOT / "docs" / "CONTRIBUTING_ONBOARDING.md",
+    ROOT / "CHANGELOG.md",
+)
+# Small PRs move the total by a handful of tests; doc rot moves it by the
+# hundreds (#316: exact, #630: 135). Tolerance 30 splits the difference.
+TOLERANCE = 30
+
+_COLLECTED_RE = re.compile(r"~([\d,]+)`?\s+collected")
+
+
+def documented_total(path: Path) -> int:
+    matches = _COLLECTED_RE.findall(path.read_text(encoding="utf-8"))
+    assert matches, f"{path.name} states no ~N collected figure"
+    totals = {int(m.replace(",", "")) for m in matches}
+    assert len(totals) == 1, f"{path.name} states inconsistent figures: {sorted(totals)}"
+    return totals.pop()
+
+
+def live_total() -> int:
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-p", "no:cacheprovider"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=ROOT,
+    )
+    assert proc.returncode == 0, f"collect-only failed:\n{proc.stderr[-2000:]}"
+    match = re.search(r"(\d[\d,]*)\s+tests? collected", proc.stdout)
+    assert match, f"unparsable collect-only output:\n{proc.stdout[-500:]}"
+    return int(match.group(1).replace(",", ""))
+
+
+def test_documented_counts_agree() -> None:
+    totals = {f.name: documented_total(f) for f in COUNTED_FILES}
+    assert len(set(totals.values())) == 1, f"documented counts disagree: {totals}"
+
+
+def test_documented_count_matches_suite() -> None:
+    documented = documented_total(COUNTED_FILES[0])
+    live = live_total()
+    assert abs(live - documented) <= TOLERANCE, (
+        f"suite collects {live} tests but docs say ~{documented}: "
+        "re-sync README.md, docs/CONTRIBUTING_ONBOARDING.md, and CHANGELOG.md "
+        "(pytest --collect-only -q; pytest -q)"
+    )

--- a/tests/test_docs_counts.py
+++ b/tests/test_docs_counts.py
@@ -24,12 +24,20 @@ COUNTED_FILES = (
 # hundreds (#316: exact, #630: 135). Tolerance 30 splits the difference.
 TOLERANCE = 30
 
-_COLLECTED_RE = re.compile(r"~([\d,]+)`?\s+collected")
+# Every prose form the three files use for the collected total (#664 review):
+# "~2,053 collected", "roughly 2,053 tests collected", "~2,053 tests".
+# Passed/skipped figures are deliberately unmatched: they vary by environment.
+_COLLECTED_RES = (
+    re.compile(r"~([\d,]+)`?\s+collected"),
+    re.compile(r"roughly\s+([\d,]+)\s+tests\s+collected"),
+    re.compile(r"~([\d,]+)\s+tests\b"),
+)
 
 
 def documented_total(path: Path) -> int:
-    matches = _COLLECTED_RE.findall(path.read_text(encoding="utf-8"))
-    assert matches, f"{path.name} states no ~N collected figure"
+    text = path.read_text(encoding="utf-8")
+    matches = [m for rx in _COLLECTED_RES for m in rx.findall(text)]
+    assert matches, f"{path.name} states no collected-total figure"
     totals = {int(m.replace(",", "")) for m in matches}
     assert len(totals) == 1, f"{path.name} states inconsistent figures: {sorted(totals)}"
     return totals.pop()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -13,7 +13,7 @@ from continuum.environment import (
     diff_environments,
     process_fingerprint,
 )
-from continuum.models import EnvResource
+from continuum.models import EnvResource, StateStatus
 
 # --- capture --------------------------------------------------------------- #
 
@@ -100,11 +100,59 @@ def test_an_unreadable_file_becomes_unknown(tmp_path: Path) -> None:
 
 
 def test_large_files_are_sized_rather_than_hashed(tmp_path: Path) -> None:
+    """An oversized file is reported as unknown, never as a fake identity.
+
+    The size used to be stamped into the version as ``size:<n>``, which
+    diff_environments then compared as an identity: a replaced file of the same
+    byte size verified as unchanged and the environment check failed open
+    (issue #738). The size lives in metadata instead.
+    """
     big = tmp_path / "big.bin"
     big.write_bytes(b"x" * 5000)
     resource = capture("run_1", FileProvider([big], max_bytes=1000)).resources[str(big)]
-    assert resource.version == "size:5000"
+    assert resource.version == UNKNOWN_VERSION
     assert resource.metadata["skipped"]
+    assert resource.metadata["size"] == 5000
+
+
+def test_a_replaced_same_size_oversized_file_is_not_verified_unchanged(tmp_path: Path) -> None:
+    """The fail-open regression (issue #738): same size, different content.
+
+    Two captures of a fully replaced file must never read as a verified
+    unchanged resource when the content was never hashed.
+    """
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"A" * 5000)
+    before = capture("run_1", FileProvider([big], max_bytes=1000))
+    big.write_bytes(b"B" * 5000)
+    after = capture("run_1", FileProvider([big], max_bytes=1000))
+
+    delta = next(d for d in diff_environments(before, after).deltas if d.resource == str(big))
+    assert delta.change is ResourceChange.UNKNOWN
+    assert "larger than max_bytes" in (delta.detail or "")
+
+
+def test_an_oversized_dependency_does_not_resume_as_verified(tmp_path: Path) -> None:
+    """The validator side of issue #738: unknown content must not read VALID."""
+    from continuum.models import ExternalDependency, Goal, Progress, SemanticState
+    from continuum.state.validator import validate_state
+
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"A" * 5000)
+    before = capture("run_1", FileProvider([big], max_bytes=1000))
+    big.write_bytes(b"B" * 5000)
+    after = capture("run_1", FileProvider([big], max_bytes=1000))
+
+    state = SemanticState(
+        run_id="run_1",
+        goal=Goal(description="analyse dataset"),
+        progress=Progress(),
+        external_dependencies=[ExternalDependency(resource=str(big), kind="file")],
+    )
+    outcome = validate_state(state, checkpoint_environment=before, current_environment=after)
+    entry = next(e for e in outcome.report.statuses if e.component_id == str(big))
+    assert entry.status is StateStatus.UNKNOWN
+    assert not outcome.report.safe_to_resume
 
 
 def test_value_provider_fingerprints_in_memory_state() -> None:

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -260,3 +260,23 @@ def test_composite_chains_without_double_applying_events() -> None:
     assert state.progress.completed == 1  # not 2 — events folded exactly once
     assert {w.task_id for w in state.pending_work} == {"t_llm"}
     assert state.decision("d1") is not None
+
+
+def test_a_string_evidence_field_is_wrapped_not_split_into_characters() -> None:
+    """LLM proposals are stringly by nature; a bare-string evidence field is
+    the most common shape drift. Iterating it split the citation into
+    per-character ids (['e','v','_','4','2']), corrupting the persisted state
+    and blocking resume under strict_unknown via phantom dangling evidence."""
+    log = build_log()
+    extractor = LLMExtractor(
+        lambda ctx, state: LLMProposal(
+            decisions=[{"decision_id": "d_llm", "decision": "inferred", "evidence": "ev_42"}],
+            findings=[{"finding_id": "f_llm", "claim": "inferred", "evidence": "ev_42"}],
+        )
+    )
+    state = extractor.extract(context(log))
+
+    decision = next(d for d in state.decisions if d.decision_id == "d_llm")
+    finding = next(f for f in state.findings if f.finding_id == "f_llm")
+    assert decision.evidence == ["ev_42"]
+    assert finding.evidence == ["ev_42"]

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -257,7 +257,7 @@ def test_composite_chains_without_double_applying_events() -> None:
     )
     state = composite.extract(context(log))
 
-    assert state.progress.completed == 1  # not 2 — events folded exactly once
+    assert state.progress.completed == 1  # not 2, events folded exactly once
     assert {w.task_id for w in state.pending_work} == {"t_llm"}
     assert state.decision("d1") is not None
 

--- a/tests/test_family.py
+++ b/tests/test_family.py
@@ -175,6 +175,38 @@ def test_uncertain_child_blocks_the_parent_resume(db: str) -> None:
     assert payload["safe"] is True
 
 
+def test_a_family_blocked_parent_never_exits_zero(db: str) -> None:
+    """The exit-code contract: only a verified safe-to-resume run exits 0.
+
+    A clean parent with an unsafe child presented request_human in the JSON
+    but still exited 0, so `resume "$PARENT" && ./start-agent.sh` launched an
+    agent onto a family holding an unreconciled side effect (issue #741).
+    """
+    run("--db", db, "start", "par", "--goal", "supervise")
+    run("--db", db, "start", "kid", "--goal", "work", "--parent", "par")
+    ActionLedger(SQLiteStorage(db), "kid").claim("send_invoice", {}, key="invoice:I-9")
+
+    code, out, err = run("--db", db, "--json", "resume", "par")
+    payload = json.loads(out)
+    assert payload["mode"] == "request_human"
+    assert payload["safe"] is False
+    assert code == ExitCode.REQUIRES_HUMAN, err
+
+    # Text mode agrees: the decision line and permitted action follow the
+    # family overlay, not the parent's own per-run verdict.
+    code, out, _ = run("--db", db, "resume", "par")
+    assert code == ExitCode.REQUIRES_HUMAN
+    assert "Recovery decision: REQUEST_HUMAN" in out
+    assert "FAMILY BLOCKED" in out
+    assert "Next permitted action: continue" not in out
+
+    # Settling the child restores the zero exit.
+    key = idempotency_key("send_invoice", None, scope="kid", key="invoice:I-9")
+    ActionLedger(SQLiteStorage(db), "kid").reconcile(str(key), occurred=True)
+    code, _, _ = run("--db", db, "--json", "resume", "par")
+    assert code == ExitCode.OK
+
+
 def test_clean_children_do_not_block_the_parent(db: str) -> None:
     run("--db", db, "start", "par", "--goal", "supervise")
     code, out, _ = run("--db", db, "--json", "resume", "par")

--- a/tests/test_interchange_evidence.py
+++ b/tests/test_interchange_evidence.py
@@ -82,7 +82,7 @@ def test_truncation_is_detectable() -> None:
         _make_run(store)
         primitives = export_evidence(store, "run_1")
         assert verify_export(primitives) is True
-        # Drop a middle line — sequence and prev_hash break
+        # Drop a middle line, so sequence and prev_hash break
         truncated = primitives[:2] + primitives[3:]
         assert verify_export(truncated) is False
         # Tail truncation is detectable by length and final hash mismatch

--- a/tests/test_ledger_source.py
+++ b/tests/test_ledger_source.py
@@ -1,0 +1,62 @@
+"""Remote-agent ledger writes carry EXTERNAL_AGENT (#653).
+
+MCP and sidecar servers stamp their direct appends EXTERNAL_AGENT but built
+their ledgers with the deterministic default, so agent-asserted effects
+laundered to trusted in derived provenance. Both now construct their ledger
+with AGENT_SOURCE. Stacked on the #612 mechanism.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from continuum.actions import ActionLedger
+from continuum.events import EventType
+from continuum.models import Origin, Run
+from continuum.provenance_map import derived_provenance_for_events
+from continuum.storage import SQLiteStorage
+
+
+def _run(db: str) -> None:
+    with SQLiteStorage(db) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+
+
+def test_mcp_completed_action_derives_external_agent(tmp_path: Path) -> None:
+    from continuum.mcp.server import AuthorizationPolicy, build_server
+
+    db = str(tmp_path / "mcp.db")
+    _run(db)
+    server, ctx = build_server(
+        storage=SQLiteStorage(db), policy=AuthorizationPolicy(["test-client"])
+    )
+    outcome = ctx.ledger("run_1").claim("send_invoice", {}, key="invoice:1")
+    ctx.ledger("run_1").complete(outcome.key, external_id="ext-1")
+    with SQLiteStorage(db) as store:
+        events = store.read_events("run_1")
+    assert derived_provenance_for_events(events) is Origin.EXTERNAL_AGENT
+    ctx.storage.close()
+
+
+def test_sidecar_completed_action_derives_external_agent(tmp_path: Path) -> None:
+    from continuum.serve import SidecarServer
+
+    db = str(tmp_path / "sidecar.db")
+    _run(db)
+    srv = SidecarServer(database=db)
+    claim = srv.dispatch("intercept_action", {"run_id": "run_1", "action_type": "x", "key": "k"})
+    srv.dispatch("complete_action", {"run_id": "run_1", "action_key": claim["action_key"]})
+    with SQLiteStorage(db) as store:
+        events = store.read_events("run_1")
+    assert derived_provenance_for_events(events) is Origin.EXTERNAL_AGENT
+    srv.close()
+
+
+def test_direct_ledger_default_is_unchanged(tmp_path: Path) -> None:
+    db = str(tmp_path / "plain.db")
+    _run(db)
+    with SQLiteStorage(db) as store:
+        ActionLedger(store, "run_1").claim("x", {}, key="k")
+        events = store.read_events("run_1")
+    assert derived_provenance_for_events(events) is Origin.DETERMINISTIC

--- a/tests/test_mcp_authz.py
+++ b/tests/test_mcp_authz.py
@@ -6,7 +6,7 @@ asking "is this safe to resume?" should never require permission.
 
 This is authorization by declared identity, not authentication. ``clientInfo``
 is asserted by the client at handshake and never verified, so these tests prove
-that honestly-named agents are kept apart — not that a hostile one is stopped.
+that honestly-named agents are kept apart, not that a hostile one is stopped.
 """
 
 from __future__ import annotations
@@ -311,7 +311,7 @@ async def test_read_only_tools_stay_open_to_anyone(
     """Asking "is this safe to resume?" must never require permission.
 
     A stranger denied read access could not even discover why its writes are
-    failing, and the information disclosed — a run's goal and progress — is
+    failing, and the information disclosed (a run's goal and progress) is
     already readable by anyone holding the database file.
     """
     await seed(server)

--- a/tests/test_mcp_docs.py
+++ b/tests/test_mcp_docs.py
@@ -23,10 +23,16 @@ from continuum.storage import SQLiteStorage
 #: The API reference page whose tool table mirrors ``tools/list``.
 MCP_DOC = Path(__file__).resolve().parents[1] / "docs" / "api" / "mcp.md"
 
+#: The MCP adversarial audit report whose coverage table must also stay complete.
+MCP_AUDIT = Path(__file__).resolve().parents[1] / "docs" / "TESTING_MCP.md"
+
 #: One documented tool: name and kind. The purpose column is prose and is left
 #: to a human reviewer, as is the sentence of totals under the table; the two
 #: columns that can silently contradict the server are not.
 ROW = re.compile(r"^\| `(continuum_\w+)` \| (mutate|read) \|", re.MULTILINE)
+
+#: Tool names listed in the audit coverage table (issue #759).
+AUDIT_TOOL = re.compile(r"^\| `(continuum_\w+)` \|", re.MULTILINE)
 
 #: The character house style bans, by code point so this file carries none.
 EM_DASH = chr(0x2014)
@@ -67,6 +73,23 @@ async def test_the_table_lists_every_served_tool_with_its_kind(server: Any) -> N
     rows = ROW.findall(MCP_DOC.read_text(encoding="utf-8"))
     assert len(rows) == len({name for name, _ in rows}), "a tool is documented twice"
     assert dict(rows) == kinds(await server.list_tools())
+
+
+@pytest.mark.asyncio
+async def test_the_audit_coverage_table_lists_every_served_tool(server: Any) -> None:
+    """``docs/TESTING_MCP.md`` must name every tool ``tools/list`` exposes.
+
+    The audit once claimed "all 11 tools" while ``continuum_record_plan`` was
+    already served (issue #759). Pinning the coverage table to ``tools/list``
+    keeps that claim from rotting again.
+    """
+    text = MCP_AUDIT.read_text(encoding="utf-8")
+    section = text.split("## Tool coverage", 1)[1].split("## Findings", 1)[0]
+    covered = AUDIT_TOOL.findall(section)
+    assert len(covered) == len(set(covered)), "a tool is audited twice"
+    served = {tool.name for tool in await server.list_tools()}
+    assert set(covered) == served
+    assert "All 12 tools were exercised" in text
 
 
 def test_the_page_carries_no_em_dashes() -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -60,7 +60,7 @@ def _no_confirm_token(monkeypatch: pytest.MonkeyPatch) -> None:
 def server_ctx() -> Iterator[tuple[Any, Any]]:
     """A server whose caller is authorized to mutate.
 
-    These tests cover tool behaviour, not the authorization layer — that lives
+    These tests cover tool behaviour, not the authorization layer, which lives
     in test_mcp_authz.py. Without an explicit policy the server denies every
     mutation, and a policy failure here would look like a logic bug.
     """
@@ -269,7 +269,7 @@ async def test_a_rejected_progress_call_writes_nothing_at_all(
     """A rejected call must not even create the run (issue #203).
 
     The counter checks used to run after `ensure_run`, so a typo'd or hostile
-    call left a goal-bearing run row and a RUN_STARTED event behind — facts no
+    call left a goal-bearing run row and a RUN_STARTED event behind, facts no
     tool can delete. Validation now precedes creation, matching the guard's
     own rule that a refusal writes nothing.
     """
@@ -545,7 +545,7 @@ async def test_validate_flags_a_changed_dependency(server_ctx: tuple[Any, Any]) 
 # The test above declares the dependency by appending an event straight to
 # storage, which no MCP client can do. Checkpointing with ``env`` used to record
 # a snapshot and nothing else, and the validator returns early for a state with
-# no declared dependencies — so drift was rendered in ``environment_changes``
+# no declared dependencies, so drift was rendered in ``environment_changes``
 # while the verdict stayed ``safe``, which is precisely "reported as verified
 # when it is not". These drive the whole path through the tools.
 
@@ -579,7 +579,7 @@ async def test_drift_in_an_env_declared_dependency_blocks_resume(
     """A moved dataset must stop the run even once the self-report is confirmed.
 
     Confirming clears the REQUIRES_REVIEW on goal and progress, so nothing else
-    is left to mask the environment check — if the verdict were still ``safe``
+    is left to mask the environment check. If the verdict were still ``safe``
     the agent would resume on top of data that changed underneath it.
     """
     server, _ = server_ctx
@@ -734,7 +734,7 @@ async def test_deterministic_state_still_resumes_cleanly(
     """The provenance check must not block genuinely verified state.
 
     Written through the storage API directly (as the CLI or an in-process
-    adapter would), the same run resumes cleanly — proving the gate keys on
+    adapter would), the same run resumes cleanly, proving the gate keys on
     *who asserted it*, not on some blanket refusal.
     """
     server, ctx = server_ctx
@@ -1748,8 +1748,8 @@ def test_server_startup_never_deletes_the_write_ahead_log(tmp_path: Any) -> None
     """A blocking ``-wal`` is quarantined, not destroyed.
 
     Deleting it would turn committed transactions into silent loss, and an
-    emptied database still verifies as an intact chain — the failure would look
-    like success. The bytes must survive somewhere recoverable.
+    emptied database still verifies as an intact chain, so the failure would
+    look like success. The bytes must survive somewhere recoverable.
     """
     path = str(tmp_path / "agent.db")
     SQLiteStorage(path).close()
@@ -2119,7 +2119,7 @@ async def test_a_log_not_beginning_with_run_started_is_refused(
     If some other writer appends before RUN_STARTED, inserting the start event
     afterwards would place the run's beginning *after* events that supposedly
     preceded it. The resulting projection would be wrong in a way nothing
-    downstream can detect, so this raises instead — naming the problem beats
+    downstream can detect, so this raises instead: naming the problem beats
     silently producing bad state.
     """
     from continuum.mcp.server import MalformedRunLog

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2277,6 +2277,65 @@ async def test_a_completed_action_still_deduplicates_at_budget(
 
 
 @pytest.mark.asyncio
+async def test_the_retry_budget_survives_compaction(
+    server_ctx: tuple[Any, Any],
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate counted attempts from the live log only (issue #734).
+
+    Compaction archives the ACTION_RECORDED events of the failed attempts, so a
+    live-tail-only count dropped to zero and an exhausted budget re-opened,
+    granting a fresh allowance to a model hammering a failing upstream after
+    every compaction.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".continuum").mkdir()
+    (tmp_path / ".continuum" / "budgets.json").write_text('{"default_max_attempts": 2}')
+    server, ctx = server_ctx
+    await seed_run(server)
+
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    for _ in range(2):
+        stuck = await call(
+            server,
+            "continuum_intercept_action",
+            run_id="run_1",
+            action_type="charge",
+            key="charge:stuck",
+        )
+        await call(
+            server,
+            "continuum_fail_action",
+            run_id="run_1",
+            action_key=stuck["action_key"],
+            error="500 from upstream",
+            certain=True,
+        )
+    with pytest.raises(ToolError, match="retry budget exhausted"):
+        await call(
+            server,
+            "continuum_intercept_action",
+            run_id="run_1",
+            action_type="charge",
+            key="charge:stuck",
+        )
+
+    # Compaction moves the failed attempts into the archive; the exhausted
+    # budget must survive that.
+    ctx.storage.compact_run("run_1")
+    with pytest.raises(ToolError, match="retry budget exhausted"):
+        await call(
+            server,
+            "continuum_intercept_action",
+            run_id="run_1",
+            action_type="charge",
+            key="charge:stuck",
+        )
+
+
+@pytest.mark.asyncio
 async def test_a_never_retried_operation_is_not_blocked_by_its_neighbours(
     server_ctx: tuple[Any, Any],
     tmp_path: Any,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1992,7 +1992,7 @@ raise SystemExit(main(["--db", "agent.db"]))
 
 
 def test_main_reports_a_missing_mcp_extra_instead_of_a_traceback(tmp_path: Any) -> None:
-    """Regression for #87: `pip install continuum` ships the script, not the SDK.
+    """Regression for #87: `pip install continuum-agent` ships the script, not the SDK.
 
     Run in a subprocess because blocking an already-imported package in-process
     would corrupt the import state of every later test.
@@ -2014,7 +2014,7 @@ def test_main_reports_a_missing_mcp_extra_instead_of_a_traceback(tmp_path: Any) 
     assert proc.returncode == 1, proc.stderr
     assert proc.stdout == "", "the protocol stream must stay clean"
     assert "Traceback" not in proc.stderr
-    assert "continuum[mcp]" in proc.stderr, "the operator needs the fix, not just the fault"
+    assert "continuum-agent[mcp]" in proc.stderr, "the operator needs the fix, not just the fault"
     assert not (tmp_path / "agent.db").exists(), "a server that never started created a database"
 
 
@@ -2024,7 +2024,7 @@ def test_a_missing_unrelated_module_keeps_its_traceback(
     """The extra is blamed only when the extra is what is missing.
 
     A broken install of something else must not be reported as "install
-    continuum[mcp]", which would send the operator after the wrong fix.
+    continuum-agent[mcp]", which would send the operator after the wrong fix.
     """
     monkeypatch.chdir(tmp_path)
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,6 +17,7 @@ import sqlite3
 import subprocess
 import sys
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -2004,9 +2005,13 @@ def test_main_reports_a_missing_mcp_extra_instead_of_a_traceback(tmp_path: Any) 
     stdio the client parses that stream as protocol frames, so diagnostics must
     never be printed there, however tempting it is.
     """
+    env = os.environ.copy()
+    source_path = str(Path(__file__).resolve().parents[1] / "src")
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [source_path, env.get("PYTHONPATH")]))
     proc = subprocess.run(
         [sys.executable, "-c", _WITHOUT_MCP_SDK],
         cwd=tmp_path,
+        env=env,
         capture_output=True,
         text=True,
     )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -202,6 +202,73 @@ async def test_progress_accumulates_across_calls(server_ctx: tuple[Any, Any]) ->
 
 
 @pytest.mark.asyncio
+async def test_record_plan_upserts_units_and_rejects_bad_payloads(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """Exercise continuum_record_plan the way the MCP audit claims (issue #759)."""
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, ctx = server_ctx
+    await seed_run(server)
+    units = [
+        {"id": "u2", "title": "second", "status": "pending"},
+        {"id": "u1", "title": "first", "status": "working", "depends_on": []},
+    ]
+    payload = await call(
+        server,
+        "continuum_record_plan",
+        run_id="run_1",
+        plan_id="plan-a",
+        units=units,
+    )
+    assert payload["plan_id"] == "plan-a"
+    assert payload["units"] == 2
+    assert [step["id"] for step in payload["plan"]] == ["u1", "u2"]
+    assert {step["id"]: step["status"] for step in payload["plan"]}["u1"] in {
+        "working",
+        "in_progress",
+    }
+    assert {step["id"]: step["status"] for step in payload["plan"]}["u2"] == "pending"
+    assert any(e.type == EventType.PLAN_UPSERT for e in ctx.storage.read_events("run_1"))
+
+    with pytest.raises(ToolError, match="plan_id"):
+        await server.call_tool(
+            "continuum_record_plan",
+            {"run_id": "run_1", "plan_id": "  ", "units": units},
+            context=_ctx(TEST_CLIENT),
+        )
+    with pytest.raises(ToolError, match="units"):
+        await server.call_tool(
+            "continuum_record_plan",
+            {"run_id": "run_1", "plan_id": "plan-a", "units": []},
+            context=_ctx(TEST_CLIENT),
+        )
+    with pytest.raises(ToolError, match="duplicate"):
+        await server.call_tool(
+            "continuum_record_plan",
+            {
+                "run_id": "run_1",
+                "plan_id": "plan-a",
+                "units": [
+                    {"id": "u1", "title": "a", "status": "pending"},
+                    {"id": "u1", "title": "b", "status": "pending"},
+                ],
+            },
+            context=_ctx(TEST_CLIENT),
+        )
+    with pytest.raises(ToolError, match="status"):
+        await server.call_tool(
+            "continuum_record_plan",
+            {
+                "run_id": "run_1",
+                "plan_id": "plan-a",
+                "units": [{"id": "u1", "title": "a", "status": "nope"}],
+            },
+            context=_ctx(TEST_CLIENT),
+        )
+
+
+@pytest.mark.asyncio
 async def test_over_total_progress_is_rejected_before_being_written(
     server_ctx: tuple[Any, Any],
 ) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -106,6 +106,21 @@ def test_actions_start_planned_and_side_effect_is_certain_by_default() -> None:
     assert action.external_id is None
 
 
+def test_action_origin_digest_must_be_sha256_hex() -> None:
+    """The origin_digest validator used to be accidentally nested inside
+    validate_caused_by (after its return), so it never registered on Action
+    and any string was accepted despite the documented 64-hex invariant.
+    """
+    good = "a" * 64
+    assert Action(run_id="run_1", action_type="t", origin_digest=good).origin_digest == good
+    assert Action(run_id="run_1", action_type="t").origin_digest is None
+
+    with pytest.raises(ValidationError, match="64 lowercase hex"):
+        Action(run_id="run_1", action_type="t", origin_digest="NOT-HEX-AT-ALL")
+    with pytest.raises(ValidationError, match="64 lowercase hex"):
+        Action(run_id="run_1", action_type="t", origin_digest="A" * 64)  # uppercase
+
+
 def test_approvals_start_pending() -> None:
     assert Approval(subject="publish results").status is ApprovalStatus.PENDING
 

--- a/tests/test_precommit_config.py
+++ b/tests/test_precommit_config.py
@@ -11,6 +11,9 @@ local gate and the CI gate honest about each other:
 * **The same paths.** Every directory the CI lint job hands to ruff is in scope
   for both hooks, and a directory CI does not lint stays out of scope, so
   `pre-commit run --all-files` on an untouched tree has nothing to say.
+* **No pre-commit ecosystem in dependabot.** Dependabot groups cannot cross
+  ecosystems, so a pre-commit update would land alone and break the ruff
+  agreement above in its own PR (issue #627, #689).
 """
 
 from __future__ import annotations
@@ -24,6 +27,7 @@ PRECOMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DEPENDABOT = REPO_ROOT / ".github" / "dependabot.yml"
 
 
 # --------------------------------------------------------------------------- #
@@ -80,12 +84,37 @@ def _ci_lint_directories() -> set[str]:
 
 def test_precommit_pins_the_ruff_version_from_the_dev_extra() -> None:
     expected = f"v{_pinned_ruff_version()}"
+    mismatches = []
     for path in (PRECOMMIT_CONFIG, CONTRIBUTING):
         revisions = re.findall(r"^\s*rev:\s*(\S+)\s*$", path.read_text(encoding="utf-8"), re.M)
-        assert revisions == [expected], (
-            f"{path.name} must name the ruff version pinned in pyproject's dev extra "
-            f"({expected}), got {revisions}"
-        )
+        if revisions != [expected]:
+            mismatches.append(f"{path.name} says {revisions}")
+    assert not mismatches, (
+        f"ruff version skew, not a broken test: pyproject's dev extra pins "
+        f"ruff=={expected[1:]}, but {'; '.join(mismatches)}. Bump all three pins "
+        "in the same PR: the ruff== pin in pyproject.toml, rev in "
+        ".pre-commit-config.yaml, and the rev quoted in CONTRIBUTING.md "
+        "(the lockstep note there lists them)."
+    )
+
+
+def test_dependabot_does_not_watch_the_pre_commit_ecosystem() -> None:
+    """The pre-commit ecosystem is deliberately absent from dependabot (#689).
+
+    Dependabot groups cannot cross ecosystems, so a pre-commit update would
+    arrive as its own PR bumping only ``rev`` in ``.pre-commit-config.yaml``,
+    leaving the pyproject pin and the CONTRIBUTING quote stale and failing
+    the pin test above in that PR: the #627 failure in reverse. Re-adding the
+    ecosystem should be a deliberate decision that also solves the lockstep,
+    not a drive-by completeness fix.
+    """
+    text = DEPENDABOT.read_text(encoding="utf-8")
+    ecosystems = set(re.findall(r"^\s*- package-ecosystem:\s*\"?([\w-]+)\"?\s*$", text, re.M))
+    assert "pre-commit" not in ecosystems, (
+        "dependabot watches the pre-commit ecosystem, but its updates cannot be "
+        "grouped with the pip bumps and would break the three-file ruff rev "
+        "lockstep in their own PR (see the comment in .github/dependabot.yml)"
+    )
 
 
 def test_hooks_are_scoped_to_the_directories_ci_lints() -> None:

--- a/tests/test_projection_edges.py
+++ b/tests/test_projection_edges.py
@@ -142,6 +142,22 @@ def test_granting_an_approval_that_was_never_requested_still_records_it() -> Non
     assert approval.reason == "out of band"
 
 
+def test_naive_expires_at_is_folded_as_utc() -> None:
+    """Issue #704: an expires_at payload without a UTC offset must not fold to
+    a naive datetime, because everything downstream compares against the
+    tz-aware utcnow(), and a naive value would TypeError and brick validation."""
+    log = started(EventLog())
+    log.append(
+        "run_1",
+        EventType.APPROVAL_GRANTED,
+        {"approval_id": "ap_10", "subject": "deploy", "expires_at": "2027-01-01"},
+    )
+    approval = project("run_1", log.events("run_1")).approvals[0]
+    assert approval.expires_at is not None
+    assert approval.expires_at.tzinfo is not None, "naive expires_at must be normalized to UTC"
+    assert approval.expires_at.utcoffset().total_seconds() == 0
+
+
 def test_model_assumptions_can_be_recorded_before_any_model_is_known() -> None:
     log = started(EventLog())
     log.append(

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -128,7 +128,7 @@ def test_progress_stays_tainted_once_an_agent_contributes(store: SQLiteStorage) 
     """Progress is cumulative, so the weakest contributor wins.
 
     A trusted event appended after an agent's self-report does not launder the
-    running total — the agent's contribution is still inside it.
+    running total: the agent's contribution is still inside it.
     """
     store.create_run(Run(run_id="r", goal="g"))
     store.append_event("r", EventType.RUN_STARTED, {"goal": "g", "total": 100})

--- a/tests/test_reconcilers.py
+++ b/tests/test_reconcilers.py
@@ -213,6 +213,28 @@ def test_settled_events_are_sourced_deterministic(db: str, tmp_path: Path) -> No
     assert all(e.source is Origin.DETERMINISTIC for e in reconciled)
 
 
+def test_settle_run_settles_archived_actions_after_compaction(db: str, tmp_path: Path) -> None:
+    """Compaction must not break the operator path for clearing risk (issue #647).
+
+    pending() is archive-aware, so an action claimed before a compaction is
+    still listed; settle_run used to resolve its ledger key from the live tail
+    only and abort the whole report with LookupError.
+    """
+    action_id = seed_pending(db, key="invoice:9")
+    with SQLiteStorage(db) as store:
+        store.compact_run("run_1", through_sequence=store.last_sequence("run_1"))
+        assert action_id in {a.action_id for a in ActionLedger(store, "run_1").pending()}
+    probes = load_reconcilers(registry(tmp_path, {"send_invoice": "echo occurred=true"}))
+    report = settle_run(SQLiteStorage(db), "run_1", probes)
+    assert report.settled == 1 and report.settled_true
+    with SQLiteStorage(db) as store:
+        from continuum.actions.ledger import fold_action_events
+
+        folded = fold_action_events(store.read_all_events("run_1"))
+    action = next(a for a in folded.values() if a.action_id == action_id)
+    assert action.status is ActionStatus.COMPLETED
+
+
 # --- CLI ------------------------------------------------------------------------------ #
 
 

--- a/tests/test_recovery_context.py
+++ b/tests/test_recovery_context.py
@@ -65,7 +65,7 @@ def test_stale_state_is_surfaced_not_buried() -> None:
         )
     )
     rendered = context.render()
-    assert "STALE STATE — DO NOT RELY ON" in rendered
+    assert "STALE STATE: DO NOT RELY ON" in rendered
     assert "decision_12" in rendered
     assert "dataset changed" in rendered
     assert "dependency dataset" in rendered
@@ -220,9 +220,9 @@ def test_stale_state_survives_a_tight_budget_even_with_a_next_action() -> None:
     )
     context = build_recovery_context(stale, token_budget=60, next_action="reconcile_action:x")
     assert "STALE STATE" in context.render()
-    assert "STALE STATE — DO NOT RELY ON" not in context.dropped_sections
+    assert "STALE STATE: DO NOT RELY ON" not in context.dropped_sections
     titles = [section.title for section in context.sections]
-    assert "STALE STATE — DO NOT RELY ON" in titles
+    assert "STALE STATE: DO NOT RELY ON" in titles
     assert "CURRENT GOAL" in titles
     assert "VERIFIED PROGRESS" in titles
 
@@ -249,9 +249,9 @@ def test_the_protected_sections_are_never_dropped_across_budgets() -> None:
                 next_action=next_action,
                 environment_changes=("data pipeline redeployed",),
             )
-            assert "STALE STATE — DO NOT RELY ON" not in context.dropped_sections
+            assert "STALE STATE: DO NOT RELY ON" not in context.dropped_sections
             titles = [section.title for section in context.sections]
-            assert "STALE STATE — DO NOT RELY ON" in titles
+            assert "STALE STATE: DO NOT RELY ON" in titles
             assert "CURRENT GOAL" in titles
             assert "VERIFIED PROGRESS" in titles
 

--- a/tests/test_recovery_engine.py
+++ b/tests/test_recovery_engine.py
@@ -428,7 +428,7 @@ def test_assessment_changes_nothing(store: SQLiteStorage) -> None:
 def test_lenient_mode_still_never_resumes_over_an_uncertain_side_effect(
     store: SQLiteStorage,
 ) -> None:
-    """Tolerating uncertainty downgrades REQUEST_HUMAN to WAIT — not to RESUME.
+    """Tolerating uncertainty downgrades REQUEST_HUMAN to WAIT, not to RESUME.
 
     Opting out of strictness may change who resolves the doubt; it must never
     make an unresolved side effect look settled.

--- a/tests/test_recovery_engine.py
+++ b/tests/test_recovery_engine.py
@@ -507,6 +507,57 @@ def test_self_certified_runs_are_confirmable(store: SQLiteStorage) -> None:
     )
 
 
+def test_confirmation_survives_compaction(store: SQLiteStorage) -> None:
+    """A human confirmation must survive compaction: the confirm event sits in
+    the pre-anchor prefix, so the confirm scan has to read the archived
+    prefix too, or a confirmed run silently re-escalates to request_human."""
+    store.create_run(Run(run_id="r1", goal="do X"))
+    store.append_event("r1", EventType.RUN_STARTED, {"goal": "do X"}, source=Origin.EXTERNAL_AGENT)
+    store.append_event(
+        "r1", EventType.TASK_UPDATED, {"completed": 1, "failed": 0}, source=Origin.EXTERNAL_AGENT
+    )
+    store.append_event(
+        "r1",
+        EventType.REVIEW_CONFIRMED,
+        {"components": ["goal", "progress"]},
+        source=Origin.HUMAN,
+    )
+
+    confirmed = RecoveryEngine(store).assess("r1")
+    assert confirmed.mode is RecoveryMode.RESUME
+
+    store.compact_run("r1")
+    # The confirm event is archived out of the live tail by the compaction.
+    assert not any(e.type is EventType.REVIEW_CONFIRMED for e in store.read_events("r1")), (
+        "precondition failed: confirm event still live"
+    )
+
+    after = RecoveryEngine(store).assess("r1")
+    assert after.mode is RecoveryMode.RESUME
+    assert after.safe
+
+
+def test_assess_degrades_when_the_archive_read_fails(store: SQLiteStorage) -> None:
+    """A failing archive read must not fail assess(): the shared fetch falls
+    back to the live log, so a broken archive view degrades to the live-only
+    verdict instead of bricking the assessment."""
+
+    class FlakyArchiveView:
+        """Raises on the first read_all_events call, like a broken archive."""
+
+        def __init__(self) -> None:
+            self._raised = False
+
+        def __getattr__(self, name: str) -> object:
+            if name == "read_all_events" and not self._raised:
+                self._raised = True
+                raise RuntimeError("archive unreadable")
+            return getattr(store, name)
+
+    decision = RecoveryEngine(FlakyArchiveView()).assess("run_1")  # type: ignore[arg-type]
+    assert decision.mode is RecoveryMode.RESUME
+
+
 # --- unprojectable logs (issue #383) ---------------------------------------- #
 
 

--- a/tests/test_recovery_ledger.py
+++ b/tests/test_recovery_ledger.py
@@ -66,6 +66,37 @@ def test_compact_keeps_anchors_and_recent_and_stays_verifiable(ledger: RecoveryL
     assert ok is True
 
 
+def test_append_after_compact_keeps_chain_and_clears_gate(ledger: RecoveryLedger) -> None:
+    """Entries appended after a compaction must not collide with the sparse
+    sequences the survivors kept: verify() must stay ok on an untampered
+    ledger, and a post-compaction gate approval must clear the pending gate.
+    """
+    for _ in range(55):
+        ledger.record_attempt("run_1")
+    ledger.append_decision("run_1", _contract(), gate="required")
+    for _ in range(5):
+        ledger.record_attempt("run_1")
+
+    removed = ledger.compact("run_1", keep=10)
+    assert removed == 51
+    ok, _ = ledger.verify("run_1")
+    assert ok is True
+    # Precondition: the gate-required decision survived the compaction and is
+    # still pending, so the post-approval assertion below actually tests
+    # clearing rather than an already-empty gate.
+    assert ledger.pending_gate("run_1") is not None
+
+    max_sequence = max(e.sequence for e in ledger.entries("run_1"))
+    approved = ledger.record_gate("run_1", "approved")
+    assert approved.sequence == max_sequence + 1
+
+    sequences = [e.sequence for e in ledger.entries("run_1")]
+    assert len(set(sequences)) == len(sequences), "sequences must not collide"
+    ok, broken_at = ledger.verify("run_1")
+    assert ok is True, f"untampered ledger reported broken at index {broken_at}"
+    assert ledger.pending_gate("run_1") is None
+
+
 def test_attempts_and_requires_human(ledger: RecoveryLedger) -> None:
     ledger.record_attempt("run_1")
     ledger.record_attempt("run_1")

--- a/tests/test_replayguard.py
+++ b/tests/test_replayguard.py
@@ -25,6 +25,7 @@ from continuum.events import EventType  # noqa: E402
 from continuum.models import ActionStatus, Run  # noqa: E402
 from continuum.replayguard import (  # noqa: E402
     GuardKind,
+    ReplayBlocked,
     evaluate,
     langgraph_protected_node,
     protected_call,
@@ -90,6 +91,32 @@ def test_decision_table_matches_the_gate_contract(db: str) -> None:
     assert verdict(db, "send_invoice", "i:3").kind is GuardKind.BLOCK_UNCERTAIN
     seed(db, "send_invoice", "i:4", ActionStatus.FAILED)
     assert verdict(db, "send_invoice", "i:4").kind is GuardKind.DENY_RECLAIM
+
+
+def test_block_uncertain_decision_carries_its_key(db: str) -> None:
+    # The decision table contract: every decision names the ledger key it is
+    # about, so protected_call can act on it. BLOCK_UNCERTAIN used to be built
+    # without the key, which turned the documented ReplayBlocked into a bare
+    # AssertionError at the `decision.key is not None` checkpoint (issue #735).
+    seed(db, "send_invoice", "i:3", ActionStatus.UNKNOWN)
+    assert verdict(db, "send_invoice", "i:3").key is not None
+
+
+def test_protected_call_raises_replayblocked_for_an_uncertain_action(db: str) -> None:
+    # The public contract: uncertain states raise ReplayBlocked rather than
+    # guessing. With the key missing the wrapper died on an AssertionError
+    # first, so callers could not catch the documented exception (issue #735).
+    seed(db, "send_invoice", "i:5", ActionStatus.UNKNOWN)
+    with pytest.raises(ReplayBlocked) as excinfo:
+        protected_call(
+            SQLiteStorage(db),
+            "run_1",
+            action_type="send_invoice",
+            key="i:5",
+            fn=lambda: "SHOULD_NOT_RUN",
+        )
+    assert excinfo.value.decision.kind is GuardKind.BLOCK_UNCERTAIN
+    assert excinfo.value.decision.key is not None
 
 
 def make_run(db: str) -> None:

--- a/tests/test_replayguard.py
+++ b/tests/test_replayguard.py
@@ -152,6 +152,67 @@ def test_protected_call_executes_once_then_returns_cached_result(db: str) -> Non
     assert len(calls) == 1, "side effect must not re-fire"
 
 
+def test_replay_returns_the_callers_own_dict_even_with_a_return_key(db: str) -> None:
+    # A dict result containing the literal key "return" used to be journalled
+    # as-is and then unwrapped on replay, so the second call returned one
+    # member of the dict while the first returned the whole thing (issue #736).
+    payload = {"return": "receipt-1", "amount": 100}
+
+    kind1, result1 = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="send_invoice",
+        key="inv:9",
+        fn=lambda: payload,
+    )
+    kind2, result2 = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="send_invoice",
+        key="inv:9",
+        fn=lambda: payload,
+    )
+    assert kind1 is GuardKind.ALLOW and kind2 is GuardKind.SKIP_DUPLICATE
+    assert result2 == result1 == payload, "replay must answer as the first call did"
+
+
+def test_non_dict_results_round_trip_through_the_envelope(db: str) -> None:
+    kind1, result1 = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="charge_card",
+        key="card:2",
+        fn=lambda: "charged",
+    )
+    kind2, result2 = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="charge_card",
+        key="card:2",
+        fn=lambda: "charged",
+    )
+    assert kind1 is GuardKind.ALLOW and result1 == "charged"
+    assert kind2 is GuardKind.SKIP_DUPLICATE and result2 == "charged"
+
+
+def test_a_legacy_return_journal_still_unwraps_on_replay(db: str) -> None:
+    # Records written before the envelope (issue #736) wrap non-dict results
+    # as {"return": ...}; replay must keep unwrapping those.
+    with SQLiteStorage(db) as store:
+        ledger = ActionLedger(store, "run_1")
+        outcome = ledger.claim("legacy_call", {}, key="legacy:1")
+        ledger.complete(outcome.key, result={"return": "legacy-value"})
+    kind, value = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="legacy_call",
+        key="legacy:1",
+        fn=lambda: "SHOULD_NOT_RUN",
+    )
+    assert kind is GuardKind.SKIP_DUPLICATE
+    assert value == "legacy-value"
+
+
 def test_exception_marks_uncertain_failure_and_reraises(db: str) -> None:
     with pytest.raises(RuntimeError):
         protected_call(

--- a/tests/test_retry_budgets.py
+++ b/tests/test_retry_budgets.py
@@ -1031,6 +1031,34 @@ def test_cli_budget_exhausted_exit_is_reported_not_raised(db: str, tmp_path: Pat
     assert any(r["action_type"] == "deploy" and r["attempts"] >= 1 for r in rows)
 
 
+def test_cli_budget_counts_archived_attempts_after_compaction(db: str, tmp_path: Path) -> None:
+    """Attempts live in the event log; compaction moves them to the archive.
+
+    The report read only the live tail, so after a compaction it understated
+    attempts and overstated remaining for exactly the runs long enough to have
+    been compacted (issue #734).
+    """
+    with SQLiteStorage(db) as store:
+        ledger = ActionLedger(store, "run_1")
+        outcome = ledger.claim("send_invoice", {}, key="invoice:1")
+        ledger.fail(outcome.key, "500 from upstream")
+        store.compact_run("run_1")
+
+    code, out, err = run(
+        "--db",
+        db,
+        "--json",
+        "budget",
+        "run_1",
+        "--config",
+        registry(tmp_path, {"default_max_attempts": 3}),
+    )
+    assert code == ExitCode.OK, err
+    by_type = {r["action_type"]: r for r in json.loads(out)["budgets"]}
+    assert by_type["send_invoice"]["attempts"] == 1, "archived attempt must still count"
+    assert by_type["send_invoice"]["remaining"] == 2
+
+
 def test_hand_built_authorization_counter_bool_is_rejected() -> None:
     raw = bound_registry()
     raw["authorization_bound"]["send_invoice"]["authz:stripe-cust-1"]["counter"] = True

--- a/tests/test_rewind_dual_state.py
+++ b/tests/test_rewind_dual_state.py
@@ -1,4 +1,4 @@
-"""Atomic dual-state rewind (issue #292) — 6 acceptance criteria."""
+"""Atomic dual-state rewind (issue #292): 6 acceptance criteria."""
 
 from __future__ import annotations
 

--- a/tests/test_storage_concurrency.py
+++ b/tests/test_storage_concurrency.py
@@ -6,7 +6,7 @@ overwrite each other.** One wins, the other is told it lost.
 
 These tests are the reason the engine takes an IMMEDIATE lock and keeps a
 UNIQUE constraint on ``(run_id, sequence)``. Without both, a race produces a
-forked chain that verifies clean — the worst possible failure, because it looks
+forked chain that verifies clean: the worst possible failure, because it looks
 correct.
 """
 

--- a/tests/test_storage_concurrency.py
+++ b/tests/test_storage_concurrency.py
@@ -261,6 +261,16 @@ def test_the_run_lease_restores_exactly_once_under_concurrency(tmp_path: Path) -
     Wrapping the claim in the run's lease collapses eight simultaneous claimants
     to a single go-ahead, which is what makes docs/multi_agent_isolation.md's
     "one run, one owner at a time" sufficient for exactly-once.
+
+    The holder settles what it starts before letting go of the lease (issue
+    #672). A claim left STARTED at release is a live claim to every later
+    claimant: the ledger correctly raises UnknownSideEffect for a foreign
+    in-flight action, so a test whose winner never completes passes only when
+    no loser happens to acquire the lease after the winner's release, which is
+    timing and not a contract. Completing inside the hold makes the outcome
+    deterministic for every interleaving: one fresh claim, and every other
+    claimant is either turned away by the lease or served the deduplicated
+    result of the completed one.
     """
     from continuum.actions.ledger import ActionLedger
     from continuum.concurrency import SQLiteLeaseCoordinator
@@ -275,7 +285,10 @@ def test_the_run_lease_restores_exactly_once_under_concurrency(tmp_path: Path) -
             return "no-lease"
         try:
             with SQLiteStorage(db) as store:
-                outcome = ActionLedger(store, "run_1").claim("charge", {"amt": 100}, key="k")
+                ledger = ActionLedger(store, "run_1")
+                outcome = ledger.claim("charge", {"amt": 100}, key="k")
+                if outcome.fresh:
+                    ledger.complete(outcome.key, result={"charged": True})
                 return "fresh" if outcome.fresh else "dedup"
         finally:
             coordinator.release("run_1", holder)
@@ -284,6 +297,7 @@ def test_the_run_lease_restores_exactly_once_under_concurrency(tmp_path: Path) -
         outcomes = list(pool.map(claim, range(8)))
 
     assert outcomes.count("fresh") == 1, f"expected one winner, got {outcomes}"
+    assert set(outcomes) <= {"fresh", "dedup", "no-lease"}
 
 
 # --- the ledger takes the lease itself (issue #345, remaining half) ---------- #

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,533 @@
+"""The terminal dashboard (issue #782).
+
+TuiApp is a pure state machine (keys in, lines out) so every flow below
+drives it without a terminal. The curses driver is exercised through a fake
+screen, and the two refusal paths (no curses, no TTY) are the ones that must
+never half-render.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.actions.idempotency import idempotency_key
+from continuum.cli import ExitCode, main
+from continuum.events import EventType
+from continuum.models import RunStatus
+from continuum.storage import SQLiteStorage
+from continuum.tui import TuiApp, run_tui
+from continuum.tui import model as tui_model
+from continuum.tui.app import _driver
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    return str(tmp_path / "tui.db")
+
+
+@pytest.fixture
+def store(db: str) -> Iterator[SQLiteStorage]:
+    with SQLiteStorage(db) as s:
+        yield s
+
+
+# --------------------------------------------------------------------------- #
+# view models
+# --------------------------------------------------------------------------- #
+
+
+def test_run_rows_carry_the_recovery_verdict(db: str, store: SQLiteStorage) -> None:
+    run("--db", db, "start", "ok_run", "--goal", "fine")
+    run("--db", db, "start", "risky", "--goal", "danger")
+    ActionLedger(SQLiteStorage(db), "risky").claim("send_invoice", {}, key="invoice:I-1")
+
+    rows = {r.run_id: r for r in tui_model.run_rows(store)}
+    assert rows["ok_run"].mode == "resume"
+    assert rows["ok_run"].safe == "yes"
+    assert rows["risky"].safe == "no"
+    assert rows["risky"].mode != "resume"
+    assert rows["risky"].events >= rows["ok_run"].events
+
+
+def test_a_run_that_fails_to_assess_is_listed_not_dropped(
+    db: str, store: SQLiteStorage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable run must surface in the index, not vanish from it."""
+
+    class _Boom(tui_model.RecoveryEngine):
+        def assess(self, run_id: str, **kw: Any) -> Any:
+            raise RuntimeError("chain will not fold")
+
+    run("--db", db, "start", "broken", "--goal", "b")
+    monkeypatch.setattr(tui_model, "RecoveryEngine", _Boom)
+
+    rows = tui_model.run_rows(store)
+    assert len(rows) == 1
+    assert rows[0].mode.startswith("error:")
+    assert rows[0].safe == "unknown"
+
+
+def test_overview_lines_mirror_inspect(db: str, store: SQLiteStorage) -> None:
+    run("--db", db, "start", "r1", "--goal", "analyse documents")
+    lines = tui_model.overview_lines(store, "r1")
+    joined = "\n".join(lines)
+    assert "analyse documents" in joined
+    assert "progress:" in joined
+    assert "version:" in joined
+    assert "plan:" in joined
+
+
+def test_checkpoint_rows_match_history(db: str, store: SQLiteStorage) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    run("--db", db, "checkpoint", "r1", "--trigger", "manual", "--reason", "before lunch")
+
+    rows = tui_model.checkpoint_rows(store, "r1")
+    assert len(rows) == 1
+    assert rows[0].trigger == "manual"
+    assert isinstance(rows[0].version, int)
+
+
+def test_action_rows_flag_uncertain_actions_with_their_ledger_key(
+    db: str, store: SQLiteStorage
+) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    ActionLedger(SQLiteStorage(db), "r1").claim("send_invoice", {}, key="invoice:I-1")
+
+    rows = tui_model.action_rows(store, "r1")
+    assert len(rows) == 1
+    assert rows[0].uncertain is True
+    expected = str(idempotency_key("send_invoice", None, scope="r1", key="invoice:I-1"))
+    assert rows[0].key == expected
+    assert rows[0].action_type == "send_invoice"
+
+
+def test_event_rows_include_the_archived_prefix_after_compaction(
+    db: str, store: SQLiteStorage
+) -> None:
+    """A compacted run must read the same as one that was never compacted."""
+    run("--db", db, "start", "r1", "--goal", "g")
+    store.compact_run("r1")
+
+    rows = tui_model.event_rows(store, "r1")
+    # the archived prefix is included even though the live tail starts later
+    assert len(rows) == len(store.read_all_events("r1"))
+    assert len(rows) > len(store.read_events("r1"))
+    assert rows[0].sequence == 1
+    assert rows[0].type == "RUN_STARTED"
+
+
+def test_budget_rows_count_attempts_over_the_whole_log(db: str, store: SQLiteStorage) -> None:
+    """Attempts are per operation (issue #368), so a retried key is the one
+    that must show a drawdown."""
+    run("--db", db, "start", "r1", "--goal", "g")
+    ledger = ActionLedger(SQLiteStorage(db), "r1")
+    ledger.claim("send_invoice", {}, key="invoice:I-1")
+    key = str(idempotency_key("send_invoice", None, scope="r1", key="invoice:I-1"))
+    ledger.reconcile(key, occurred=False)  # confirmed absent, so a retry is legal
+    ledger.claim("send_invoice", {}, key="invoice:I-1")
+
+    rows = {r.action_type: r for r in tui_model.budget_rows(store, "r1")}
+    assert rows["send_invoice"].attempts == 2
+    assert rows["send_invoice"].remaining == rows["send_invoice"].max_attempts - 2
+
+
+def test_family_lines_show_every_child_verdict(db: str, store: SQLiteStorage) -> None:
+    run("--db", db, "start", "par", "--goal", "supervise")
+    run("--db", db, "start", "kid", "--goal", "work", "--parent", "par")
+    ActionLedger(SQLiteStorage(db), "kid").claim("send_invoice", {}, key="invoice:I-9")
+
+    lines = "\n".join(tui_model.family_lines(store, "par"))
+    assert "kid" in lines
+    assert "!!" in lines
+
+
+def test_recovery_lines_render_the_verdict_and_the_family_block(
+    db: str, store: SQLiteStorage
+) -> None:
+    run("--db", db, "start", "par", "--goal", "supervise")
+    run("--db", db, "start", "kid", "--goal", "work", "--parent", "par")
+    ActionLedger(SQLiteStorage(db), "kid").claim("send_invoice", {}, key="invoice:I-9")
+
+    lines = "\n".join(tui_model.recovery_lines(store, "par"))
+    assert "CONTINUUM RECOVERY" in lines
+    assert "Recovery decision:" in lines
+    assert "FAMILY BLOCKED" in lines
+
+
+# --------------------------------------------------------------------------- #
+# the landing splash
+# --------------------------------------------------------------------------- #
+
+
+def test_the_app_opens_on_a_landing_screen_with_the_logo(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+
+    assert app.view == "landing"
+    app.width = 100  # wide enough for the ASCII logo
+    body = "\n".join(app.body_lines())
+    assert "██╔═══██╗" in body  # the logo, not just the word
+    assert "run(s) recorded" in body
+    assert "press any key to open the dashboard" in app.footer()
+
+
+def test_a_narrow_terminal_gets_a_banner_that_fits(db: str) -> None:
+    app = TuiApp(SQLiteStorage(db))
+    app.width = 40
+    body = app.body_lines()
+    assert all(len(line) <= 40 for line in body)
+    assert "C O N T I N U U M" in body[1]
+
+
+def test_any_key_leaves_the_landing_screen(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+
+    assert app.handle_key(" ") is True
+    assert app.view == "runs"
+    assert "r1" in "\n".join(app.body_lines())
+
+
+def test_q_quits_from_the_landing_screen(db: str) -> None:
+    app = TuiApp(SQLiteStorage(db))
+    assert app.handle_key("q") is False
+
+
+# --------------------------------------------------------------------------- #
+# the app state machine
+# --------------------------------------------------------------------------- #
+
+
+def _enter_dashboard(app: TuiApp) -> None:
+    """Dismiss the landing splash: any key opens the dashboard."""
+    assert app.handle_key(" ") is True
+    assert app.view == "runs"
+
+
+def test_the_app_lists_runs_and_quits_on_q(db: str) -> None:
+    run("--db", db, "start", "ok_run", "--goal", "fine")
+    run("--db", db, "start", "other", "--goal", "more work")
+    app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
+
+    assert app.view == "runs"
+    body = "\n".join(app.body_lines())
+    assert "ok_run" in body
+    assert "other" in body
+    assert app.handle_key("q") is False
+
+
+def test_enter_opens_the_detail_and_esc_returns(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "analyse documents")
+    app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
+
+    app.handle_key("enter")
+    assert app.view == "detail"
+    assert "overview" in app.header()
+    assert "analyse documents" in "\n".join(app.body_lines())
+
+    app.handle_key("esc")
+    assert app.view == "runs"
+    # the cursor from the detail view must not highlight a runs-list row
+    assert app.cursor == -1
+
+
+def test_tab_keys_switch_views(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    ActionLedger(SQLiteStorage(db), "r1").claim("send_invoice", {}, key="invoice:I-1")
+    app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
+    app.handle_key("enter")
+
+    for tab in ("4", "5", "6", "7", "3", "2"):
+        app.handle_key(tab)
+        assert app.TABS[app.tab] in app.header()
+
+    app.handle_key("4")  # actions
+    body = "\n".join(app.body_lines())
+    assert "send_invoice" in body
+    assert "(!)" in body  # uncertain actions are marked where the eye lands
+
+    app.handle_key("5")  # events
+    assert "RUN_STARTED" in "\n".join(app.body_lines())
+
+
+def test_the_help_overlay_lists_the_keys(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
+    app.handle_key("?")
+    assert "quit" in "\n".join(app.body_lines())
+
+
+def test_reconcile_requires_confirmation_and_only_y_writes(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    ActionLedger(SQLiteStorage(db), "r1").claim("send_invoice", {}, key="invoice:I-1")
+
+    app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
+    app.handle_key("enter")
+    app.handle_key("4")  # actions tab, cursor on the one action
+    app.handle_key("y")  # queue reconcile-as-occurred
+    assert app.pending is not None
+    assert "OCCURRED" in app.pending[0]
+
+    app.handle_key("n")  # anything but y cancels
+    assert app.pending is None
+    assert ActionLedger(SQLiteStorage(db), "r1").all()[0].status.value == "started"
+
+    app.handle_key("y")
+    app.handle_key("y")  # confirm the write
+    assert app.pending is None
+    assert app.message.startswith("reconciled")
+
+    with SQLiteStorage(db) as s:
+        assert any(e.type is EventType.ACTION_RECONCILED for e in s.read_events("r1"))
+    assert ActionLedger(SQLiteStorage(db), "r1").all()[0].status.value == "completed"
+
+
+def test_a_settled_action_cannot_be_reconciled_again_from_the_tui(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    key = str(idempotency_key("send_invoice", None, scope="r1", key="invoice:I-1"))
+    ledger = ActionLedger(SQLiteStorage(db), "r1")
+    ledger.claim("send_invoice", {}, key="invoice:I-1")
+    ledger.reconcile(key, occurred=True)
+
+    app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
+    app.handle_key("enter")
+    app.handle_key("4")
+    app.handle_key("y")
+    assert app.pending is None  # refused before any confirmation prompt
+    assert "only uncertain actions" in app.message
+
+
+def test_checkpoint_and_complete_confirmations_write(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
+
+    app.handle_key("c")
+    assert app.pending is not None
+    app.handle_key("y")
+    with SQLiteStorage(db) as s:
+        assert len(s.list_checkpoints("r1")) == 1
+
+    app.handle_key("x")
+    assert "RUN_COMPLETED" in app.pending[0]
+    app.handle_key("y")
+    with SQLiteStorage(db) as s:
+        assert s.get_run("r1").status is RunStatus.COMPLETED
+
+
+def test_confirm_state_writes_review_confirmed(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
+
+    app.handle_key("y")
+    assert "REVIEW_CONFIRMED" in app.pending[0]
+    app.handle_key("y")
+    with SQLiteStorage(db) as s:
+        assert any(e.type is EventType.REVIEW_CONFIRMED for e in s.read_events("r1"))
+
+
+def test_a_cancelled_action_writes_nothing(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
+    events_before = len(SQLiteStorage(db).read_events("r1"))
+
+    app.handle_key("c")
+    app.handle_key("x")  # not y: cancels
+    assert app.pending is None
+    assert len(SQLiteStorage(db).read_events("r1")) == events_before
+
+
+# --------------------------------------------------------------------------- #
+# the curses driver and the refusal paths
+# --------------------------------------------------------------------------- #
+
+
+class _FakeCurses:
+    """Just enough curses for the driver: constants, attrs, no terminal."""
+
+    KEY_UP = 259
+    KEY_DOWN = 258
+    KEY_LEFT = 260
+    KEY_RIGHT = 261
+    KEY_ENTER = 343
+    KEY_RESIZE = 410
+    KEY_BACKSPACE = 263
+    A_BOLD = 1
+    A_REVERSE = 2
+
+    class error(Exception):
+        pass
+
+    @staticmethod
+    def curs_set(visible: int) -> None:
+        return None
+
+
+class _FakeScreen:
+    """Records what the driver draws and replays a fixed key script."""
+
+    def __init__(self, keys: list[int]) -> None:
+        self._keys = list(keys)
+        self.lines: list[tuple[int, str]] = []
+
+    def keypad(self, on: bool) -> None:
+        return None
+
+    def timeout(self, ms: int) -> None:
+        return None
+
+    def erase(self) -> None:
+        self.lines = []
+
+    def getmaxyx(self) -> tuple[int, int]:
+        return (24, 80)
+
+    def addnstr(self, y: int, x: int, text: str, n: int, attr: int = 0) -> None:
+        self.lines.append((y, text[:n]))
+
+    def refresh(self) -> None:
+        return None
+
+    def getch(self) -> int:
+        return self._keys.pop(0) if self._keys else ord("q")
+
+
+def test_the_driver_draws_and_honours_keys(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    # a space dismisses the landing splash, then the driver is driven normally
+    screen = _FakeScreen([ord(" "), _FakeCurses.KEY_DOWN, _FakeCurses.KEY_ENTER, ord("4")])
+    code = _driver(_FakeCurses(), screen, TuiApp(SQLiteStorage(db)), 0.0)
+
+    assert code == ExitCode.OK
+    drawn = "\n".join(text for _, text in screen.lines)
+    assert "CONTINUUM" in drawn
+    assert "actions" in drawn
+
+
+def test_the_driver_draws_the_splash_first(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    screen = _FakeScreen([])  # the default key is q: the splash is all we see
+    _driver(_FakeCurses(), screen, TuiApp(SQLiteStorage(db)), 0.0)
+
+    drawn = "\n".join(text for _, text in screen.lines)
+    assert "██╔═══██╗" in drawn  # the logo: 80 columns is just wide enough
+    assert "press any key" in drawn
+
+
+def test_run_tui_refuses_when_curses_is_missing(db: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "curses", None)
+    err = io.StringIO()
+    code = run_tui(SQLiteStorage(db), err=err)
+
+    assert code == ExitCode.ERROR
+    assert "dashboard" in err.getvalue()
+
+
+def test_run_tui_refuses_without_a_tty(db: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    class _NotATty(io.StringIO):
+        def isatty(self) -> bool:
+            return False
+
+    monkeypatch.setattr(sys, "stdout", _NotATty())
+    err = io.StringIO()
+    code = run_tui(SQLiteStorage(db), err=err)
+
+    assert code == ExitCode.ERROR
+    # On platforms without curses (Windows) the import check refuses first,
+    # before the TTY check is reached. Both are refusals pointing at the
+    # browser dashboard, so either message satisfies this test.
+    out = err.getvalue()
+    assert "not a TTY" in out or "not available on this platform" in out
+
+
+def test_the_tui_command_is_registered_and_documented(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main(["tui", "--help"])
+    assert exit_info.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "--refresh" in help_text
+    assert "dashboard" in help_text
+
+
+# --------------------------------------------------------------------------- #
+# bare `continuum`: splash when interactive, help otherwise
+# --------------------------------------------------------------------------- #
+
+
+class _Tty(io.StringIO):
+    """A stream that claims to be a terminal, as a real shell would give."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+def test_bare_continuum_opens_the_tui_when_interactive(
+    db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: dict[str, Any] = {}
+
+    def fake_run_tui(storage: Any, **kw: Any) -> int:
+        seen["storage"] = storage
+        return 77
+
+    monkeypatch.setattr("continuum.tui.run_tui", fake_run_tui)
+    code = main(["--db", db], out=_Tty())
+
+    assert code == 77
+    assert seen["storage"] is not None
+
+
+def test_bare_continuum_prints_help_when_piped(db: str) -> None:
+    """A script running `continuum` blind must find usage text, not curses."""
+    code, out, _ = run("--db", db)
+
+    assert code == ExitCode.OK
+    assert "usage:" in out
+    assert "dashboard" in out
+
+
+def test_bare_continuum_prints_help_with_json(db: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--json` is a machine contract: it never opens an interactive screen."""
+
+    def fail_tui(storage: Any, **kw: Any) -> int:
+        raise AssertionError("the tui must not open under --json")
+
+    monkeypatch.setattr("continuum.tui.run_tui", fail_tui)
+    code, out, _ = run("--db", db, "--json")
+
+    assert code == ExitCode.OK
+    assert "usage:" in out
+
+
+def test_bare_continuum_reports_an_unopenable_database(db: str, tmp_path: Path) -> None:
+    bad = tmp_path / "not-a-dir" / "continuum.db"
+    out, err = _Tty(), io.StringIO()
+
+    code = main(["--db", str(bad)], out=out, err=err)
+
+    assert code == ExitCode.ERROR
+    assert "error:" in err.getvalue()
+    assert "usage:" not in out.getvalue()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -153,6 +153,55 @@ def test_staleness_propagates_from_dependency_to_decision() -> None:
     assert original.decisions[0].status is StateStatus.VALID
 
 
+def test_staleness_cascades_along_finding_to_finding_citations() -> None:
+    """A finding citing another finding is supported by it (issue #739).
+
+    Taint used to stop at the first finding: a finding resting entirely on a
+    now-stale finding, and the decision built on it, kept VALID in the revised
+    state, so a repair plan driven by that state skipped the downstream work.
+    """
+    outcome = validate_state(
+        state(
+            external_dependencies=[ExternalDependency(resource="dataset", version="v3")],
+            evidence=[Evidence(evidence_id="paper_128", source="dataset")],
+            findings=[
+                Finding(finding_id="f_raw", claim="rows shifted", evidence=["paper_128"]),
+                Finding(finding_id="f_derived", claim="X holds", evidence=["f_raw"]),
+            ],
+            decisions=[Decision(decision_id="d_1", decision="Publish X", evidence=["f_derived"])],
+        ),
+        checkpoint_environment=capture("run_4821", StaticProvider(dataset="v3")),
+        current_environment=capture("run_4821", StaticProvider(dataset="v4")),
+    )
+    revised = outcome.state
+    assert revised.evidence[0].status is StateStatus.STALE
+    assert revised.findings[0].status is StateStatus.STALE
+    assert revised.findings[1].status is StateStatus.STALE
+    assert revised.decisions[0].status is StateStatus.STALE
+    assert not outcome.safe
+
+
+def test_finding_citation_cascade_is_independent_of_list_order() -> None:
+    """A forward citation (a finding citing one listed after it) taints the
+    same set, so the cascade must not depend on list order (issue #739)."""
+    outcome = validate_state(
+        state(
+            external_dependencies=[ExternalDependency(resource="dataset", version="v3")],
+            evidence=[Evidence(evidence_id="paper_128", source="dataset")],
+            findings=[
+                # Listed before the raw finding it rests on.
+                Finding(finding_id="f_derived", claim="X holds", evidence=["f_raw"]),
+                Finding(finding_id="f_raw", claim="rows shifted", evidence=["paper_128"]),
+            ],
+        ),
+        checkpoint_environment=capture("run_4821", StaticProvider(dataset="v3")),
+        current_environment=capture("run_4821", StaticProvider(dataset="v4")),
+    )
+    revised = {f.finding_id: f.status for f in outcome.state.findings}
+    assert revised["f_raw"] is StateStatus.STALE
+    assert revised["f_derived"] is StateStatus.STALE
+
+
 def test_propagation_spares_state_that_did_not_depend_on_the_change() -> None:
     outcome = validate_state(
         state(

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from continuum.environment import CallableProvider, StaticProvider, capture
 from continuum.models import (
@@ -299,6 +299,25 @@ def test_an_expired_approval_is_caught_by_its_timestamp() -> None:
     )
     assert status_for(outcome, Component.APPROVAL, "ap_1") is StateStatus.EXPIRED
     assert not outcome.safe
+
+
+def test_a_naive_expires_at_grades_instead_of_raising() -> None:
+    """Issue #704: a naive expires_at (persisted before the fold normalized
+    offsets, or constructed directly) must grade as EXPIRED, not raise
+    TypeError comparing naive against the tz-aware utcnow()."""
+    outcome = validate_state(
+        state(
+            approvals=[
+                Approval(
+                    approval_id="ap_1",
+                    subject="publish",
+                    status=ApprovalStatus.GRANTED,
+                    expires_at=datetime(2020, 1, 1),  # naive, and in the past
+                )
+            ]
+        )
+    )
+    assert status_for(outcome, Component.APPROVAL, "ap_1") is StateStatus.EXPIRED
 
 
 def test_a_live_approval_passes() -> None:


### PR DESCRIPTION
## Description

Stacked on #652: uses its ActionLedger source parameter for the two remote-agent surfaces. MCP ctx.ledger and sidecar _ledger now stamp EXTERNAL_AGENT like their direct appends already do, so agent-asserted effects stop laundering to trusted in derived provenance. Direct ledger construction keeps the deterministic default, pinned by test.

## Related issues

Fixes #653
Depends on #652 (merge that first, then retarget this to main)

## Types of changes

- Type: bugfix

## Breaking changes

MCP and sidecar driven runs now derive external_agent where they derived deterministic. That is the intended verdict change, stated openly: agent-reported work no longer self-certifies. Direct and adapter-internal writers are unchanged.

## How has this been tested?

- New tests/test_ledger_source.py (3 tests): MCP and sidecar completed actions derive external_agent, direct default stays deterministic.
- MCP plus serve suites pass through the change.
- Ruff and format clean. CI runs the full gate.

## Checklist

Tests added. No changelog entry yet: it belongs with the #652 entry at merge time to describe the verdict change once.