### PR TITLE
fix(state): diff constraint pins so add/retract is never no semantic change

### DIFF
--- a/src/continuum/models.py
+++ b/src/continuum/models.py
@@ -144,6 +144,7 @@ class Component(StrEnum):
     MODEL = "model"
     APPROVAL = "approval"
     ENVIRONMENT = "environment"
+    PIN = "pin"
 
 
 class DiffKind(StrEnum):

--- a/src/continuum/state/diff.py
+++ b/src/continuum/state/diff.py
@@ -203,6 +203,18 @@ def diff_states(before: SemanticState, after: SemanticState) -> StateDiff:
         describe=lambda d: f"{d.resource} {d.version or ''}".strip(),
         fields=("version", "checksum", "status", "kind"),
     )
+    # Pins are first-class state (issue #417): the active constraint set a
+    # resuming agent must honour. The semantic diff predates them, so a pin
+    # added or retracted between two states used to yield an empty diff and
+    # `continuum diff` reported "no semantic change" (issue #740).
+    entries += _compare_collection(
+        list(before.pins.values()),
+        list(after.pins.values()),
+        component=Component.PIN,
+        key=lambda p: p.constraint_id,
+        describe=lambda p: f"{p.constraint_id} {p.sha256[:12]}",
+        fields=("sha256", "status", "pinned_at"),
+    )
 
     before_model = before.model.model if before.model else None
     after_model = after.model.model if after.model else None

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -4,6 +4,7 @@ import pytest
 
 from continuum.models import (
     Component,
+    ConstraintPin,
     Decision,
     DiffKind,
     Evidence,
@@ -13,6 +14,7 @@ from continuum.models import (
     ModelState,
     PendingWork,
     Progress,
+    Provenance,
     SemanticState,
     StateStatus,
 )
@@ -53,6 +55,43 @@ def test_added_and_removed_components_are_reported() -> None:
     after = make_state(findings=[Finding(finding_id="f81", claim="new")])
     diff = diff_states(before, after)
     assert kinds(diff, Component.FINDING) == {DiffKind.ADDED, DiffKind.REMOVED}
+
+
+def test_pin_add_and_retract_are_reported() -> None:
+    """Pins are the active constraint set a resuming agent must honour.
+
+    The diff predates pins, so adding or retracting one used to yield an empty
+    diff and `continuum diff` said "no semantic change" (issue #740).
+    """
+    pin = ConstraintPin(
+        constraint_id="c1", sha256="a" * 64, status="active", provenance=Provenance()
+    )
+    added = diff_states(make_state(), make_state(pins={"c1": pin}))
+    assert kinds(added, Component.PIN) == {DiffKind.ADDED}
+
+    retracted = diff_states(make_state(pins={"c1": pin}), make_state())
+    assert kinds(retracted, Component.PIN) == {DiffKind.REMOVED}
+
+
+def test_a_pin_whose_digest_changes_is_reported() -> None:
+    """Same label, different constraint text: the digest is the identity."""
+    before = make_state(
+        pins={"c1": ConstraintPin(constraint_id="c1", sha256="a" * 64, provenance=Provenance())}
+    )
+    after = make_state(
+        pins={"c1": ConstraintPin(constraint_id="c1", sha256="b" * 64, provenance=Provenance())}
+    )
+    diff = diff_states(before, after)
+    assert kinds(diff, Component.PIN) == {DiffKind.CHANGED}
+
+
+def test_unchanged_pins_produce_no_entries() -> None:
+    pin = ConstraintPin(
+        constraint_id="c1", sha256="a" * 64, status="active", provenance=Provenance()
+    )
+    before = make_state(pins={"c1": pin})
+    after = make_state(pins={"c1": pin})
+    assert diff_states(before, after).entries == []
 
 
 def test_invalidation_is_distinguished_from_an_ordinary_change() -> None:


### PR DESCRIPTION
## Summary

- Constraint pins (#417) live on `SemanticState.pins`, but `diff_states`
  compared every other collection and never pins. A pin could be added,
  retracted, or re-pinned against a different digest with the diff reporting
  "No semantic change", so a checkpoint restore or contract review could not
  see that the constraint the run promised to honour had moved.
- Pins are now diffed like every other collection via `_compare_collection`,
  keyed by `constraint_id`, comparing `sha256`, `status` and `pinned_at`,
  under a new `Component.PIN` value so entries are labelled distinctly in the
  rendered diff.

Fixes #740

## Testing

- `test_pin_add_and_retract_are_reported`
- `test_a_pin_whose_digest_changes_is_reported`
- `test_unchanged_pins_produce_no_entries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Bug fixes:**
    - Count archived attempts so the retry budget survives compaction in `src/continuum/...`
    - Guard `fail()` against statuses that are not in flight in `src/continuum/...`

<sub>This will update automatically on new commits.</sub>