### PR TITLE
chore: ignore benchmarks/out directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ demo-run/*
 
 # opencode local state
 .opencode/
+
+# Benchmark artifacts
+benchmarks/out/


### PR DESCRIPTION
## Description

`benchmarks/run.py` writes its output into `benchmarks/out/` by default (`report.json` and `report.md`), but that directory was neither tracked nor gitignored. This PR adds `benchmarks/out/` to `.gitignore` so benchmark runs leave the Git working tree clean, preventing accidental commits of generated artifacts.

## Related issues

Fixes #<ISSUE_NUMBER>

## Types of changes

- Type: `build`

## Breaking changes

No

## How has this been tested?

Verified locally that the new rule correctly ignores generated output:
- Ran `git check-ignore -v benchmarks/out/report.json` and confirmed it successfully ignores the file via `.gitignore`.
- Ran `git ls-files benchmarks/out/` and confirmed no existing tracked files are accidentally hidden by the new rule.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

This is a safe, one-line change that keeps local development and `git status` clean when executing the benchmark suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Excluded generated benchmark output files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->