### PR TITLE
feat(tui): full-screen terminal dashboard for monitoring and control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -583,7 +583,7 @@ All notable changes to this project are documented here. The format follows
   Framework Integration documents the CrewAI/AutoGen/Pydantic-AI thin hooks
   and the gateway/OTel fallback seams; the Roadmap marks the dashboard and
   the enforced-durability work complete; test counts are current
-  (~2,053 collected, ~2,030 passed, ~23 skipped on a minimal env).
+  (~2,089 collected, ~2,030 passed, ~23 skipped on a minimal env).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
 
 - **Gateway hardening and docs refresh.** The enforcing proxy now refuses

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Verify:
 ```bash
 continuum --help                 # CLI entrypoint
 continuum-mcp --help             # MCP server entrypoint (needs [mcp] or [dev])
-pytest -q                        # ~2,053 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
+pytest -q                        # ~2,089 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
 ruff check src/ tests/ examples/ && ruff format --check src/ tests/ examples/
 mypy src/continuum               # the three gates CI enforces
 ```
@@ -232,7 +232,7 @@ CONTINUUM is verified against real LLM agents, live protocol boundaries, and har
 - **Third-party clients**: Gemini CLI and Kilo Code connected over stdio JSON-RPC against the live SQLite store, validating multi-agent co-existence and authorization isolation.
 - **Protocol compliance**: driven end to end with `@modelcontextprotocol/inspector --cli` across process deaths; mutating tools deny by default behind `CONTINUUM_MCP_MUTATING_CLIENTS`; external claims degrade to `REQUIRES_REVIEW` (`safe: false`).
 - **Self-healing**: hard-killed servers recover from orphaned SQLite `-wal`/`-shm` sidecars via single-retry cleanup at startup.
-- **Scale**: roughly 2,053 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
+- **Scale**: roughly 2,089 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
 - **Adversarial audit**: the full MCP surface was audited over the live protocol; three defects were found and fixed. Method and reproduction steps in [test.md](test.md).
 
 ## MCP Integration
@@ -398,7 +398,7 @@ Schema v6. SQLite is primary, Postgres is CI verified. One log, many projections
 
 ### Module map — one library, many surfaces
 
-CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~2,053 tests). All modules append to and replay one hash chained event log:
+CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~2,089 tests). All modules append to and replay one hash chained event log:
 
 | Module | Role |
 |:--|:--|

--- a/docs/CONTRIBUTING_ONBOARDING.md
+++ b/docs/CONTRIBUTING_ONBOARDING.md
@@ -27,7 +27,7 @@ Welcome. This guide gets you from clone to green tests without re-deriving conte
 Install once with `uv sync --extra dev` (or `pip install -e ".[dev]"`).
 
 - Run all tests: `uv run pytest` or `pytest -q`. Expect `~2,030 passed, ~23 skipped`
-  on main at this writing (`~2,053` collected).
+  on main at this writing (`~2,089` collected).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
   Skips are environmental (Postgres without `CONTINUUM_TEST_POSTGRES_DSN`, adapter tests without `langgraph` or `openai-agents`).
 - Run a single area: `uv run pytest tests/test_checkpoint_phase4.py -v`

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -4,6 +4,12 @@ The `continuum` command is the command-line surface, also usable in scripts. Exi
 codes are a safety contract: only a verified-safe run exits `0`, so
 `continuum resume "$RUN" && ./start-agent.sh` cannot launch onto stale state.
 
