### PR TITLE
test(concurrency): settle the claim inside the lease hold (#672)

### DIFF
--- a/tests/test_storage_concurrency.py
+++ b/tests/test_storage_concurrency.py
@@ -261,6 +261,16 @@ def test_the_run_lease_restores_exactly_once_under_concurrency(tmp_path: Path) -
     Wrapping the claim in the run's lease collapses eight simultaneous claimants
     to a single go-ahead, which is what makes docs/multi_agent_isolation.md's
     "one run, one owner at a time" sufficient for exactly-once.
+
+    The holder settles what it starts before letting go of the lease (issue
+    #672). A claim left STARTED at release is a live claim to every later
+    claimant: the ledger correctly raises UnknownSideEffect for a foreign
+    in-flight action, so a test whose winner never completes passes only when
+    no loser happens to acquire the lease after the winner's release, which is
+    timing and not a contract. Completing inside the hold makes the outcome
+    deterministic for every interleaving: one fresh claim, and every other
+    claimant is either turned away by the lease or served the deduplicated
+    result of the completed one.
     """
     from continuum.actions.ledger import ActionLedger
     from continuum.concurrency import SQLiteLeaseCoordinator
@@ -275,7 +285,10 @@ def test_the_run_lease_restores_exactly_once_under_concurrency(tmp_path: Path) -
             return "no-lease"
         try:
             with SQLiteStorage(db) as store:
-                outcome = ActionLedger(store, "run_1").claim("charge", {"amt": 100}, key="k")
+                ledger = ActionLedger(store, "run_1")
+                outcome = ledger.claim("charge", {"amt": 100}, key="k")
+                if outcome.fresh:
+                    ledger.complete(outcome.key, result={"charged": True})
                 return "fresh" if outcome.fresh else "dedup"
         finally:
             coordinator.release("run_1", holder)
@@ -284,6 +297,7 @@ def test_the_run_lease_restores_exactly_once_under_concurrency(tmp_path: Path) -
         outcomes = list(pool.map(claim, range(8)))
 
     assert outcomes.count("fresh") == 1, f"expected one winner, got {outcomes}"
+    assert set(outcomes) <= {"fresh", "dedup", "no-lease"}
 
 
 # --- the ledger takes the lease itself (issue #345, remaining half) ---------- #


### PR DESCRIPTION
## What

Makes `test_the_run_lease_restores_exactly_once_under_concurrency` deterministic, per #672's acceptance criteria. Ledger `UnknownSideEffect` semantics are untouched: the ledger was behaving correctly, the test's contract was timing-dependent.

## Root cause, reproduced deterministically

The winner claimed key `k` (STARTED) and released the lease **without completing**. Any thread that then acquired the lease saw a foreign in-flight action and correctly raised `UnknownSideEffect`. The test only passed when no loser happened to acquire post-release, which is load-sensitive scheduling, not a contract.

Sequential two-thread repro against current main raises exactly the CI failure from the issue, down to the same key hash:

```
thread A: fresh
UnknownSideEffect reproduced: action 'charge' (key b640e167c5e7...) was interrupted before its outcome was rec
```

That `b640e167...` matches the key quoted in both CI failures linked from the issue (#655, #662).

## Fix

The holder now completes the action before releasing the lease, which is also what real usage does (intercept, perform, complete, all under the run's lease). No later claimant can observe a claim mid-flight, so every interleaving yields: exactly one `fresh`, and every other claimant is either turned away by the lease (`no-lease`) or served the deduplicated result of the completed claim (`dedup`). A new assertion pins that outcome set.

## Verification

- Deterministic repro above fails the assertion path on main; with the fix, no interleaving can produce `UnknownSideEffect`
- 40 consecutive runs of the test: 40 pass, 0 fail
- Full suite green, `ruff check`/`format --check` clean

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)