### PR TITLE
fix: correct --json flag order in session_start_resume.sh

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -142,6 +142,8 @@ per-client notes for Gemini and Codex):
   (`^Bash$|^shell$`).
 - **`SessionStart` (`briefing`)**: runs `continuum briefing` to inject the active
   run id, goal, progress, and recovery next steps at session start or resume.
+  For a ready-made out-of-band alternative that prints `continuum --json resume`
+  (no model turn), see [`scripts/session_start_resume.sh`](../../scripts/session_start_resume.sh).
 - **`PreCompact` (`precompact`)**: runs `continuum precompact` to seal a
   checkpoint before context compaction discards unverified transcript state
   (configured by default on clients with a compaction event, such as Claude Code).

--- a/scripts/session_start_resume.sh
+++ b/scripts/session_start_resume.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # SessionStart hook that runs continuum resume out of band without a model turn.
 # Install as a Claude Code SessionStart hook to make detection instant.
+# Global flags such as --json must precede the subcommand (issue #774).
 set -e
 if command -v continuum >/dev/null 2>&1; then
-  continuum resume --json 2>/dev/null | head -c 2000
+  continuum --json resume 2>/dev/null | head -c 2000
 fi


### PR DESCRIPTION
﻿## Summary

- Fixes `scripts/session_start_resume.sh` to use `continuum --json resume` (global `--json` before the subcommand).
- Links the script from the SessionStart bullet in `docs/api/cli.md` hooks section.

Fixes #774

## Test plan

- [x] `python -m continuum.cli resume --json` → `unrecognized arguments: --json`
- [x] `python -m continuum.cli --json resume` → parses (exits with no-active-run when none exists)
- [x] `markdownlint-cli2 docs/api/cli.md` → 0 issues
