### PR TITLE
docs: put global --json before subcommands in guides and recipes

### DIFF
--- a/docs/guides/bring-your-own-dashboard.md
+++ b/docs/guides/bring-your-own-dashboard.md
@@ -12,12 +12,12 @@ Your dashboard is presentation. CONTINUUM stays the substrate. That separation i
 
 ## Substrates consumed
 
-### 1. Resume contract (`continuum resume --json`)
+### 1. Resume contract (`continuum --json resume`)
 
 Shell:
 
 ```bash
-continuum resume my-task --json | python -m json.tool
+continuum --json resume my-task | python -m json.tool
 ```
 
 Python:
@@ -139,7 +139,7 @@ For an external verifier that holds only the attestation file:
 ```bash
 continuum attest-keygen --out signer.pem --pub signer.pem.pub
 continuum attest my-task --key signer.pem --out my-task.attest.json
-continuum attest-verify my-task --attest my-task.attest.json --json | python -m json.tool
+continuum --json attest-verify my-task --attest my-task.attest.json | python -m json.tool
 ```
 
 Verdicts are `SIGNED`, `ALTERED`, or `UNTRUSTED` and appear in both human text and JSON.
@@ -251,7 +251,7 @@ print("claimed", out.key)
 PY
 
 # SIGKILL simulation done, now ask the dashboard substrate what it should show
-continuum --db /tmp/byod-demo.db resume dashboard-demo --json | python -m json.tool | head -n 60
+continuum --db /tmp/byod-demo.db --json resume dashboard-demo | python -m json.tool | head -n 60
 continuum --db /tmp/byod-demo.db export-evidence dashboard-demo | wc -l
 continuum --db /tmp/byod-demo.db verify dashboard-demo
 ```
@@ -285,7 +285,7 @@ Measured from a fresh checkout:
 
 1. `uv pip install -e ".[dev]"` (about 40s)
 2. `continuum start my-task --goal "trial"` (1s)
-3. `python dashboard_minimal.py` (or `continuum resume my-task --json` from any UI) (1s)
+3. `python dashboard_minimal.py` (or `continuum --json resume my-task` from any UI) (1s)
 4. Simulate kill, re-poll `GET /api/run/my-task/resume` and see `request_human` (under 1s)
 5. Reconcile, re-poll, see `resume` (under 1s)
 

--- a/docs/guides/embed-claude-code.md
+++ b/docs/guides/embed-claude-code.md
@@ -34,7 +34,7 @@ Expected hooks installed:
 Verify without starting Claude Code:
 
 ```bash
-continuum briefing --json | python -m json.tool
+continuum --json briefing | python -m json.tool
 ```
 
 With no active run you get a silent exit (no DB open, no latency). With an interrupted run you get a banner similar to:
@@ -44,10 +44,10 @@ With no active run you get a silent exit (no DB open, no latency). With an inter
   "active_run": "my-task",
   "mode": "resume",
   "safe": true,
-  "context": "Interrupted run my-task – resume pending\n  run: continuum resume my-task --json\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)",
+  "context": "Interrupted run my-task – resume pending\n  run: continuum --json resume my-task\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)",
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
-    "additionalContext": "Interrupted run my-task – resume pending\n  run: continuum resume my-task --json\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)"
+    "additionalContext": "Interrupted run my-task – resume pending\n  run: continuum --json resume my-task\n\nCONTINUUM active run: my-task\ngoal: Summarize quarterly reports from dataset v3\nprogress: 3/10 completed\nrecovery: resume (safe=True)"
   }
 }
 ```
@@ -68,7 +68,7 @@ Fast path keeps cold starts under a second: if `.continuum/resume.json` does not
 To consume the JSON resume contract directly inside an agent turn, use:
 
 ```bash
-continuum resume my-task --json | python -m json.tool
+continuum --json resume my-task | python -m json.tool
 ```
 
 Key fields:
