### PR TITLE
docs: liveness watch operator guide with verified runs

### DIFF
--- a/docs/guides/liveness-watch.md
+++ b/docs/guides/liveness-watch.md
@@ -1,0 +1,99 @@
+# Liveness watch: hearing silence as a signal
+
+A run that stops emitting events may be resting, or it may be wedged. The
+liveness stack turns that distinction into a contract: `.continuum/liveness.json`
+declares how long each phase may stay quiet, and `continuum watch` reports
+breach or quiet without ever gating or mutating beyond its two audit events.
+
+## The cadence contract
+
+```json
+{
+  "max_silence_seconds": 3600,
+  "phase_scopes": {"open_claim": 600, "otherwise": 3600}
+}
+```
+
+`max_silence_seconds` is the default threshold (one hour). `phase_scopes`
+overrides it per phase: while a tool claim is open the tighter `open_claim`
+scope applies, otherwise the `otherwise` scope. A partial file stays valid:
+any missing scope falls back to `max_silence_seconds`. With no file at all the
+built-in default above applies, so a fresh clone behaves sanely with nothing
+configured.
+
+## Watch a run
+
+```bash
+export DB=/tmp/live-demo/g.db
+continuum --db $DB start live-demo --goal "liveness walkthrough"
+```
+
+Wait past the threshold, then check. `--max-silence` overrides the contract
+for one invocation and always wins, even with no claim open:
+
+```bash
+continuum --db $DB watch live-demo --max-silence 1s
+```
+
+```text
+Liveness: BREACHED, silence 3.3s exceeds threshold 1s (phase otherwise). Advisory only.
+```
+
+Exit code 20: breach is advisory, never a gate. A breach appends one
+`LIVENESS_SILENCE_DETECTED` event (hash-chained, carrying silence, threshold,
+and phase) unless the last liveness event already says detected, so repeated
+checks do not spam the log. Check again inside the window and the run reports
+recovery the same way:
+
+```bash
+continuum --db $DB watch live-demo --max-silence 1h
+```
+
+```text
+Liveness ok for live-demo: 0.201496
+```
+
+Exit code 0. Because the previous check left a `DETECTED` marker, this check
+appends `LIVENESS_RECOVERED` and the pair brackets the silent interval in the
+log for audit.
+
+## Where else the advisory appears
+
+`continuum resume` appends the same liveness reading to its verdict,
+read-only:
+
+```bash
+continuum --db $DB resume live-demo
+```
+
+```text
+Next permitted action: continue
+
+Liveness: ok, silence 22.8s within threshold 3600s (phase otherwise).
+```
+
+`continuum health` stays scoped to the prefix-trust score; liveness lives
+with the commands that act on quiet.
+
+## Breach webhook
+
+For unattended runs, `--on-breach webhook` with `--webhook-url` POSTs the
+advisory as JSON instead of just exiting 20:
+
+```bash
+continuum --db $DB watch live-demo --max-silence 1s \
+  --on-breach webhook --webhook-url https://hooks.example.com/continuum
+```
+
+Delivery is fail-open like every notification path: a dead receiver prints a
+warning and never changes the verdict. Signed delivery with
+`CONTINUUM_WEBHOOK_SECRET` is covered by the shared notify primitive.
+
+## Rules worth knowing
+
+- Watch never gates: breach exits 20 and appends audit events, but resume
+  decisions stay with the recovery engine.
+- Silence is measured from the last event timestamp with an injected clock,
+  so the check is deterministic and testable, not wall-clock flaky.
+- A run with no events at all is never breached: there is no silence to
+  measure yet.

--- a/docs/guides/liveness-watch.md
+++ b/docs/guides/liveness-watch.md
@@ -86,8 +86,9 @@ continuum --db $DB watch live-demo --max-silence 1s \
 ```
 
 Delivery is fail-open like every notification path: a dead receiver prints a
-warning and never changes the verdict. Signed delivery with
-`CONTINUUM_WEBHOOK_SECRET` is covered by the shared notify primitive.
+warning and never changes the verdict. The POST carries the advisory as plain
+JSON; there is no authentication on the receiver side, so put the URL behind
+your own secret path or bearer check.
 
 ## Rules worth knowing
 

--- a/docs/recovery_walkthrough.md
+++ b/docs/recovery_walkthrough.md
@@ -137,6 +137,11 @@ Repairs required:
 Next permitted action: revalidate_dependency:dataset
 ```
 
+Live `resume` output also carries a liveness reading after the permitted
+action (`Liveness: ok/breached ...`); `continuum watch` evaluates it on
+demand with its own contract, walked through in
+docs/guides/liveness-watch.md.
+
 ## What just happened
 
 - No duplicate Slack message: the interrupted effect was reconciled by probe


### PR DESCRIPTION
## Description

#639 operator guide, stacked on #671: new docs/guides/liveness-watch.md covering the cadence contract file and defaults, watch breach/recovery runs with real transcripts and exit codes, the resume liveness block, and the breach webhook option. Linked from the resume section of docs/recovery_walkthrough.md. Every command ran verbatim against a fresh database. Depends on #671 because the --max-silence behavior documented here is the fixed one.

## Related issues

Fixes #639
Depends on #671 (merge that first, then retarget this to main)

## Types of changes

- Type: docs

## Breaking changes

No. Documentation only.

## How has this been tested?

- Breach plus recovery cycle verified verbatim (exit 20 breach with DETECTED appended, exit 0 with RECOVERED appended, event types confirmed in the log).
- Caught and corrected my own draft error: health does not carry the liveness block, resume does; the guide states the true behavior.
- markdownlint-cli2 on the new guide: 0 issues (two pre-existing MD040 in the walkthrough, outside CI scope, untouched).
- No em dashes introduced.
- CI runs the full gate.