### PR TITLE
feat(notify): page subscribed endpoints on blocked verdicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- Blocked verdicts page subscribed webhook endpoints once per verdict (#305).
+  `continuum resume` loads `.continuum/webhooks.json` on `request_human`,
+  fans out through the shared primitive, records delivery for dedup so cron
+  re-assessments stay silent, and writes dead letters for failures. Verdict,
+  text, and exit code are unchanged.
+
 - Shared signed webhook delivery primitive for human notification (#305).
   `continuum.recovery.notify` posts JSON with an HMAC-SHA256 signature when
   `CONTINUUM_WEBHOOK_SECRET` is set and plain JSON otherwise, always

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1303,6 +1303,19 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         palette=getattr(args, "_palette", None),
     )
 
+    # Human notification (issue #305): a blocked verdict pages subscribed
+    # endpoints once per distinct verdict. Best effort and silent: delivery
+    # must never change the verdict, the output, or the exit code.
+    if presented_mode == "request_human":
+        try:
+            from continuum.recovery.notify import notify_blocked
+
+            notify_blocked(
+                storage, run_id, presented_mode, decision.contract.model_dump(mode="json")
+            )
+        except Exception:
+            pass
+
     if decision.mode is not RecoveryMode.RESUME and not args.repair:
         print(
             "\nRun with --repair to record the repair plan, or resolve the items above first.",

--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -149,6 +149,9 @@ class EventType(StrEnum):
     # delivery. Audit only, never state; DETERMINISTIC because the failure
     # is observed by local code, not asserted by an agent.
     NOTIFY_FAILED = "NOTIFY_FAILED"
+    # human notification (issue #305): record of a delivered notification,
+    # used to dedup repeat assessments of the same blocked verdict.
+    NOTIFY_SENT = "NOTIFY_SENT"
 
 
 class AppendOnlyViolation(RuntimeError):

--- a/src/continuum/recovery/notify.py
+++ b/src/continuum/recovery/notify.py
@@ -210,3 +210,101 @@ def record_delivery_failure(storage: Any, run_id: str, url: str, event: str, err
             EventType.NOTIFY_FAILED,
             {"url": url, "event": event, "error": str(error)[:512]},
         )
+
+
+def record_notified(storage: Any, run_id: str, mode: str, contract_hash: str) -> None:
+    """Record a delivered notification for later dedup. Best effort."""
+    from contextlib import suppress
+
+    from continuum.events import EventType
+
+    with suppress(Exception):
+        storage.append_event(
+            run_id,
+            EventType.NOTIFY_SENT,
+            {"mode": mode, "contract_hash": contract_hash},
+        )
+
+
+def already_notified(storage: Any, run_id: str, mode: str, contract_hash: str) -> bool:
+    """True when the same blocked verdict was already notified.
+
+    Dedup key is (mode, contract hash): a new verdict re-notifies, a repeat
+    assessment of the identical verdict stays silent, so a cron calling
+    resume every minute does not spam. Read failures answer False (notify
+    rather than risk silence) since delivery itself stays fail-open.
+    """
+    from continuum.events import EventType
+
+    try:
+        events = storage.read_events(run_id)
+    except Exception:
+        return False
+    for ev in reversed(events):
+        if ev.type is not EventType.NOTIFY_SENT:
+            continue
+        payload = ev.payload or {}
+        return payload.get("mode") == mode and payload.get("contract_hash") == contract_hash
+    return False
+
+
+# Contract fields that define the verdict. Volatile telemetry (liveness ages,
+# created_at, post-checkpoint observations) is excluded: hashing the whole
+# contract would never dedup because wall-clock fields move every assessment.
+_STABLE_CONTRACT_KEYS = (
+    "recovery_status",
+    "invalidated",
+    "required_actions",
+    "next_allowed_action",
+    "evidence",
+    "reason",
+    "triggering_risks",
+)
+
+
+def verdict_fingerprint(contract: dict[str, Any]) -> str:
+    """Stable hash of a blocked verdict for dedup."""
+    from continuum.security.hashing import stable_hash
+
+    if any(k in contract for k in _STABLE_CONTRACT_KEYS):
+        stable = {k: contract.get(k) for k in _STABLE_CONTRACT_KEYS}
+    else:
+        stable = dict(contract)
+    return stable_hash(stable)
+
+
+def notify_blocked(
+    storage: Any,
+    run_id: str,
+    mode: str,
+    contract: dict[str, Any],
+    *,
+    registry_path: str | Path | None = None,
+) -> dict[str, bool]:
+    """Notify subscribed endpoints about a blocked verdict. Never raises.
+
+    Loads the registry, skips silently when nothing subscribes to request_human
+    or the identical verdict was already notified, otherwise fans out and
+    records one NOTIFY_SENT per delivered endpoint plus NOTIFY_FAILED dead
+    letters for failures. Returns {url: delivered}.
+    """
+    try:
+        endpoints = load_webhooks(registry_path)
+    except Exception:
+        return {}
+    targets = [ep for ep in endpoints if ep.wants("request_human")]
+    if not targets:
+        return {}
+    try:
+        digest = verdict_fingerprint(contract)
+    except Exception:
+        return {}
+    if already_notified(storage, run_id, mode, digest):
+        return {}
+    results = notify_endpoints(targets, "request_human", {"run_id": run_id, "mode": mode})
+    if any(results.values()):
+        record_notified(storage, run_id, mode, digest)
+    for url, delivered in results.items():
+        if not delivered:
+            record_delivery_failure(storage, run_id, url, "request_human", "delivery failed")
+    return results

--- a/src/continuum/recovery/notify.py
+++ b/src/continuum/recovery/notify.py
@@ -285,8 +285,14 @@ def notify_blocked(
 
     Loads the registry, skips silently when nothing subscribes to request_human
     or the identical verdict was already notified, otherwise fans out and
-    records one NOTIFY_SENT per delivered endpoint plus NOTIFY_FAILED dead
+    records one NOTIFY_SENT per delivered verdict plus NOTIFY_FAILED dead
     letters for failures. Returns {url: delivered}.
+
+    Single page per verdict by design: with several endpoints where one is
+    down, the first pass delivers to the working ones, dead-letters the
+    rest, and later repeats stay silent for that verdict. A recovered
+    endpoint catches the next distinct verdict. This bounds cron-driven
+    assessments to one page per genuinely new blockage.
     """
     try:
         endpoints = load_webhooks(registry_path)

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -733,6 +733,8 @@ _NON_PROJECTING = frozenset(
         EventType.RISK_OBSERVED,
         # human notification (issue #305): delivery dead letter, never state
         EventType.NOTIFY_FAILED,
+        # human notification (issue #305): delivery record for dedup, never state
+        EventType.NOTIFY_SENT,
     }
 )
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -271,16 +271,19 @@ def test_notify_blocked_delivers_once_per_verdict(tmp_path) -> None:  # type: ig
         os.chdir(tmp_path)
         try:
             with SQLiteStorage(db) as store:
-                first = notify_blocked(store, "run_1", "request_human", {"v": 1},
-                                       registry_path=str(registry))
+                first = notify_blocked(
+                    store, "run_1", "request_human", {"v": 1}, registry_path=str(registry)
+                )
                 assert list(first.values()) == [True]
                 assert captured["n"] == 1
-                repeat = notify_blocked(store, "run_1", "request_human", {"v": 1},
-                                        registry_path=str(registry))
+                repeat = notify_blocked(
+                    store, "run_1", "request_human", {"v": 1}, registry_path=str(registry)
+                )
                 assert repeat == {}
                 assert captured["n"] == 1
-                changed = notify_blocked(store, "run_1", "request_human", {"v": 2},
-                                         registry_path=str(registry))
+                changed = notify_blocked(
+                    store, "run_1", "request_human", {"v": 2}, registry_path=str(registry)
+                )
                 assert list(changed.values()) == [True]
                 assert captured["n"] == 2
                 sent = [e for e in store.read_events("run_1") if e.type is EventType.NOTIFY_SENT]

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -38,6 +38,7 @@ def _receiver(captured: dict, status: int = 200):
             length = int(self.headers.get("Content-Length", 0))
             captured["body"] = self.rfile.read(length)
             captured["signature"] = self.headers.get(SIGNATURE_HEADER)
+            captured["n"] = captured.get("n", 0) + 1
             self.send_response(status)
             self.end_headers()
 
@@ -238,3 +239,101 @@ def test_delivery_failure_is_audit_only(tmp_path) -> None:  # type: ignore[no-un
         assert after.progress == before.progress
         assert after.goal == before.goal
         assert store.verify_events("run_1").ok
+
+
+def _registry(tmp_path, url: str):  # type: ignore[no-untyped-def]
+    import json as _json
+
+    dot = tmp_path / ".continuum"
+    dot.mkdir(exist_ok=True)
+    path = dot / "webhooks.json"
+    path.write_text(_json.dumps({"webhooks": [{"url": url}]}))
+    return path
+
+
+def test_notify_blocked_delivers_once_per_verdict(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Repeat assessments of one verdict notify once; new verdicts renotify."""
+    from continuum.events import EventType
+    from continuum.models import Run
+    from continuum.recovery.notify import notify_blocked
+    from continuum.storage import SQLiteStorage
+
+    captured: dict = {}
+    server = _receiver(captured)
+    try:
+        db = str(tmp_path / "hookup.db")
+        with SQLiteStorage(db) as store:
+            store.create_run_started(Run(run_id="run_1", goal="g"))
+        registry = _registry(tmp_path, f"http://127.0.0.1:{server.server_port}/hook")
+        import os
+
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            with SQLiteStorage(db) as store:
+                first = notify_blocked(store, "run_1", "request_human", {"v": 1},
+                                       registry_path=str(registry))
+                assert list(first.values()) == [True]
+                assert captured["n"] == 1
+                repeat = notify_blocked(store, "run_1", "request_human", {"v": 1},
+                                        registry_path=str(registry))
+                assert repeat == {}
+                assert captured["n"] == 1
+                changed = notify_blocked(store, "run_1", "request_human", {"v": 2},
+                                         registry_path=str(registry))
+                assert list(changed.values()) == [True]
+                assert captured["n"] == 2
+                sent = [e for e in store.read_events("run_1") if e.type is EventType.NOTIFY_SENT]
+                assert len(sent) == 2
+                assert store.verify_events("run_1").ok
+        finally:
+            os.chdir(cwd)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_resume_notifies_blocked_run_without_changing_output(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """CLI resume pages once per verdict and keeps verdict, text, and exit code."""
+    import io
+
+    from continuum.actions import ActionLedger
+    from continuum.cli import ExitCode, main
+    from continuum.events import EventType
+    from continuum.models import Run
+    from continuum.storage import SQLiteStorage
+
+    captured: dict = {}
+    server = _receiver(captured)
+    try:
+        db = str(tmp_path / "cli.db")
+        with SQLiteStorage(db) as store:
+            store.create_run_started(Run(run_id="run_1", goal="g"))
+            ActionLedger(store, "run_1").claim("send_invoice", {}, key="invoice:1")
+        monkeypatch.chdir(tmp_path)
+
+        def resume():
+            out, err = io.StringIO(), io.StringIO()
+            code = main(["--db", db, "resume", "run_1"], out=out, err=err)
+            return code, out.getvalue()
+
+        code, text = resume()
+        assert code == ExitCode.REQUIRES_HUMAN
+        with SQLiteStorage(db) as store:
+            assert not [e for e in store.read_events("run_1") if e.type is EventType.NOTIFY_SENT]
+        _registry(tmp_path, f"http://127.0.0.1:{server.server_port}/hook")
+        code2, text2 = resume()
+        assert (code2, text2) == (code, text)
+        assert captured.get("n", 0) == 1
+        with SQLiteStorage(db) as store:
+            sent = [e for e in store.read_events("run_1") if e.type is EventType.NOTIFY_SENT]
+            assert len(sent) == 1
+            code3, text3 = resume()
+            assert (code3, text3) == (code, text)
+            assert captured["n"] == 1
+            sent2 = [e for e in store.read_events("run_1") if e.type is EventType.NOTIFY_SENT]
+            assert len(sent2) == 1
+            assert store.verify_events("run_1").ok
+    finally:
+        server.shutdown()
+        server.server_close()


### PR DESCRIPTION
## Description

Unit 4b of #305, stacked on the dead-letter unit: resume notifies on request_human verdicts. notify_blocked loads the registry, skips when nothing subscribes, dedups repeat assessments of the identical verdict via a stable-field fingerprint (wall-clock telemetry excluded, which an honest test failure caught mid-work), fans out, records one NOTIFY_SENT per delivered verdict plus dead letters for failures, and never raises into resume. Verdict, text, and exit code are byte-identical with and without a registry.

## Related issues

Refs #305 (registry, dead-letter, hookup now done; only docs remain)
Depends on #691 (merge that first, then retarget this to main)

## Types of changes

- Type: feature

## Breaking changes

No. Additive; no-registry behavior is byte-identical, proven by test.

## How has this been tested?

Python 3.14, editable installation.

- notify_blocked unit test: delivers once per verdict, silent on repeats, renotifies on changed verdict, verify clean.
- CLI test: uncertain action resumes to REQUIRES_HUMAN; output and exit identical without registry, one delivery plus one sent row with registry, third identical resume stays at one of each, verify clean.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,044 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy src/continuum: passed, 122 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Changelog updated. CI has not yet run on this PR.