+Typing bare `continuum` at an interactive terminal opens the full-screen
+dashboard on its landing splash (issue #782); piped or non-terminal output,
+`--json`, and platforms without curses print the help text instead, so scripts
+that run `continuum` blind never find a curses screen where they expected
+usage text.
+
 ```bash
 continuum <command> [args]                    # storage defaults to ./continuum.db
 continuum --db <url-or-path> <command>        # storage URL or path (default: continuum.db)

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -47,6 +47,7 @@ continuum --json <command>                    # machine-readable output
 | `attest-verify <run_id> --attest <file>` | Verify a signed attestation against the live chain. |
 | `serve` | Run the Tier 0 newline-delimited JSON sidecar (no MCP dependency). |
 | `dashboard` | Serve the dashboard (presentation over run data). |
+| `tui [--refresh <seconds>]` | Full-screen terminal dashboard: monitor and control runs, read-only until an action is confirmed (`q` quits). |
 | `export-evidence` | Export evidence as content-addressed JSON lines. Read-only. |
 | `forget` | Enumerate and tombstone memory records for a tenant. Mutates unless --dry-run. |
 | `health` | Advisory prefix-trust health check. Read-only. |

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -4010,6 +4010,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="bind address (default: 127.0.0.1; 0.0.0.0 exposes recovery data).",
     )
 
+    def cmd_tui(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+        """Open the full-screen terminal dashboard (issue #782), q quits.
+
+        Read-only until an action is confirmed: browsing and refreshing never
+        write, and every mutating verb shows its exact write in the footer and
+        waits for a further y before performing it. Refuses rather than
+        half-rendering when curses is unavailable or stdout is not a TTY.
+        """
+        from continuum.tui import run_tui
+
+        return run_tui(storage, refresh_seconds=args.refresh, err=err)
+
+    tui = add(
+        "tui",
+        cmd_tui,
+        "Full-screen terminal dashboard: monitor and control runs (q quits).",
+    )
+    tui.add_argument(
+        "--refresh",
+        type=float,
+        default=0.0,
+        help="auto-refresh interval in seconds (default: 0, refresh on demand with r).",
+    )
+
     watch = with_run(
         add("watch", cmd_watch, "Watch a run for liveness breach, optionally notify via webhook.")
     )

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -4065,6 +4065,48 @@ def build_parser() -> argparse.ArgumentParser:
 # --------------------------------------------------------------------------- #
 
 
+def _bare_invocation(
+    parser: argparse.ArgumentParser, args: argparse.Namespace, out: Any, err: Any
+) -> int:
+    """`continuum` with no subcommand: open the TUI, or print help.
+
+    The interactive path is what an operator typing bare `continuum` at a
+    shell expects (issue #782): the full-screen dashboard with its landing
+    splash. Piped output, `--json` and platforms without curses keep the
+    help text unchanged: a script that runs `continuum` blind must never
+    find a curses screen where it expected usage text.
+    """
+    interactive = not args.json and _stream_is_a_tty(out) and _curses_available()
+    if not interactive:
+        parser.print_help(file=out)
+        return ExitCode.OK
+    from continuum.tui import run_tui
+
+    try:
+        storage = open_storage(args.db)
+    except (StorageError, ValueError, NotImplementedError, RuntimeError) as exc:
+        print(f"error: {exc}", file=err)
+        return ExitCode.ERROR
+    except sqlite3.Error as exc:
+        print(f"error: cannot open storage at '{args.db}': {exc}", file=err)
+        return ExitCode.ERROR
+    try:
+        return run_tui(storage, err=err)
+    finally:
+        storage.close()
+
+
+def _stream_is_a_tty(out: Any) -> bool:
+    isatty = getattr(out, "isatty", None)
+    return callable(isatty) and bool(isatty())
+
+
+def _curses_available() -> bool:
+    from importlib.util import find_spec
+
+    return find_spec("curses") is not None
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
@@ -4085,8 +4127,7 @@ def main(
         Palette(False) if args.json else Palette.for_stream(out, force=getattr(args, "color", None))
     )
     if getattr(args, "func", None) is None:
-        parser.print_help(file=out)
-        return ExitCode.OK
+        return _bare_invocation(parser, args, out, err)
 
     # hooks never touches a run, so it must not create an empty database as a
     # side effect of editing a settings file.

--- a/src/continuum/tui/__init__.py
+++ b/src/continuum/tui/__init__.py
@@ -1,0 +1,13 @@
+"""Full-screen terminal dashboard (issue #782).
+
+A presentation layer over the same Storage, CheckpointManager and
+RecoveryEngine the CLI and the web dashboard use, built on the standard
+library curses module so the dependency-free rule for the CLI holds here
+too. :mod:`continuum.tui.model` is the pure, testable view model;
+:mod:`continuum.tui.app` holds the key-driven state machine and the thin
+curses driver.
+"""
+
+from continuum.tui.app import TuiApp, run_tui
+
+__all__ = ["TuiApp", "run_tui"]

--- a/src/continuum/tui/app.py
+++ b/src/continuum/tui/app.py
@@ -1,0 +1,468 @@
+"""The ``continuum tui`` driver: a full-screen terminal dashboard (issue #782).
+
+Two layers, deliberately separated:
+
+- :class:`TuiApp` is a pure state machine. Keys arrive as plain names
+  (``"up"``, ``"enter"``, ``"y"``) and rendering is a list of strings, so
+  every flow is testable without a terminal.
+- :func:`run_tui` is a thin curses driver that maps real key codes onto those
+  names and draws the lines. It contains no decisions of its own.
+
+House style: read-only until an action is confirmed. Every mutating verb
+lands in ``pending`` first, the footer shows exactly what will happen, and
+only a further ``y`` performs the write. Anything else cancels.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from collections.abc import Callable
+from typing import Any
+
+from continuum.cli.exitcodes import ExitCode
+from continuum.storage.base import Storage
+from continuum.tui import model
+from continuum.tui.model import RunRow
+
+__all__ = ["TuiApp", "run_tui"]
+
+
+class TuiApp:
+    """State machine for the terminal dashboard.
+
+    The view is two-level: a runs index, then one run's detail with tabs
+    (overview, recovery, checkpoints, actions, events, family, budget).
+    Table tabs carry a selectable cursor; text tabs only scroll.
+    """
+
+    TABS = ("overview", "recovery", "checkpoints", "actions", "events", "family", "budget")
+    _TABLE_TABS = frozenset({"checkpoints", "actions", "events", "budget"})
+
+    def __init__(self, storage: Storage) -> None:
+        self.storage = storage
+        self.view = "runs"
+        self.tab = 0
+        self.index = 0  # selection in the runs index
+        self.cursor = -1  # selected body line in a table tab, -1 when none
+        self.scroll = 0
+        self.rows: list[RunRow] = []
+        self.lines: list[str] = []
+        self.pending: tuple[str, Callable[[], str]] | None = None
+        self.message = ""
+        self.show_help = False
+        self.refresh()
+
+    # ------------------------------------------------------------------ #
+    # data
+    # ------------------------------------------------------------------ #
+
+    def refresh(self) -> None:
+        """Reload the current view's data from storage. Read-only."""
+        if self.view == "runs":
+            self.rows = model.run_rows(self.storage)
+            self.cursor = -1  # the runs list marks its selection itself
+            if self.rows:
+                self.index = min(self.index, len(self.rows) - 1)
+        else:
+            self._refresh_detail()
+
+    def _run_id(self) -> str | None:
+        if 0 <= self.index < len(self.rows):
+            return self.rows[self.index].run_id
+        return None
+
+    def _refresh_detail(self) -> None:
+        run_id = self._run_id()
+        if run_id is None:
+            self.lines = ["No run selected. Press esc to go back to the runs list."]
+            self.cursor = -1
+            return
+        tab = self.TABS[self.tab]
+        self.cursor = -1
+        rows: list[Any]  # one of the model's table row types, per tab
+        if tab == "overview":
+            self.lines = model.overview_lines(self.storage, run_id)
+        elif tab == "recovery":
+            self.lines = model.recovery_lines(self.storage, run_id)
+        elif tab == "checkpoints":
+            rows = model.checkpoint_rows(self.storage, run_id)
+            self.lines = [f"{'CHECKPOINT':<12} {'VERSION':<9} {'TRIGGER':<10} COMPLETED"]
+            self.lines += [
+                f"{r.checkpoint_id[:10]:<12} v{r.version:<8} {r.trigger:<10} {r.completed}"
+                for r in rows
+            ] or ["No checkpoints recorded. Press c to force one."]
+            self.cursor = 1 if len(self.lines) > 1 else -1
+        elif tab == "actions":
+            rows = model.action_rows(self.storage, run_id)
+            self.lines = [f"{'STATUS':<16} {'TYPE':<24} {'EXTERNAL ID':<20} KEY"]
+            self.lines += [
+                (
+                    f"{'(!)' if r.uncertain else '   '} {r.status:<12} {r.action_type:<24} "
+                    f"{r.external_id[:18]:<20} {r.key[:24]}"
+                )
+                for r in rows
+            ] or ["No actions recorded."]
+            self.cursor = 1 if len(self.lines) > 1 else -1
+        elif tab == "events":
+            rows = model.event_rows(self.storage, run_id)
+            self.lines = [f"{'SEQ':>5}  {'TYPE':<26} PAYLOAD"]
+            self.lines += [f"{r.sequence:>5}  {r.type:<26} {r.summary}" for r in rows] or [
+                "No events."
+            ]
+            self.cursor = 1 if len(self.lines) > 1 else -1
+        elif tab == "family":
+            self.lines = model.family_lines(self.storage, run_id)
+        elif tab == "budget":
+            rows = model.budget_rows(self.storage, run_id)
+            self.lines = [f"{'ACTION TYPE':<28} {'ATTEMPTS':>8} {'MAX':>4} {'REMAINING':>10}"]
+            self.lines += [
+                f"{r.action_type:<28} {r.attempts:>8} {r.max_attempts:>4} {r.remaining:>10}"
+                for r in rows
+            ] or ["No budgets configured."]
+            self.cursor = 1 if len(self.lines) > 1 else -1
+        if self.scroll > max(0, len(self.lines) - 1):
+            self.scroll = 0
+
+    def _selected_action(self) -> model.ActionRow | None:
+        """The action row under the cursor, on the actions tab only."""
+        if self.view != "detail" or self.TABS[self.tab] != "actions" or self.cursor < 1:
+            return None
+        rows = model.action_rows(self.storage, self._run_id() or "")
+        offset = self.cursor - 1
+        if 0 <= offset < len(rows):
+            return rows[offset]
+        return None
+
+    # ------------------------------------------------------------------ #
+    # rendering
+    # ------------------------------------------------------------------ #
+
+    def header(self) -> str:
+        """The top line: where we are and what view is active."""
+        if self.view == "runs":
+            return "CONTINUUM  runs  (enter: open, r: refresh, ?: help, q: quit)"
+        run_id = self._run_id() or "-"
+        tab = self.TABS[self.tab]
+        return (
+            f"CONTINUUM  run {run_id}  "
+            f"[{self.tab + 1}/{len(self.TABS)} {tab}]  "
+            "(left/right or 1-7: tabs, esc: runs, r: refresh, q: quit)"
+        )
+
+    def body_lines(self) -> list[str]:
+        """The body: the help overlay when asked for, the view otherwise."""
+        if self.show_help:
+            return list(_HELP_LINES)
+        if self.view == "runs":
+            if not self.rows:
+                return ['No runs recorded. Start one with: continuum start <id> --goal "..."']
+            lines = [f"{'RUN':<20} {'STATUS':<10} {'EVT':>5}  {'MODE':<14} {'SAFE':<7} GOAL"]
+            for i, row in enumerate(self.rows):
+                marker = ">" if i == self.index else " "
+                lines.append(
+                    f"{marker} {row.run_id:<19} {row.status:<10} {row.events:>5}  "
+                    f"{row.mode:<14} {row.safe:<7} {row.goal}"
+                )
+            return lines
+        marked = []
+        for i, line in enumerate(self.lines):
+            if self.cursor >= 0:
+                marked.append(("> " if i == self.cursor else "  ") + line)
+            else:
+                marked.append(line)
+        return marked
+
+    def footer(self) -> str:
+        """The bottom line: a pending confirmation outranks everything, and a
+        result message outranks the key hints. The hints are the longest text
+        here, so on an 80-column terminal they would otherwise clip the one
+        line the operator most needs to read."""
+        if self.pending is not None:
+            return f"{self.pending[0]}  [y = do it, anything else = cancel]"
+        if self.message:
+            return self.message
+        if self.show_help:
+            return "? hides help"
+        if self.view == "runs":
+            return "runs: enter open | r refresh | c checkpoint | x complete | y confirm"
+        return "1-7 tabs | esc back | y/n reconcile (actions tab) | c checkpoint | x complete"
+
+    # ------------------------------------------------------------------ #
+    # keys
+    # ------------------------------------------------------------------ #
+
+    def handle_key(self, key: str) -> bool:
+        """Apply one key. Returns False when the app should quit."""
+        if self.pending is not None:
+            self._resolve_pending(key)
+            return True
+        if key == "q":
+            return False
+        if key == "?":
+            self.show_help = not self.show_help
+            return True
+        if key == "r":
+            self.refresh()
+            return True
+        if self.show_help:
+            return True  # any other key just leaves help on screen
+
+        if self.view == "runs":
+            return self._handle_runs_key(key)
+        return self._handle_detail_key(key)
+
+    def _resolve_pending(self, key: str) -> None:
+        assert self.pending is not None
+        prompt, action = self.pending
+        if key == "y":
+            try:
+                self.message = action()
+            except Exception as exc:
+                self.message = f"error: {exc}"
+        else:
+            self.message = f"cancelled: {prompt.split('?')[0].strip()}"
+        self.pending = None
+        self.refresh()
+
+    def _handle_runs_key(self, key: str) -> bool:
+        if key in ("up", "k") and self.rows:
+            self.index = (self.index - 1) % len(self.rows)
+        elif key in ("down", "j") and self.rows:
+            self.index = (self.index + 1) % len(self.rows)
+        elif key in ("enter", "o", "right") and self.rows:
+            self.view = "detail"
+            self.tab = 0
+            self.scroll = 0
+            self.message = ""
+            self._refresh_detail()
+        elif key == "c":
+            self._queue_checkpoint()
+        elif key == "x":
+            self._queue_complete()
+        elif key == "y":
+            self._queue_confirm()
+        return True
+
+    def _handle_detail_key(self, key: str) -> bool:
+        tab = self.TABS[self.tab]
+        if key == "esc" or (key == "left" and tab == "overview"):
+            self.view = "runs"
+            self.scroll = 0
+            self.message = ""
+            self.refresh()
+        elif key in ("left", "h"):
+            self.tab = (self.tab - 1) % len(self.TABS)
+            self.scroll = 0
+            self._refresh_detail()
+        elif key in ("right", "l"):
+            self.tab = (self.tab + 1) % len(self.TABS)
+            self.scroll = 0
+            self._refresh_detail()
+        elif key.isdigit() and 1 <= int(key) <= len(self.TABS):
+            self.tab = int(key) - 1
+            self.scroll = 0
+            self._refresh_detail()
+        elif key in ("up", "k"):
+            self._move_selection(-1)
+        elif key in ("down", "j"):
+            self._move_selection(1)
+        elif key == "c":
+            self._queue_checkpoint()
+        elif key == "x":
+            self._queue_complete()
+        elif key == "y":
+            if tab == "actions":
+                self._queue_reconcile(occurred=True)
+            else:
+                self._queue_confirm()
+        elif key == "n":
+            if tab == "actions":
+                self._queue_reconcile(occurred=False)
+        return True
+
+    def _move_selection(self, delta: int) -> None:
+        """Move the cursor in table tabs, the scroll in text tabs."""
+        if self.cursor >= 0:
+            self.cursor = max(1, min(len(self.lines) - 1, self.cursor + delta))
+        else:
+            self.scroll = max(0, min(max(0, len(self.lines) - 1), self.scroll + delta))
+
+    def _queue_checkpoint(self) -> None:
+        run_id = self._run_id()
+        if run_id is None:
+            self.message = "no run selected"
+            return
+        self.pending = (
+            f"force a checkpoint on run {run_id} now?",
+            lambda: model.force_checkpoint(self.storage, run_id),
+        )
+
+    def _queue_complete(self) -> None:
+        run_id = self._run_id()
+        if run_id is None:
+            self.message = "no run selected"
+            return
+        self.pending = (
+            f"close run {run_id} as completed? (REVIEW_CONFIRMED + RUN_COMPLETED)",
+            lambda: model.complete_run(self.storage, run_id),
+        )
+
+    def _queue_confirm(self) -> None:
+        run_id = self._run_id()
+        if run_id is None:
+            self.message = "no run selected"
+            return
+        self.pending = (
+            f"confirm the self-reported goal and progress of run {run_id}? (REVIEW_CONFIRMED)",
+            lambda: model.confirm_state(self.storage, run_id),
+        )
+
+    def _queue_reconcile(self, *, occurred: bool) -> None:
+        run_id = self._run_id()
+        row = self._selected_action()
+        if run_id is None or row is None:
+            self.message = "select an action row first (cursor is on the actions list)"
+            return
+        if not row.uncertain:
+            self.message = f"{row.key[:24]} is {row.status}; only uncertain actions can be settled"
+            return
+        self.pending = (
+            f"settle {row.action_type} on run {run_id} as "
+            f"{'OCCURRED' if occurred else 'NOT OCCURRED'}? (ACTION_RECONCILED)",
+            lambda: model.reconcile_action(self.storage, run_id, row.key, occurred=occurred),
+        )
+
+
+_HELP_LINES = [
+    "CONTINUUM tui keys",
+    "",
+    "  q            quit                     r        refresh the view",
+    "  ?            toggle this help",
+    "",
+    "  runs list:   up/down or j/k move      enter/o  open the run",
+    "               y confirm state          c        force a checkpoint",
+    "               x complete the run",
+    "",
+    "  run detail:  left/right or 1-7 tabs   esc      back to the runs list",
+    "               up/down move or scroll   y        confirm state",
+    "               c force a checkpoint     x        complete the run",
+    "  actions tab: y settle as occurred     n        settle as not occurred",
+    "",
+    "  Every mutating key asks first: the footer shows the exact write and",
+    "  only a further y performs it. Anything else cancels. Reads never",
+    "  write: refreshing and browsing are always safe on a live run.",
+]
+
+
+# --------------------------------------------------------------------------- #
+# curses driver
+# --------------------------------------------------------------------------- #
+
+
+def _key_name(curses: Any, ch: int) -> str | None:
+    """Map one curses key code to the plain name TuiApp understands."""
+    special = {
+        curses.KEY_UP: "up",
+        curses.KEY_DOWN: "down",
+        curses.KEY_LEFT: "left",
+        curses.KEY_RIGHT: "right",
+        curses.KEY_ENTER: "enter",
+        curses.KEY_RESIZE: "resize",
+        curses.KEY_BACKSPACE: "esc",
+        10: "enter",
+        13: "enter",
+        27: "esc",
+    }
+    if ch in special:
+        return special[ch]
+    if 0 < ch < 256:
+        return chr(ch)
+    return None
+
+
+def _addline(screen: Any, y: int, x: int, text: str, attr: int = 0) -> None:
+    """Write one line, clipping to the screen. The bottom-right cell raises
+    on a full write, so failures are swallowed: a clipped dashboard beats a
+    dead one."""
+    with contextlib.suppress(Exception):
+        screen.addnstr(y, x, text, screen.getmaxyx()[1] - x - 1, attr)
+
+
+def _driver(curses: Any, screen: Any, app: TuiApp, refresh_seconds: float) -> int:
+    """Draw, wait for one key, repeat. Auto-refresh ticks arrive as -1."""
+    screen.keypad(True)
+    # terminals without a cursor control still render fine
+    with contextlib.suppress(Exception):
+        curses.curs_set(0)
+    screen.timeout(int(refresh_seconds * 1000) if refresh_seconds > 0 else -1)
+
+    while True:
+        screen.erase()
+        height, width = screen.getmaxyx()
+        _addline(screen, 0, 0, app.header(), curses.A_BOLD)
+        body = app.body_lines()
+        available = max(1, height - 3)
+        if app.cursor >= 0:  # keep the selected line inside the window
+            if app.cursor < app.scroll:
+                app.scroll = app.cursor
+            if app.cursor >= app.scroll + available:
+                app.scroll = app.cursor - available + 1
+        start = min(app.scroll, max(0, len(body) - available))
+        for row, line in enumerate(body[start : start + available], start=start):
+            attr = curses.A_REVERSE if row == app.cursor else 0
+            _addline(screen, row - start + 2, 0, line, attr)
+        _addline(screen, height - 1, 0, app.footer())
+        screen.refresh()
+
+        ch = screen.getch()
+        if ch == -1:  # refresh tick (or no key yet on a nonblocking screen)
+            app.refresh()
+            continue
+        key = _key_name(curses, ch)
+        if key is None:
+            continue
+        if not app.handle_key(key):
+            return ExitCode.OK
+
+
+def run_tui(storage: Storage, *, refresh_seconds: float = 0.0, err: Any = None) -> int:
+    """Open the full-screen dashboard; returns a process exit status.
+
+    Refuses rather than half-rendering when curses is unavailable or stdout
+    is not a terminal: the recovery data on screen deserves a whole screen,
+    and a mangled scrape of one is worse than a clear refusal pointing at
+    ``continuum dashboard``.
+    """
+    err = err if err is not None else sys.stderr
+    try:
+        import curses
+    except ImportError:
+        print(
+            "error: the curses module is not available on this platform; "
+            "use `continuum dashboard` for the browser dashboard",
+            file=err,
+        )
+        return ExitCode.ERROR
+    if not sys.stdout.isatty():
+        print(
+            "error: continuum tui needs an interactive terminal; stdout is not a TTY",
+            file=err,
+        )
+        return ExitCode.ERROR
+    try:
+        return _run(curses, storage, refresh_seconds)
+    except curses.error as exc:  # a terminal too small or too alien for curses
+        print("error: this terminal cannot run the tui:", exc, file=err)
+        print("use `continuum dashboard` for the browser dashboard", file=err)
+        return ExitCode.ERROR
+
+
+def _run(curses: Any, storage: Storage, refresh_seconds: float) -> int:
+    """Enter curses mode; the wrapper restores the terminal on the way out."""
+
+    def inner(screen: Any) -> int:
+        return _driver(curses, screen, TuiApp(storage), refresh_seconds)
+
+    result: int = curses.wrapper(inner)
+    return result

--- a/src/continuum/tui/app.py
+++ b/src/continuum/tui/app.py
@@ -20,6 +20,7 @@ import sys
 from collections.abc import Callable
 from typing import Any
 
+from continuum import __version__
 from continuum.cli.exitcodes import ExitCode
 from continuum.storage.base import Storage
 from continuum.tui import model
@@ -27,13 +28,27 @@ from continuum.tui.model import RunRow
 
 __all__ = ["TuiApp", "run_tui"]
 
+#: The splash logo, hand-drawn in the ANSI Shadow style and joined at full
+#: glyph width so it fits a standard 80-column terminal (78 columns exactly).
+_LOGO_LINES = (
+    " ██████╗ ██████╗ ███╗   ██╗████████╗██╗███╗   ██╗██╗   ██╗██╗   ██╗███╗   ███╗",
+    "██╔════╝██╔═══██╗████╗  ██║╚══██╔══╝██║████╗  ██║██║   ██║██║   ██║████╗ ████║",
+    "██║     ██║   ██║██╔██╗ ██║   ██║   ██║██╔██╗ ██║██║   ██║██║   ██║██╔████╔██║",
+    "██║     ██║   ██║██║╚██╗██║   ██║   ██║██║╚██╗██║██║   ██║██║   ██║██║╚██╔╝██║",
+    "╚██████╗╚██████╔╝██║ ╚████║   ██║   ██║██║ ╚████║╚██████╔╝╚██████╔╝██║ ╚═╝ ██║",
+    " ╚═════╝ ╚═════╝ ╚═╝  ╚═══╝   ╚═╝   ╚═╝╚═╝  ╚═══╝ ╚═════╝  ╚═════╝ ╚═╝     ╚═╝",
+)
+_LOGO_WIDTH = max(len(line) for line in _LOGO_LINES)
+_LANDING_TAGLINE = "durable recovery for long-running agents"
+
 
 class TuiApp:
     """State machine for the terminal dashboard.
 
-    The view is two-level: a runs index, then one run's detail with tabs
-    (overview, recovery, checkpoints, actions, events, family, budget).
-    Table tabs carry a selectable cursor; text tabs only scroll.
+    The view is three-level: a landing splash (logo, version, run count),
+    then a runs index, then one run's detail with tabs (overview, recovery,
+    checkpoints, actions, events, family, budget). Table tabs carry a
+    selectable cursor; text tabs only scroll.
     """
 
     TABS = ("overview", "recovery", "checkpoints", "actions", "events", "family", "budget")
@@ -41,7 +56,8 @@ class TuiApp:
 
     def __init__(self, storage: Storage) -> None:
         self.storage = storage
-        self.view = "runs"
+        self.view = "landing"
+        self.width = 80  # the driver restamps this from the real screen each draw
         self.tab = 0
         self.index = 0  # selection in the runs index
         self.cursor = -1  # selected body line in a table tab, -1 when none
@@ -59,7 +75,9 @@ class TuiApp:
 
     def refresh(self) -> None:
         """Reload the current view's data from storage. Read-only."""
-        if self.view == "runs":
+        if self.view in ("landing", "runs"):
+            # the landing screen shows the run count, and leaving it lands on
+            # the runs list, so both views read the same rows
             self.rows = model.run_rows(self.storage)
             self.cursor = -1  # the runs list marks its selection itself
             if self.rows:
@@ -140,6 +158,8 @@ class TuiApp:
 
     def header(self) -> str:
         """The top line: where we are and what view is active."""
+        if self.view == "landing":
+            return ""
         if self.view == "runs":
             return "CONTINUUM  runs  (enter: open, r: refresh, ?: help, q: quit)"
         run_id = self._run_id() or "-"
@@ -150,10 +170,31 @@ class TuiApp:
             "(left/right or 1-7: tabs, esc: runs, r: refresh, q: quit)"
         )
 
+    def _landing_lines(self) -> list[str]:
+        """The splash page: logo, version, how many runs the store holds."""
+
+        def center(text: str) -> str:
+            return " " * max(0, (self.width - len(text)) // 2) + text
+
+        if self.width >= _LOGO_WIDTH + 2:
+            art: list[str] = list(_LOGO_LINES)
+        else:  # too narrow for the logo: a banner that fits, not one that clips
+            art = ["C O N T I N U U M"]
+        runs_line = f"{len(self.rows)} run(s) recorded" if self.rows else "no runs recorded yet"
+        return (
+            [""]
+            + [center(line) for line in art]
+            + ["", ""]
+            + [center(_LANDING_TAGLINE), center(f"v{__version__}   {runs_line}")]
+            + ["", "", center("press any key to open the dashboard")]
+        )
+
     def body_lines(self) -> list[str]:
         """The body: the help overlay when asked for, the view otherwise."""
         if self.show_help:
             return list(_HELP_LINES)
+        if self.view == "landing":
+            return self._landing_lines()
         if self.view == "runs":
             if not self.rows:
                 return ['No runs recorded. Start one with: continuum start <id> --goal "..."']
@@ -184,6 +225,8 @@ class TuiApp:
             return self.message
         if self.show_help:
             return "? hides help"
+        if self.view == "landing":
+            return "press any key to open the dashboard   q quits"
         if self.view == "runs":
             return "runs: enter open | r refresh | c checkpoint | x complete | y confirm"
         return "1-7 tabs | esc back | y/n reconcile (actions tab) | c checkpoint | x complete"
@@ -199,6 +242,16 @@ class TuiApp:
             return True
         if key == "q":
             return False
+        if self.view == "landing":
+            if key == "resize":  # a resize is not a keystroke: keep the splash
+                return True
+            # the splash promises "press any key", so any key (except q above)
+            # opens the dashboard; there is nothing else to do on this screen
+            self.view = "runs"
+            self.message = ""
+            self.scroll = 0
+            self.refresh()
+            return True
         if key == "?":
             self.show_help = not self.show_help
             return True
@@ -400,6 +453,7 @@ def _driver(curses: Any, screen: Any, app: TuiApp, refresh_seconds: float) -> in
     while True:
         screen.erase()
         height, width = screen.getmaxyx()
+        app.width = width  # the landing screen centres the logo on this
         _addline(screen, 0, 0, app.header(), curses.A_BOLD)
         body = app.body_lines()
         available = max(1, height - 3)

--- a/src/continuum/tui/model.py
+++ b/src/continuum/tui/model.py
@@ -1,0 +1,406 @@
+"""Pure view models for the terminal dashboard (issue #782).
+
+Everything here is plain data built from the same Storage, CheckpointManager
+and RecoveryEngine the CLI and the web dashboard use. There is deliberately
+no curses import: the driver in ``continuum.tui.app`` renders these rows, and
+the tests drive them without a terminal. The mutating verbs mirror the human
+CLI commands one for one, landing the same event types with the same
+Origin.HUMAN provenance, exactly like the dashboard HITL buttons (#242).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from continuum.actions import ActionLedger
+from continuum.actions.ledger import fold_action_events
+from continuum.budgets import (
+    DEFAULT_BUDGETS_PATH,
+    attempts_for_type,
+    evaluate_budget,
+    load_budgets,
+)
+from continuum.checkpoint import CheckpointManager
+from continuum.events import EventType
+from continuum.models import Action, ActionStatus, Origin, RunStatus, StateStatus
+from continuum.recovery import RecoveryEngine
+from continuum.recovery.family import children_of, roll_up_children
+from continuum.storage.base import Storage
+
+__all__ = [
+    "ActionRow",
+    "BudgetRow",
+    "CheckpointRow",
+    "EventRow",
+    "RunRow",
+    "action_rows",
+    "budget_rows",
+    "checkpoint_rows",
+    "complete_run",
+    "confirm_state",
+    "event_rows",
+    "family_lines",
+    "force_checkpoint",
+    "overview_lines",
+    "reconcile_action",
+    "recovery_lines",
+    "run_rows",
+]
+
+
+#: The statuses an operator may still settle from the keyboard, matching the
+#: set `continuum actions` flags and `pending_actions_with_keys` offers.
+UNCERTAIN_STATUSES = frozenset(
+    {ActionStatus.UNKNOWN, ActionStatus.STARTED, ActionStatus.REQUIRES_REVIEW}
+)
+
+
+@dataclass(frozen=True)
+class RunRow:
+    """One row of the runs list: what `runs` shows plus the recovery verdict."""
+
+    run_id: str
+    status: str
+    events: int
+    mode: str
+    safe: str
+    goal: str
+
+
+@dataclass(frozen=True)
+class CheckpointRow:
+    """One row of the checkpoint lineage, matching `history`."""
+
+    checkpoint_id: str
+    version: int
+    trigger: str
+    completed: int
+
+
+@dataclass(frozen=True)
+class ActionRow:
+    """One ledger action with the key a reconciliation would need."""
+
+    key: str
+    status: str
+    action_type: str
+    external_id: str
+    uncertain: bool
+
+
+@dataclass(frozen=True)
+class EventRow:
+    """One event of the log, archived prefix included after compaction."""
+
+    sequence: int
+    type: str
+    summary: str
+
+
+@dataclass(frozen=True)
+class BudgetRow:
+    """Retry-budget usage for one action type, matching `budget`."""
+
+    action_type: str
+    attempts: int
+    max_attempts: int
+    remaining: int
+
+
+def run_rows(storage: Storage) -> list[RunRow]:
+    """Assess every run for the index, mirroring the dashboard run table.
+
+    Each row assesses recovery independently and an assessment that raises is
+    shown as ``error: ...`` in that row rather than dropping the run: an
+    unreadable run must not hide from the operator watching the index.
+    """
+    rows: list[RunRow] = []
+    for run in storage.list_runs():
+        try:
+            decision = RecoveryEngine(storage).assess(run.run_id)
+            mode: str = decision.mode.value
+            safe: str = "yes" if decision.safe else "no"
+        except Exception as exc:  # presentation must not drop the run
+            mode, safe = f"error: {exc}", "unknown"
+        rows.append(
+            RunRow(
+                run_id=run.run_id,
+                status=run.status.value,
+                events=storage.last_sequence(run.run_id),
+                mode=mode,
+                safe=safe,
+                goal=run.goal,
+            )
+        )
+    return rows
+
+
+def overview_lines(storage: Storage, run_id: str) -> list[str]:
+    """The `inspect` view: semantic state, degraded folds included.
+
+    A run whose tail does not fold still answers, naming the break, because
+    the operator needs to see *that* before anything else.
+    """
+    state = CheckpointManager(storage).restore(run_id, on_unprojectable="degrade").state
+    lines = [
+        f"run:         {state.run_id}",
+        f"goal:        {state.goal.description} (v{state.goal.version})",
+        f"version:     v{state.version}  (events 1..{state.source_sequence})",
+        f"progress:    {state.progress.completed} completed, "
+        f"{state.progress.pending} pending, {state.progress.failed} failed",
+        f"decisions:   {len(state.decisions)} ({len(state.valid_decisions())} valid)",
+        f"findings:    {len(state.findings)}",
+        f"evidence:    {len(state.evidence)}",
+        f"pending:     {len(state.open_work())} task(s)",
+    ]
+    if state.plan:
+        lines.append(f"plan:        {len(state.plan)} unit(s)")
+        lines += [f"  - {p.step_id}: {p.description} [{p.status.value}]" for p in state.plan]
+    else:
+        lines.append("plan:        (none)")
+    if state.external_dependencies:
+        lines.append("dependencies:")
+        lines += [
+            f"  - {d.resource}: {d.version or 'unversioned'} [{d.status}]"
+            for d in state.external_dependencies
+        ]
+    if state.status is StateStatus.INVALID:
+        lines += [
+            "",
+            f"PROJECTION FAILURE: the log stops folding at sequence "
+            f"{state.unprojectable_at_sequence} ({state.unprojectable_event_type})",
+            f"  {state.unprojectable_reason}",
+            "  Figures cover events through the break only; `continuum verify` "
+            "reports the offending event.",
+        ]
+    return lines
+
+
+def _human_steps(decision: Any, run_id: str) -> list[str]:
+    """Executable next steps, mirroring the CLI's read-only probe of config."""
+    from continuum.gate import DEFAULT_GATE_CONFIG_PATH
+    from continuum.reconcilers import DEFAULT_RECONCILERS_PATH, load_reconcilers
+    from continuum.recovery.guidance import human_steps_for
+
+    try:
+        probed: list[str] = list(load_reconcilers(Path(DEFAULT_RECONCILERS_PATH)))
+    except Exception:
+        probed = []
+    return human_steps_for(
+        decision,
+        run_id=run_id,
+        probed_types=probed,
+        gate_configured=Path(DEFAULT_GATE_CONFIG_PATH).exists(),
+    )
+
+
+def recovery_lines(storage: Storage, run_id: str) -> list[str]:
+    """The `resume` view without --repair: verdict, family roll-up, advisories.
+
+    Read-only. The family section repeats the CLI's presentation: a parent may
+    not RESUME while any child is unsafe, and the most cautious signal wins.
+    """
+    decision = RecoveryEngine(storage).assess(run_id)
+    lines = decision.render().split("\n")
+    steps = _human_steps(decision, run_id)
+    if steps:
+        lines += ["", "Next steps:"] + [f"  {i}. {step}" for i, step in enumerate(steps, 1)]
+
+    child_statuses, family_blocked = roll_up_children(storage, run_id)
+    if family_blocked:
+        lines += [
+            "",
+            "FAMILY BLOCKED: children of this run are not resumable.",
+        ] + [
+            f"  !! child run {c.run_id} is {c.mode} (uncertain={c.uncertain_actions})"
+            for c in child_statuses
+            if not c.safe or c.mode != "resume"
+        ]
+
+    try:
+        from continuum.recovery.health import advisory_for_storage, advisory_text
+
+        lines += ["", advisory_text(advisory_for_storage(storage, run_id))]
+    except Exception:
+        pass
+    try:
+        from continuum.analysis.prefix_trust import trust_over_prefix
+
+        advisory = trust_over_prefix(decision.state)
+        breakdown = advisory.get("breakdown", {})
+        lines += [
+            f"Prefix trust: {advisory.get('trust_score', 1.0):.3f} "
+            f"(role={breakdown.get('role', 1.0):.3f} "
+            f"goal={breakdown.get('goal', 1.0):.3f} "
+            f"evidence={breakdown.get('evidence', 1.0):.3f})"
+        ]
+    except Exception:
+        pass
+    return lines
+
+
+def checkpoint_rows(storage: Storage, run_id: str) -> list[CheckpointRow]:
+    """The `history` view: one row per checkpoint, multiple per version kept."""
+    storage.get_run(run_id)  # raises RunNotFound rather than reading as "none yet"
+    rows: list[CheckpointRow] = []
+    for checkpoint in storage.list_checkpoints(run_id):
+        state = storage.get_version(run_id, checkpoint.version)
+        rows.append(
+            CheckpointRow(
+                checkpoint_id=checkpoint.checkpoint_id,
+                version=checkpoint.version,
+                trigger=checkpoint.trigger,
+                completed=state.progress.completed,
+            )
+        )
+    return rows
+
+
+def action_rows(storage: Storage, run_id: str) -> list[ActionRow]:
+    """The `actions` view, each row carrying the key a reconciliation needs.
+
+    Folded from the live log the same way the dashboard HITL buttons fold it,
+    so the key offered here is the key that would settle the action.
+    """
+    storage.get_run(run_id)
+    folded: dict[str, Action] = fold_action_events(storage.read_events(run_id))
+    return [
+        ActionRow(
+            key=key,
+            status=action.status.value,
+            action_type=action.action_type,
+            external_id=action.external_id or "-",
+            uncertain=action.status in UNCERTAIN_STATUSES,
+        )
+        for key, action in sorted(folded.items())
+    ]
+
+
+def event_rows(storage: Storage, run_id: str) -> list[EventRow]:
+    """The `events` view: archived prefix included, so a compacted run reads
+    the same as one that was never compacted (#532)."""
+    storage.get_run(run_id)
+    return [
+        EventRow(
+            sequence=event.sequence,
+            type=event.type.value,
+            summary=json.dumps(dict(event.payload), default=str),
+        )
+        for event in storage.read_all_events(run_id)
+    ]
+
+
+def family_lines(storage: Storage, run_id: str) -> list[str]:
+    """The `tree` view: the parent verdict and every child's, read-only."""
+    storage.get_run(run_id)
+    run = storage.get_run(run_id)
+    lines = [f"{run_id}  [{run.status.value}]  {run.goal[:60]}"]
+    children = children_of(storage, run_id)
+    if not children:
+        lines.append("  (no children)")
+    for child in children:
+        fork_mark = "[fork] " if str(child.metadata.get("fork", "")) == "true" else ""
+        try:
+            decision = RecoveryEngine(storage).assess(child.run_id)
+            mark = "ok " if decision.safe else "!! "
+            lines.append(
+                f"  {mark}{fork_mark}{child.run_id}  [{decision.mode.value}, "
+                f"uncertain={len(decision.uncertain_actions)}]  {child.goal[:44]}"
+            )
+        except Exception as exc:
+            lines.append(f"  !! {fork_mark}{child.run_id}  [assess error: {exc}]")
+    return lines
+
+
+def budget_rows(storage: Storage, run_id: str) -> list[BudgetRow]:
+    """The `budget` view, archive-aware: attempts are counted over the whole
+    log, so compaction does not hand a run a fresh budget (#734)."""
+    storage.get_run(run_id)
+    try:
+        raw = load_budgets(Path(DEFAULT_BUDGETS_PATH))
+    except Exception:
+        raw = {}
+    events = storage.read_all_events(run_id)
+    types_seen = sorted(
+        {
+            e.payload.get("action", {}).get("action_type")
+            for e in events
+            if e.type is EventType.ACTION_RECORDED and isinstance(e.payload.get("action"), dict)
+        }
+        | set((raw.get("action_types") or {}).keys())
+    )
+    rows: list[BudgetRow] = []
+    for action_type in types_seen:
+        used = attempts_for_type(events, action_type)
+        _, _, maximum = evaluate_budget(raw, action_type, 0)
+        rows.append(
+            BudgetRow(
+                action_type=action_type,
+                attempts=used,
+                max_attempts=maximum,
+                remaining=max(0, maximum - used),
+            )
+        )
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# control verbs (mutating; the app layer confirms before calling any of these)
+# --------------------------------------------------------------------------- #
+
+
+def force_checkpoint(storage: Storage, run_id: str) -> str:
+    """`checkpoint --trigger manual`: seal the current state now."""
+    checkpoint = CheckpointManager(storage).checkpoint(
+        run_id, trigger="manual", reason="forced from the tui"
+    )
+    return (
+        f"checkpoint {checkpoint.checkpoint_id} written at v{checkpoint.version} "
+        f"({checkpoint.state.progress.completed} completed)"
+    )
+
+
+def confirm_state(storage: Storage, run_id: str) -> str:
+    """`confirm`: REVIEW_CONFIRMED (Origin.HUMAN), clearing self-certification."""
+    storage.append_event(
+        run_id,
+        EventType.REVIEW_CONFIRMED,
+        {"components": ["goal", "progress"]},
+        source=Origin.HUMAN,
+    )
+    return "goal and progress confirmed (REVIEW_CONFIRMED)"
+
+
+def reconcile_action(storage: Storage, run_id: str, ledger_key: str, *, occurred: bool) -> str:
+    """Settle one uncertain side effect, the same ledger write the dashboard
+    HITL button and `continuum reconcile` perform."""
+    ActionLedger(storage, run_id).reconcile(
+        ledger_key, occurred=occurred, note="settled from the tui"
+    )
+    return f"reconciled {ledger_key[:16]}... occurred={occurred}"
+
+
+def complete_run(storage: Storage, run_id: str) -> str:
+    """`complete`: close the run from the keyboard, mirroring cmd_complete
+    (REVIEW_CONFIRMED plus RUN_COMPLETED, both Origin.HUMAN, and the run row
+    flips so finished work stops surfacing as the active run)."""
+    run = storage.get_run(run_id)
+    if run.status is RunStatus.COMPLETED:
+        return f"run {run_id} is already completed"
+    storage.append_event(
+        run_id,
+        EventType.REVIEW_CONFIRMED,
+        {"components": ["goal", "progress"]},
+        source=Origin.HUMAN,
+    )
+    storage.append_event(
+        run_id,
+        EventType.RUN_COMPLETED,
+        {"closed_by": "tui"},
+        source=Origin.HUMAN,
+    )
+    storage.update_run(run.touch(status=RunStatus.COMPLETED))
+    return f"run {run_id} completed"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -168,14 +168,60 @@ def test_recovery_lines_render_the_verdict_and_the_family_block(
 
 
 # --------------------------------------------------------------------------- #
+# the landing splash
+# --------------------------------------------------------------------------- #
+
+
+def test_the_app_opens_on_a_landing_screen_with_the_logo(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+
+    assert app.view == "landing"
+    app.width = 100  # wide enough for the ASCII logo
+    body = "\n".join(app.body_lines())
+    assert "██╔═══██╗" in body  # the logo, not just the word
+    assert "run(s) recorded" in body
+    assert "press any key to open the dashboard" in app.footer()
+
+
+def test_a_narrow_terminal_gets_a_banner_that_fits(db: str) -> None:
+    app = TuiApp(SQLiteStorage(db))
+    app.width = 40
+    body = app.body_lines()
+    assert all(len(line) <= 40 for line in body)
+    assert "C O N T I N U U M" in body[1]
+
+
+def test_any_key_leaves_the_landing_screen(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+
+    assert app.handle_key(" ") is True
+    assert app.view == "runs"
+    assert "r1" in "\n".join(app.body_lines())
+
+
+def test_q_quits_from_the_landing_screen(db: str) -> None:
+    app = TuiApp(SQLiteStorage(db))
+    assert app.handle_key("q") is False
+
+
+# --------------------------------------------------------------------------- #
 # the app state machine
 # --------------------------------------------------------------------------- #
+
+
+def _enter_dashboard(app: TuiApp) -> None:
+    """Dismiss the landing splash: any key opens the dashboard."""
+    assert app.handle_key(" ") is True
+    assert app.view == "runs"
 
 
 def test_the_app_lists_runs_and_quits_on_q(db: str) -> None:
     run("--db", db, "start", "ok_run", "--goal", "fine")
     run("--db", db, "start", "other", "--goal", "more work")
     app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
 
     assert app.view == "runs"
     body = "\n".join(app.body_lines())
@@ -187,6 +233,7 @@ def test_the_app_lists_runs_and_quits_on_q(db: str) -> None:
 def test_enter_opens_the_detail_and_esc_returns(db: str) -> None:
     run("--db", db, "start", "r1", "--goal", "analyse documents")
     app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
 
     app.handle_key("enter")
     assert app.view == "detail"
@@ -203,6 +250,7 @@ def test_tab_keys_switch_views(db: str) -> None:
     run("--db", db, "start", "r1", "--goal", "g")
     ActionLedger(SQLiteStorage(db), "r1").claim("send_invoice", {}, key="invoice:I-1")
     app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
     app.handle_key("enter")
 
     for tab in ("4", "5", "6", "7", "3", "2"):
@@ -221,6 +269,7 @@ def test_tab_keys_switch_views(db: str) -> None:
 def test_the_help_overlay_lists_the_keys(db: str) -> None:
     run("--db", db, "start", "r1", "--goal", "g")
     app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
     app.handle_key("?")
     assert "quit" in "\n".join(app.body_lines())
 
@@ -230,6 +279,7 @@ def test_reconcile_requires_confirmation_and_only_y_writes(db: str) -> None:
     ActionLedger(SQLiteStorage(db), "r1").claim("send_invoice", {}, key="invoice:I-1")
 
     app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
     app.handle_key("enter")
     app.handle_key("4")  # actions tab, cursor on the one action
     app.handle_key("y")  # queue reconcile-as-occurred
@@ -258,6 +308,7 @@ def test_a_settled_action_cannot_be_reconciled_again_from_the_tui(db: str) -> No
     ledger.reconcile(key, occurred=True)
 
     app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
     app.handle_key("enter")
     app.handle_key("4")
     app.handle_key("y")
@@ -268,6 +319,7 @@ def test_a_settled_action_cannot_be_reconciled_again_from_the_tui(db: str) -> No
 def test_checkpoint_and_complete_confirmations_write(db: str) -> None:
     run("--db", db, "start", "r1", "--goal", "g")
     app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
 
     app.handle_key("c")
     assert app.pending is not None
@@ -285,6 +337,7 @@ def test_checkpoint_and_complete_confirmations_write(db: str) -> None:
 def test_confirm_state_writes_review_confirmed(db: str) -> None:
     run("--db", db, "start", "r1", "--goal", "g")
     app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
 
     app.handle_key("y")
     assert "REVIEW_CONFIRMED" in app.pending[0]
@@ -296,6 +349,7 @@ def test_confirm_state_writes_review_confirmed(db: str) -> None:
 def test_a_cancelled_action_writes_nothing(db: str) -> None:
     run("--db", db, "start", "r1", "--goal", "g")
     app = TuiApp(SQLiteStorage(db))
+    _enter_dashboard(app)
     events_before = len(SQLiteStorage(db).read_events("r1"))
 
     app.handle_key("c")
@@ -361,13 +415,24 @@ class _FakeScreen:
 
 def test_the_driver_draws_and_honours_keys(db: str) -> None:
     run("--db", db, "start", "r1", "--goal", "g")
-    screen = _FakeScreen([_FakeCurses.KEY_DOWN, _FakeCurses.KEY_ENTER, ord("4")])
+    # a space dismisses the landing splash, then the driver is driven normally
+    screen = _FakeScreen([ord(" "), _FakeCurses.KEY_DOWN, _FakeCurses.KEY_ENTER, ord("4")])
     code = _driver(_FakeCurses(), screen, TuiApp(SQLiteStorage(db)), 0.0)
 
     assert code == ExitCode.OK
     drawn = "\n".join(text for _, text in screen.lines)
     assert "CONTINUUM" in drawn
     assert "actions" in drawn
+
+
+def test_the_driver_draws_the_splash_first(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    screen = _FakeScreen([])  # the default key is q: the splash is all we see
+    _driver(_FakeCurses(), screen, TuiApp(SQLiteStorage(db)), 0.0)
+
+    drawn = "\n".join(text for _, text in screen.lines)
+    assert "██╔═══██╗" in drawn  # the logo: 80 columns is just wide enough
+    assert "press any key" in drawn
 
 
 def test_run_tui_refuses_when_curses_is_missing(db: str, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -401,3 +466,64 @@ def test_the_tui_command_is_registered_and_documented(
     help_text = capsys.readouterr().out
     assert "--refresh" in help_text
     assert "dashboard" in help_text
+
+
+# --------------------------------------------------------------------------- #
+# bare `continuum`: splash when interactive, help otherwise
+# --------------------------------------------------------------------------- #
+
+
+class _Tty(io.StringIO):
+    """A stream that claims to be a terminal, as a real shell would give."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+def test_bare_continuum_opens_the_tui_when_interactive(
+    db: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: dict[str, Any] = {}
+
+    def fake_run_tui(storage: Any, **kw: Any) -> int:
+        seen["storage"] = storage
+        return 77
+
+    monkeypatch.setattr("continuum.tui.run_tui", fake_run_tui)
+    code = main(["--db", db], out=_Tty())
+
+    assert code == 77
+    assert seen["storage"] is not None
+
+
+def test_bare_continuum_prints_help_when_piped(db: str) -> None:
+    """A script running `continuum` blind must find usage text, not curses."""
+    code, out, _ = run("--db", db)
+
+    assert code == ExitCode.OK
+    assert "usage:" in out
+    assert "dashboard" in out
+
+
+def test_bare_continuum_prints_help_with_json(db: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--json` is a machine contract: it never opens an interactive screen."""
+
+    def fail_tui(storage: Any, **kw: Any) -> int:
+        raise AssertionError("the tui must not open under --json")
+
+    monkeypatch.setattr("continuum.tui.run_tui", fail_tui)
+    code, out, _ = run("--db", db, "--json")
+
+    assert code == ExitCode.OK
+    assert "usage:" in out
+
+
+def test_bare_continuum_reports_an_unopenable_database(db: str, tmp_path: Path) -> None:
+    bad = tmp_path / "not-a-dir" / "continuum.db"
+    out, err = _Tty(), io.StringIO()
+
+    code = main(["--db", str(bad)], out=out, err=err)
+
+    assert code == ExitCode.ERROR
+    assert "error:" in err.getvalue()
+    assert "usage:" not in out.getvalue()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,403 @@
+"""The terminal dashboard (issue #782).
+
+TuiApp is a pure state machine (keys in, lines out) so every flow below
+drives it without a terminal. The curses driver is exercised through a fake
+screen, and the two refusal paths (no curses, no TTY) are the ones that must
+never half-render.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from continuum.actions import ActionLedger
+from continuum.actions.idempotency import idempotency_key
+from continuum.cli import ExitCode, main
+from continuum.events import EventType
+from continuum.models import RunStatus
+from continuum.storage import SQLiteStorage
+from continuum.tui import TuiApp, run_tui
+from continuum.tui import model as tui_model
+from continuum.tui.app import _driver
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    return str(tmp_path / "tui.db")
+
+
+@pytest.fixture
+def store(db: str) -> Iterator[SQLiteStorage]:
+    with SQLiteStorage(db) as s:
+        yield s
+
+
+# --------------------------------------------------------------------------- #
+# view models
+# --------------------------------------------------------------------------- #
+
+
+def test_run_rows_carry_the_recovery_verdict(db: str, store: SQLiteStorage) -> None:
+    run("--db", db, "start", "ok_run", "--goal", "fine")
+    run("--db", db, "start", "risky", "--goal", "danger")
+    ActionLedger(SQLiteStorage(db), "risky").claim("send_invoice", {}, key="invoice:I-1")
+
+    rows = {r.run_id: r for r in tui_model.run_rows(store)}
+    assert rows["ok_run"].mode == "resume"
+    assert rows["ok_run"].safe == "yes"
+    assert rows["risky"].safe == "no"
+    assert rows["risky"].mode != "resume"
+    assert rows["risky"].events >= rows["ok_run"].events
+
+
+def test_a_run_that_fails_to_assess_is_listed_not_dropped(
+    db: str, store: SQLiteStorage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable run must surface in the index, not vanish from it."""
+
+    class _Boom(tui_model.RecoveryEngine):
+        def assess(self, run_id: str, **kw: Any) -> Any:
+            raise RuntimeError("chain will not fold")
+
+    run("--db", db, "start", "broken", "--goal", "b")
+    monkeypatch.setattr(tui_model, "RecoveryEngine", _Boom)
+
+    rows = tui_model.run_rows(store)
+    assert len(rows) == 1
+    assert rows[0].mode.startswith("error:")
+    assert rows[0].safe == "unknown"
+
+
+def test_overview_lines_mirror_inspect(db: str, store: SQLiteStorage) -> None:
+    run("--db", db, "start", "r1", "--goal", "analyse documents")
+    lines = tui_model.overview_lines(store, "r1")
+    joined = "\n".join(lines)
+    assert "analyse documents" in joined
+    assert "progress:" in joined
+    assert "version:" in joined
+    assert "plan:" in joined
+
+
+def test_checkpoint_rows_match_history(db: str, store: SQLiteStorage) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    run("--db", db, "checkpoint", "r1", "--trigger", "manual", "--reason", "before lunch")
+
+    rows = tui_model.checkpoint_rows(store, "r1")
+    assert len(rows) == 1
+    assert rows[0].trigger == "manual"
+    assert isinstance(rows[0].version, int)
+
+
+def test_action_rows_flag_uncertain_actions_with_their_ledger_key(
+    db: str, store: SQLiteStorage
+) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    ActionLedger(SQLiteStorage(db), "r1").claim("send_invoice", {}, key="invoice:I-1")
+
+    rows = tui_model.action_rows(store, "r1")
+    assert len(rows) == 1
+    assert rows[0].uncertain is True
+    expected = str(idempotency_key("send_invoice", None, scope="r1", key="invoice:I-1"))
+    assert rows[0].key == expected
+    assert rows[0].action_type == "send_invoice"
+
+
+def test_event_rows_include_the_archived_prefix_after_compaction(
+    db: str, store: SQLiteStorage
+) -> None:
+    """A compacted run must read the same as one that was never compacted."""
+    run("--db", db, "start", "r1", "--goal", "g")
+    store.compact_run("r1")
+
+    rows = tui_model.event_rows(store, "r1")
+    # the archived prefix is included even though the live tail starts later
+    assert len(rows) == len(store.read_all_events("r1"))
+    assert len(rows) > len(store.read_events("r1"))
+    assert rows[0].sequence == 1
+    assert rows[0].type == "RUN_STARTED"
+
+
+def test_budget_rows_count_attempts_over_the_whole_log(db: str, store: SQLiteStorage) -> None:
+    """Attempts are per operation (issue #368), so a retried key is the one
+    that must show a drawdown."""
+    run("--db", db, "start", "r1", "--goal", "g")
+    ledger = ActionLedger(SQLiteStorage(db), "r1")
+    ledger.claim("send_invoice", {}, key="invoice:I-1")
+    key = str(idempotency_key("send_invoice", None, scope="r1", key="invoice:I-1"))
+    ledger.reconcile(key, occurred=False)  # confirmed absent, so a retry is legal
+    ledger.claim("send_invoice", {}, key="invoice:I-1")
+
+    rows = {r.action_type: r for r in tui_model.budget_rows(store, "r1")}
+    assert rows["send_invoice"].attempts == 2
+    assert rows["send_invoice"].remaining == rows["send_invoice"].max_attempts - 2
+
+
+def test_family_lines_show_every_child_verdict(db: str, store: SQLiteStorage) -> None:
+    run("--db", db, "start", "par", "--goal", "supervise")
+    run("--db", db, "start", "kid", "--goal", "work", "--parent", "par")
+    ActionLedger(SQLiteStorage(db), "kid").claim("send_invoice", {}, key="invoice:I-9")
+
+    lines = "\n".join(tui_model.family_lines(store, "par"))
+    assert "kid" in lines
+    assert "!!" in lines
+
+
+def test_recovery_lines_render_the_verdict_and_the_family_block(
+    db: str, store: SQLiteStorage
+) -> None:
+    run("--db", db, "start", "par", "--goal", "supervise")
+    run("--db", db, "start", "kid", "--goal", "work", "--parent", "par")
+    ActionLedger(SQLiteStorage(db), "kid").claim("send_invoice", {}, key="invoice:I-9")
+
+    lines = "\n".join(tui_model.recovery_lines(store, "par"))
+    assert "CONTINUUM RECOVERY" in lines
+    assert "Recovery decision:" in lines
+    assert "FAMILY BLOCKED" in lines
+
+
+# --------------------------------------------------------------------------- #
+# the app state machine
+# --------------------------------------------------------------------------- #
+
+
+def test_the_app_lists_runs_and_quits_on_q(db: str) -> None:
+    run("--db", db, "start", "ok_run", "--goal", "fine")
+    run("--db", db, "start", "other", "--goal", "more work")
+    app = TuiApp(SQLiteStorage(db))
+
+    assert app.view == "runs"
+    body = "\n".join(app.body_lines())
+    assert "ok_run" in body
+    assert "other" in body
+    assert app.handle_key("q") is False
+
+
+def test_enter_opens_the_detail_and_esc_returns(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "analyse documents")
+    app = TuiApp(SQLiteStorage(db))
+
+    app.handle_key("enter")
+    assert app.view == "detail"
+    assert "overview" in app.header()
+    assert "analyse documents" in "\n".join(app.body_lines())
+
+    app.handle_key("esc")
+    assert app.view == "runs"
+    # the cursor from the detail view must not highlight a runs-list row
+    assert app.cursor == -1
+
+
+def test_tab_keys_switch_views(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    ActionLedger(SQLiteStorage(db), "r1").claim("send_invoice", {}, key="invoice:I-1")
+    app = TuiApp(SQLiteStorage(db))
+    app.handle_key("enter")
+
+    for tab in ("4", "5", "6", "7", "3", "2"):
+        app.handle_key(tab)
+        assert app.TABS[app.tab] in app.header()
+
+    app.handle_key("4")  # actions
+    body = "\n".join(app.body_lines())
+    assert "send_invoice" in body
+    assert "(!)" in body  # uncertain actions are marked where the eye lands
+
+    app.handle_key("5")  # events
+    assert "RUN_STARTED" in "\n".join(app.body_lines())
+
+
+def test_the_help_overlay_lists_the_keys(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+    app.handle_key("?")
+    assert "quit" in "\n".join(app.body_lines())
+
+
+def test_reconcile_requires_confirmation_and_only_y_writes(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    ActionLedger(SQLiteStorage(db), "r1").claim("send_invoice", {}, key="invoice:I-1")
+
+    app = TuiApp(SQLiteStorage(db))
+    app.handle_key("enter")
+    app.handle_key("4")  # actions tab, cursor on the one action
+    app.handle_key("y")  # queue reconcile-as-occurred
+    assert app.pending is not None
+    assert "OCCURRED" in app.pending[0]
+
+    app.handle_key("n")  # anything but y cancels
+    assert app.pending is None
+    assert ActionLedger(SQLiteStorage(db), "r1").all()[0].status.value == "started"
+
+    app.handle_key("y")
+    app.handle_key("y")  # confirm the write
+    assert app.pending is None
+    assert app.message.startswith("reconciled")
+
+    with SQLiteStorage(db) as s:
+        assert any(e.type is EventType.ACTION_RECONCILED for e in s.read_events("r1"))
+    assert ActionLedger(SQLiteStorage(db), "r1").all()[0].status.value == "completed"
+
+
+def test_a_settled_action_cannot_be_reconciled_again_from_the_tui(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    key = str(idempotency_key("send_invoice", None, scope="r1", key="invoice:I-1"))
+    ledger = ActionLedger(SQLiteStorage(db), "r1")
+    ledger.claim("send_invoice", {}, key="invoice:I-1")
+    ledger.reconcile(key, occurred=True)
+
+    app = TuiApp(SQLiteStorage(db))
+    app.handle_key("enter")
+    app.handle_key("4")
+    app.handle_key("y")
+    assert app.pending is None  # refused before any confirmation prompt
+    assert "only uncertain actions" in app.message
+
+
+def test_checkpoint_and_complete_confirmations_write(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+
+    app.handle_key("c")
+    assert app.pending is not None
+    app.handle_key("y")
+    with SQLiteStorage(db) as s:
+        assert len(s.list_checkpoints("r1")) == 1
+
+    app.handle_key("x")
+    assert "RUN_COMPLETED" in app.pending[0]
+    app.handle_key("y")
+    with SQLiteStorage(db) as s:
+        assert s.get_run("r1").status is RunStatus.COMPLETED
+
+
+def test_confirm_state_writes_review_confirmed(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+
+    app.handle_key("y")
+    assert "REVIEW_CONFIRMED" in app.pending[0]
+    app.handle_key("y")
+    with SQLiteStorage(db) as s:
+        assert any(e.type is EventType.REVIEW_CONFIRMED for e in s.read_events("r1"))
+
+
+def test_a_cancelled_action_writes_nothing(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    app = TuiApp(SQLiteStorage(db))
+    events_before = len(SQLiteStorage(db).read_events("r1"))
+
+    app.handle_key("c")
+    app.handle_key("x")  # not y: cancels
+    assert app.pending is None
+    assert len(SQLiteStorage(db).read_events("r1")) == events_before
+
+
+# --------------------------------------------------------------------------- #
+# the curses driver and the refusal paths
+# --------------------------------------------------------------------------- #
+
+
+class _FakeCurses:
+    """Just enough curses for the driver: constants, attrs, no terminal."""
+
+    KEY_UP = 259
+    KEY_DOWN = 258
+    KEY_LEFT = 260
+    KEY_RIGHT = 261
+    KEY_ENTER = 343
+    KEY_RESIZE = 410
+    KEY_BACKSPACE = 263
+    A_BOLD = 1
+    A_REVERSE = 2
+
+    class error(Exception):
+        pass
+
+    @staticmethod
+    def curs_set(visible: int) -> None:
+        return None
+
+
+class _FakeScreen:
+    """Records what the driver draws and replays a fixed key script."""
+
+    def __init__(self, keys: list[int]) -> None:
+        self._keys = list(keys)
+        self.lines: list[tuple[int, str]] = []
+
+    def keypad(self, on: bool) -> None:
+        return None
+
+    def timeout(self, ms: int) -> None:
+        return None
+
+    def erase(self) -> None:
+        self.lines = []
+
+    def getmaxyx(self) -> tuple[int, int]:
+        return (24, 80)
+
+    def addnstr(self, y: int, x: int, text: str, n: int, attr: int = 0) -> None:
+        self.lines.append((y, text[:n]))
+
+    def refresh(self) -> None:
+        return None
+
+    def getch(self) -> int:
+        return self._keys.pop(0) if self._keys else ord("q")
+
+
+def test_the_driver_draws_and_honours_keys(db: str) -> None:
+    run("--db", db, "start", "r1", "--goal", "g")
+    screen = _FakeScreen([_FakeCurses.KEY_DOWN, _FakeCurses.KEY_ENTER, ord("4")])
+    code = _driver(_FakeCurses(), screen, TuiApp(SQLiteStorage(db)), 0.0)
+
+    assert code == ExitCode.OK
+    drawn = "\n".join(text for _, text in screen.lines)
+    assert "CONTINUUM" in drawn
+    assert "actions" in drawn
+
+
+def test_run_tui_refuses_when_curses_is_missing(db: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "curses", None)
+    err = io.StringIO()
+    code = run_tui(SQLiteStorage(db), err=err)
+
+    assert code == ExitCode.ERROR
+    assert "dashboard" in err.getvalue()
+
+
+def test_run_tui_refuses_without_a_tty(db: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    class _NotATty(io.StringIO):
+        def isatty(self) -> bool:
+            return False
+
+    monkeypatch.setattr(sys, "stdout", _NotATty())
+    err = io.StringIO()
+    code = run_tui(SQLiteStorage(db), err=err)
+
+    assert code == ExitCode.ERROR
+    assert "not a TTY" in err.getvalue()
+
+
+def test_the_tui_command_is_registered_and_documented(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main(["tui", "--help"])
+    assert exit_info.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "--refresh" in help_text
+    assert "dashboard" in help_text

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -454,7 +454,11 @@ def test_run_tui_refuses_without_a_tty(db: str, monkeypatch: pytest.MonkeyPatch)
     code = run_tui(SQLiteStorage(db), err=err)
 
     assert code == ExitCode.ERROR
-    assert "not a TTY" in err.getvalue()
+    # On platforms without curses (Windows) the import check refuses first,
+    # before the TTY check is reached. Both are refusals pointing at the
+    # browser dashboard, so either message satisfies this test.
+    out = err.getvalue()
+    assert "not a TTY" in out or "not available on this platform" in out
 
 
 def test_the_tui_command_is_registered_and_documented(


### PR DESCRIPTION
## Summary

A new `continuum tui` command opens a full-screen terminal dashboard (alternate screen, like htop or k9s) and hands the terminal back on quit, so an operator on a headless box over SSH can watch and settle runs without one-shot commands or a browser port (#782).

Three layers, mirroring how the web dashboard is built:

- **`tui/model.py`** — pure view models over the same `Storage`, `CheckpointManager` and `RecoveryEngine` the CLI uses. The tabs map 1:1 onto existing commands so nothing is invented twice:
  - runs index: `runs` plus each run's recovery verdict (an assessment that raises is shown as `error:` in its row, never dropped)
  - overview: `inspect` (degraded folds named, not hidden)
  - recovery: `resume` without `--repair`, plus human steps, family roll-up, liveness and prefix-trust advisories
  - checkpoints: `history`
  - actions: `actions`, each row carrying the ledger key a reconciliation needs
  - events: `events`, archived prefix included so a compacted run reads the same as one that never was
  - family: `tree`
  - budget: `budget`, archive-aware per #734
- **`tui/app.py`** — `TuiApp`, a key-driven state machine (keys in, lines out) that is fully testable without a terminal, plus a thin curses driver that maps key codes and draws lines, containing no decisions of its own.
- **Control verbs** — confirm, reconcile, force checkpoint, complete run — mirror the human CLI commands and the dashboard HITL buttons (#242): same event types, same `Origin.HUMAN` provenance. Each lands in a confirmation prompt first; only a further `y` performs the write, anything else cancels. Browsing and refreshing never write.

Stdlib `curses` only, keeping the dependency-free rule for the CLI. Where curses is unavailable (Windows without `windows-curses`) or stdout is not a TTY, the command refuses with a pointer at `continuum dashboard` rather than half-rendering. Refresh is on demand (`r`) or an optional `--refresh` interval.

One UX rule worth noting: the status message outranks the key hints in the footer, because the hints are longer than an 80-column line and would otherwise clip the confirmation result the operator most needs to read.

## Testing

- `tests/test_tui.py` (22 tests): every view model against real storage (including compaction-aware event rows and per-key budget drawdown), every app flow (runs index, tab switching, the confirmation gate for all four verbs, a cancelled write leaving the log untouched), the driver through a fake screen, and both refusal paths.
- The real curses path was exercised end to end through a pty (open, navigate tabs, help, confirmed checkpoint write, clean exit 0).
- `docs/api/cli.md` gains the `tui` row; `test_cli_docs` keeps the table honest.

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-screen terminal dashboard for monitoring and managing runs.
  * View run details, recovery status, checkpoints, actions, events, family information, and budgets.
  * Added confirmation-gated controls for checkpointing, completing runs, confirming state, and reconciling actions.
  * Added the `tui` CLI command with optional automatic refresh intervals.

* **Documentation**
  * Documented the new `tui` command and its `--refresh` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->