### PR TITLE
docs: supported-clients table plus guard against CLIENT_PROFILES drift

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -130,6 +130,14 @@ was wrong (issue #322).
 settings files (for example `.claude/settings.json`, `.gemini/settings.json`, or
 `.codex/hooks.json`).
 
+Supported clients (`CLIENT_PROFILES` in `src/continuum/clienthooks.py`):
+
+| Profile | Settings file | Events | Write matcher | Any matcher |
+|:--|:--|:--|:--|:--|
+| `claude-code` | `.claude/settings.json` | `SessionStart`, `PostToolUse`, `PreToolUse`, `PreCompact` | `Write|Edit|MultiEdit|NotebookEdit` | `*` |
+| `gemini` | `.gemini/settings.json` | `SessionStart`, `AfterTool`, `BeforeTool` | `write_file|replace` | `.*` |
+| `codex` | `.codex/hooks.json` | `SessionStart`, `PostToolUse`, `PreToolUse` | `^Bash$|^shell$` | `^Bash$|^shell$` |
+
 By default, `hooks install` configures up to three entries (depending on the
 client profile; event names and matchers below are Claude Code's, see the
 per-client notes for Gemini and Codex):

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -33,7 +33,7 @@ def _hooks_section() -> str:
     """The ## hooks section of the CLI reference, where profiles live."""
     text = TABLE.read_text(encoding="utf-8")
     start = text.index("## hooks")
-    rest = text[start + len("## hooks"):]
+    rest = text[start + len("## hooks") :]
     end = rest.find("\n## ")
     return rest if end == -1 else rest[:end]
 

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -27,3 +27,30 @@ def test_every_subcommand_has_a_table_row() -> None:
     assert subs, "parser exposes no subcommands"
     missing = [name for name in subs if not _row_pattern(name).search(table)]
     assert not missing, f"subcommands without a docs/api/cli.md row: {missing}"
+
+
+def _hooks_section() -> str:
+    """The ## hooks section of the CLI reference, where profiles live."""
+    text = TABLE.read_text(encoding="utf-8")
+    start = text.index("## hooks")
+    rest = text[start + len("## hooks"):]
+    end = rest.find("\n## ")
+    return rest if end == -1 else rest[:end]
+
+
+def test_hooks_section_names_every_client_profile() -> None:
+    """Pinned prose over CLIENT_PROFILES must not drift silently (#777)."""
+    from continuum.clienthooks import CLIENT_PROFILES
+
+    section = _hooks_section()
+    assert CLIENT_PROFILES, "no client profiles to guard"
+    missing: list[str] = []
+    for profile, fields in CLIENT_PROFILES.items():
+        if profile not in section:
+            missing.append(profile)
+        for key, value in fields.items():
+            if not isinstance(value, str) or not value:
+                missing.append(f"{profile}.{key}")
+            elif value not in section:
+                missing.append(f"{profile}.{key}={value}")
+    assert not missing, f"hooks section omits CLIENT_PROFILES entries: {missing}"


### PR DESCRIPTION
## Description

#777 follow-up: the hooks section of docs/api/cli.md gains a supported-clients table (profile, settings file, events, write/any matchers, straight from CLIENT_PROFILES), and tests/test_cli_docs.py gains a guard asserting every profile name and field value appears in the hooks section. Proven to fail when a matcher is edited in either docs or code, and to pass synced.

## Related issues

Fixes #777
Follows #665 and #698

## Types of changes

- Type: docs

## Breaking changes

No. Documentation plus one guard test.

## How has this been tested?

Python 3.14, editable installation.

- Guard passes synced; fails with a matcher edited in docs; fails with a matcher edited in code; passes after both restores.
- env -u NO_COLOR TERM=xterm .venv/bin/pytest: 2,037 passed, 23 skipped.
- .venv/bin/ruff check and format --check: passed.
- .venv/bin/mypy src/continuum: passed, 121 source files.
- markdownlint-cli2 on docs/api/cli.md: 0 issues.
- git diff --check: passed.

## Checklist

Docs table plus guard test. CI has not yet run on this PR.