### PR TITLE
test: mark slow integration tests so contributors get a fast local loop

### DIFF
--- a/docs/CONTRIBUTING_ONBOARDING.md
+++ b/docs/CONTRIBUTING_ONBOARDING.md
@@ -31,6 +31,8 @@ Install once with `uv sync --extra dev` (or `pip install -e ".[dev]"`).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
   Skips are environmental (Postgres without `CONTINUUM_TEST_POSTGRES_DSN`, adapter tests without `langgraph` or `openai-agents`).
 - Run a single area: `uv run pytest tests/test_checkpoint_phase4.py -v`
+- Fast loop (skip slow integration tests): `uv run pytest -m "not slow"` or `pytest -q -m "not slow"`
+- Full suite (as CI runs it, slow tests included): `uv run pytest` or `pytest -q`
 - Lint: `uv run ruff check src/ tests/ examples/`
 - Format check: `uv run ruff format --check src/ tests/ examples/`
 - Auto fix lint and format: `uv run ruff check --fix src/ tests/ examples/` then `uv run ruff format src/ tests/ examples/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,10 @@ warn_required_dynamic_aliases = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
-addopts = "-q"
+addopts = "-q --strict-markers"
+markers = [
+    "slow: integration test that takes more than about 2 seconds. Deselect it during development with `pytest -m 'not slow'`; CI runs the suite unfiltered.",
+]
 # The MCP server's tools are async; without this, pytest silently skips them
 # as "not natively supported" rather than failing, which would let the whole
 # suite pass while testing nothing.

--- a/tests/test_demo_notebook.py
+++ b/tests/test_demo_notebook.py
@@ -20,6 +20,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 import continuum
 
 NOTEBOOK = Path(__file__).parent.parent / "examples" / "demo.ipynb"
@@ -41,6 +43,7 @@ def test_notebook_stays_plain_python() -> None:
             assert not line.lstrip().startswith(("%", "!")), f"IPython escape in a cell: {line!r}"
 
 
+@pytest.mark.slow
 def test_notebook_runs_end_to_end(tmp_path: Path) -> None:
     script = tmp_path / "demo_cells.py"
     script.write_text("\n".join(_code_cells()) + "\n", encoding="utf-8")

--- a/tests/test_docs_counts.py
+++ b/tests/test_docs_counts.py
@@ -14,6 +14,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 COUNTED_FILES = (
     ROOT / "README.md",
@@ -62,6 +64,7 @@ def test_documented_counts_agree() -> None:
     assert len(set(totals.values())) == 1, f"documented counts disagree: {totals}"
 
 
+@pytest.mark.slow
 def test_documented_count_matches_suite() -> None:
     documented = documented_total(COUNTED_FILES[0])
     live = live_total()

--- a/tests/test_horizon_benchmark.py
+++ b/tests/test_horizon_benchmark.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 
+
+@pytest.mark.slow
 def test_horizon_scenarios_run_with_at_least_100_reconstruction_cycles() -> None:
     from benchmarks.horizon.runner import run_horizon_suite
 
@@ -40,6 +43,7 @@ def test_judge_labels_exist_for_every_scenario_and_disagreements_resolved() -> N
     assert "Disagreements resolved" in doc or "resolved" in doc.lower()
 
 
+@pytest.mark.slow
 def test_all_six_metrics_emitted_per_run_and_rendered() -> None:
     from benchmarks.horizon.emitter import emit_horizon_report
     from benchmarks.horizon.runner import run_horizon_suite
@@ -82,6 +86,7 @@ def test_all_six_metrics_emitted_per_run_and_rendered() -> None:
             assert metric.lower() in md.lower()
 
 
+@pytest.mark.slow
 def test_table_regenerates_from_runner_no_invented_numbers(tmp_path: Path) -> None:
     # Prove the table is not hand-edited: delete it and re-run, it should reappear identical
     from benchmarks.horizon.emitter import emit_horizon_report
@@ -122,6 +127,7 @@ def test_table_regenerates_from_runner_no_invented_numbers(tmp_path: Path) -> No
             readme.write_text(original, encoding="utf-8")
 
 
+@pytest.mark.slow
 def test_shared_emitter_schema_with_fault_injection() -> None:
     # Both suites share the same BenchmarkReport envelope
     import json


### PR DESCRIPTION
Registered a slow marker and applied it per test rather than per module, since all three files hold cheap tests worth keeping in the fast loop. Measurement corrected the issue: six slow tests, not three. Added --strict-markers so a mistyped mark fails collection instead of silently staying in the fast loop. pytest -m "not slow" runs in 83.6s against 111s full; collection stays at 2058, so #630's count guard is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added strict validation for pytest markers.
  * Classified notebook, documentation-count, and horizon benchmark tests as slow-running.
  * Slow tests can be excluded during local development while remaining included in CI runs.

* **Documentation**
  * Documented commands for running the fast local test loop and the full CI-equivalent suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->