### PR TITLE
fix(storage): reject through_sequence that would archive the anchor

### DIFF
--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -482,7 +482,7 @@ class SQLiteStorage(Storage):
         ``through_sequence`` must stay below the anchor marker's sequence:
         the live log always retains its anchor, so a value at or above it is
         rejected (issue #705) instead of silently deleting the anchor and
-        every live row — which would leave the next append minting a fresh
+        every live row, which would leave the next append minting a fresh
         genesis and fork the hash chain away from the archive.
         """
         from continuum.checkpoint.manager import CheckpointManager

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -478,6 +478,12 @@ class SQLiteStorage(Storage):
         crash in between leave an anchored live log whose prefix never
         reached the archive, so verify would trust a genesis that was never
         earned.
+
+        ``through_sequence`` must stay below the anchor marker's sequence:
+        the live log always retains its anchor, so a value at or above it is
+        rejected (issue #705) instead of silently deleting the anchor and
+        every live row — which would leave the next append minting a fresh
+        genesis and fork the hash chain away from the archive.
         """
         from continuum.checkpoint.manager import CheckpointManager
 
@@ -493,6 +499,14 @@ class SQLiteStorage(Storage):
         storage_version = lv
         if storage_version is None:
             raise ValueError(f"run {run_id!r} could not be anchored: no projectable state")
+        # The anchor marker is appended at the head of the log in the
+        # transaction below, so its sequence is the current head + 1.
+        anchor_sequence = self.last_sequence(run_id) + 1
+        if through_sequence is not None and through_sequence >= anchor_sequence:
+            raise ValueError(
+                f"through_sequence {through_sequence} would archive the anchor marker"
+                f" at sequence {anchor_sequence}: the live log must retain its anchor"
+            )
         through = (
             through_sequence
             if through_sequence is not None

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -346,3 +346,32 @@ def test_anchor_event_is_non_projecting(db: str) -> None:
     assert not report.ignored_types, (
         "EVENT_LOG_ANCHORED must be declared non-projecting, not silently ignored"
     )
+
+
+def test_compact_run_rejects_through_sequence_that_would_eat_the_anchor(db: str) -> None:
+    """Issue #705: through_sequence at or above the anchor's own sequence
+    must be rejected. Accepting it archived and deleted the anchor (and with
+    it the whole live log), so the next append minted a fresh genesis and
+    forked the hash chain away from the archive."""
+    for i in range(4):
+        work(db, i)
+    with SQLiteStorage(db) as store:
+        pre_live = len(store.read_events("run_1"))
+
+        with pytest.raises(ValueError, match="anchor"):
+            store.compact_run("run_1", through_sequence=10_000)
+
+        # The rejected call leaves a healthy, verifiable log behind: nothing
+        # was archived, only the forced checkpoint marker was appended.
+        report = store.verify_events("run_1")
+        assert report.ok, [v.kind for v in report.violations]
+        live = store.read_events("run_1")
+        assert len(live) == pre_live + 1
+        assert store.read_events("run_1")[0].sequence == 1, "live rows must not have moved"
+
+        # A bounded value below the anchor still compacts normally.
+        result = store.compact_run("run_1", through_sequence=1)
+        assert result["archived"] >= 1
+        assert any(e.type is EventType.EVENT_LOG_ANCHORED for e in store.read_events("run_1"))
+        report = store.verify_events("run_1")
+        assert report.ok, [v.kind for v in report.violations]


### PR DESCRIPTION
Fixes #705

## Problem

`compact_run` guarded only `through < 1`. A `through_sequence` at or above the anchor marker's own sequence was accepted, and the `DELETE ... WHERE sequence <= ?` then removed **the anchor the method had just appended**, together with the entire live log. The next `append_event` found no head and minted a fresh genesis (`sequence=1`, `prev_hash=None`), forking the hash chain away from the archive: `verify_events` reported permanent `SEQUENCE_GAP` + `BROKEN_CHAIN`, and `read_all_events` interleaved two sequence-1 rows, scrambling every fold over the log.

The caller cannot know the anchor's sequence in advance (it is appended during the call), so even a plausible value like `last_sequence() + 2` triggered this.

## Change

Reject with a clear `ValueError` before any deletion runs: the anchor's sequence is the head + 1, known inside the method after the forced checkpoint. The docstring documents the bound. (The alternative — clamping — was considered; rejecting is explicit and cannot silently archive less than the caller asked.)

A rejected call leaves a healthy log behind: nothing is archived, only the forced checkpoint marker was appended (asserted in the test).

## Verification

- New regression test `test_compact_run_rejects_through_sequence_that_would_eat_the_anchor`:
  - `through_sequence=10_000` raises `ValueError` mentioning the anchor
  - the log still verifies, live rows intact, nothing archived
  - a bounded value below the anchor still compacts normally and the anchor lands in the live tail
- Full suite green (`pytest --no-cov -q`, 100%), `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)