### PR TITLE
fix(cli): health and watch honor the global json flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,11 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- `health` and `watch` honor the global `--json` flag (#677).
+  Both re-registered the flag on their subparser, whose default silently
+  replaced the global value, so machine output never appeared. The shadow
+  registrations are removed.
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,8 +168,9 @@ All notable changes to this project are documented here. The format follows
 
 - `health` and `watch` honor the global `--json` flag (#677).
   Both re-registered the flag on their subparser, whose default silently
-  replaced the global value, so machine output never appeared. The shadow
-  registrations are removed.
+  replaced the global value, so machine output never appeared. The subparser
+  defaults are now SUPPRESS: both flag positions work and trailing `--json`
+  keeps working.
 
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -3630,7 +3630,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--dashboard", action="store_true", help="render the Phase 14 recovery dashboard."
     )
 
-    with_run(add("health", cmd_health, "Advisory prefix-trust health check. Read-only."))
+    health = with_run(add("health", cmd_health, "Advisory prefix-trust health check. Read-only."))
+    # Subparser default SUPPRESS: accepts trailing --json without shadowing the global flag (#677).
+    health.add_argument("--json", action="store_true", default=argparse.SUPPRESS)
     # health is advisory only; it never gates, never moves mode, never changes exit code
     # (issue #401). It reports trust_score with per-dimension breakdown.
 
@@ -4030,6 +4032,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="webhook URL for --on-breach webhook",
     )
+    # Subparser default SUPPRESS: accepts trailing --json without shadowing the global flag (#677).
+    watch.add_argument("--json", action="store_true", default=argparse.SUPPRESS)
 
     return parser
 

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -3630,8 +3630,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--dashboard", action="store_true", help="render the Phase 14 recovery dashboard."
     )
 
-    health = with_run(add("health", cmd_health, "Advisory prefix-trust health check. Read-only."))
-    health.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
+    with_run(add("health", cmd_health, "Advisory prefix-trust health check. Read-only."))
     # health is advisory only; it never gates, never moves mode, never changes exit code
     # (issue #401). It reports trust_score with per-dimension breakdown.
 
@@ -4031,7 +4030,6 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="webhook URL for --on-breach webhook",
     )
-    watch.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
 
     return parser
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1189,3 +1189,13 @@ def test_a_healthy_compacted_run_still_resumes_after_degrade_landed(db: str) -> 
     assert code in (ExitCode.OK, ExitCode.REQUIRES_HUMAN), f"{out}{err}"
     assert "PROJECTION FAILURE" not in out
     assert "Traceback" not in err
+
+
+def test_health_and_watch_honor_global_json_flag(db: str) -> None:
+    """Subparsers must not shadow the global --json flag (#677)."""
+    code, out, _ = run("--db", db, "--json", "health", "run_1")
+    assert code == ExitCode.OK
+    assert json.loads(out)["advisory"]["trust_score"] >= 0
+    code, out, _ = run("--db", db, "--json", "watch", "run_1", "--max-silence", "1h")
+    assert code == ExitCode.OK, out
+    assert json.loads(out)["breached"] is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1199,3 +1199,13 @@ def test_health_and_watch_honor_global_json_flag(db: str) -> None:
     code, out, _ = run("--db", db, "--json", "watch", "run_1", "--max-silence", "1h")
     assert code == ExitCode.OK, out
     assert json.loads(out)["breached"] is False
+
+
+def test_json_flag_works_after_the_subcommand(db: str) -> None:
+    """Trailing --json keeps working once shadowing is fixed (#677)."""
+    code, out, _ = run("--db", db, "health", "run_1", "--json")
+    assert code == ExitCode.OK
+    assert json.loads(out)["advisory"]["trust_score"] >= 0
+    code, out, _ = run("--db", db, "watch", "run_1", "--max-silence", "1h", "--json")
+    assert code == ExitCode.OK, out
+    assert json.loads(out)["breached"] is False


### PR DESCRIPTION
## Description

health and watch re-registered --json on their subparsers, whose default False silently replaced the global True, so machine output never appeared. Worse, removing the registrations outright breaks the trailing position (health r1 --json), which an existing test pins. The subparser defaults are now argparse.SUPPRESS: the flag works in both positions and the default stays False.

## Related issues

Fixes #677

## Types of changes

- Type: bugfix

## Breaking changes

No. Both flag positions now produce JSON; default output unchanged.

## How has this been tested?

Python 3.14, editable installation.

- New tests pin both positions for both commands; the global-position test fails on unpatched code, and the suite caught the trailing-position regression in my first approach before this revision.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,032 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Changelog updated. CI has not yet run on this PR.