### PR TITLE
fix(mcp): remediation message names the real PyPI package (#697)

### DIFF
--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -28,7 +28,7 @@ behaviour, not a leak.
 The optional dependency
 -----------------------
 
-The ``mcp`` SDK is an optional extra, but ``pip install continuum`` installs
+The ``mcp`` SDK is an optional extra, but ``pip install continuum-agent`` installs
 the ``continuum-mcp`` console script regardless. So the entry point exists in
 environments where its dependency does not, and importing the SDK at module
 scope makes that combination fail with a bare ``ModuleNotFoundError``.
@@ -1609,7 +1609,7 @@ def main(argv: list[str] | None = None) -> int:
             raise
         print(
             f"error: the MCP server needs the optional 'mcp' dependency, which is "
-            f"not importable ({exc}). Install it with: pip install 'continuum[mcp]'",
+            f"not importable ({exc}). Install it with: pip install continuum-agent[mcp]",
             file=sys.stderr,
         )
         return 1

--- a/src/continuum/storage/postgres.py
+++ b/src/continuum/storage/postgres.py
@@ -170,7 +170,7 @@ def _require_psycopg() -> Any:
         import psycopg
     except ImportError as exc:  # pragma: no cover - depends on environment
         raise RuntimeError(
-            "PostgreSQL storage requires the 'psycopg' extra: pip install continuum[postgres]"
+            "PostgreSQL storage requires the 'psycopg' extra: pip install continuum-agent[postgres]"
         ) from exc
     return psycopg
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1992,7 +1992,7 @@ raise SystemExit(main(["--db", "agent.db"]))
 
 
 def test_main_reports_a_missing_mcp_extra_instead_of_a_traceback(tmp_path: Any) -> None:
-    """Regression for #87: `pip install continuum` ships the script, not the SDK.
+    """Regression for #87: `pip install continuum-agent` ships the script, not the SDK.
 
     Run in a subprocess because blocking an already-imported package in-process
     would corrupt the import state of every later test.
@@ -2014,7 +2014,7 @@ def test_main_reports_a_missing_mcp_extra_instead_of_a_traceback(tmp_path: Any) 
     assert proc.returncode == 1, proc.stderr
     assert proc.stdout == "", "the protocol stream must stay clean"
     assert "Traceback" not in proc.stderr
-    assert "continuum[mcp]" in proc.stderr, "the operator needs the fix, not just the fault"
+    assert "continuum-agent[mcp]" in proc.stderr, "the operator needs the fix, not just the fault"
     assert not (tmp_path / "agent.db").exists(), "a server that never started created a database"
 
 
@@ -2024,7 +2024,7 @@ def test_a_missing_unrelated_module_keeps_its_traceback(
     """The extra is blamed only when the extra is what is missing.
 
     A broken install of something else must not be reported as "install
-    continuum[mcp]", which would send the operator after the wrong fix.
+    continuum-agent[mcp]", which would send the operator after the wrong fix.
     """
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
## What

Fixes the remediation half of #697. When `continuum-mcp` runs without the optional SDK installed, it told the operator to run:

```
pip install 'continuum[mcp]'
```

which resolves to an unrelated PyPI distribution. The published package is `continuum-agent`, so the command was unrunnable. The message now reads:

```
error: the MCP server needs the optional 'mcp' dependency, which is not importable (No module named 'mcp'). Install it with: pip install continuum-agent[mcp]
```

matching the convention the adapters already use (`pip install continuum-agent[openai]`, `[langgraph]`, `[langchain]`).

Also fixes the same stale name in two more places:

- `src/continuum/storage/postgres.py`: the `psycopg` extra error said `pip install continuum[postgres]`
- the `mcp/server.py` module docstring referenced ``pip install continuum``

## Why the extra stays optional

`pyproject.toml` documents the design intent: the core library and CLI never import the SDK, so the base install stays server-free. The bug was not the optional split, it was handing the operator a fix command that cannot work. (Issue #697's expected behaviour explicitly allows either resolution; this takes the one that preserves the documented packaging decision.)

## Verification

End-to-end repro of the issue's steps against this tree:

1. `python -m venv /tmp/venv && /tmp/venv/bin/pip install .` (clean environment, no extras)
2. `/tmp/venv/bin/continuum-mcp` -> exits 1 with the corrected one-line error, no traceback
3. `/tmp/venv/bin/pip install '.[mcp]'` -> the remediation command shape resolves
4. `continuum-mcp` now completes the MCP `initialize` handshake over stdio

Regression test updated to assert `continuum-agent[mcp]` in stderr (the old assertion is not a substring of the new message, so it would fail without the fix). Full suite green, `ruff check`/`format --check` clean, strict `mypy` clean.

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)