### PR TITLE
fix(bench): give localized_repair and graph_build_overhead --help

### DIFF
--- a/benchmarks/graph_build_overhead.py
+++ b/benchmarks/graph_build_overhead.py
@@ -10,6 +10,7 @@ See issue #111.
 
 from __future__ import annotations
 
+import argparse
 import tempfile
 import time
 from pathlib import Path
@@ -23,7 +24,26 @@ def _make_repo(root: Path, n_files: int) -> None:
         f.write_text("import os\nimport sys\nimport numpy\nimport pandas\n", encoding="utf-8")
 
 
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``benchmarks/graph_build_overhead.py`` argument parser.
+
+    Only ``--help`` is recognised; anything else fails with exit code 2
+    (argparse convention) instead of silently launching the measurement
+    (issue #773).
+    """
+    return argparse.ArgumentParser(
+        prog="python benchmarks/graph_build_overhead.py",
+        description=(
+            "Micro-benchmark for source DependencyGraph build time over a "
+            "synthetic repository. Reports timings for several sizes; makes "
+            "no claim about caching or production scale."
+        ),
+        epilog="With no arguments, runs the measurement for 50, 100, and 200 files.",
+    )
+
+
 def main() -> None:
+    build_parser().parse_args()
     print("Source DependencyGraph build overhead (synthetic fixture, no caching claim)")
     for n in (50, 100, 200):
         with tempfile.TemporaryDirectory() as tmp:

--- a/benchmarks/localized_repair.py
+++ b/benchmarks/localized_repair.py
@@ -12,6 +12,8 @@ issue #106.
 
 from __future__ import annotations
 
+import argparse
+
 from continuum.checkpoint import CheckpointManager
 from continuum.environment import StaticProvider, capture
 from continuum.events import EventType
@@ -66,7 +68,27 @@ def _preserved(decision) -> int:
     return sum(1 for it in items if it.status.value == "valid")
 
 
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``benchmarks/localized_repair.py`` argument parser.
+
+    Only ``--help`` is recognised; anything else fails with exit code 2
+    (argparse convention) instead of silently launching the measurement
+    (issue #773).
+    """
+    return argparse.ArgumentParser(
+        prog="python benchmarks/localized_repair.py",
+        description=(
+            "Synthetic localized-repair measurement: compare how many state "
+            "items stay VALID under a scoped recovery assessment versus a "
+            "naive global reset. Runs against an in-memory store; no external "
+            "world claims."
+        ),
+        epilog="With no arguments, runs the measurement and prints the summary.",
+    )
+
+
 def main() -> None:
+    build_parser().parse_args()
     storage = _build()
     engine = RecoveryEngine(storage)
 


### PR DESCRIPTION
﻿## Summary

- Adds minimal `argparse` to `benchmarks/localized_repair.py` and `benchmarks/graph_build_overhead.py`, matching the shape established for `benchmarks/run.py` (#701 / #682).
- `--help` exits 0; unknown flags exit 2; no-arg runs are unchanged.

Fixes #773

## Test plan

- [x] `python benchmarks/localized_repair.py --help` exits 0
- [x] `python benchmarks/graph_build_overhead.py --help` exits 0
- [x] Unknown flag exits 2
- [x] `ruff check` / `ruff format --check` pass on both files