@@ -101,7 +101,7 @@ Claude Code fires `PreCompact` before context compaction. Use it to force a chec
 `continuum hooks install claude-code` wires this for you: the `PreCompact` entry runs `continuum precompact`, which resolves the active run itself, seals a checkpoint with trigger `context_pressure`, and writes both snapshots below. Pass `--no-precompact` to keep the managed entry off the event, which also takes out one an earlier install wrote, and `continuum hooks remove claude-code` takes it out again with the rest.
 
 ```bash
-continuum precompact --json   # what the hook runs; safe to try by hand
+continuum --json precompact   # what the hook runs; safe to try by hand
 ```
 
 It never fails its host: with no active run it exits 0 with nothing sealed, and a snapshot it cannot write is reported in `failures` while the checkpoint stands.
@@ -117,7 +117,7 @@ If you want to pin one run instead of following the active one, the hand-written
         "hooks": [
           {
             "type": "command",
-            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum resume my-task --json > .continuum/precompact-resume.json; continuum verify my-task --json > .continuum/precompact-verify.json"
+            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum --json resume my-task > .continuum/precompact-resume.json; continuum --json verify my-task > .continuum/precompact-verify.json"
           }
         ]
       }
@@ -141,10 +141,10 @@ What this gives:
 - `.continuum/precompact-resume.json` with the recovery decision as of that checkpoint (inspect `contract.verified` and `contract.invalidated`)
 - `.continuum/precompact-verify.json` proving the chain is intact up to the checkpoint
 
-Constraint verification: if your run pins constraints by digest (see below), `resume --json` surfaces `pinning_drift` when the current environment pins differ from the recorded set. A non-empty drift does not block resume, it is informational. Check it in PreCompact:
+Constraint verification: if your run pins constraints by digest (see below), `--json resume` surfaces `pinning_drift` when the current environment pins differ from the recorded set. A non-empty drift does not block resume, it is informational. Check it in PreCompact:
 
 ```bash
-continuum resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' --json | python -c "import json,sys; j=json.load(sys.stdin); print(j['pinning_drift'])"
+continuum --json resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' | python -c "import json,sys; j=json.load(sys.stdin); print(j['pinning_drift'])"
 ```
 
 If you need to record constraint pins at run start (hash-only, plaintext never stored):
@@ -199,7 +199,7 @@ If you prefer to hand-edit instead of running `hooks install`:
         "hooks": [
           {
             "type": "command",
-            "command": "continuum briefing --json"
+            "command": "continuum --json briefing"
           }
         ]
       }
@@ -232,7 +232,7 @@ If you prefer to hand-edit instead of running `hooks install`:
         "hooks": [
           {
             "type": "command",
-            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum resume my-task --json > .continuum/precompact-resume.json"
+            "command": "continuum checkpoint my-task --reason \"pre-compact\" || true; continuum --json resume my-task > .continuum/precompact-resume.json"
           }
         ]
       }
@@ -272,7 +272,7 @@ PY
 # (the ledger STILL holds the claim as STARTED; no cleanup ran)
 
 # fresh session resumes (new process, same DB, no prompt needed)
