### PR TITLE
fix(bench): add argparse so run.py handles --help and --list

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,7 +1,7 @@
 """Run the Phase 6 recovery-correctness scenario suite and emit a report.
 
 Usage:
-    uv run python benchmarks/run.py
+    uv run python benchmarks/run.py [--list]
 
 Writes ``benchmarks/out/report.json`` and ``benchmarks/out/report.md``. The run
 is reproducible: scenarios build their own in-memory state, so the output can be
@@ -25,6 +25,7 @@ Continuum bench byte counts (issue #568, #293a):
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 from pathlib import Path
@@ -197,7 +198,49 @@ def _append_continuum_bench(out_dir: str | Path) -> None:
         print("continuum bench: unexpected report shape, skipping merge")
 
 
+_SUITES: dict[str, str] = {
+    "phase6": "recovery-correctness scenarios -> out/report.{json,md}",
+    "continuum-bench": "crash-recovery byte counts -> merged into out/report.json",
+    "fault-injection": "chaos suite (#397) -> out/fault_injection_report.{json,md}",
+    "horizon": (
+        "horizon-scale suite (#398) -> out/horizon_report.{json,md}; "
+        "also regenerates the README bench table"
+    ),
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``benchmarks/run.py`` argument parser.
+
+    Only ``--help`` and ``--list`` are recognised; anything else fails with
+    exit code 2 (argparse convention, matching ``src/continuum/cli/main.py``)
+    instead of silently launching the full multi-minute suite (issue #682).
+    """
+    parser = argparse.ArgumentParser(
+        prog="python benchmarks/run.py",
+        description=(
+            "Run the full benchmark suite: Phase 6 recovery-correctness scenarios, "
+            "the CONTINUUM crash-recovery byte-count bench, the fault-injection "
+            "chaos suite, and the horizon-scale suite. Takes minutes and writes "
+            "reports under benchmarks/out/."
+        ),
+        epilog="With no arguments, runs every suite in order and writes all reports.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="print the suites this runner executes and where each report lands, then exit.",
+    )
+    return parser
+
+
 def main() -> None:
+    args = build_parser().parse_args()
+    if args.list:
+        for name, what in _SUITES.items():
+            print(f"{name}: {what}")
+        return
+
     report = run_benchmark(scenarios.ALL_SCENARIOS)
     out_dir = os.path.join(os.path.dirname(__file__), "out")
     os.makedirs(out_dir, exist_ok=True)

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -199,11 +199,11 @@ def _append_continuum_bench(out_dir: str | Path) -> None:
 
 
 _SUITES: dict[str, str] = {
-    "phase6": "recovery-correctness scenarios -> out/report.{json,md}",
-    "continuum-bench": "crash-recovery byte counts -> merged into out/report.json",
-    "fault-injection": "chaos suite (#397) -> out/fault_injection_report.{json,md}",
+    "phase6": "recovery-correctness scenarios -> benchmarks/out/report.{json,md}",
+    "continuum-bench": "crash-recovery byte counts -> merged into benchmarks/out/report.json",
+    "fault-injection": "chaos suite (#397) -> benchmarks/out/fault_injection_report.{json,md}",
     "horizon": (
-        "horizon-scale suite (#398) -> out/horizon_report.{json,md}; "
+        "horizon-scale suite (#398) -> benchmarks/out/horizon_report.{json,md}; "
         "also regenerates the README bench table"
     ),
 }


### PR DESCRIPTION
## Summary

Fixes #682.

`benchmarks/run.py` parsed no arguments at all: typing `--help` launched the full multi-minute benchmark suite (writing reports under `benchmarks/out/`) instead of printing usage.

This PR adds an argparse parser following the conventions in `src/continuum/cli/main.py` (`build_parser()` + dispatch in `main()`):

- `--help` prints usage (what runs, what it writes, where) and exits 0 without running anything
- `--list` (new) prints the four suites the runner executes and where each report lands, then exits
- unknown flags fail with exit code 2 via argparse
- no arguments: runs every suite in order, unchanged behavior

## Verification

```console
$ python benchmarks/run.py --help
usage: python benchmarks/run.py [-h] [--list]

Run the full benchmark suite: ...
exit: 0

$ python benchmarks/run.py --list
phase6: recovery-correctness scenarios -> out/report.{json,md}
continuum-bench: crash-recovery byte counts -> merged into out/report.json
fault-injection: chaos suite (#397) -> out/fault_injection_report.{json,md}
horizon: horizon-scale suite (#398) -> out/horizon_report.{json,md}; also regenerates the README bench table
exit: 0

$ python benchmarks/run.py --bogus
python benchmarks/run.py: error: unrecognized arguments: --bogus
exit: 2
```

Full run still works (local, Windows): `scenarios: 13 passed: 13 failed: 0`, fault-injection `7 passed=7 failed=0`, exit code 0.

`ruff check benchmarks/run.py` and `ruff format --check benchmarks/run.py` both pass with ruff 0.16.5 (the CI pin).

## Notes

CI lints `src|tests|examples` only, but the file is kept ruff-clean anyway per the issue's checklist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional command-line option to list available benchmark suites and their output locations.
  * Added validation for command-line arguments, with clear rejection of unsupported options.
* **Documentation**
  * Updated runner usage information to describe the new listing option and output locations.
* **Compatibility**
  * Running the benchmark tool without arguments continues to execute the full benchmark suite as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->