### PR TITLE
fix(recovery): scan the archived prefix for REVIEW_CONFIRMED events

### DIFF
--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -229,8 +229,16 @@ class RecoveryEngine:
         # Scoped confirm (issue #394) narrows this to named components only;
         # the payload may carry "components" or "scope" as a list, a single
         # string, or be absent (legacy full confirm of both).
+        # The scan includes the archived prefix so compaction cannot silently
+        # discard a human's confirmation (same archive-blindness family as
+        # issue #553): without it, a confirmed run re-escalates to
+        # request_human after every compaction.
         confirmed_components: set[str] = set()
-        for _ev in self.storage.read_events(run_id):
+        try:
+            _confirm_events = self.storage.read_all_events(run_id)
+        except Exception:
+            _confirm_events = self.storage.read_events(run_id)
+        for _ev in _confirm_events:
             if _ev.type is not EventType.REVIEW_CONFIRMED:
                 continue
             # Only human confirmations clear self-certification; an agent

--- a/src/continuum/recovery/engine.py
+++ b/src/continuum/recovery/engine.py
@@ -234,11 +234,15 @@ class RecoveryEngine:
         # issue #553): without it, a confirmed run re-escalates to
         # request_human after every compaction.
         confirmed_components: set[str] = set()
+        # Both archive-aware scans below (confirmations and provenance) share
+        # this one fetch: read_all_events walks the archived prefix too, and
+        # re-walking it twice per assess() doubles the archive scan for no
+        # gain.
         try:
-            _confirm_events = self.storage.read_all_events(run_id)
+            archive_aware_events = self.storage.read_all_events(run_id)
         except Exception:
-            _confirm_events = self.storage.read_events(run_id)
-        for _ev in _confirm_events:
+            archive_aware_events = self.storage.read_events(run_id)
+        for _ev in archive_aware_events:
             if _ev.type is not EventType.REVIEW_CONFIRMED:
                 continue
             # Only human confirmations clear self-certification; an agent
@@ -261,11 +265,8 @@ class RecoveryEngine:
             else:
                 confirmed_components.update(["goal", "progress"])
 
-        # Provenance N-hop staleness (issue #553): include archived events so compaction does not launder
-        try:
-            provenance_events = self.storage.read_all_events(run_id)
-        except Exception:
-            provenance_events = self.storage.read_events(run_id)
+        # Provenance N-hop staleness (issue #553): the shared archive-aware
+        # fetch above feeds the validator so compaction does not launder it.
         validation = self.validator.validate(
             restored.state,
             current_environment=current_environment,
@@ -274,7 +275,7 @@ class RecoveryEngine:
             expected_model=expected_model,
             confirmed=confirmed_components,
             scope=scope,
-            events=provenance_events,
+            events=archive_aware_events,
         )
 
         ledger = ActionLedger(self.storage, run_id)

--- a/tests/test_recovery_engine.py
+++ b/tests/test_recovery_engine.py
@@ -507,6 +507,36 @@ def test_self_certified_runs_are_confirmable(store: SQLiteStorage) -> None:
     )
 
 
+def test_confirmation_survives_compaction(store: SQLiteStorage) -> None:
+    """A human confirmation must survive compaction: the confirm event sits in
+    the pre-anchor prefix, so the confirm scan has to read the archived
+    prefix too, or a confirmed run silently re-escalates to request_human."""
+    store.create_run(Run(run_id="r1", goal="do X"))
+    store.append_event("r1", EventType.RUN_STARTED, {"goal": "do X"}, source=Origin.EXTERNAL_AGENT)
+    store.append_event(
+        "r1", EventType.TASK_UPDATED, {"completed": 1, "failed": 0}, source=Origin.EXTERNAL_AGENT
+    )
+    store.append_event(
+        "r1",
+        EventType.REVIEW_CONFIRMED,
+        {"components": ["goal", "progress"]},
+        source=Origin.HUMAN,
+    )
+
+    confirmed = RecoveryEngine(store).assess("r1")
+    assert confirmed.mode is RecoveryMode.RESUME
+
+    store.compact_run("r1")
+    # The confirm event is archived out of the live tail by the compaction.
+    assert not any(e.type is EventType.REVIEW_CONFIRMED for e in store.read_events("r1")), (
+        "precondition failed: confirm event still live"
+    )
+
+    after = RecoveryEngine(store).assess("r1")
+    assert after.mode is RecoveryMode.RESUME
+    assert after.safe
+
+
 # --- unprojectable logs (issue #383) ---------------------------------------- #
 
 

--- a/tests/test_recovery_engine.py
+++ b/tests/test_recovery_engine.py
@@ -537,6 +537,27 @@ def test_confirmation_survives_compaction(store: SQLiteStorage) -> None:
     assert after.safe
 
 
+def test_assess_degrades_when_the_archive_read_fails(store: SQLiteStorage) -> None:
+    """A failing archive read must not fail assess(): the shared fetch falls
+    back to the live log, so a broken archive view degrades to the live-only
+    verdict instead of bricking the assessment."""
+
+    class FlakyArchiveView:
+        """Raises on the first read_all_events call, like a broken archive."""
+
+        def __init__(self) -> None:
+            self._raised = False
+
+        def __getattr__(self, name: str) -> object:
+            if name == "read_all_events" and not self._raised:
+                self._raised = True
+                raise RuntimeError("archive unreadable")
+            return getattr(store, name)
+
+    decision = RecoveryEngine(FlakyArchiveView()).assess("run_1")  # type: ignore[arg-type]
+    assert decision.mode is RecoveryMode.RESUME
+
+
 # --- unprojectable logs (issue #383) ---------------------------------------- #
 
 


### PR DESCRIPTION
Fixes #703

## Problem

The confirm scan in `RecoveryEngine.assess` read only the live tail, so once `compact_run` archived the pre-anchor prefix (where a `REVIEW_CONFIRMED` typically sits), the human's confirmation vanished from the scan and a confirmed run silently reverted to `request_human` — re-escalating after **every** compaction, with only a human able to re-clear it.

## Change

Mirror the archive-aware read the provenance scan ten lines below already uses (#553): `read_all_events` with a `read_events` fallback.

```python
try:
    _confirm_events = self.storage.read_all_events(run_id)
except Exception:
    _confirm_events = self.storage.read_events(run_id)
```

## Verification

- Repro from the issue: before → `mode=request_human`, `next_allowed='human_review:goal'` after compaction; after → `mode=resume`, `next_allowed=None`
- New regression test `test_confirmation_survives_compaction` (asserts the precondition that the confirm event is actually archived, then that assess still resumes)
- Full suite green (`pytest --no-cov -q`, 100%), `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)