### PR TITLE
test: import the checkout in the missing MCP extra subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,9 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- The missing-MCP-extra subprocess test now imports the working tree even when
+  CONTINUUM is not installed or an older copy is installed (#810).
+
 - Preserve archived action history in grant and authority enforcement, CLI and
   gateway gate decisions, cross-run action scans, and memory enumeration and
   forensic joins (#615, #616). Compaction no longer hides spent authority or

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,6 +17,7 @@ import sqlite3
 import subprocess
 import sys
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -2004,9 +2005,13 @@ def test_main_reports_a_missing_mcp_extra_instead_of_a_traceback(tmp_path: Any) 
     stdio the client parses that stream as protocol frames, so diagnostics must
     never be printed there, however tempting it is.
     """
+    env = os.environ.copy()
+    source_path = str(Path(__file__).resolve().parents[1] / "src")
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [source_path, env.get("PYTHONPATH")]))
     proc = subprocess.run(
         [sys.executable, "-c", _WITHOUT_MCP_SDK],
         cwd=tmp_path,
+        env=env,
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Description

The missing-MCP-extra subprocess test changes its working directory to a temporary directory, so it can import an installed CONTINUUM copy instead of the checkout being tested. Prepend this repository's `src` directory to the child's `PYTHONPATH`, preserving the inherited environment and any existing entries. The subprocess and its diagnostic assertions remain unchanged. Added an Unreleased changelog entry.

## Related issues

Fixes #810.

## Types of changes

- Type: `tests`

## Breaking changes

No.

## How has this been tested?

Python 3.12.10 on Windows, with the dev extra installed:

- Uninstalled only this checkout's editable distribution from its isolated test environment. The original test failed with `ModuleNotFoundError: No module named 'continuum'`; after the change, `python -m pytest tests/test_mcp_server.py -q` passed all 77 tests without the package installed.
- Reinstalled the checkout and ran `python -m pytest`: 2021 passed, 37 skipped. Unset inherited `NO_COLOR` and set `TERM=xterm` for this process because two unchanged color tests otherwise fail with the host's `NO_COLOR=1` / `TERM=dumb` environment.
- `ruff check src/ tests/ examples/`: passed.
- `ruff format --check src/ tests/ examples/`: passed, 294 files.
- `mypy src/continuum`: passed, 121 source files (one unused optional-module configuration note).

## Checklist

The existing subprocess regression test is updated and the changelog is updated. Local checks pass. Upstream CI has not yet run. No runtime or security behavior changes.

## Additional context

This preserves `SystemRoot` and the other subprocess environment variables on Windows, and keeps existing `PYTHONPATH` entries after the checkout's source directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing MCP extras so the appropriate error is reported instead of an unexpected traceback.
  - Ensured this behavior works consistently even when another installation is present or the package is not otherwise available.

- **Tests**
  - Improved subprocess test reliability across different working directories and installation environments.

- **Documentation**
  - Added a changelog entry describing the missing-MCP-extra fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->