### PR TITLE
fix(budgets): count archived attempts so the retry budget survives compaction

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1408,7 +1408,10 @@ def cmd_budget(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         print(f"error: budget registry invalid: {exc}", file=err)
         return ExitCode.ERROR
 
-    events = storage.read_events(args.run_id)
+    # Archive-aware (issue #734): compaction moves attempts into the archive,
+    # so a live-tail-only count understates attempts and overstates remaining
+    # after every compaction.
+    events = storage.read_all_events(args.run_id)
     types_seen = sorted(
         {
             e.payload.get("action", {}).get("action_type")

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -1276,7 +1276,10 @@ def build_server(
         )
 
         if not settled:
-            events = ctx.storage.read_events(run_id)
+            # Archive-aware (issue #734): attempts live in the event log, and
+            # compaction moves failed attempts into the archive. Counting only
+            # the live tail reset an exhausted budget after every compaction.
+            events = ctx.storage.read_all_events(run_id)
             # Counted per key, so the budget caps retries of *this* operation
             # rather than the run's distinct work of this type (issue #368).
             claim_key = str(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2277,6 +2277,65 @@ async def test_a_completed_action_still_deduplicates_at_budget(
 
 
 @pytest.mark.asyncio
+async def test_the_retry_budget_survives_compaction(
+    server_ctx: tuple[Any, Any],
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate counted attempts from the live log only (issue #734).
+
+    Compaction archives the ACTION_RECORDED events of the failed attempts, so a
+    live-tail-only count dropped to zero and an exhausted budget re-opened,
+    granting a fresh allowance to a model hammering a failing upstream after
+    every compaction.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".continuum").mkdir()
+    (tmp_path / ".continuum" / "budgets.json").write_text('{"default_max_attempts": 2}')
+    server, ctx = server_ctx
+    await seed_run(server)
+
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    for _ in range(2):
+        stuck = await call(
+            server,
+            "continuum_intercept_action",
+            run_id="run_1",
+            action_type="charge",
+            key="charge:stuck",
+        )
+        await call(
+            server,
+            "continuum_fail_action",
+            run_id="run_1",
+            action_key=stuck["action_key"],
+            error="500 from upstream",
+            certain=True,
+        )
+    with pytest.raises(ToolError, match="retry budget exhausted"):
+        await call(
+            server,
+            "continuum_intercept_action",
+            run_id="run_1",
+            action_type="charge",
+            key="charge:stuck",
+        )
+
+    # Compaction moves the failed attempts into the archive; the exhausted
+    # budget must survive that.
+    ctx.storage.compact_run("run_1")
+    with pytest.raises(ToolError, match="retry budget exhausted"):
+        await call(
+            server,
+            "continuum_intercept_action",
+            run_id="run_1",
+            action_type="charge",
+            key="charge:stuck",
+        )
+
+
+@pytest.mark.asyncio
 async def test_a_never_retried_operation_is_not_blocked_by_its_neighbours(
     server_ctx: tuple[Any, Any],
     tmp_path: Any,

--- a/tests/test_retry_budgets.py
+++ b/tests/test_retry_budgets.py
@@ -1031,6 +1031,34 @@ def test_cli_budget_exhausted_exit_is_reported_not_raised(db: str, tmp_path: Pat
     assert any(r["action_type"] == "deploy" and r["attempts"] >= 1 for r in rows)
 
 
+def test_cli_budget_counts_archived_attempts_after_compaction(db: str, tmp_path: Path) -> None:
+    """Attempts live in the event log; compaction moves them to the archive.
+
+    The report read only the live tail, so after a compaction it understated
+    attempts and overstated remaining for exactly the runs long enough to have
+    been compacted (issue #734).
+    """
+    with SQLiteStorage(db) as store:
+        ledger = ActionLedger(store, "run_1")
+        outcome = ledger.claim("send_invoice", {}, key="invoice:1")
+        ledger.fail(outcome.key, "500 from upstream")
+        store.compact_run("run_1")
+
+    code, out, err = run(
+        "--db",
+        db,
+        "--json",
+        "budget",
+        "run_1",
+        "--config",
+        registry(tmp_path, {"default_max_attempts": 3}),
+    )
+    assert code == ExitCode.OK, err
+    by_type = {r["action_type"]: r for r in json.loads(out)["budgets"]}
+    assert by_type["send_invoice"]["attempts"] == 1, "archived attempt must still count"
+    assert by_type["send_invoice"]["remaining"] == 2
+
+
 def test_hand_built_authorization_counter_bool_is_rejected() -> None:
     raw = bound_registry()
     raw["authorization_bound"]["send_invoice"]["authz:stripe-cust-1"]["counter"] = True


### PR DESCRIPTION
## Summary

The retry-budget gate in `continuum_intercept_action` and the `continuum budget` report folded `ACTION_RECORDED` events from `read_events()`, the live tail only. Compaction moves failed attempts into the archive, so an exhausted budget silently reset after every compaction: a 3-attempt budget that refused the 4th claim before compaction allowed it afterwards.

Fixes #734.

## What changed

- `src/continuum/mcp/server.py`: the gate now reads `read_all_events(run_id)` (archive-aware, per the base-storage contract)
- `src/continuum/cli/main.py`: `cmd_budget` likewise, so the report no longer understates `attempts` / overstates `remaining` after compaction

## Testing

- `tests/test_mcp_server.py`: `test_the_retry_budget_survives_compaction` burns the full allowance, asserts the refusal, compacts the run, and asserts the refusal again
- `tests/test_retry_budgets.py`: `test_cli_budget_counts_archived_attempts_after_compaction` pins the CLI report's archive-aware count
- Full suite, `ruff check` + `ruff format --check` on `src/ tests/ examples/`, and strict `mypy src/continuum` all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
