### PR TITLE
feat(notify): notify-test command verifies wiring

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -36,6 +36,7 @@ continuum --json <command>                    # machine-readable output
 | `briefing` | Session-start context: active run, progress, next steps. Read-only. |
 | `gate` | Decide whether a tool call may proceed (pre-tool-use hook). Read-only. |
 | `hooks` | Manage host-side observation hooks. |
+| `notify-test` | Send a test notification through webhooks. |
 | `verify <run_id>` | Re-audit the event chain for tampering. |
 | `reconcile <run_id>` | Settle uncertain actions with registered probes. Mutates storage. |
 | `actions <run_id>` | List recorded side effects and flag uncertain outcomes. |

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1112,6 +1112,57 @@ def cmd_watch(args: argparse.Namespace, storage: Storage, out: Any, err: Any) ->
     return 0
 
 
+def cmd_notify_test(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Send a test notification through the webhook registry (issue #305).
+
+    Verifies operator wiring without manufacturing a real blockage: loads
+    ``.continuum/webhooks.json`` (or ``--registry``), delivers a test payload
+    to every endpoint subscribed to ``--event``, and reports per-url results.
+    Exit 0 only when every subscribed endpoint answers 2xx.
+    """
+    from continuum.recovery.notify import (
+        WEBHOOK_EVENTS,
+        WebhookConfigError,
+        load_webhooks,
+        notify_endpoints,
+    )
+
+    del storage
+    event = getattr(args, "event", None) or "request_human"
+    if event not in WEBHOOK_EVENTS:
+        print(
+            f"error: unknown event {event!r} (known: {sorted(WEBHOOK_EVENTS)})",
+            file=err,
+        )
+        return ExitCode.ERROR
+    registry = getattr(args, "registry", None)
+    try:
+        endpoints = load_webhooks(registry)
+    except WebhookConfigError as exc:
+        print(f"error: {exc}", file=err)
+        return ExitCode.ERROR
+    targets = [ep for ep in endpoints if ep.wants(event)]
+    if not targets:
+        _emit(
+            {"event": event, "results": {}},
+            f"no endpoints subscribe to {event!r}",
+            as_json=args.json,
+            stream=out,
+            palette=getattr(args, "_palette", None),
+        )
+        return ExitCode.OK
+    results = notify_endpoints(targets, event, {"event": event, "test": True})
+    lines = [f"  {'ok' if delivered else 'FAILED'}  {url}" for url, delivered in results.items()]
+    _emit(
+        {"event": event, "results": results},
+        "\n".join(lines),
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK if all(results.values()) else ExitCode.ERROR
+
+
 def cmd_health(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Advisory prefix-trust health check (issue #401). Read-only."""
     # Health is advisory only: it never moves mode, never gates, never changes
@@ -3637,6 +3688,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     health = with_run(add("health", cmd_health, "Advisory prefix-trust health check. Read-only."))
     health.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
+    notify_test = add("notify-test", cmd_notify_test, "Send a test notification through webhooks.")
+    notify_test.add_argument("--event", default="request_human", help="event to test delivery for")
+    notify_test.add_argument("--registry", default=None, help="webhook registry path")
     # health is advisory only; it never gates, never moves mode, never changes exit code
     # (issue #401). It reports trust_score with per-dimension breakdown.
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -340,3 +340,67 @@ def test_resume_notifies_blocked_run_without_changing_output(tmp_path, monkeypat
     finally:
         server.shutdown()
         server.server_close()
+
+
+def test_notify_test_command_reports_per_url(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """notify-test verifies wiring without a real blockage (#305)."""
+    import http.server
+    import io
+    import json as _json
+    import threading
+
+    from continuum.cli import ExitCode, main
+    from continuum.models import Run
+    from continuum.storage import SQLiteStorage
+
+    received: list = []
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length", 0))
+            received.append(_json.loads(self.rfile.read(length)))
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        db = str(tmp_path / "nt.db")
+        with SQLiteStorage(db) as store:
+            store.create_run_started(Run(run_id="run_1", goal="g"))
+        dot = tmp_path / ".continuum"
+        dot.mkdir(exist_ok=True)
+        (dot / "webhooks.json").write_text(
+            _json.dumps(
+                {
+                    "webhooks": [
+                        {"url": f"http://127.0.0.1:{server.server_port}/a"},
+                        {"url": "http://127.0.0.1:1/dead"},
+                    ]
+                }
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+
+        def invoke(*argv):  # type: ignore[no-untyped-def]
+            out, err = io.StringIO(), io.StringIO()
+            code = main(["--db", db, *argv], out=out, err=err)
+            return code, out.getvalue(), err.getvalue()
+
+        code, out, _ = invoke("notify-test")
+        assert code == ExitCode.ERROR, out
+        assert "ok" in out and "FAILED" in out
+        assert received and received[0]["test"] is True
+        code, out, _ = invoke("--json", "notify-test")
+        payload = _json.loads(out)
+        assert payload["event"] == "request_human"
+        assert len(payload["results"]) == 2
+        code, _, err = invoke("notify-test", "--event", "nope")
+        assert code == ExitCode.ERROR
+        assert "unknown event" in err
+    finally:
+        server.shutdown()
+        server.server_close()


### PR DESCRIPTION
## Description

Final unit of #305: continuum notify-test delivers a test payload through the registry without needing a real blockage. Loads .continuum/webhooks.json (or --registry), fans out to --event subscribers (default request_human), prints per-url ok/FAILED lines, emits machine JSON, exits 0 only when every subscribed endpoint answers 2xx. Unknown event names error; empty subscriber sets report and exit 0. Also adds the command's row to the CLI reference table.

## Related issues

Refs #305 (registry, dead letters, hookup, and operator verification now all done)
Depends on #692 (merge that first, then retarget this to main)

## Types of changes

- Type: feature

## Breaking changes

No. New command only.

## How has this been tested?

Python 3.14, editable installation.

- New CLI test against a loopback receiver plus a dead port: mixed exit ERROR with both lines, JSON shape with both results, unknown event errors.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,045 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy src/continuum: passed, 122 source files.
- git diff --check: passed.

## Checklist

Tests added for changed behavior. Docs table updated. CI has not yet run on this PR.