### PR TITLE
fix(cli): resume exits REQUIRES_HUMAN for a family-blocked parent

### DIFF
--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -1225,7 +1225,16 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
     text = decision.render()
     if family_blocked and decision.mode.value == "resume":
         # House rule: the most cautious signal wins (#243). A clean parent
-        # with an unsafe child is presented as request_human.
+        # with an unsafe child is presented as request_human on every surface:
+        # this text, the JSON payload and the exit code. The engine's per-run
+        # verdict stays visible in the rationale, but it must not read as
+        # permission to continue (issue #741).
+        text = text.replace(
+            "Recovery decision: RESUME", "Recovery decision: REQUEST_HUMAN"
+        ).replace(
+            "Next permitted action: continue",
+            "Next permitted action: none (settle the children below first)",
+        )
         text += "\n\nFAMILY BLOCKED: children of this run are not resumable.\n" + "\n".join(
             f"  !! {r}" for r in family_rationale
         )
@@ -1259,12 +1268,18 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             print(f"error: --pinning: {exc}", file=err)
             return ExitCode.ERROR
 
-    presented_mode = (
-        "request_human"
-        if (family_blocked and decision.mode.value == "resume")
-        else decision.mode.value
+    # The same house rule, as a mode: what the exit code and the JSON report.
+    # Following the engine's per-run mode here let `resume "$PARENT" &&
+    # ./start-agent.sh` exit 0 onto a family holding an unreconciled side
+    # effect, breaking the only-a-verified-safe-run-exits-0 contract
+    # (issue #741).
+    effective_mode = (
+        RecoveryMode.REQUEST_HUMAN
+        if (family_blocked and decision.mode is RecoveryMode.RESUME)
+        else decision.mode
     )
-    presented_safe = decision.safe and not (family_blocked and decision.mode.value == "resume")
+    presented_mode = effective_mode.value
+    presented_safe = decision.safe and effective_mode is decision.mode
     # Advisory prefix-trust (issue #401): deterministic, read-only, never gates.
     try:
         from continuum.analysis.prefix_trust import trust_over_prefix
@@ -1311,7 +1326,7 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
         palette=getattr(args, "_palette", None),
     )
 
-    if decision.mode is not RecoveryMode.RESUME and not args.repair:
+    if effective_mode is not RecoveryMode.RESUME and not args.repair:
         print(
             "\nRun with --repair to record the repair plan, or resolve the items above first.",
             file=err,
@@ -1339,7 +1354,7 @@ def cmd_resume(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -
             file=err,
         )
 
-    return exit_code_for(decision.mode)
+    return exit_code_for(effective_mode)
 
 
 def cmd_confirm(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:

--- a/tests/test_family.py
+++ b/tests/test_family.py
@@ -175,6 +175,38 @@ def test_uncertain_child_blocks_the_parent_resume(db: str) -> None:
     assert payload["safe"] is True
 
 
+def test_a_family_blocked_parent_never_exits_zero(db: str) -> None:
+    """The exit-code contract: only a verified safe-to-resume run exits 0.
+
+    A clean parent with an unsafe child presented request_human in the JSON
+    but still exited 0, so `resume "$PARENT" && ./start-agent.sh` launched an
+    agent onto a family holding an unreconciled side effect (issue #741).
+    """
+    run("--db", db, "start", "par", "--goal", "supervise")
+    run("--db", db, "start", "kid", "--goal", "work", "--parent", "par")
+    ActionLedger(SQLiteStorage(db), "kid").claim("send_invoice", {}, key="invoice:I-9")
+
+    code, out, err = run("--db", db, "--json", "resume", "par")
+    payload = json.loads(out)
+    assert payload["mode"] == "request_human"
+    assert payload["safe"] is False
+    assert code == ExitCode.REQUIRES_HUMAN, err
+
+    # Text mode agrees: the decision line and permitted action follow the
+    # family overlay, not the parent's own per-run verdict.
+    code, out, _ = run("--db", db, "resume", "par")
+    assert code == ExitCode.REQUIRES_HUMAN
+    assert "Recovery decision: REQUEST_HUMAN" in out
+    assert "FAMILY BLOCKED" in out
+    assert "Next permitted action: continue" not in out
+
+    # Settling the child restores the zero exit.
+    key = idempotency_key("send_invoice", None, scope="kid", key="invoice:I-9")
+    ActionLedger(SQLiteStorage(db), "kid").reconcile(str(key), occurred=True)
+    code, _, _ = run("--db", db, "--json", "resume", "par")
+    assert code == ExitCode.OK
+
+
 def test_clean_children_do_not_block_the_parent(db: str) -> None:
     run("--db", db, "start", "par", "--goal", "supervise")
     code, out, _ = run("--db", db, "--json", "resume", "par")


### PR DESCRIPTION
## Summary

- `cmd_resume` rolled the family verdict into the JSON payload (`mode:
  request_human`, `safe: false`) but still printed the parent's own per-run
  verdict in text mode and still exited 0, because `exit_code_for` was fed
  `decision.mode` rather than the family-overlay result. A script doing
  `resume "$PARENT" && ./start-agent.sh` would launch an agent onto a family
  holding an unreconciled side effect.
- The family overlay is now applied before anything is presented: the
  effective mode drives the text-mode decision line, the permitted-action
  line (family-blocked runs say "none (settle the children below first)"
  instead of "continue"), the `--repair` hint and the exit code. Text mode
  keeps showing the parent's own verdict alongside a FAMILY BLOCKED section,
  but the decision line and exit code follow the family. Only a fully
  verified, safe-to-resume run exits 0, per the exit-code contract in
  exitcodes.py.

Fixes #741

## Testing

- `test_a_family_blocked_parent_never_exits_zero`: JSON mode asserts
  `REQUIRES_HUMAN` (not 0), text mode asserts the REQUEST_HUMAN decision line
  and the absence of "Next permitted action: continue", and reconciling the
  child restores the zero exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Family-blocked runs now clearly report `REQUEST_HUMAN` instead of indicating they can resume.
  - Resume commands no longer exit successfully when unresolved child actions remain.
  - Text output now identifies blocked families and removes the misleading “continue” action.
  - After child actions are reconciled, resume behavior returns to a successful status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->