### PR TITLE
fix(replayguard): build the BLOCK_UNCERTAIN decision with its key

### DIFF
--- a/src/continuum/replayguard.py
+++ b/src/continuum/replayguard.py
@@ -79,6 +79,7 @@ def evaluate(
         return GuardDecision(
             GuardKind.BLOCK_UNCERTAIN,
             f"{action_type!r} {rendered_key!r} has an unknown outcome; reconcile first",
+            key=key,
         )
     return GuardDecision(
         GuardKind.DENY_RECLAIM,

--- a/tests/test_replayguard.py
+++ b/tests/test_replayguard.py
@@ -25,6 +25,7 @@ from continuum.events import EventType  # noqa: E402
 from continuum.models import ActionStatus, Run  # noqa: E402
 from continuum.replayguard import (  # noqa: E402
     GuardKind,
+    ReplayBlocked,
     evaluate,
     langgraph_protected_node,
     protected_call,
@@ -90,6 +91,32 @@ def test_decision_table_matches_the_gate_contract(db: str) -> None:
     assert verdict(db, "send_invoice", "i:3").kind is GuardKind.BLOCK_UNCERTAIN
     seed(db, "send_invoice", "i:4", ActionStatus.FAILED)
     assert verdict(db, "send_invoice", "i:4").kind is GuardKind.DENY_RECLAIM
+
+
+def test_block_uncertain_decision_carries_its_key(db: str) -> None:
+    # The decision table contract: every decision names the ledger key it is
+    # about, so protected_call can act on it. BLOCK_UNCERTAIN used to be built
+    # without the key, which turned the documented ReplayBlocked into a bare
+    # AssertionError at the `decision.key is not None` checkpoint (issue #735).
+    seed(db, "send_invoice", "i:3", ActionStatus.UNKNOWN)
+    assert verdict(db, "send_invoice", "i:3").key is not None
+
+
+def test_protected_call_raises_replayblocked_for_an_uncertain_action(db: str) -> None:
+    # The public contract: uncertain states raise ReplayBlocked rather than
+    # guessing. With the key missing the wrapper died on an AssertionError
+    # first, so callers could not catch the documented exception (issue #735).
+    seed(db, "send_invoice", "i:5", ActionStatus.UNKNOWN)
+    with pytest.raises(ReplayBlocked) as excinfo:
+        protected_call(
+            SQLiteStorage(db),
+            "run_1",
+            action_type="send_invoice",
+            key="i:5",
+            fn=lambda: "SHOULD_NOT_RUN",
+        )
+    assert excinfo.value.decision.kind is GuardKind.BLOCK_UNCERTAIN
+    assert excinfo.value.decision.key is not None
 
 
 def make_run(db: str) -> None:


### PR DESCRIPTION
## Summary

`evaluate()` built the `BLOCK_UNCERTAIN` `GuardDecision` without `key=`, unlike every other branch of the decision table. `protected_call` then hit its `assert decision.key is not None` checkpoint and raised a bare `AssertionError` where the documented contract promises `ReplayBlocked`; under `python -O` the stripped assert let a `None` key flow onward instead.

Fixes #735.

## What changed

- The `BLOCK_UNCERTAIN` decision now carries its key, like `DENY_UNCLAIMED` / `ALLOW` / `SKIP_DUPLICATE` / `DENY_RECLAIM` already did

## Testing

- `tests/test_replayguard.py`: `test_block_uncertain_decision_carries_its_key` pins the decision-table invariant; `test_protected_call_raises_replayblocked_for_an_uncertain_action` pins the public contract (ReplayBlocked with kind and key, not AssertionError)
- Full suite, `ruff check` + `ruff format --check` on `src/ tests/ examples/`, and strict `mypy src/continuum` all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Uncertain replay decisions now include the related ledger key.
  - Protected calls with uncertain actions now raise the documented replay-blocking error instead of an assertion failure.
  - Replay now correctly preserves dictionaries containing a `"return"` field, supports non-dictionary results, and remains compatible with previously recorded return data.

- **Tests**
  - Added coverage for ledger-key propagation, replay blocking, and return-value compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->