### PR TITLE
fix(validator): cascade staleness along finding-to-finding citations

### DIFF
--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -433,19 +433,44 @@ class StateValidator:
             else:
                 evidence.append(item)
 
+        # A finding's support may be evidence or another finding
+        # (`dangling_evidence` blesses citing finding ids), so taint has to
+        # cascade along finding-to-finding edges too, and the pass repeats
+        # until no new finding is affected: a finding can cite one listed
+        # after it, which a single ordered pass would miss (issue #739).
         tainted_findings: set[str] = set()
+        finding_details: dict[str, str] = {}
+        changed = True
+        while changed:
+            changed = False
+            for finding in state.findings:
+                if finding.finding_id in tainted_findings:
+                    continue
+                if finding.status is not StateStatus.VALID:
+                    continue
+                affected_evidence = sorted(set(finding.evidence) & tainted_evidence)
+                affected_findings = sorted(set(finding.evidence) & tainted_findings)
+                if not (affected_evidence or affected_findings):
+                    continue
+                changed = True
+                tainted_findings.add(finding.finding_id)
+                parts = []
+                if affected_evidence:
+                    parts.append(f"changed evidence: {', '.join(affected_evidence)}")
+                if affected_findings:
+                    parts.append(f"stale finding: {', '.join(affected_findings)}")
+                finding_details[finding.finding_id] = "; ".join(parts)
+
         findings = []
         for finding in state.findings:
-            affected = sorted(set(finding.evidence) & tainted_evidence)
-            if affected and finding.status is StateStatus.VALID:
-                tainted_findings.add(finding.finding_id)
+            if finding.finding_id in tainted_findings:
                 findings.append(finding.model_copy(update={"status": StateStatus.STALE}))
                 entries.append(
                     ComponentValidationEntry(
                         component=Component.FINDING,
                         component_id=finding.finding_id,
                         status=StateStatus.STALE,
-                        detail=f"rests on changed evidence: {', '.join(affected)}",
+                        detail=f"rests on {finding_details[finding.finding_id]}",
                     )
                 )
             else:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -153,6 +153,55 @@ def test_staleness_propagates_from_dependency_to_decision() -> None:
     assert original.decisions[0].status is StateStatus.VALID
 
 
+def test_staleness_cascades_along_finding_to_finding_citations() -> None:
+    """A finding citing another finding is supported by it (issue #739).
+
+    Taint used to stop at the first finding: a finding resting entirely on a
+    now-stale finding, and the decision built on it, kept VALID in the revised
+    state, so a repair plan driven by that state skipped the downstream work.
+    """
+    outcome = validate_state(
+        state(
+            external_dependencies=[ExternalDependency(resource="dataset", version="v3")],
+            evidence=[Evidence(evidence_id="paper_128", source="dataset")],
+            findings=[
+                Finding(finding_id="f_raw", claim="rows shifted", evidence=["paper_128"]),
+                Finding(finding_id="f_derived", claim="X holds", evidence=["f_raw"]),
+            ],
+            decisions=[Decision(decision_id="d_1", decision="Publish X", evidence=["f_derived"])],
+        ),
+        checkpoint_environment=capture("run_4821", StaticProvider(dataset="v3")),
+        current_environment=capture("run_4821", StaticProvider(dataset="v4")),
+    )
+    revised = outcome.state
+    assert revised.evidence[0].status is StateStatus.STALE
+    assert revised.findings[0].status is StateStatus.STALE
+    assert revised.findings[1].status is StateStatus.STALE
+    assert revised.decisions[0].status is StateStatus.STALE
+    assert not outcome.safe
+
+
+def test_finding_citation_cascade_is_independent_of_list_order() -> None:
+    """A forward citation (a finding citing one listed after it) taints the
+    same set, so the cascade must not depend on list order (issue #739)."""
+    outcome = validate_state(
+        state(
+            external_dependencies=[ExternalDependency(resource="dataset", version="v3")],
+            evidence=[Evidence(evidence_id="paper_128", source="dataset")],
+            findings=[
+                # Listed before the raw finding it rests on.
+                Finding(finding_id="f_derived", claim="X holds", evidence=["f_raw"]),
+                Finding(finding_id="f_raw", claim="rows shifted", evidence=["paper_128"]),
+            ],
+        ),
+        checkpoint_environment=capture("run_4821", StaticProvider(dataset="v3")),
+        current_environment=capture("run_4821", StaticProvider(dataset="v4")),
+    )
+    revised = {f.finding_id: f.status for f in outcome.state.findings}
+    assert revised["f_raw"] is StateStatus.STALE
+    assert revised["f_derived"] is StateStatus.STALE
+
+
 def test_propagation_spares_state_that_did_not_depend_on_the_change() -> None:
     outcome = validate_state(
         state(


### PR DESCRIPTION
## Summary

- `validate_state` cascaded staleness one hop: evidence → finding → decision.
  But findings can cite other findings, so a chain like
  evidence-e1 → finding-f1 → finding-f2 → decision-d2 only tainted f1 and the
  decisions citing f1; f2 and d2 stayed VALID even though they rest on stale
  ground. The propagation is now a fixpoint over both tainted evidence and
  tainted findings, so a citation chain of any depth is followed, and the
  result is independent of the order findings appear in the state.
- Each tainted finding's detail names what it rests on ("changed evidence:
  ..." / "stale finding: ..."), chained with `; ` when a finding cites several
  tainted things.

Fixes #739

## Testing

- `test_staleness_cascades_along_finding_to_finding_citations`: the
  reproduction from the issue; the whole citation chain now lands in STALE,
  including the decision two hops from the changed evidence.
- `test_finding_citation_cascade_is_independent_of_list_order`: same state
  with the findings list reversed produces the same verdicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
