### PR TITLE
fix(mcp): resolve continuum-mcp via ${CLAUDE_PROJECT_DIR} so fresh clones connect

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "continuum-mcp": {
-      "command": "continuum-mcp",
+      "command": "${CLAUDE_PROJECT_DIR:-.}/.venv/bin/continuum-mcp",
       "args": ["--db", "continuum.db"],
       "env": {
         "CONTINUUM_MCP_MUTATING_CLIENTS": "claude-code"


### PR DESCRIPTION
Fixes #699

## Problem

The project-scoped `.mcp.json` registers the server with a bare command, `continuum-mcp`, which only resolves if the contributor's venv is active in the shell that launched Claude Code. On a fresh clone the server fails to spawn and shows as failed/pending in `claude mcp list`.

## Change

```diff
-      "command": "continuum-mcp",
+      "command": "${CLAUDE_PROJECT_DIR:-.}/.venv/bin/continuum-mcp",
```

Claude Code expands `${VAR}` (and `${VAR:-default}`) in the `command` field of `.mcp.json`. The `:-.` default is required because `${CLAUDE_PROJECT_DIR}` is set in the spawned server's environment, not Claude Code's own, so without a default the unexpanded text is passed through as-is.

## Verification

- `which continuum-mcp` on a clean shell: not found (reproduces the failure)
- With the new command string: the venv binary resolves both with `CLAUDE_PROJECT_DIR` set and unset (fallback `.` from the project root)
- JSON-RPC `initialize` over stdio against `.venv/bin/continuum-mcp --db /tmp/mcp-verify.db` returns a valid initialize result

## Notes for reviewers

The path is POSIX; Windows contributors using `.venv\Scripts\` still need to adjust it (or activate the venv). A cross-platform story could be a follow-up (e.g. documenting the Windows path or a launcher script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCP server startup by resolving the server command relative to the project directory, with the current directory used as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->