### PR TITLE
test: cover continuum_record_plan in MCP audit

### DIFF
--- a/docs/TESTING_MCP.md
+++ b/docs/TESTING_MCP.md
@@ -1,6 +1,6 @@
 # CONTINUUM MCP test report
 
-Adversarial verification of the CONTINUUM MCP server: all 11 registered tools,
+Adversarial verification of the CONTINUUM MCP server: all 12 registered tools,
 their failure modes, and the guarantees that must not move.
 
 - **Date:** 2026-08-24
@@ -16,7 +16,7 @@ their failure modes, and the guarantees that must not move.
 | `python -m pytest` | 1361 passed, 24 skipped, stable across consecutive runs |
 | `ruff check` / `ruff format --check` | clean on every changed file |
 | `mypy src` | 25 errors, identical to baseline (missing stubs for the optional `mcp` extra and `cryptography`) |
-| In-process audit, all 11 tools | 23 of 23 assertions passed |
+| In-process audit, all 12 tools | 23 of 23 assertions passed |
 | Adversarial probe round 2 | 14 of 14 assertions passed |
 | Adversarial probe round 3 | 14 of 16, both failures diagnosed (one probe bug, one real finding) |
 | Live MCP audit through the running server | all fixes confirmed present |
@@ -48,12 +48,13 @@ fix carries a test that fails without it.
 
 ## Tool coverage
 
-All 11 tools were exercised. None was covered by inspection alone.
+All 12 tools were exercised. None was covered by inspection alone.
 
 | Tool | Exercised with |
 |---|---|
 | `continuum_record_progress` | valid, `completed > total`, negative counters, blank and whitespace `run_id`, unicode goal |
 | `continuum_record_summary` | full structured payload, 20 KB oversized note |
+| `continuum_record_plan` | valid upsert on an existing run, blank `plan_id`, empty `units`, duplicate unit `id`, invalid status |
 | `continuum_checkpoint` | with and without `env`, unknown run, version increment |
 | `continuum_validate` | no `env`, matching `env`, drifted `env`, `expected_model`, unknown run |
 | `continuum_resume` | by id, no id (active-run path), unknown run, `expected_model`, both guidance branches |

--- a/tests/test_mcp_docs.py
+++ b/tests/test_mcp_docs.py
@@ -23,10 +23,16 @@ from continuum.storage import SQLiteStorage
 #: The API reference page whose tool table mirrors ``tools/list``.
 MCP_DOC = Path(__file__).resolve().parents[1] / "docs" / "api" / "mcp.md"
 
+#: The MCP adversarial audit report whose coverage table must also stay complete.
+MCP_AUDIT = Path(__file__).resolve().parents[1] / "docs" / "TESTING_MCP.md"
+
 #: One documented tool: name and kind. The purpose column is prose and is left
 #: to a human reviewer, as is the sentence of totals under the table; the two
 #: columns that can silently contradict the server are not.
 ROW = re.compile(r"^\| `(continuum_\w+)` \| (mutate|read) \|", re.MULTILINE)
+
+#: Tool names listed in the audit coverage table (issue #759).
+AUDIT_TOOL = re.compile(r"^\| `(continuum_\w+)` \|", re.MULTILINE)
 
 #: The character house style bans, by code point so this file carries none.
 EM_DASH = chr(0x2014)
@@ -67,6 +73,23 @@ async def test_the_table_lists_every_served_tool_with_its_kind(server: Any) -> N
     rows = ROW.findall(MCP_DOC.read_text(encoding="utf-8"))
     assert len(rows) == len({name for name, _ in rows}), "a tool is documented twice"
     assert dict(rows) == kinds(await server.list_tools())