-continuum --db /tmp/embed-claude-demo.db resume hardkill-demo --json | python -m json.tool
+continuum --db /tmp/embed-claude-demo.db --json resume hardkill-demo | python -m json.tool
 echo "exit code: $?"
 ```
 
@@ -295,7 +295,7 @@ Expected contract (real output from this repo, ids vary per run):
 
 Exit code is 20 (`REQUIRES_HUMAN`), not 0, so a guarded launch stops. Resolve by reconciling or, if the effect indeed never landed, retrying with a budget-aware claim, then `continuum resume` returns `resume` with `safe: true`.
 
-With a clean run (no uncertain actions), the same `resume --json` reports:
+With a clean run (no uncertain actions), the same `--json resume` reports:
 
 ```json
 {
@@ -325,7 +325,7 @@ A newcomer with only this guide should have crash recovery inside ten minutes. S
 3. `continuum hooks install claude-code` (1s)
 4. Do any work (write a file, claim an action via adapter, checkpoint)
 5. `kill -9` the agent (or `os._exit(9)` in the example) (instant)
-6. New shell: `continuum resume my-task --json` shows correct mode and next steps (under 1s)
+6. New shell: `continuum --json resume my-task` shows correct mode and next steps (under 1s)
 
 Gap list as of this doc (honest): LangChain/LangGraph/Codex adapters require their optional dependency (`pip install "continuum-agent[langchain]"` etc.) which adds install time but stays inside ten minutes on a warm cache. No gap found for generic adapter path.
 
@@ -335,7 +335,7 @@ Gap list as of this doc (honest): LangChain/LangGraph/Codex adapters require the
 - Hook writes stale command path after moving a virtualenv: re-run `continuum hooks install claude-code` (reports `updated` and rewrites the command).
 - `CONNECTION_CLOSED` from MCP: see `docs/api/mcp.md` troubleshooting; hook path issues, not CONTINUUM.
 - PreCompact never fires: confirm your Claude Code version supports the event, then confirm the entry is actually there. `hooks install` writes it by default (PostToolUse, SessionStart, PreCompact, and PreToolUse only under `--with-gate`), so a missing entry means the install ran with `--no-precompact` or predates #449; re-run `continuum hooks install claude-code` and look for `precompact` in the output.
-- Resume still `request_human` after reconcile: run `continuum actions my-task --json` to confirm no STARTED/UNKNOWN remains, then `continuum resume` again.
+- Resume still `request_human` after reconcile: run `continuum --json actions my-task` to confirm no STARTED/UNKNOWN remains, then `continuum resume` again.
 
 ## See also
 

--- a/docs/guides/embed-codex.md
+++ b/docs/guides/embed-codex.md
@@ -58,8 +58,8 @@ Expected entries in `.codex/hooks.json`:
 Manual verification without starting Codex:
 
 ```bash
-continuum briefing --json | python -m json.tool
-continuum resume my-task --json | python -m json.tool
+continuum --json briefing | python -m json.tool
+continuum --json resume my-task | python -m json.tool
 ```
 
 As with Claude Code, `briefing` exits 0 with no output when no interrupted run exists (checked via `.continuum/resume.json` before any DB open), so cold starts stay fast.
@@ -72,10 +72,10 @@ Same behavior as the Claude Code recipe: banner when `.continuum/resume.json` ex
 
 ```
 Interrupted run my-task – resume pending
-  run: continuum resume my-task --json
+  run: continuum --json resume my-task
 ```
 
-Example `resume --json` contract while safe:
+Example `--json resume` contract while safe:
 
 ```json
 {
@@ -137,7 +137,7 @@ Codex does not yet expose a PreCompact-equivalent event. Mirror the Claude Code 
 ```bash
 # append to your agent loop or as a stop hook
 continuum checkpoint my-task --reason "periodic" || true
-continuum resume my-task --json > .continuum/precompact-resume.json
+continuum --json resume my-task > .continuum/precompact-resume.json
 ```
 
 Or use the tiny glue script:
@@ -161,7 +161,7 @@ If you prefer to hand-edit rather than running `hooks install`:
         "hooks": [
           {
             "type": "command",
-            "command": "continuum briefing --json"
+            "command": "continuum --json briefing"
           }
         ]
       }
@@ -213,7 +213,7 @@ store.append_event("my-task", EventType.CONSTRAINT_PINNED, ConstraintPinned(cons
 Check drift on resume:
 
 ```bash
-continuum resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' --json | python -m json.tool | grep pinning_drift -A3
+continuum --json resume my-task --pinning '{"prompt_sha256":"abc...","tool_schema_sha256":"def..."}' | python -m json.tool | grep pinning_drift -A3
 ```
 
 Non-empty drift is surfaced as informational lines in the resume text and as `pinning_drift` in JSON. It does not block resume, it is the verification layer.
@@ -243,7 +243,7 @@ PY
 
 # SIGKILL simulation: no cleanup runs, ledger stays STARTED
 
-continuum --db /tmp/embed-codex-demo.db resume hardkill-codex --json | python -m json.tool
+continuum --db /tmp/embed-codex-demo.db --json resume hardkill-codex | python -m json.tool
 echo "exit code: $?"
 ```
 
@@ -264,7 +264,7 @@ Expected (real output from this repo, ids vary per run):
 }
 ```
 
-Exit code 20 (`REQUIRES_HUMAN`). After `continuum reconcile` or manual reconcile settling the claim, a fresh `continuum resume hardkill-codex --json` reports `resume` with `safe: true` and exit 0.
+Exit code 20 (`REQUIRES_HUMAN`). After `continuum reconcile` or manual reconcile settling the claim, a fresh `continuum --json resume hardkill-codex` reports `resume` with `safe: true` and exit 0.
 
 Clean-run case (no uncertain actions) stays `resume` / `safe: true` and exit 0, identical to the Claude Code path.
 
@@ -279,7 +279,7 @@ Measured from a fresh `git clone`:
 3. `continuum hooks install codex --with-gate` (1s)
 4. Do work, claim an action, checkpoint (any adapter or raw events)
 5. `kill -9` (instant)
-6. `continuum resume my-task --json` shows `request_human` with reconciliate step when uncertain, `resume` when clean (under 1s)
+6. `continuum --json resume my-task` shows `request_human` with reconciliate step when uncertain, `resume` when clean (under 1s)
 
 Gap list: Codex file writes via `apply_patch` are not hook-traversed and therefore not observed unless routed through `Bash`/`shell`. That is a Codex hook scope limit, not a CONTINUUM missing glue, and the workaround (write via shell) is copy-paste. No gap for Bash-mediated runs. If a future Codex release expands hook traversal, this line becomes stale and should be deleted.
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -6,7 +6,7 @@ Copy-paste recipes for wiring CONTINUUM into your harness and for consuming it a
 
 - **[Claude Code: SessionStart + PreCompact](claude-code.md)** – three hook entries, all installed by `continuum hooks install claude-code` (PostToolUse `observe`, SessionStart `briefing`, PreCompact `precompact`). Pairs with the instant-detection work in #394 (`.continuum/resume.json` fast path, scoped confirm, slim subset).
 - **[Codex: SessionStart, plus a copy-paste PreCompact (Bash-only)](codex.md)** – two hook entries from `continuum hooks install codex` (PostToolUse `observe`, SessionStart `briefing`), the `[features] codex_hooks = true` flag, Bash-only limitation documented, same hard-kill test as Claude Code. Codex publishes no compaction event, so unlike Claude Code there is no PreCompact hook for the installer to write; that section of the recipe reuses SessionStart and you paste it yourself.
-- **[Bring your own dashboard](control-plane.md)** – poll `continuum resume --json` and `continuum export-evidence` as the verification substrate; your UI owns orchestration, CONTINUUM owns `safe` and the sealed contract.
+- **[Bring your own dashboard](control-plane.md)** – poll `continuum --json resume` and `continuum export-evidence` as the verification substrate; your UI owns orchestration, CONTINUUM owns `safe` and the sealed contract.
 
 ## Adapter funnel
 
@@ -16,11 +16,11 @@ Copy-paste recipes for wiring CONTINUUM into your harness and for consuming it a
 
 - `docs/recipes/` (new, 4 pages, all docs-first, no CLI table overlapping #363)
 - `docs/api/adapters.md`: added four one-paragraph crash-recovery pointers (Generic, LangGraph, LangChain, OpenAI) – 12 lines total, no CLI table
-- No new runtime code; the glue was already on `main` (`continuum hooks install`, `continuum briefing`, `continuum resume --json`, `continuum export-evidence`)
+- No new runtime code; the glue was already on `main` (`continuum hooks install`, `continuum briefing`, `continuum --json resume`, `continuum export-evidence`)
 
 ## How these were tested
 
-Every recipe has a **Hard-kill test** section that is not a mock: it starts a run, claims a side effect, hard-kills the process with `os._exit(9)` mid-action, then in a fresh process runs the hook command (`continuum briefing` or `continuum resume --json`) and asserts `REQUEST_HUMAN` with one uncertain action and `safe:false`. The silent path (no `resume.json`, no active run) is also tested: the hook exits 0 with no output and no DB open. Timings above are wall-clock on a darwin Python 3.13 SSD box, measured with `time`.
+Every recipe has a **Hard-kill test** section that is not a mock: it starts a run, claims a side effect, hard-kills the process with `os._exit(9)` mid-action, then in a fresh process runs the hook command (`continuum briefing` or `continuum --json resume`) and asserts `REQUEST_HUMAN` with one uncertain action and `safe:false`. The silent path (no `resume.json`, no active run) is also tested: the hook exits 0 with no output and no DB open. Timings above are wall-clock on a darwin Python 3.13 SSD box, measured with `time`.
 
 ## Ten-minute metric (honest)
 

--- a/docs/recipes/claude-code.md
+++ b/docs/recipes/claude-code.md
@@ -45,7 +45,7 @@ instead if you want the compaction boundary to report without writing:
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum briefing --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json briefing"
           }
         ]
       }
@@ -56,7 +56,7 @@ instead if you want the compaction boundary to report without writing:
 
 Replace `/absolute/path/to/.venv/bin/continuum` with `which continuum`.
 
-For an explicit `resume --json` variant (pairs with #394):
+For an explicit `--json resume` variant (pairs with #394):
 
 ```json
 {
@@ -67,7 +67,7 @@ For an explicit `resume --json` variant (pairs with #394):
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum resume --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json resume"
           }
         ]
       }
