### PR TITLE
fix(state): read an offset-less expires_at as UTC instead of crashing

### DIFF
--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -198,7 +198,7 @@ def _as_utc(value: datetime) -> datetime:
 
     Event payloads are external input: an ``expires_at`` ISO string without a
     UTC offset (``"2027-01-01"``) parses to a naive datetime, and everything
-    downstream compares against the tz-aware ``utcnow()`` — which would raise
+    downstream compares against the tz-aware ``utcnow()``, which would raise
     TypeError and brick validation for the run (issue #704). The project
     convention is UTC everywhere, so a missing offset is read as UTC.
     """

--- a/src/continuum/state/semantic.py
+++ b/src/continuum/state/semantic.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
 from continuum.events import Event, EventType
@@ -191,6 +191,18 @@ def _as_str_list(value: Any) -> list[str]:
     if isinstance(value, Iterable):
         return [str(v) for v in value]
     return [str(value)]
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Interpret a naive datetime as UTC; aware values pass through.
+
+    Event payloads are external input: an ``expires_at`` ISO string without a
+    UTC offset (``"2027-01-01"``) parses to a naive datetime, and everything
+    downstream compares against the tz-aware ``utcnow()`` — which would raise
+    TypeError and brick validation for the run (issue #704). The project
+    convention is UTC everywhere, so a missing offset is read as UTC.
+    """
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value
 
 
 def _replace(items: list[Any], key: str, identifier: str, updated: Any) -> bool:
@@ -467,7 +479,9 @@ class _Accumulator:
                     if event.payload.get("granted_by") is not None
                     else None
                 ),
-                "expires_at": datetime.fromisoformat(str(expires_raw)) if expires_raw else None,
+                "expires_at": (
+                    _as_utc(datetime.fromisoformat(str(expires_raw))) if expires_raw else None
+                ),
                 "reason": (
                     str(event.payload["reason"])
                     if event.payload.get("reason") is not None

--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from datetime import UTC
 from typing import Any
 
 from continuum.environment.diff import EnvironmentDiff, ResourceChange, diff_environments
@@ -867,14 +868,21 @@ class StateValidator:
     def _check_approvals(state: SemanticState, entries: list[ComponentValidationEntry]) -> None:
         now = utcnow()
         for approval in state.approvals:
+            # A naive expires_at (persisted by versions before issue #704, or
+            # constructed directly) must grade, not raise: comparing it against
+            # the tz-aware `now` would TypeError and take down the whole
+            # validation pass. Read a missing offset as UTC, as the fold does.
+            expires_at = approval.expires_at
+            if expires_at is not None and expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=UTC)
             if approval.status is ApprovalStatus.REVOKED:
                 status, detail = StateStatus.INVALID, "approval was revoked"
             elif approval.status is ApprovalStatus.EXPIRED:
                 status, detail = StateStatus.EXPIRED, "approval expired"
-            elif approval.expires_at is not None and approval.expires_at <= now:
+            elif expires_at is not None and expires_at <= now:
                 status, detail = (
                     StateStatus.EXPIRED,
-                    f"expired at {approval.expires_at.isoformat()}",
+                    f"expired at {expires_at.isoformat()}",
                 )
             elif approval.status is ApprovalStatus.PENDING:
                 status, detail = StateStatus.REQUIRES_REVIEW, "approval never granted"

--- a/tests/test_projection_edges.py
+++ b/tests/test_projection_edges.py
@@ -142,6 +142,22 @@ def test_granting_an_approval_that_was_never_requested_still_records_it() -> Non
     assert approval.reason == "out of band"
 
 
+def test_naive_expires_at_is_folded_as_utc() -> None:
+    """Issue #704: an expires_at payload without a UTC offset must not fold to
+    a naive datetime — everything downstream compares against the tz-aware
+    utcnow(), and a naive value would TypeError and brick validation."""
+    log = started(EventLog())
+    log.append(
+        "run_1",
+        EventType.APPROVAL_GRANTED,
+        {"approval_id": "ap_10", "subject": "deploy", "expires_at": "2027-01-01"},
+    )
+    approval = project("run_1", log.events("run_1")).approvals[0]
+    assert approval.expires_at is not None
+    assert approval.expires_at.tzinfo is not None, "naive expires_at must be normalized to UTC"
+    assert approval.expires_at.utcoffset().total_seconds() == 0
+
+
 def test_model_assumptions_can_be_recorded_before_any_model_is_known() -> None:
     log = started(EventLog())
     log.append(

--- a/tests/test_projection_edges.py
+++ b/tests/test_projection_edges.py
@@ -144,8 +144,8 @@ def test_granting_an_approval_that_was_never_requested_still_records_it() -> Non
 
 def test_naive_expires_at_is_folded_as_utc() -> None:
     """Issue #704: an expires_at payload without a UTC offset must not fold to
-    a naive datetime — everything downstream compares against the tz-aware
-    utcnow(), and a naive value would TypeError and brick validation."""
+    a naive datetime, because everything downstream compares against the
+    tz-aware utcnow(), and a naive value would TypeError and brick validation."""
     log = started(EventLog())
     log.append(
         "run_1",

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from continuum.environment import CallableProvider, StaticProvider, capture
 from continuum.models import (
@@ -299,6 +299,25 @@ def test_an_expired_approval_is_caught_by_its_timestamp() -> None:
     )
     assert status_for(outcome, Component.APPROVAL, "ap_1") is StateStatus.EXPIRED
     assert not outcome.safe
+
+
+def test_a_naive_expires_at_grades_instead_of_raising() -> None:
+    """Issue #704: a naive expires_at (persisted before the fold normalized
+    offsets, or constructed directly) must grade as EXPIRED, not raise
+    TypeError comparing naive against the tz-aware utcnow()."""
+    outcome = validate_state(
+        state(
+            approvals=[
+                Approval(
+                    approval_id="ap_1",
+                    subject="publish",
+                    status=ApprovalStatus.GRANTED,
+                    expires_at=datetime(2020, 1, 1),  # naive, and in the past
+                )
+            ]
+        )
+    )
+    assert status_for(outcome, Component.APPROVAL, "ap_1") is StateStatus.EXPIRED
 
 
 def test_a_live_approval_passes() -> None:


### PR DESCRIPTION
Fixes #704

## Problem

An `APPROVAL_GRANTED` payload whose `expires_at` ISO string carries no UTC offset (e.g. `"2027-01-01"` — `fromisoformat` accepts date-only strings) folded to a **naive** datetime, while every downstream comparison uses the tz-aware `utcnow()`. The next `validate`/`assess` raised `TypeError: can't compare offset-naive and offset-aware datetimes`, taking down the whole validation pass and **bricking recovery for the run** — its persisted state could no longer be graded.

## Change

Two layers, matching the issue's suggestion:

1. **Boundary (semantic fold, `semantic.py`)**: a new `_as_utc()` helper normalizes a naive `expires_at` to UTC at the fold — the project convention is UTC everywhere, so a missing offset is read as UTC.
2. **Defense in depth (`_check_approvals`, `validator.py`)**: states persisted by older versions (or constructed directly) can already carry naive values; the validator normalizes before comparing so they **grade** (EXPIRED/VALID) instead of raising.

## Verification

- Repro from the issue no longer raises; a naive past `expires_at` grades EXPIRED
- New regression tests:
  - `test_naive_expires_at_is_folded_as_utc` (fold produces a tz-aware UTC datetime from an offset-less payload)
  - `test_a_naive_expires_at_grades_instead_of_raising` (validator grades instead of TypeError)
- Full suite green (`pytest --no-cov -q`, 100%), `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)