+
+
+@pytest.mark.asyncio
+async def test_the_audit_coverage_table_lists_every_served_tool(server: Any) -> None:
+    """``docs/TESTING_MCP.md`` must name every tool ``tools/list`` exposes.
+
+    The audit once claimed "all 11 tools" while ``continuum_record_plan`` was
+    already served (issue #759). Pinning the coverage table to ``tools/list``
+    keeps that claim from rotting again.
+    """
+    text = MCP_AUDIT.read_text(encoding="utf-8")
+    section = text.split("## Tool coverage", 1)[1].split("## Findings", 1)[0]
+    covered = AUDIT_TOOL.findall(section)
+    assert len(covered) == len(set(covered)), "a tool is audited twice"
+    served = {tool.name for tool in await server.list_tools()}
+    assert set(covered) == served
+    assert "All 12 tools were exercised" in text
 
 
 def test_the_page_carries_no_em_dashes() -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -202,6 +202,73 @@ async def test_progress_accumulates_across_calls(server_ctx: tuple[Any, Any]) ->
 
 
 @pytest.mark.asyncio
+async def test_record_plan_upserts_units_and_rejects_bad_payloads(
+    server_ctx: tuple[Any, Any],
+) -> None:
+    """Exercise continuum_record_plan the way the MCP audit claims (issue #759)."""
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    server, ctx = server_ctx
+    await seed_run(server)
+    units = [
+        {"id": "u2", "title": "second", "status": "pending"},
+        {"id": "u1", "title": "first", "status": "working", "depends_on": []},
+    ]
+    payload = await call(
+        server,
+        "continuum_record_plan",
+        run_id="run_1",
+        plan_id="plan-a",
+        units=units,
+    )
+    assert payload["plan_id"] == "plan-a"
+    assert payload["units"] == 2
+    assert [step["id"] for step in payload["plan"]] == ["u1", "u2"]
+    assert {step["id"]: step["status"] for step in payload["plan"]}["u1"] in {
+        "working",
+        "in_progress",
+    }
+    assert {step["id"]: step["status"] for step in payload["plan"]}["u2"] == "pending"
+    assert any(e.type == EventType.PLAN_UPSERT for e in ctx.storage.read_events("run_1"))
+
+    with pytest.raises(ToolError, match="plan_id"):
+        await server.call_tool(
+            "continuum_record_plan",
+            {"run_id": "run_1", "plan_id": "  ", "units": units},
+            context=_ctx(TEST_CLIENT),
+        )
+    with pytest.raises(ToolError, match="units"):
+        await server.call_tool(
+            "continuum_record_plan",
+            {"run_id": "run_1", "plan_id": "plan-a", "units": []},
+            context=_ctx(TEST_CLIENT),
+        )
+    with pytest.raises(ToolError, match="duplicate"):
+        await server.call_tool(
+            "continuum_record_plan",
+            {
+                "run_id": "run_1",
+                "plan_id": "plan-a",
+                "units": [
+                    {"id": "u1", "title": "a", "status": "pending"},
+                    {"id": "u1", "title": "b", "status": "pending"},
+                ],
+            },
+            context=_ctx(TEST_CLIENT),
+        )
+    with pytest.raises(ToolError, match="status"):
+        await server.call_tool(
+            "continuum_record_plan",
+            {
+                "run_id": "run_1",
+                "plan_id": "plan-a",
+                "units": [{"id": "u1", "title": "a", "status": "nope"}],
+            },
+            context=_ctx(TEST_CLIENT),
+        )
+
+
+@pytest.mark.asyncio
 async def test_over_total_progress_is_rejected_before_being_written(
     server_ctx: tuple[Any, Any],
 ) -> None:


### PR DESCRIPTION
﻿## Summary
- Update `docs/TESTING_MCP.md` from 11 to 12 tools and add `continuum_record_plan` to the coverage table.
- Guard the audit coverage table against `tools/list` drift in `tests/test_mcp_docs.py`.
- Add an in-process `call_tool` exercise for valid upsert plus blank plan_id / empty units / duplicate id / bad status.

Fixes #759

## Test plan
- [x] `pytest tests/test_mcp_docs.py tests/test_mcp_server.py::test_record_plan_upserts_units_and_rejects_bad_payloads`
- [x] `markdownlint-cli2 docs/TESTING_MCP.md`