@@ -78,7 +78,7 @@ For an explicit `resume --json` variant (pairs with #394):
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum resume --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json resume"
           }
         ]
       }
@@ -114,7 +114,7 @@ Measured: briefing silent 0.01 ms, resume 0.05 ms with resume.json, well under 1
 
 ## Constraint verification
 
-`continuum resume --json` includes `pins` from `SemanticState`. The PreCompact hook sees the same contract.
+`continuum --json resume` includes `pins` from `SemanticState`. The PreCompact hook sees the same contract.
 
 ## Troubleshooting
 

--- a/docs/recipes/codex.md
+++ b/docs/recipes/codex.md
@@ -47,7 +47,7 @@ cat .codex/hooks.json | python -m json.tool
         "hooks": [
           {
             "type": "command",
-            "command": "/absolute/path/to/.venv/bin/continuum resume --json"
+            "command": "/absolute/path/to/.venv/bin/continuum --json resume"
           }
         ]
       }


### PR DESCRIPTION
﻿## Summary
- Move post-position global `--json` before subcommands in the guides and recipes listed in #750 so pasted hook commands match `docs/api/cli.md`.
- Verified live: `continuum briefing --json` is rejected; `continuum --json briefing` works.
- `markdownlint-cli2` MD040 hits on these files are pre-existing on `main`.

Fixes #750

## Test plan
- [x] `continuum briefing --json` errors with unrecognized arguments
- [x] `continuum --json briefing` succeeds
- [ ] Spot-check one hook `command` paste from `embed-claude-code.md` / `recipes/claude-code.md`
- [ ] Confirm no remaining `continuum <subcommand> ... --json` in the six touched files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated CLI examples across dashboard, Claude Code, and Codex guides and recipes to place the `--json` flag before the command.
  - Revised related prose and hook examples to consistently use the updated command syntax.
  - Adjusted resume examples to reflect the correct placement of the `--pinning` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->