### PR TITLE
feat(notify): non-projecting dead-letter event plus recorder

### DIFF
--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -145,6 +145,11 @@ class EventType(StrEnum):
     # memory governance (issue #304, #567): per-tenant tombstone for erasure
     MEMORY_TOMBSTONED = "MEMORY_TOMBSTONED"
 
+    # human notification (issue #305): dead letter for a failed webhook
+    # delivery. Audit only, never state; DETERMINISTIC because the failure
+    # is observed by local code, not asserted by an agent.
+    NOTIFY_FAILED = "NOTIFY_FAILED"
+
 
 class AppendOnlyViolation(RuntimeError):
     """Raised when an operation would rewrite history."""

--- a/src/continuum/recovery/notify.py
+++ b/src/continuum/recovery/notify.py
@@ -191,3 +191,22 @@ def load_webhooks(path: str | Path | None = None) -> list[WebhookEndpoint]:
             )
         )
     return endpoints
+
+
+def record_delivery_failure(storage: Any, run_id: str, url: str, event: str, error: str) -> None:
+    """Append a NOTIFY_FAILED dead letter for an undelivered notification.
+
+    Audit only: the type is non-projecting, so the dead letter never changes
+    state, verdicts, or resume behavior. Best effort itself: storage errors
+    are swallowed because a failing audit write must not break the caller.
+    """
+    from contextlib import suppress
+
+    from continuum.events import EventType
+
+    with suppress(Exception):
+        storage.append_event(
+            run_id,
+            EventType.NOTIFY_FAILED,
+            {"url": url, "event": event, "error": str(error)[:512]},
+        )

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -731,6 +731,8 @@ _NON_PROJECTING = frozenset(
         EventType.LIVENESS_RECOVERED,
         # risk (issue #303): real-time risk signal, never state
         EventType.RISK_OBSERVED,
+        # human notification (issue #305): delivery dead letter, never state
+        EventType.NOTIFY_FAILED,
     }
 )
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -215,3 +215,26 @@ def test_notify_endpoints_fans_out_by_subscription() -> None:
     finally:
         server.shutdown()
         server.server_close()
+
+
+def test_delivery_failure_is_audit_only(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Dead letters record without touching projection or verify (#305)."""
+    from continuum.events import EventType
+    from continuum.models import Run
+    from continuum.recovery.notify import record_delivery_failure
+    from continuum.state.semantic import project
+    from continuum.storage import SQLiteStorage
+
+    db = str(tmp_path / "deadletter.db")
+    with SQLiteStorage(db) as store:
+        store.create_run_started(Run(run_id="run_1", goal="g"))
+        before = project("run_1", store.read_events("run_1"))
+        record_delivery_failure(store, "run_1", "http://dead/hook", "request_human", "refused")
+        events = store.read_events("run_1")
+        dead = [e for e in events if e.type is EventType.NOTIFY_FAILED]
+        assert len(dead) == 1
+        assert dead[0].payload["url"] == "http://dead/hook"
+        after = project("run_1", events)
+        assert after.progress == before.progress
+        assert after.goal == before.goal
+        assert store.verify_events("run_1").ok


### PR DESCRIPTION
## Description

Unit 4a of #305, stacked on the registry unit: NOTIFY_FAILED event type registered as non-projecting (audit only, never state), plus record_delivery_failure helper that appends url, event, and truncated error best-effort. One deliberate deviation for review: the issue text suggests EXTERNAL origin, but the failure is observed by local code, so the recorder uses the append default DETERMINISTIC like other system bookkeeping; say the word and it changes.

## Related issues

Refs #305 (assess hookup remains)
Depends on #690 (merge that first, then retarget this to main)

## Types of changes

- Type: feature

## Breaking changes

No. New event type and helper; projection explicitly ignores the type.

## How has this been tested?

- New audit-only test: dead letter present with url, projection progress and goal unchanged, verify clean.
- Ruff, format, and mypy clean on touched files. CI runs the full gate.

## Checklist

Tests added. No changelog entry: covered by the unit-1 entry at merge time.