### PR TITLE
fix(models): register the origin_digest validator on Action

### DIFF
--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -917,6 +917,15 @@ class Action(BaseModel):
     consumed_inputs: ConsumedInputs = Field(default_factory=ConsumedInputs)
     """Commitment inputs consumed to produce this action (issue #295)."""
 
+    @field_validator("origin_digest")
+    @classmethod
+    def _origin_digest_is_sha256(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not _SHA256_PATTERN.fullmatch(value):
+            raise ValueError("origin_digest must be 64 lowercase hex characters")
+        return value
+
 
 class ActionRecordPayload(BaseModel):
     """Payload for ACTION_RECORDED (issue #551).
@@ -970,15 +979,6 @@ def validate_caused_by(caused_by: list[str] | None, known_ids: set[str] | None =
     if known_ids is not None:
         _validate_caused_by_known(caused_by, known_ids)
     return list(caused_by)
-
-    @field_validator("origin_digest")  # type: ignore[misc]
-    @classmethod
-    def _origin_digest_is_sha256(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
-        if not _SHA256_PATTERN.fullmatch(value):
-            raise ValueError("origin_digest must be 64 lowercase hex characters")
-        return value
 
 
 class UnknownSideEffect(RuntimeError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -106,6 +106,21 @@ def test_actions_start_planned_and_side_effect_is_certain_by_default() -> None:
     assert action.external_id is None
 
 
+def test_action_origin_digest_must_be_sha256_hex() -> None:
+    """The origin_digest validator used to be accidentally nested inside
+    validate_caused_by (after its return), so it never registered on Action
+    and any string was accepted despite the documented 64-hex invariant.
+    """
+    good = "a" * 64
+    assert Action(run_id="run_1", action_type="t", origin_digest=good).origin_digest == good
+    assert Action(run_id="run_1", action_type="t").origin_digest is None
+
+    with pytest.raises(ValidationError, match="64 lowercase hex"):
+        Action(run_id="run_1", action_type="t", origin_digest="NOT-HEX-AT-ALL")
+    with pytest.raises(ValidationError, match="64 lowercase hex"):
+        Action(run_id="run_1", action_type="t", origin_digest="A" * 64)  # uppercase
+
+
 def test_approvals_start_pending() -> None:
     assert Approval(subject="publish results").status is ApprovalStatus.PENDING
 


### PR DESCRIPTION
Fixes #710

## Problem

The `@field_validator("origin_digest")` block was accidentally indented inside the module-level `validate_caused_by` function, after its `return` statements — an unreachable nested function that never registered on any model. `Action(origin_digest="NOT-HEX-AT-ALL")` was accepted despite the field's documented 64-lowercase-hex (SHA-256) invariant, and the poisoning-forensics join silently degraded on garbage digests instead of refusing them at the boundary.

## Change

Move the validator into the `Action` model class. The `# type: ignore[misc]` from d026104 existed precisely because the decorator sat in the dead position (mypy complaining about a decorated nested function); properly placed, mypy now flags the ignore as **unused** — verified — so it is removed.

## Verification

- Runtime: bad digest rejected with "64 lowercase hex", `None` and valid 64-hex accepted
- New regression test `test_action_origin_digest_must_be_sha256_hex` (also covers uppercase rejection)
- `mypy src/continuum/models.py`: clean; full suite green (`pytest --no-cov -q`); `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)