### PR TITLE
fix(state): wrap a string evidence proposal instead of splitting it

### DIFF
--- a/src/continuum/state/extractor.py
+++ b/src/continuum/state/extractor.py
@@ -37,7 +37,7 @@ from continuum.models import (
     SemanticState,
     StateStatus,
 )
-from continuum.state.semantic import ProjectionReport, project_incremental
+from continuum.state.semantic import ProjectionReport, _as_str_list, project_incremental
 
 __all__ = [
     "ExtractionContext",
@@ -155,7 +155,7 @@ class LLMExtractor:
                     decision_id=decision_id,
                     decision=str(raw.get("decision", "")),
                     reason=str(raw.get("reason", "")),
-                    evidence=[str(e) for e in raw.get("evidence", [])],
+                    evidence=_as_str_list(raw.get("evidence")),
                     status=StateStatus.REQUIRES_REVIEW,
                     provenance=provenance,
                 )
@@ -173,7 +173,7 @@ class LLMExtractor:
                 Finding(
                     finding_id=finding_id,
                     claim=str(raw.get("claim", "")),
-                    evidence=[str(e) for e in raw.get("evidence", [])],
+                    evidence=_as_str_list(raw.get("evidence")),
                     confidence=min(max(confidence, 0.0), 1.0),
                     status=StateStatus.REQUIRES_REVIEW,
                     provenance=provenance,

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -260,3 +260,23 @@ def test_composite_chains_without_double_applying_events() -> None:
     assert state.progress.completed == 1  # not 2 — events folded exactly once
     assert {w.task_id for w in state.pending_work} == {"t_llm"}
     assert state.decision("d1") is not None
+
+
+def test_a_string_evidence_field_is_wrapped_not_split_into_characters() -> None:
+    """LLM proposals are stringly by nature; a bare-string evidence field is
+    the most common shape drift. Iterating it split the citation into
+    per-character ids (['e','v','_','4','2']), corrupting the persisted state
+    and blocking resume under strict_unknown via phantom dangling evidence."""
+    log = build_log()
+    extractor = LLMExtractor(
+        lambda ctx, state: LLMProposal(
+            decisions=[{"decision_id": "d_llm", "decision": "inferred", "evidence": "ev_42"}],
+            findings=[{"finding_id": "f_llm", "claim": "inferred", "evidence": "ev_42"}],
+        )
+    )
+    state = extractor.extract(context(log))
+
+    decision = next(d for d in state.decisions if d.decision_id == "d_llm")
+    finding = next(f for f in state.findings if f.finding_id == "f_llm")
+    assert decision.evidence == ["ev_42"]
+    assert finding.evidence == ["ev_42"]


### PR DESCRIPTION
Fixes #711

## Problem

`LLMExtractor._merge` coerced the evidence field of proposed decisions/findings with `[str(e) for e in raw.get("evidence", [])]`. A model emitting the citation as a bare string — the most common shape drift in LLM output — was iterated per character: `evidence == ['e','v','_','4','2']`. The corrupted citations were **persisted**, then failed `dangling_evidence()`, emitting UNKNOWN and blocking resume under default `strict_unknown` — enrichment silently costing a recovery, which the module's core asymmetry forbids.

## Change

Use the same `_as_str_list` coercion the deterministic fold already applies to this exact case (semantic.py): a bare string wraps to `[value]`, `None` to `[]`, iterables to their string items. The two `_merge` sites were the only inconsistent ones.

## Verification

- New regression test `test_a_string_evidence_field_is_wrapped_not_split_into_characters` (both the decisions and findings sites)
- Full suite green (`pytest --no-cov -q`), `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)