### PR TITLE
fix(environment): stamp oversized files UNKNOWN_VERSION so a size is never an identity

### DIFF
--- a/src/continuum/environment/diff.py
+++ b/src/continuum/environment/diff.py
@@ -159,6 +159,8 @@ def diff_environments(
             reason = str(
                 current.metadata.get("error")
                 or previous.metadata.get("error")
+                or current.metadata.get("skipped")
+                or previous.metadata.get("skipped")
                 or "resource could not be inspected"
             )
             deltas.append(

--- a/src/continuum/environment/snapshot.py
+++ b/src/continuum/environment/snapshot.py
@@ -125,10 +125,15 @@ class FileProvider(EnvironmentProvider):
             try:
                 stat = path.stat()
                 if self.max_bytes is not None and stat.st_size > self.max_bytes:
+                    # UNKNOWN_VERSION, not a synthetic "size:<n>" stamp: a size
+                    # is not an identity, but diff_environments compared the old
+                    # stamp as one, so a replaced file of the same byte size
+                    # verified as unchanged and the environment check failed
+                    # open (issue #738). The size stays in metadata.
                     captured[key] = EnvResource(
                         name=key,
                         kind="file",
-                        version=f"size:{stat.st_size}",
+                        version=UNKNOWN_VERSION,
                         metadata={"skipped": "larger than max_bytes", "size": stat.st_size},
                     )
                     continue

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -13,7 +13,7 @@ from continuum.environment import (
     diff_environments,
     process_fingerprint,
 )
-from continuum.models import EnvResource
+from continuum.models import EnvResource, StateStatus
 
 # --- capture --------------------------------------------------------------- #
 
@@ -100,11 +100,59 @@ def test_an_unreadable_file_becomes_unknown(tmp_path: Path) -> None:
 
 
 def test_large_files_are_sized_rather_than_hashed(tmp_path: Path) -> None:
+    """An oversized file is reported as unknown, never as a fake identity.
+
+    The size used to be stamped into the version as ``size:<n>``, which
+    diff_environments then compared as an identity: a replaced file of the same
+    byte size verified as unchanged and the environment check failed open
+    (issue #738). The size lives in metadata instead.
+    """
     big = tmp_path / "big.bin"
     big.write_bytes(b"x" * 5000)
     resource = capture("run_1", FileProvider([big], max_bytes=1000)).resources[str(big)]
-    assert resource.version == "size:5000"
+    assert resource.version == UNKNOWN_VERSION
     assert resource.metadata["skipped"]
+    assert resource.metadata["size"] == 5000
+
+
+def test_a_replaced_same_size_oversized_file_is_not_verified_unchanged(tmp_path: Path) -> None:
+    """The fail-open regression (issue #738): same size, different content.
+
+    Two captures of a fully replaced file must never read as a verified
+    unchanged resource when the content was never hashed.
+    """
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"A" * 5000)
+    before = capture("run_1", FileProvider([big], max_bytes=1000))
+    big.write_bytes(b"B" * 5000)
+    after = capture("run_1", FileProvider([big], max_bytes=1000))
+
+    delta = next(d for d in diff_environments(before, after).deltas if d.resource == str(big))
+    assert delta.change is ResourceChange.UNKNOWN
+    assert "larger than max_bytes" in (delta.detail or "")
+
+
+def test_an_oversized_dependency_does_not_resume_as_verified(tmp_path: Path) -> None:
+    """The validator side of issue #738: unknown content must not read VALID."""
+    from continuum.models import ExternalDependency, Goal, Progress, SemanticState
+    from continuum.state.validator import validate_state
+
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"A" * 5000)
+    before = capture("run_1", FileProvider([big], max_bytes=1000))
+    big.write_bytes(b"B" * 5000)
+    after = capture("run_1", FileProvider([big], max_bytes=1000))
+
+    state = SemanticState(
+        run_id="run_1",
+        goal=Goal(description="analyse dataset"),
+        progress=Progress(),
+        external_dependencies=[ExternalDependency(resource=str(big), kind="file")],
+    )
+    outcome = validate_state(state, checkpoint_environment=before, current_environment=after)
+    entry = next(e for e in outcome.report.statuses if e.component_id == str(big))
+    assert entry.status is StateStatus.UNKNOWN
+    assert not outcome.report.safe_to_resume
 
 
 def test_value_provider_fingerprints_in_memory_state() -> None:


### PR DESCRIPTION
## Summary

- Files larger than `max_bytes` are skipped by the hashing providers, but the
  snapshot stamped them with `version=f"size:{stat.st_size}"`. A size is not a
  content identity: swap an oversized file for a different file of identical
  length and the environment diff reports UNCHANGED, so an agent resumes
  believing the environment was verified when nothing about the file's content
  was ever checked.
- Oversized files now stamp `UNKNOWN_VERSION`, the same marker every other
  resource that could not be inspected uses. The file size stays available in
  the snapshot metadata, and the diff's reason chain names `skipped` metadata
  so an UNKNOWN delta on an oversized file says why it could not be verified
  instead of the generic "resource could not be inspected".

Fixes #738

## Testing

- `test_large_files_are_sized_rather_than_hashed` updated to assert the
  UNKNOWN_VERSION stamp plus the preserved `metadata["size"]`.
- `test_a_replaced_same_size_oversized_file_is_not_verified_unchanged`: the
  reproduction from the issue, same-length swap now yields an UNKNOWN delta
  rather than UNCHANGED.
- `test_an_oversized_dependency_does_not_resume_as_verified`: the recovery
  verdict follows the uncertainty instead of resuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
