### PR TITLE
feat(bench): make benchmarks/run.py answer --help and --list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **`benchmarks/run.py` answers `--help` and `--list` instead of running the
+  suite (#682).**
+  The runner parsed no arguments, so `--help` started the full multi-minute
+  benchmark suite and wrote reports. It now takes argparse: `--help` prints
+  what runs, what it writes, and where, then exits 0; `--list` names the four
+  suites (phase6, continuum-bench, fault-injection, horizon) and exits without
+  running; unknown flags fail with exit code 2. A no-argument run is unchanged.
+  Covered by `tests/test_bench_runner_cli.py`.
+
 - **External probe for consumed authorities via reconcilers.json (#557).**
   `reconcile --authority <id>` runs the configured authority probe with the
   recorded consumption payload on stdin; `valid=true` appends

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -2,6 +2,8 @@
 
 Usage:
     uv run python benchmarks/run.py
+    uv run python benchmarks/run.py --help    # what runs, what it writes, where
+    uv run python benchmarks/run.py --list    # name the suites, run nothing
 
 Writes ``benchmarks/out/report.json`` and ``benchmarks/out/report.md``. The run
 is reproducible: scenarios build their own in-memory state, so the output can be
@@ -25,6 +27,7 @@ Continuum bench byte counts (issue #568, #293a):
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 from pathlib import Path
@@ -37,6 +40,45 @@ from typing import Any
 
 from continuum.benchmark import run_benchmark as run_continuum_benchmark
 from continuum.benchmark.phase6 import run_benchmark, scenarios, write_report
+
+# What main() executes, in order, for --help and --list. A full run takes
+# minutes and writes reports, so the runner must answer questions before
+# doing any work (issue #682).
+_SUITES: tuple[tuple[str, str], ...] = (
+    ("phase6", "recovery-correctness scenarios -> benchmarks/out/report.json / report.md"),
+    (
+        "continuum-bench",
+        "crash-recovery byte and token counts, merged into benchmarks/out/report.json",
+    ),
+    (
+        "fault-injection",
+        "chaos suite (#397) -> benchmarks/out/fault_injection_report.json / .md",
+    ),
+    (
+        "horizon",
+        "years-scale suite (#398) -> benchmarks/out/horizon_report.json / .md,"
+        " plus README bench table regeneration",
+    ),
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """The runner's CLI surface: --help and --list answer without running."""
+    return argparse.ArgumentParser(
+        prog="benchmarks/run.py",
+        description=(
+            "Run the full CONTINUUM benchmark suite: phase-6 recovery-correctness "
+            "scenarios, the crash-recovery byte-count bench, the fault-injection "
+            "chaos suite, and the horizon-scale suite. A full run takes minutes "
+            "and writes reports under benchmarks/out/."
+        ),
+        epilog="With no arguments, every suite runs. Use --list to see them first.",
+    )
+
+
+def _print_suites() -> None:
+    for name, what in _SUITES:
+        print(f"{name:<18} {what}")
 
 
 def _regenerate_readme_bench(horizon_report: Any, fault_report: Any | None = None) -> None:
@@ -198,6 +240,16 @@ def _append_continuum_bench(out_dir: str | Path) -> None:
 
 
 def main() -> None:
+    parser = _build_parser()
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="name the suites this runner executes, then exit without running",
+    )
+    args = parser.parse_args()
+    if args.list:
+        _print_suites()
+        return
     report = run_benchmark(scenarios.ALL_SCENARIOS)
     out_dir = os.path.join(os.path.dirname(__file__), "out")
     os.makedirs(out_dir, exist_ok=True)

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -64,7 +64,7 @@ _SUITES: tuple[tuple[str, str], ...] = (
 
 def _build_parser() -> argparse.ArgumentParser:
     """The runner's CLI surface: --help and --list answer without running."""
-    return argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(
         prog="benchmarks/run.py",
         description=(
             "Run the full CONTINUUM benchmark suite: phase-6 recovery-correctness "
@@ -74,6 +74,12 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
         epilog="With no arguments, every suite runs. Use --list to see them first.",
     )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="name the suites this runner executes, then exit without running",
+    )
+    return parser
 
 
 def _print_suites() -> None:
@@ -240,13 +246,7 @@ def _append_continuum_bench(out_dir: str | Path) -> None:
 
 
 def main() -> None:
-    parser = _build_parser()
-    parser.add_argument(
-        "--list",
-        action="store_true",
-        help="name the suites this runner executes, then exit without running",
-    )
-    args = parser.parse_args()
+    args = _build_parser().parse_args()
     if args.list:
         _print_suites()
         return

--- a/tests/test_bench_runner_cli.py
+++ b/tests/test_bench_runner_cli.py
@@ -1,0 +1,45 @@
+"""The benchmark runner's CLI surface (issue #682).
+
+``benchmarks/run.py`` used to parse no arguments at all: ``--help`` ran the
+full multi-minute suite instead of printing usage. These tests pin the
+contract that questions get answered before any work starts.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+_RUNNER = pathlib.Path(__file__).resolve().parent.parent / "benchmarks" / "run.py"
+
+
+def _run(*argv: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - our own repo's runner, fixed argv
+        [sys.executable, str(_RUNNER), *argv],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_help_prints_usage_and_exits_zero_without_running() -> None:
+    completed = _run("--help")
+    assert completed.returncode == 0, completed.stderr
+    assert "usage:" in completed.stdout.lower()
+    # Help must describe what it runs and where it writes, not just the flags.
+    assert "benchmarks/out/" in completed.stdout
+    assert "fault-injection" in completed.stdout
+
+
+def test_list_names_the_suites_and_runs_nothing() -> None:
+    completed = _run("--list")
+    assert completed.returncode == 0, completed.stderr
+    for suite in ("phase6", "continuum-bench", "fault-injection", "horizon"):
+        assert suite in completed.stdout, f"--list must name {suite}"
+
+
+def test_unknown_flags_fail_fast_with_exit_two() -> None:
+    completed = _run("--bogus")
+    assert completed.returncode == 2
+    assert "unrecognized arguments" in completed.stderr


### PR DESCRIPTION
## What

Fixes #682.

`benchmarks/run.py` parsed no arguments at all (no argparse, no `sys.argv` handling), so `--help` ran the full multi-minute benchmark suite and wrote reports instead of printing usage.

## How

The runner now takes argparse:

- `--help` prints what it runs, what it writes, and where, then exits 0 without running anything.
- `--list` names the four suites (`phase6`, `continuum-bench`, `fault-injection`, `horizon`) with their outputs, then exits 0 without running anything.
- Unknown flags fail with exit code 2 via argparse, matching CLI conventions elsewhere in the repo.
- A no-argument run is byte-for-byte the previous behavior; the suite list lives in one `_SUITES` tuple used only by `--list`.

## Verification

- `python benchmarks/run.py --help` prints usage, exits 0, runs nothing.
- `python benchmarks/run.py --list` names the suites, exits 0, runs nothing.
- `python benchmarks/run.py --bogus` exits 2 with `unrecognized arguments`.
- A full run still works end to end: phase6 13/13 passed, fault-injection 7/7 passed, horizon suite completes. (Horizon reports 3/5 passed, which is identical with and without this change - pre-existing, and deterministic across runs.)
- New `tests/test_bench_runner_cli.py` pins all three behaviors via subprocess; verified to fail without the fix (each test watched `--help` run the whole suite) and pass with it.
- `ruff check` and `ruff format --check` clean on both changed files; full `pytest` suite passes.
- `CHANGELOG.md` updated under `Unreleased -> Added`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)