### PR TITLE
fix(reconcile): settle archived actions and keep authority context after compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,18 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **`reconcile --auto` settles archived actions and probes authorities with
+  full consumption context after compaction (#647).**
+  `ActionLedger.pending` folds archived plus live events, but
+  `reconcilers._key_for` folded only the live tail, so one action claimed
+  before a compaction aborted the whole settle report with `LookupError`;
+  `settle_authority` scanned only live events for the `AUTHORITY_CONSUMED`
+  row, silently handing the probe a bare `authority_id` payload without
+  `consumer_run_id`, `via_action_id`, or `sequence`. Both now read full
+  history via `read_all_events`, the same archive-aware pattern the library
+  reconciliation path already used. Covered by `tests/test_reconcilers.py`
+  and `tests/test_authority_probe.py`.
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/src/continuum/reconcilers.py
+++ b/src/continuum/reconcilers.py
@@ -236,10 +236,14 @@ def _key_for(storage: Storage, run_id: str, action: Action) -> Any:
     The fold is keyed by derived idempotency key while the Action record does
     not carry it, so recover the key by matching action_id against the run's
     folded ledger.
+
+    Folds full history, not the live tail: pending actions claimed before a
+    compaction live on as archived events (issue #647), and a live-only fold
+    would make every one of them "vanish mid-reconcile" and abort settle_run.
     """
     from continuum.actions.ledger import fold_action_events
 
-    folded = fold_action_events(storage.read_events(run_id))
+    folded = fold_action_events(storage.read_all_events(run_id))
     for key, candidate in folded.items():
         if candidate.action_id == action.action_id:
             return key
@@ -339,7 +343,10 @@ def settle_authority(
     from continuum.models import Origin
 
     payload: dict[str, Any] = {"authority_id": authority_id}
-    for ev in reversed(list(storage.read_events(run_id))):
+    # Full history, not the live tail: the AUTHORITY_CONSUMED row can predate a
+    # compaction (issue #647), and a live-only scan would hand the probe a bare
+    # authority_id, silently dropping the consumption context.
+    for ev in reversed(list(storage.read_all_events(run_id))):
         if (
             ev.type is not None
             and str(ev.type) == "AUTHORITY_CONSUMED"

--- a/tests/test_authority_probe.py
+++ b/tests/test_authority_probe.py
@@ -228,3 +228,40 @@ def test_authority_probe_no_probe_registered_leaves_blocked(tmp_path: pathlib.Pa
         assert "auth-no-probe" in consumed
     finally:
         storage.close()
+
+
+def test_probe_payload_keeps_consumption_context_after_compaction(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Post-compaction probes must still see how the authority was consumed (issue #647).
+
+    The AUTHORITY_CONSUMED row can predate a compaction. settle_authority used
+    to scan the live tail only, silently handing the probe a bare authority_id
+    payload with no consumer_run_id, via_action_id, or sequence.
+    """
+    storage = _storage()
+    try:
+        record_authority_consumed(storage, "run_1", "auth-compact-1", via_action_id="act-1")
+        storage.compact_run("run_1", through_sequence=storage.last_sequence("run_1"))
+        # Premise guard: the consumption row really is archived, not live.
+        live_types = [e.type for e in storage.read_events("run_1")]
+        assert EventType.AUTHORITY_CONSUMED not in live_types
+
+        payload_file = tmp_path / "payload.json"
+        # Single quotes inside the double-quoted -c argument survive both sh
+        # grouping and cmd's C-runtime unescaping (see _probe_command).
+        cmd = f"\"{sys.executable}\" -c \"import sys; open('{payload_file.as_posix()}', 'w').write(sys.stdin.read())\""
+        cfg = tmp_path / "reconcilers.json"
+        cfg.write_text(json.dumps({"probes": {"auth-compact-1": {"command": cmd, "timeout": 5}}}))
+        probes = load_reconcilers(cfg)
+        report = settle_authority(storage, "run_1", "auth-compact-1", probes)
+        assert report.settled is False  # prints no verdict line: stays unknown
+
+        received = json.loads(payload_file.read_text(encoding="utf-8"))
+        assert received["authority_id"] == "auth-compact-1"
+        assert received["consumer_run_id"] == "run_1"
+        assert received["via_action_id"] == "act-1"
+        assert isinstance(received["sequence"], int)
+        assert received["consumed_at"]
+    finally:
+        storage.close()

--- a/tests/test_authority_probe.py
+++ b/tests/test_authority_probe.py
@@ -265,3 +265,35 @@ def test_probe_payload_keeps_consumption_context_after_compaction(
         assert received["consumed_at"]
     finally:
         storage.close()
+
+
+def test_probe_for_an_authority_that_was_never_consumed_settles_with_a_bare_id(
+    tmp_path: pathlib.Path,
+) -> None:
+    """No AUTHORITY_CONSUMED row at all: the scan exhausts and the probe still runs.
+
+    Covers the loop-exhaustion branch of the consumption scan (every other
+    test finds a row and breaks). The payload is intentionally bare: only
+    authority_id, with no consumption context to lose.
+    """
+    storage = _storage()
+    try:
+        cfg = tmp_path / "reconcilers.json"
+        cfg.write_text(
+            json.dumps(
+                {
+                    "probes": {
+                        "auth-never-consumed": {
+                            "command": _probe_command('{"valid": true}'),
+                            "timeout": 5,
+                        }
+                    }
+                }
+            )
+        )
+        probes = load_reconcilers(cfg)
+        report = settle_authority(storage, "run_1", "auth-never-consumed", probes)
+        assert report.valid is True
+        assert report.settled is True
+    finally:
+        storage.close()

--- a/tests/test_reconcilers.py
+++ b/tests/test_reconcilers.py
@@ -213,6 +213,28 @@ def test_settled_events_are_sourced_deterministic(db: str, tmp_path: Path) -> No
     assert all(e.source is Origin.DETERMINISTIC for e in reconciled)
 
 
+def test_settle_run_settles_archived_actions_after_compaction(db: str, tmp_path: Path) -> None:
+    """Compaction must not break the operator path for clearing risk (issue #647).
+
+    pending() is archive-aware, so an action claimed before a compaction is
+    still listed; settle_run used to resolve its ledger key from the live tail
+    only and abort the whole report with LookupError.
+    """
+    action_id = seed_pending(db, key="invoice:9")
+    with SQLiteStorage(db) as store:
+        store.compact_run("run_1", through_sequence=store.last_sequence("run_1"))
+        assert action_id in {a.action_id for a in ActionLedger(store, "run_1").pending()}
+    probes = load_reconcilers(registry(tmp_path, {"send_invoice": "echo occurred=true"}))
+    report = settle_run(SQLiteStorage(db), "run_1", probes)
+    assert report.settled == 1 and report.settled_true
+    with SQLiteStorage(db) as store:
+        from continuum.actions.ledger import fold_action_events
+
+        folded = fold_action_events(store.read_all_events("run_1"))
+    action = next(a for a in folded.values() if a.action_id == action_id)
+    assert action.status is ActionStatus.COMPLETED
+
+
 # --- CLI ------------------------------------------------------------------------------ #
 
 


### PR DESCRIPTION
## What

Fixes #647.

`reconcile --auto` aborted with `LookupError` after a compaction, and authority probes silently lost their consumption context:

- `reconcilers._key_for` folded only the live tail (`storage.read_events`), so any pending action claimed before a compaction made `settle_run` raise `LookupError: action ... vanished from run ... mid-reconcile` and the whole settle report aborted. `ActionLedger.pending` is archive-aware (via `_replay`), so the crash hit exactly the actions the operator was trying to settle.
- `reconcilers.settle_authority` scanned only live events for the `AUTHORITY_CONSUMED` row, so post-compaction probes received a bare `authority_id` payload missing `consumer_run_id`, `via_action_id`, and `sequence`.

## How

Both spots now read full history via `storage.read_all_events`, the same archive-aware pattern the library reconciliation path (`actions/reconciliation.py`) already used. No schema or API change.

## Verification

- Reproduced the exact `LookupError` from the issue before the fix.
- Two new regression tests, both verified to **fail without the fix and pass with it**:
  - `tests/test_reconcilers.py::test_settle_run_settles_archived_actions_after_compaction`
  - `tests/test_authority_probe.py::test_probe_payload_keeps_consumption_context_after_compaction`
- Full `pytest` suite passes; `ruff check`, `ruff format --check`, and `mypy` (strict) all clean.
- `CHANGELOG.md` updated under `Unreleased -> Fixed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic reconciliation after compaction by retaining access to archived action and authority-consumption details.
  - Prevented reconciliation failures when pending actions or authority records are no longer in the live event history.
  - Authority probes now receive complete consumption context, including the consumer run, action, sequence, and timestamp.

- **Tests**
  - Added coverage for reconciling archived actions and preserving authority context after compaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
