### PR TITLE
fix(actions): guard fail() against statuses that are not in flight

### DIFF
--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -1104,8 +1104,27 @@ class ActionLedger:
         — a timeout after the request was sent, for instance. Those become
         ``UNKNOWN`` rather than ``FAILED``, because a timeout is not evidence of
         absence.
+
+        Only in-flight statuses settle here (issue #733). Re-reporting a
+        ``FAILED`` action is allowed, because a caller repeating itself after a
+        dropped response is not asserting anything new. Every other status is
+        refused, mirroring :meth:`complete` (issue #366): a late ``fail`` on a
+        ``COMPLETED`` action used to flip it to ``FAILED`` while its recorded
+        result stayed on the books, which reopened the key and let the next
+        claim re-fire a side effect that had already happened. ``UNKNOWN`` is
+        refused for the same reason ``complete`` refuses it: resolving an
+        uncertain outcome is a correction that needs evidence, which is what
+        :meth:`reconcile` records.
         """
         key, existing = self._require(key)
+        if existing.status not in (ActionStatus.STARTED, ActionStatus.FAILED):
+            raise LedgerError(
+                f"action {existing.action_type!r} is {existing.status.value}, not in flight, so "
+                f"failing it would erase a recorded outcome. If a check confirmed "
+                f"the effect did not happen, call reconcile(occurred=False) "
+                f"(continuum_reconcile_action over MCP), which records the evidence "
+                f"and the note alongside the correction."
+            )
         action = existing.model_copy(
             update={
                 "status": ActionStatus.FAILED if certain else ActionStatus.UNKNOWN,

--- a/tests/test_action_ledger.py
+++ b/tests/test_action_ledger.py
@@ -295,6 +295,81 @@ def test_complete_refuses_every_status_that_is_not_in_flight(
         ledger.complete(outcome.key, external_id="txn-1")
 
 
+@pytest.mark.parametrize(
+    ("settle", "expected_status"),
+    [
+        (lambda led, key: led.complete(key, external_id="txn-1"), "completed"),
+        (lambda led, key: led.compensate(key, note="refunded"), "compensated"),
+        (lambda led, key: led.flag_for_review(key, "amount looks wrong"), "requires_review"),
+    ],
+)
+def test_fail_refuses_every_status_that_is_not_in_flight(
+    ledger: ActionLedger,
+    settle: Any,
+    expected_status: str,
+) -> None:
+    """The mirror of complete's guard (issue #366) for fail (issue #733).
+
+    A COMPLETED action flipped to FAILED by a late report reopened the key and
+    let the next claim re-fire a side effect that had already happened. The
+    other settled statuses are corrections of outcomes already on record, which
+    belong to `reconcile`.
+    """
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    settle(ledger, outcome.key)
+
+    with pytest.raises(LedgerError, match=expected_status):
+        ledger.fail(outcome.key, "late failure report")
+
+
+def test_a_refused_fail_leaves_the_completed_outcome_settled(ledger: ActionLedger) -> None:
+    """The point of the guard: dedup must survive the refused late report.
+
+    The COMPLETED action keeps its receipt, stays out of pending(), and the
+    same claim remains a cache hit instead of re-opening as a fresh attempt.
+    """
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.complete(outcome.key, external_id="txn-1")
+
+    with pytest.raises(LedgerError, match="erase a recorded outcome"):
+        ledger.fail(outcome.key, "late timeout report")
+
+    still = ledger.get(str(outcome.key))
+    assert still is not None
+    assert still.status is ActionStatus.COMPLETED
+    assert still.external_id == "txn-1"
+    assert not ledger.pending()
+
+    retry = ledger.claim("payment.charge", {"amount": 100})
+    assert retry.fresh is False, "a refused fail must not reopen the key"
+
+
+def test_failing_an_already_failed_action_is_still_allowed(ledger: ActionLedger) -> None:
+    """A caller repeating a failure report after a dropped response asserts
+    nothing new (same allowance complete makes for COMPLETED, issue #366)."""
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.fail(outcome.key, "500 from upstream")
+
+    again = ledger.fail(outcome.key, "500 from upstream, re-reported")
+    assert again.status is ActionStatus.FAILED
+
+
+def test_fail_refuses_an_unknown_action_and_reconcile_remains_the_route(
+    ledger: ActionLedger,
+) -> None:
+    """An uncertain outcome cannot be resolved by assertion; the evidence
+    goes through `reconcile`, exactly as for complete (issue #366)."""
+    outcome = ledger.claim("payment.charge", {"amount": 100})
+    ledger.fail(outcome.key, "gateway timeout", certain=False)
+
+    with pytest.raises(LedgerError, match="unknown"):
+        ledger.fail(outcome.key, "definitely did not happen")
+
+    settled = ledger.reconcile(outcome.key, occurred=False, note="gateway has no trace of it")
+    assert settled.status is ActionStatus.FAILED
+    assert not ledger.pending()
+
+
 def test_completing_an_already_completed_action_is_still_allowed(
     ledger: ActionLedger,
 ) -> None:


### PR DESCRIPTION
## Summary

`complete()` got a status guard in #366 (it refuses to settle anything not in flight); `fail()` never got the mirror-image guard. A late or duplicated failure report for an already-`COMPLETED` action flipped it to `FAILED` while the recorded result stayed on the books. The key stopped reading as settled, the next `claim()` opened a fresh attempt, and the side effect re-fired.

Fixes #733.

## What changed

- `ActionLedger.fail()` now refuses every status that is not in flight, mirroring `complete()`:
  - `STARTED` and `FAILED` settle (re-reporting a `FAILED` action asserts nothing new, the same allowance `complete()` makes for `COMPLETED`)
  - `COMPLETED`, `UNKNOWN`, `COMPENSATED`, `REQUIRES_REVIEW`, `PLANNED` raise a `LedgerError` that points at `reconcile(occurred=False)` / `continuum_reconcile_action`, which records the evidence and the note
- Regression tests pin: the refusal per settled status, that a refused fail leaves the completed outcome settled (dedup cache hit, no pending blocker), the allowed `FAILED` re-report, and that `UNKNOWN` stays a job for `reconcile`.

## Testing

- `tests/test_action_ledger.py`: four new tests / one new parametrization, mirroring the #366 test block
- Full suite, `ruff check` + `ruff format --check` on `src/ tests/ examples/`, and strict `mypy src/continuum` all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented completed, compensated, review-required, or unknown actions from being marked as failed.
  * Preserved recorded successful outcomes and deduplication state.
  * Continued to allow already-failed actions to be failed again.
  * Directs uncertain action outcomes to reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->