### PR TITLE
fix(replayguard): envelope journaled results so replay cannot unwrap a caller dict

### DIFF
--- a/src/continuum/replayguard.py
+++ b/src/continuum/replayguard.py
@@ -28,7 +28,21 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
-__all__ = ["GuardKind", "GuardDecision", "evaluate", "protected_call", "langgraph_protected_node"]
+__all__ = [
+    "GuardKind",
+    "GuardDecision",
+    "RESULT_ENVELOPE_KEY",
+    "evaluate",
+    "protected_call",
+    "langgraph_protected_node",
+]
+
+# Journal envelope, same literal adapters.generic uses for the same reason
+# (issue #44): a stored result must be distinguishable from the caller's own
+# dict, or the replay path unwraps one member of it instead of the dict
+# (issue #736). Defined locally so the core stays importable without the
+# adapter stack.
+RESULT_ENVELOPE_KEY = "__return_value__"
 
 
 class GuardKind(StrEnum):
@@ -139,7 +153,16 @@ def protected_call(
         except Exception as exc:
             ledger.fail(key_to_use, str(exc), certain=False)
             raise
-        journal = result if isinstance(result, dict) else {"return": result}
+        # A non-dict has to be wrapped to be stored. So does any dict carrying
+        # the envelope key or the legacy "return" marker: the replay path below
+        # unwraps those, and storing a caller's own dict with such a key as-is
+        # would make replay return one member of it rather than the whole dict,
+        # so a completed operation would answer differently on its second call
+        # than on its first (issue #736).
+        needs_envelope = (
+            not isinstance(result, dict) or RESULT_ENVELOPE_KEY in result or "return" in result
+        )
+        journal = {RESULT_ENVELOPE_KEY: result} if needs_envelope else result
         ledger.complete(key_to_use, external_id=key, result=journal)
         return GuardKind.ALLOW, result
 
@@ -147,7 +170,15 @@ def protected_call(
         assert decision.key is not None
         cached_action = actions[decision.key]
         cached = cached_action.result
-        value = cached.get("return", cached) if isinstance(cached, dict) else cached
+        if isinstance(cached, dict) and RESULT_ENVELOPE_KEY in cached:
+            value = cached[RESULT_ENVELOPE_KEY]
+        elif isinstance(cached, dict) and set(cached) == {"return"}:
+            # Legacy journal from before the envelope: a non-dict result
+            # wrapped as {"return": ...}. The write path now envelopes any
+            # dict containing "return", so this shape is historical only.
+            value = cached["return"]
+        else:
+            value = cached
         return GuardKind.SKIP_DUPLICATE, value
 
     raise ReplayBlocked(decision)

--- a/tests/test_replayguard.py
+++ b/tests/test_replayguard.py
@@ -152,6 +152,67 @@ def test_protected_call_executes_once_then_returns_cached_result(db: str) -> Non
     assert len(calls) == 1, "side effect must not re-fire"
 
 
+def test_replay_returns_the_callers_own_dict_even_with_a_return_key(db: str) -> None:
+    # A dict result containing the literal key "return" used to be journalled
+    # as-is and then unwrapped on replay, so the second call returned one
+    # member of the dict while the first returned the whole thing (issue #736).
+    payload = {"return": "receipt-1", "amount": 100}
+
+    kind1, result1 = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="send_invoice",
+        key="inv:9",
+        fn=lambda: payload,
+    )
+    kind2, result2 = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="send_invoice",
+        key="inv:9",
+        fn=lambda: payload,
+    )
+    assert kind1 is GuardKind.ALLOW and kind2 is GuardKind.SKIP_DUPLICATE
+    assert result2 == result1 == payload, "replay must answer as the first call did"
+
+
+def test_non_dict_results_round_trip_through_the_envelope(db: str) -> None:
+    kind1, result1 = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="charge_card",
+        key="card:2",
+        fn=lambda: "charged",
+    )
+    kind2, result2 = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="charge_card",
+        key="card:2",
+        fn=lambda: "charged",
+    )
+    assert kind1 is GuardKind.ALLOW and result1 == "charged"
+    assert kind2 is GuardKind.SKIP_DUPLICATE and result2 == "charged"
+
+
+def test_a_legacy_return_journal_still_unwraps_on_replay(db: str) -> None:
+    # Records written before the envelope (issue #736) wrap non-dict results
+    # as {"return": ...}; replay must keep unwrapping those.
+    with SQLiteStorage(db) as store:
+        ledger = ActionLedger(store, "run_1")
+        outcome = ledger.claim("legacy_call", {}, key="legacy:1")
+        ledger.complete(outcome.key, result={"return": "legacy-value"})
+    kind, value = protected_call(
+        SQLiteStorage(db),
+        "run_1",
+        action_type="legacy_call",
+        key="legacy:1",
+        fn=lambda: "SHOULD_NOT_RUN",
+    )
+    assert kind is GuardKind.SKIP_DUPLICATE
+    assert value == "legacy-value"
+
+
 def test_exception_marks_uncertain_failure_and_reraises(db: str) -> None:
     with pytest.raises(RuntimeError):
         protected_call(


### PR DESCRIPTION
## Summary

`protected_call` journalled dict results verbatim but unwrapped them on replay via the reserved `"return"` key, so a result dict containing that literal key answered differently on its second call than on its first: replay returned one member of the dict instead of the dict. The same class was fixed for `intercept_action` in #44 with an envelope sentinel; this applies it to the guard.

Fixes #736.

## What changed

- `src/continuum/replayguard.py`: results are journalled under the `__return_value__` envelope whenever they need wrapping (non-dicts, and any dict carrying the envelope key or the legacy `"return"` marker); replay unwraps only the envelope, plus the legacy `{"return": ...}` journals of already-stored non-dict results so pre-fix records stay readable. The sentinel is defined locally so the portable core stays importable without the adapter stack.

## Testing

- `tests/test_replayguard.py`: `test_replay_returns_the_callers_own_dict_even_with_a_return_key` (the reported divergence), `test_non_dict_results_round_trip_through_the_envelope`, and `test_a_legacy_return_journal_still_unwraps_on_replay`
- Full suite, `ruff check` + `ruff format --check` on `src/ tests/ examples/`, and strict `mypy src/continuum` all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
