### PR TITLE
Research note never records that instant_detection shipped

### DIFF
--- a/docs/research/instant_detection.md
+++ b/docs/research/instant_detection.md
@@ -1,5 +1,7 @@
 # Instant Autonomous Detection
 
+> **Shipped.** Both halves landed and issue #83 is closed. The `SessionStart` briefing hook runs on session start (#394), and `.continuum/resume.json` is precomputed on every checkpoint in `src/continuum/checkpoint/manager.py` (#394 fast path). This note is kept for historical context.
+
 A Claude Code session only acts after the user sends a message, so detection costs a user message plus a model inference plus an MCP round trip. There is no autonomous session start trigger today.
 
 ## Proposal


### PR DESCRIPTION
Fixes #793

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the instant detection design document to record that both proposed capabilities have shipped.
  - Documented session-start briefings and precomputed resume information at each checkpoint.
  - Noted that the related issue is closed while preserving historical context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->