### PR TITLE
docs(contributing): spell out the three-file ruff rev lockstep (#689)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+# The pre-commit ecosystem is deliberately not watched (#689). Dependabot
+# groups cannot cross ecosystems, so a pre-commit update would land as its own
+# PR bumping only .pre-commit-config.yaml, and the three-way ruff rev lockstep
+# (pyproject.toml, .pre-commit-config.yaml, CONTRIBUTING.md, enforced by
+# tests/test_precommit_config.py) would fail CI in that PR. Bump ruff in all
+# three places by hand in one PR.
 updates:
   - package-ecosystem: "pip"
     directory: "/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **Documented three-file ruff rev lockstep (#689).** CONTRIBUTING.md now
+  names all three places the ruff version lives (the `ruff==` pin in
+  `pyproject.toml`, `rev` in `.pre-commit-config.yaml`, and the `rev` quoted
+  in CONTRIBUTING.md itself) and the test that enforces them; the pin test's
+  failure message says "version skew, not a broken test" and lists the three
+  files to bump, so a dependabot PR that trips it (#627) is readable as
+  drift. The pre-commit ecosystem's absence from dependabot is recorded in a
+  comment there and pinned by a test: its updates cannot be grouped with pip
+  bumps and would break the lockstep in their own PR.
+
 - **External probe for consumed authorities via reconcilers.json (#557).**
   `reconcile --authority <id>` runs the configured authority probe with the
   recorded consumption payload on stdin; `valid=true` appends

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,10 +148,19 @@ To run it manually against all files:
 pre-commit run --all-files
 ```
 
-If you bump the `ruff==` pin in `pyproject.toml`, bump `rev` in
-`.pre-commit-config.yaml` to the matching `vX.Y.Z` tag in the same PR. A hook
-running a different ruff than CI is how a locally formatted file still fails
-`ruff format --check` on the PR.
+The ruff version lives in three places that must move together in one PR.
+`tests/test_precommit_config.py` fails any PR where they drift, which is how a
+dependabot `pip` bump surfaces (as a red test, not a version skew, so read a
+failure there as drift before anything else):
+
+1. the `ruff==` pin in the `dev` extra of `pyproject.toml`,
+2. `rev:` in `.pre-commit-config.yaml`, and
+3. the `rev:` quoted in the yaml block above. This file is itself one of the
+   pins, which is easy to miss because you are editing prose, not
+   configuration.
+
+A hook running a different ruff than CI is how a locally formatted file still
+fails `ruff format --check` on the PR.
 
 **Note on mypy:** mypy is intentionally not included in this pre-commit setup.
 Pre-commit hooks run in isolated environments without the project's installed

--- a/tests/test_precommit_config.py
+++ b/tests/test_precommit_config.py
@@ -11,6 +11,9 @@ local gate and the CI gate honest about each other:
 * **The same paths.** Every directory the CI lint job hands to ruff is in scope
   for both hooks, and a directory CI does not lint stays out of scope, so
   `pre-commit run --all-files` on an untouched tree has nothing to say.
+* **No pre-commit ecosystem in dependabot.** Dependabot groups cannot cross
+  ecosystems, so a pre-commit update would land alone and break the ruff
+  agreement above in its own PR (issue #627, #689).
 """
 
 from __future__ import annotations
@@ -24,6 +27,7 @@ PRECOMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DEPENDABOT = REPO_ROOT / ".github" / "dependabot.yml"
 
 
 # --------------------------------------------------------------------------- #
@@ -80,12 +84,37 @@ def _ci_lint_directories() -> set[str]:
 
 def test_precommit_pins_the_ruff_version_from_the_dev_extra() -> None:
     expected = f"v{_pinned_ruff_version()}"
+    mismatches = []
     for path in (PRECOMMIT_CONFIG, CONTRIBUTING):
         revisions = re.findall(r"^\s*rev:\s*(\S+)\s*$", path.read_text(encoding="utf-8"), re.M)
-        assert revisions == [expected], (
-            f"{path.name} must name the ruff version pinned in pyproject's dev extra "
-            f"({expected}), got {revisions}"
-        )
+        if revisions != [expected]:
+            mismatches.append(f"{path.name} says {revisions}")
+    assert not mismatches, (
+        f"ruff version skew, not a broken test: pyproject's dev extra pins "
+        f"ruff=={expected[1:]}, but {'; '.join(mismatches)}. Bump all three pins "
+        "in the same PR: the ruff== pin in pyproject.toml, rev in "
+        ".pre-commit-config.yaml, and the rev quoted in CONTRIBUTING.md "
+        "(the lockstep note there lists them)."
+    )
+
+
+def test_dependabot_does_not_watch_the_pre_commit_ecosystem() -> None:
+    """The pre-commit ecosystem is deliberately absent from dependabot (#689).
+
+    Dependabot groups cannot cross ecosystems, so a pre-commit update would
+    arrive as its own PR bumping only ``rev`` in ``.pre-commit-config.yaml``,
+    leaving the pyproject pin and the CONTRIBUTING quote stale and failing
+    the pin test above in that PR: the #627 failure in reverse. Re-adding the
+    ecosystem should be a deliberate decision that also solves the lockstep,
+    not a drive-by completeness fix.
+    """
+    text = DEPENDABOT.read_text(encoding="utf-8")
+    ecosystems = set(re.findall(r"^\s*- package-ecosystem:\s*\"?([\w-]+)\"?\s*$", text, re.M))
+    assert "pre-commit" not in ecosystems, (
+        "dependabot watches the pre-commit ecosystem, but its updates cannot be "
+        "grouped with the pip bumps and would break the three-file ruff rev "
+        "lockstep in their own PR (see the comment in .github/dependabot.yml)"
+    )
 
 
 def test_hooks_are_scoped_to_the_directories_ci_lints() -> None:


### PR DESCRIPTION
Closes #689.

## What

#627 broke CI because the ruff version lives in three places that must move together, and a dependabot `pip` bump moved only one. Two things made that failure misleading: the bump note in CONTRIBUTING.md named only two of the three pins (it omitted the `rev:` quoted in CONTRIBUTING.md itself), and the pin test failed with a bare assertion that read as a broken test rather than a version skew.

This PR takes the **document** direction proposed on the issue ([comment](https://github.com/Cyrax321/CONTINUUM/issues/689#issuecomment-5574514135)). The dependabot direction was rejected because dependabot groups cannot cross ecosystems: a `pre-commit` update would land as its own PR bumping only `.pre-commit-config.yaml` and would fail the same pin test in the opposite direction.

## Changes

- **CONTRIBUTING.md** - the bump note now lists all three pins, names `tests/test_precommit_config.py` as the enforcer, and says a dependabot PR failing there is drift, not breakage.
- **tests/test_precommit_config.py** - the pin test collects every stale file and fails with `ruff version skew, not a broken test` plus the three places to bump in one PR. New guard test pins dependabot's deliberate lack of a `pre-commit` ecosystem, so a future contributor cannot reintroduce the breakage as a completeness fix.
- **.github/dependabot.yml** - a comment recording the deliberate omission and the reasoning.
- **CHANGELOG.md** - entry under `Unreleased`.

## Verification

- `pytest tests/test_precommit_config.py --no-cov -q` - 3 passed.
- Full suite - green.
- `ruff check` / `ruff format --check` clean.
- Simulated a stale `rev: v0.16.4` in `.pre-commit-config.yaml` and confirmed the new failure message fires with the three-file remedy; simulated re-adding the `pre-commit` ecosystem to dependabot and confirmed the guard test fails with the reasoning. Both simulations reverted.

Direction was proposed on the issue before implementing, per its step 2; the chosen direction changes no automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)