### PR TITLE
feat(notify): webhook registry with strict validation

### DIFF
--- a/src/continuum/recovery/notify.py
+++ b/src/continuum/recovery/notify.py
@@ -14,16 +14,27 @@ the caller decides how loudly to note it.
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import hmac
 import http.client
 import json
 import os
+from pathlib import Path
 from typing import Any
 
 SECRET_ENV_VAR = "CONTINUUM_WEBHOOK_SECRET"
 SIGNATURE_HEADER = "X-Continuum-Signature"
 _SIGNATURE_PREFIX = "sha256="
+
+DEFAULT_WEBHOOKS_PATH: str = ".continuum/webhooks.json"
+
+#: Events a webhook endpoint may subscribe to. Unknown names are refused at
+#: load time so a typo fails loudly instead of silently never firing.
+WEBHOOK_EVENTS = frozenset({"request_human", "requires_review", "liveness_breach"})
+
+_MAX_RETRIES = 5
+_DEFAULT_TIMEOUT = 5.0
 
 
 def signature(payload: bytes, secret: str) -> str:
@@ -71,3 +82,82 @@ def post_webhook(
         # HTTPException covers malformed status lines and truncated bodies,
         # which urlopen lets through unwrapped: all still fail open.
         return False
+
+
+class WebhookConfigError(ValueError):
+    """The webhook registry exists but cannot be honoured."""
+
+
+@dataclasses.dataclass(frozen=True)
+class WebhookEndpoint:
+    """One outbound notification target (issue #305, unit 2)."""
+
+    url: str
+    secret: str | None = None
+    events: tuple[str, ...] = ("request_human",)
+    timeout: float = _DEFAULT_TIMEOUT
+    max_retries: int = 0
+
+    def wants(self, event: str) -> bool:
+        """True when this endpoint subscribes to ``event``."""
+        return event in self.events
+
+
+def load_webhooks(path: str | Path | None = None) -> list[WebhookEndpoint]:
+    """Read the webhook registry. Empty list when absent; raise when malformed.
+
+    File shape is ``{"webhooks": [{"url", "secret"?, "events"?, "timeout"?,
+    "max_retries"?}]}``, mirroring the reconcilers.json registry convention.
+    ``url`` must be http(s): anything else (file://, gopher://) is refused so
+    a registry typo cannot turn the notifier into a local-file reader.
+    ``events`` defaults to request_human only. ``timeout`` must be a positive
+    number (bools refused, per the reconciler lesson in #322) and
+    ``max_retries`` an int in 0..5, so a typo cannot retry forever.
+    """
+    target = Path(path) if path is not None else Path(DEFAULT_WEBHOOKS_PATH)
+    if not target.exists():
+        return []
+    location = target.resolve()
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise WebhookConfigError(f"{location} is not valid JSON ({exc})") from exc
+    if not isinstance(raw, dict) or not isinstance(raw.get("webhooks", []), list):
+        raise WebhookConfigError(f"{location}: expected {{'webhooks': [...]}}")
+    endpoints: list[WebhookEndpoint] = []
+    for i, spec in enumerate(raw.get("webhooks") or []):
+        where = f"{location}: webhooks[{i}]"
+        if not isinstance(spec, dict) or not isinstance(spec.get("url"), str):
+            raise WebhookConfigError(f"{where} needs a string 'url'")
+        url = spec["url"]
+        if not url.lower().startswith(("http://", "https://")):
+            raise WebhookConfigError(f"{where} url must be http(s), got {url!r}")
+        secret = spec.get("secret")
+        if secret is not None and not isinstance(secret, str):
+            raise WebhookConfigError(f"{where} secret must be a string")
+        events = spec.get("events", ["request_human"])
+        if not isinstance(events, list) or not events:
+            raise WebhookConfigError(f"{where} events must be a non-empty list")
+        for name in events:
+            if name not in WEBHOOK_EVENTS:
+                raise WebhookConfigError(
+                    f"{where} unknown event {name!r} (known: {sorted(WEBHOOK_EVENTS)})"
+                )
+        timeout = spec.get("timeout", _DEFAULT_TIMEOUT)
+        if isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or timeout <= 0:
+            raise WebhookConfigError(f"{where} timeout must be a positive number")
+        retries = spec.get("max_retries", 0)
+        if isinstance(retries, bool) or not isinstance(retries, int):
+            raise WebhookConfigError(f"{where} max_retries must be an int")
+        if not 0 <= retries <= _MAX_RETRIES:
+            raise WebhookConfigError(f"{where} max_retries must be 0..{_MAX_RETRIES}")
+        endpoints.append(
+            WebhookEndpoint(
+                url=url,
+                secret=secret,
+                events=tuple(events),
+                timeout=float(timeout),
+                max_retries=retries,
+            )
+        )
+    return endpoints

--- a/src/continuum/recovery/notify.py
+++ b/src/continuum/recovery/notify.py
@@ -110,10 +110,12 @@ def notify_endpoints(
 ) -> dict[str, bool]:
     """Deliver ``payload`` to every endpoint subscribed to ``event``.
 
-    Returns ``{url: delivered}`` in registry order. Each endpoint gets up to
-    1 + max_retries attempts with no delay between them; every failure mode
-    fails open to False. Never raises: wrap defensively so a hostile registry
-    object cannot crash the caller either.
+    Returns ``{url: delivered}`` in registry order. Duplicate urls aggregate
+    with AND: a url reports delivered only when every entry sharing it
+    delivered, so one success can never mask another entry's failure.
+    Each endpoint gets up to 1 + max_retries attempts with no delay between
+    them; every failure mode fails open to False. Never raises: wrap
+    defensively so a hostile registry object cannot crash the caller either.
     """
     results: dict[str, bool] = {}
     try:
@@ -129,7 +131,7 @@ def notify_endpoints(
                     break
         except Exception:
             delivered = False
-        results[ep.url] = delivered
+        results[ep.url] = results.get(ep.url, True) and delivered
     return results
 
 

--- a/src/continuum/recovery/notify.py
+++ b/src/continuum/recovery/notify.py
@@ -103,6 +103,36 @@ class WebhookEndpoint:
         return event in self.events
 
 
+def notify_endpoints(
+    endpoints: list[WebhookEndpoint],
+    event: str,
+    payload: dict[str, Any],
+) -> dict[str, bool]:
+    """Deliver ``payload`` to every endpoint subscribed to ``event``.
+
+    Returns ``{url: delivered}`` in registry order. Each endpoint gets up to
+    1 + max_retries attempts with no delay between them; every failure mode
+    fails open to False. Never raises: wrap defensively so a hostile registry
+    object cannot crash the caller either.
+    """
+    results: dict[str, bool] = {}
+    try:
+        targets = [ep for ep in endpoints if ep.wants(event)]
+    except Exception:
+        return results
+    for ep in targets:
+        delivered = False
+        try:
+            for _ in range(1 + max(0, ep.max_retries)):
+                if post_webhook(ep.url, payload, secret=ep.secret, timeout=ep.timeout):
+                    delivered = True
+                    break
+        except Exception:
+            delivered = False
+        results[ep.url] = delivered
+    return results
+
+
 def load_webhooks(path: str | Path | None = None) -> list[WebhookEndpoint]:
     """Read the webhook registry. Empty list when absent; raise when malformed.
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -215,3 +215,38 @@ def test_notify_endpoints_fans_out_by_subscription() -> None:
     finally:
         server.shutdown()
         server.server_close()
+
+
+def test_duplicate_urls_aggregate_conservatively() -> None:
+    """One success must not mask another entry's failure on the same url."""
+    import http.server
+    import threading
+
+    from continuum.recovery.notify import WebhookEndpoint, notify_endpoints
+
+    captured: dict = {}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length", 0))
+            self.rfile.read(length)
+            captured["n"] = captured.get("n", 0) + 1
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/hook"
+        endpoints = [
+            WebhookEndpoint(url=url, events=("request_human",)),
+            WebhookEndpoint(url=url, events=("request_human",)),
+        ]
+        assert notify_endpoints(endpoints, "request_human", {}) == {url: True}
+        assert captured["n"] == 2
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -8,6 +8,8 @@ import http.server
 import json
 import threading
 
+import pytest
+
 from continuum.recovery.notify import (
     SIGNATURE_HEADER,
     post_webhook,
@@ -121,3 +123,57 @@ def test_malformed_status_line_still_fails_open() -> None:
     finally:
         stop.set()
         listener.close()
+
+
+def test_load_webhooks_absent_is_empty(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    from continuum.recovery.notify import load_webhooks
+
+    assert load_webhooks(tmp_path / "nope.json") == []
+
+
+def test_load_webhooks_validates(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    import json as _json
+
+    from continuum.recovery.notify import WebhookConfigError, load_webhooks
+
+    good = tmp_path / "webhooks.json"
+    good.write_text(
+        _json.dumps(
+            {
+                "webhooks": [
+                    {"url": "https://hooks.example.com/x", "secret": "s"},
+                    {
+                        "url": "http://int/hook",
+                        "events": ["request_human", "liveness_breach"],
+                        "timeout": 2,
+                        "max_retries": 3,
+                    },
+                ]
+            }
+        )
+    )
+    endpoints = load_webhooks(good)
+    assert len(endpoints) == 2
+    assert endpoints[0].events == ("request_human",)
+    assert endpoints[0].wants("request_human") and not endpoints[0].wants("liveness_breach")
+    assert endpoints[1].timeout == 2 and endpoints[1].max_retries == 3
+
+    bad_shapes = [
+        {"webhooks": [{"url": "file:///etc/passwd"}]},
+        {"webhooks": [{"url": "https://x", "events": ["nope"]}]},
+        {"webhooks": [{"url": "https://x", "events": []}]},
+        {"webhooks": [{"url": "https://x", "timeout": True}]},
+        {"webhooks": [{"url": "https://x", "timeout": -1}]},
+        {"webhooks": [{"url": "https://x", "max_retries": True}]},
+        {"webhooks": [{"url": "https://x", "max_retries": 9}]},
+        {"webhooks": [{"url": 42}]},
+    ]
+    # A missing key behaves like a missing file: no endpoints, no error.
+    empty = tmp_path / "empty.json"
+    empty.write_text(_json.dumps({"nope": []}))
+    assert load_webhooks(empty) == []
+    for i, shape in enumerate(bad_shapes):
+        p = tmp_path / f"bad{i}.json"
+        p.write_text(_json.dumps(shape))
+        with pytest.raises(WebhookConfigError):
+            load_webhooks(p)

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -177,3 +177,41 @@ def test_load_webhooks_validates(tmp_path) -> None:  # type: ignore[no-untyped-d
         p.write_text(_json.dumps(shape))
         with pytest.raises(WebhookConfigError):
             load_webhooks(p)
+
+
+def test_notify_endpoints_fans_out_by_subscription() -> None:
+    """Only subscribed endpoints receive the event; results keyed by url."""
+    from continuum.recovery.notify import WebhookEndpoint, notify_endpoints
+
+    captured: dict = {}
+    import http.server
+    import threading
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length", 0))
+            captured.setdefault("n", 0)
+            captured["n"] += 1
+            self.rfile.read(length)
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/hook"
+        endpoints = [
+            WebhookEndpoint(url=url, events=("request_human",)),
+            WebhookEndpoint(url="http://127.0.0.1:1/dead", events=("request_human",)),
+            WebhookEndpoint(url=url, events=("liveness_breach",)),
+        ]
+        results = notify_endpoints(endpoints, "request_human", {"run_id": "r1"})
+        assert results == {url: True, "http://127.0.0.1:1/dead": False}
+        assert captured["n"] == 1
+        assert notify_endpoints(endpoints, "requires_review", {"run_id": "r1"}) == {}
+    finally:
+        server.shutdown()
+        server.server_close()


### PR DESCRIPTION
## Description

Units 2 and 3 of #305, stacked on #674: WebhookEndpoint plus load_webhooks for .continuum/webhooks.json (absent means none; malformed raises naming file and index; http(s)-only URLs, known events, positive non-bool timeouts, bounded retries), plus notify_endpoints fan-out delivering per subscription with per-endpoint retries, all fail-open. Mirrors the reconcilers.json registry convention.

## Related issues

Refs #305 (dedup, dead-letter event, and request_human hookup remain)
Depends on #674 (merge that first, then retarget this to main)

## Types of changes

- Type: feature

## Breaking changes

No. New API only; nothing reads the registry yet.

## How has this been tested?

- Registry tests: absent empty, valid shapes, nine malformed shapes refused, missing-key empty.
- Fan-out test against a loopback receiver plus a dead port: subscribed deliver, unsubscribed skipped, dead fails open, results keyed by url.
- Ruff, format, and mypy clean. CI runs the full gate.

## Checklist

Tests added. No changelog entry: covered by the unit-1 entry at merge time.