### PR TITLE
docs: link pre-commit hooks in onboarding guide

### DIFF
--- a/docs/CONTRIBUTING_ONBOARDING.md
+++ b/docs/CONTRIBUTING_ONBOARDING.md
@@ -26,6 +26,7 @@ Welcome. This guide gets you from clone to green tests without re-deriving conte
 
 Install once with `uv sync --extra dev` (or `pip install -e ".[dev]"`).
 
+- Recommended: install the [pre-commit hooks](../CONTRIBUTING.md#pre-commit-hooks-optional-but-recommended) before committing.
 - Run all tests: `uv run pytest` or `pytest -q`. Expect `~2,030 passed, ~23 skipped`
   on main at this writing (`~2,122` collected).
   <!-- generated via: pytest --collect-only -q; pytest -q -->


### PR DESCRIPTION
## Description

Adds one bullet to the contributor onboarding guide that links to the repository's recommended pre-commit hook setup. This helps newcomers discover the local checks before opening a pull request.

## Related issues

Fixes #756

## Types of changes

- Type: `docs`

## Breaking changes

No.

## How has this been tested?

Windows 11, Git Bash, Python 3.13:

- `npx --yes markdownlint-cli2@0.20.0 --config .markdownlint-cli2.jsonc docs/CONTRIBUTING_ONBOARDING.md` (0 errors)
- `.venv/Scripts/pre-commit.exe run --files docs/CONTRIBUTING_ONBOARDING.md` (both ruff hooks skipped because the documentation file is outside their configured file scope)
- `git diff --check upstream/main...HEAD` (passed)
- Verified with Python that the relative link resolves to `CONTRIBUTING.md` and its fragment matches the `Pre-commit hooks (optional but recommended)` heading.

Runtime tests were not run because this is a one-line documentation-only change. The original content change passed the full GitHub Actions matrix before the commit was rebased and reworded.

## Checklist

No tests were added because runtime behaviour is unchanged. Documentation is updated for the contributor-facing change. Fresh CI results will be required on the revised commit. This change is not security-relevant.

## Additional context

The branch contains only the requested one-line documentation addition. It is rebased onto the latest `main`; the commit was reworded in response to the maintainer review.
