### PR TITLE
feat(cli): add `continuum mcp install` / `mcp remove` (#834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **The installed `continuum-mcp` entry point is exercised over real stdio (#834).**
+  `tests/test_mcp_entrypoint.py` spawns the console script a host actually
+  spawns — by absolute path, through pipes, no shell — and drives
+  `initialize` plus `tools/list`; the `python -m continuum.mcp` fallback form
+  gets the same handshake. A Windows-only test pins the mechanism behind
+  `CONNECTION_CLOSED` (#699): `CreateProcess` resolves a bare command name
+  against the calling process's PATH, never the environment passed to the
+  child, so the suite can now tell a broken entry point (#697) from an
+  unreachable one.
+
 - **Documented three-file ruff rev lockstep (#689).** CONTRIBUTING.md now
   names all three places the ruff version lives (the `ruff==` pin in
   `pyproject.toml`, `rev` in `.pre-commit-config.yaml`, and the `rev` quoted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 
+- **`continuum mcp install` / `mcp remove` register the MCP server on the machine
+  that spawns it (#834).** A bare `continuum-mcp` in `.mcp.json` only resolves when
+  the host's own PATH contains the install environment — on Windows `CreateProcess`
+  never consults the child's PATH (#699), and no one committed file can carry the
+  venv path on every platform at once. `mcp install` resolves the entry point the
+  way `hooks install` does (executable → sibling of the running `continuum` →
+  `python -m continuum.mcp`), proves it serves the protocol by driving a real
+  `initialize` handshake over stdio — surfacing the server's own stderr, which the
+  host never shows, and refusing to touch the host's config when it fails (the
+  #697 state) — then bakes the resolved absolute path into the host's config in the
+  shape the host itself writes, for the `local` (default), `user`, and `project`
+  scopes. Re-running converges (`present`) and a moved venv repoints (`updated`);
+  `mcp remove` drops only the `continuum-mcp` key, leaving every other server and
+  project entry alone. Covered by `tests/test_mcp_install.py`.
+
 - **The installed `continuum-mcp` entry point is exercised over real stdio (#834).**
   `tests/test_mcp_entrypoint.py` spawns the console script a host actually
   spawns — by absolute path, through pipes, no shell — and drives
@@ -603,7 +618,7 @@ All notable changes to this project are documented here. The format follows
   Framework Integration documents the CrewAI/AutoGen/Pydantic-AI thin hooks
   and the gateway/OTel fallback seams; the Roadmap marks the dashboard and
   the enforced-durability work complete; test counts are current
-  (~2,089 collected, ~2,030 passed, ~23 skipped on a minimal env).
+  (~2,130 collected, ~2,030 passed, ~23 skipped on a minimal env).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
 
 - **Gateway hardening and docs refresh.** The enforcing proxy now refuses

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Verify:
 ```bash
 continuum --help                 # CLI entrypoint
 continuum-mcp --help             # MCP server entrypoint (needs [mcp] or [dev])
-pytest -q                        # ~2,089 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
+pytest -q                        # ~2,130 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
 ruff check src/ tests/ examples/ && ruff format --check src/ tests/ examples/
 mypy src/continuum               # the three gates CI enforces
 ```
@@ -232,7 +232,7 @@ CONTINUUM is verified against real LLM agents, live protocol boundaries, and har
 - **Third-party clients**: Gemini CLI and Kilo Code connected over stdio JSON-RPC against the live SQLite store, validating multi-agent co-existence and authorization isolation.
 - **Protocol compliance**: driven end to end with `@modelcontextprotocol/inspector --cli` across process deaths; mutating tools deny by default behind `CONTINUUM_MCP_MUTATING_CLIENTS`; external claims degrade to `REQUIRES_REVIEW` (`safe: false`).
 - **Self-healing**: hard-killed servers recover from orphaned SQLite `-wal`/`-shm` sidecars via single-retry cleanup at startup.
-- **Scale**: roughly 2,089 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
+- **Scale**: roughly 2,130 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 12-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions.
 - **Adversarial audit**: the full MCP surface was audited over the live protocol; three defects were found and fixed. Method and reproduction steps in [test.md](test.md).
 
 ## MCP Integration
@@ -398,7 +398,7 @@ Schema v6. SQLite is primary, Postgres is CI verified. One log, many projections
 
 ### Module map: one library, many surfaces
 
-CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~2,089 tests). All modules append to and replay one hash chained event log:
+CONTINUUM is one library (`src/continuum`, 104 modules) plus a large test suite (98 test files, ~2,130 tests). All modules append to and replay one hash chained event log:
 
 | Module | Role |
 |:--|:--|

--- a/docs/CONTRIBUTING_ONBOARDING.md
+++ b/docs/CONTRIBUTING_ONBOARDING.md
@@ -27,7 +27,7 @@ Welcome. This guide gets you from clone to green tests without re-deriving conte
 Install once with `uv sync --extra dev` (or `pip install -e ".[dev]"`).
 
 - Run all tests: `uv run pytest` or `pytest -q`. Expect `~2,030 passed, ~23 skipped`
-  on main at this writing (`~2,089` collected).
+  on main at this writing (`~2,130` collected).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
   Skips are environmental (Postgres without `CONTINUUM_TEST_POSTGRES_DSN`, adapter tests without `langgraph` or `openai-agents`).
 - Run a single area: `uv run pytest tests/test_checkpoint_phase4.py -v`

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -42,6 +42,7 @@ continuum --json <command>                    # machine-readable output
 | `briefing` | Session-start context: active run, progress, next steps. Read-only. |
 | `gate` | Decide whether a tool call may proceed (pre-tool-use hook). Read-only. |
 | `hooks` | Manage host-side observation hooks. |
+| `mcp` | Register the MCP server with a host. Mutates host config. |
 | `verify <run_id>` | Re-audit the event chain for tampering. |
 | `reconcile <run_id>` | Settle uncertain actions with registered probes. Mutates storage. |
 | `actions <run_id>` | List recorded side effects and flag uncertain outcomes. |
@@ -195,4 +196,47 @@ To remove all installed CONTINUUM hooks from a client settings file:
 ```bash
 continuum hooks remove claude-code
 ```
+
+## mcp
+
+`continuum mcp install` registers the MCP server with a host so the host can
+actually spawn it. The committed `.mcp.json` names the server by bare command,
+which only resolves when the host's own PATH contains the install environment —
+on Windows a bare command never resolves from the child's PATH, so a venv the
+host did not activate is unreachable and the host reports
+`CONNECTION_CLOSED`. The installer solves this on the machine that spawns the
+server: it resolves the real entry point, proves it serves the protocol by
+driving an `initialize` handshake over stdio, and only then writes the
+registration with the resolved absolute path baked in. A server that does not
+answer the handshake is refused before any config is written, with the
+server's own stderr surfaced — the diagnosis the host never shows.
+
+```bash
+continuum mcp install                    # local scope (this project): default
+continuum mcp install --scope user       # every project
+continuum mcp install --scope project    # the committed .mcp.json
+continuum mcp remove                     # drop the registration
+```
+
+Scopes mirror Claude Code's own: `local` (default) registers under the current
+project in `~/.claude.json`, `user` registers for every project, and `project`
+writes the `.mcp.json` at the project root — the file the repo ships — with a
+warning, because a baked absolute command path is machine-specific and that
+file is usually committed.
+
+### Flags
+
+- **`--db <path>`**: bakes a specific database path into the server command.
+  The default is the same relative `continuum.db` the committed `.mcp.json`
+  names, resolved by the host against the project it spawns the server in.
+- **`--scope {local,user,project}`**: where the registration lives (default:
+  `local`).
+- **`--config <path>`**: edits a specific host config file instead of the
+  per-profile default.
+
+Re-running `mcp install` converges (`present`) and a moved virtualenv repoints
+the registration (`updated`) rather than duplicating it; `mcp remove` drops
+only the `continuum-mcp` entry, leaving every other server and project key in
+the file untouched. Restart the host after installing (in Claude Code: `/mcp`)
+to connect.
 

--- a/src/continuum/cli/main.py
+++ b/src/continuum/cli/main.py
@@ -53,6 +53,7 @@ from continuum.gate import (
 from continuum.gate import (
     decide as gate_decide,
 )
+from continuum.mcp.install import MCP_PROFILES
 from continuum.models import (
     ActionStatus,
     EnvironmentSnapshot,
@@ -2737,6 +2738,143 @@ def cmd_hooks_remove(args: argparse.Namespace, storage: Storage, out: Any, err: 
     return ExitCode.OK
 
 
+def _mcp_config_path(args: argparse.Namespace, profile: dict[str, Any]) -> Path:
+    """The host config file an ``mcp`` action edits.
+
+    ``--config`` wins so tests (and operators with unusual setups) can point at a
+    scratch file; otherwise the scope decides: local and user registrations live
+    in the host's user config, a project registration in the ``.mcp.json`` at the
+    project root.
+    """
+    if args.config:
+        return Path(args.config).expanduser()
+    if args.scope == "project":
+        return Path(profile["project_config"])
+    return Path(os.path.expanduser(profile["user_config"]))
+
+
+def cmd_mcp_install(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Register the MCP server with a host, resolved on this machine (issue #834).
+
+    A bare ``continuum-mcp`` in a committed config only works when the host's own
+    PATH happens to contain the install environment — on Windows it never resolves
+    from the child's PATH (#699), and no one committed file can name the venv path
+    on every platform at once. So the registration is written here, where the
+    entry point can actually be found: resolve it, prove it serves the protocol
+    with a real handshake, then bake the resolved path into the host's config.
+    """
+    from continuum.mcp.install import (
+        ProbeError,
+        build_registration,
+        install_server,
+        probe_server,
+        resolve_server_command,
+    )
+
+    profile = MCP_PROFILES[args.client]
+    command = resolve_server_command()
+    try:
+        server_info = probe_server(command)
+    except ProbeError as exc:
+        print(f"error: refusing to register the MCP server: {exc}", file=err)
+        print(
+            "The command was resolved but did not complete the MCP handshake; fix the "
+            "installation (for a source checkout: pip install '.[mcp]') and retry.",
+            file=err,
+        )
+        return ExitCode.ERROR
+    registration = build_registration(command, db=args.db, client=profile["mutating_client"])
+    config_path = _mcp_config_path(args, profile)
+    try:
+        status = install_server(
+            config_path, registration, scope=args.scope, project_dir=Path.cwd(), profile=profile
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=err)
+        return ExitCode.ERROR
+
+    rendered = " ".join([registration["command"], *registration["args"]])
+    lines = [
+        f"MCP server registered with {args.client} (scope: {args.scope})",
+        f"  config: {config_path}",
+    ]
+    if args.scope == "local":
+        lines.append(f"  project: {Path.cwd().resolve().as_posix()}")
+    lines += [
+        f"  status: {status}",
+        f"  command: {rendered}",
+        f"  verified: initialize handshake with {server_info.get('name')} "
+        f"{server_info.get('version') or 'unknown version'}",
+    ]
+    if args.scope == "project":
+        # The one scope whose file is usually committed: what was just written is
+        # correct only on this machine, and the operator should know before the
+        # file reaches anyone else's clone.
+        note = (
+            "this file is usually committed; the command path above is specific to "
+            "this machine (scope 'local' is the per-machine default)"
+        )
+        lines.append(f"  note: {note}")
+    lines.append("restart the host (in Claude Code: /mcp) to connect")
+    payload: dict[str, Any] = {
+        "client": args.client,
+        "scope": args.scope,
+        "config": str(config_path),
+        "status": status,
+        "server": registration,
+        "verified": server_info,
+    }
+    if args.scope == "project":
+        payload["note"] = note
+    _emit(
+        payload,
+        "\n".join(lines),
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
+
+
+def cmd_mcp_remove(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
+    """Drop the ``continuum-mcp`` registration from a host config (issue #834).
+
+    The mirror of ``mcp install``: same client/scope/config selectors, so the
+    documented uninstall finds exactly what the documented install wrote. Only
+    the ``continuum-mcp`` key is touched — other servers in the same file are
+    the operator's, not ours.
+    """
+    from continuum.mcp.install import remove_server
+
+    profile = MCP_PROFILES[args.client]
+    config_path = _mcp_config_path(args, profile)
+    try:
+        removed = remove_server(
+            config_path, scope=args.scope, project_dir=Path.cwd(), profile=profile
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=err)
+        return ExitCode.ERROR
+    text = (
+        f"Removed continuum-mcp from {config_path} (scope: {args.scope})"
+        if removed
+        else f"No continuum-mcp registration found in {config_path} (scope: {args.scope})"
+    )
+    _emit(
+        {
+            "client": args.client,
+            "scope": args.scope,
+            "config": str(config_path),
+            "removed": removed,
+        },
+        text,
+        as_json=args.json,
+        stream=out,
+        palette=getattr(args, "_palette", None),
+    )
+    return ExitCode.OK
+
+
 def cmd_gate(args: argparse.Namespace, storage: Storage, out: Any, err: Any) -> int:
     """Decide whether one tool call may proceed (issue #217).
 
@@ -3915,6 +4053,57 @@ def build_parser() -> argparse.ArgumentParser:
     )
     hooks_client(remove, cmd_hooks_remove)
 
+    mcp = add("mcp", cmd_mcp_install, "Register the MCP server with a host. Mutates host config.")
+    mcp_sub = mcp.add_subparsers(dest="mcp_command", metavar="ACTION", required=True)
+
+    def mcp_client(p: argparse.ArgumentParser, func: Any) -> None:
+        """Give an ``mcp`` action its client/scope selectors and config override."""
+        p.add_argument(
+            "client",
+            nargs="?",
+            default="claude-code",
+            choices=tuple(MCP_PROFILES),
+            metavar="client",
+            help="which host to configure (default: claude-code).",
+        )
+        p.add_argument(
+            "--scope",
+            default="local",
+            choices=("local", "user", "project"),
+            help=(
+                "where the registration lives: local (this project, default), user "
+                "(every project), or project (.mcp.json, usually committed)."
+            ),
+        )
+        p.add_argument(
+            "--config",
+            default=None,
+            help="path to the host's config file (default: per client profile).",
+        )
+        p.set_defaults(func=func)
+
+    mcp_install = mcp_sub.add_parser(
+        "install",
+        help=(
+            "Resolve the server on this machine, verify the handshake, and write the "
+            "registration. Mutates host config."
+        ),
+    )
+    mcp_install.add_argument(
+        "--db",
+        default=None,
+        help=(
+            "bake a specific database path into the server command "
+            "(default: continuum.db, resolved by the host per project)."
+        ),
+    )
+    mcp_client(mcp_install, cmd_mcp_install)
+
+    mcp_remove = mcp_sub.add_parser(
+        "remove", help="Remove the continuum-mcp registration. Mutates host config."
+    )
+    mcp_client(mcp_remove, cmd_mcp_remove)
+
     verify = with_run(add("verify", cmd_verify, "Re-audit the event chain."))
     verify.add_argument(
         "--index",
@@ -4147,9 +4336,9 @@ def main(
     if getattr(args, "func", None) is None:
         return _bare_invocation(parser, args, out, err)
 
-    # hooks never touches a run, so it must not create an empty database as a
-    # side effect of editing a settings file.
-    if args.command in ("benchmark", "attest-keygen", "serve", "hooks"):
+    # hooks and mcp never touch a run, so they must not create an empty database
+    # as a side effect of editing a settings file.
+    if args.command in ("benchmark", "attest-keygen", "serve", "hooks", "mcp"):
         return int(args.func(args, None, out, err))
 
     # Instant resume detection (issue #394): SessionStart hook reads

--- a/src/continuum/mcp/install.py
+++ b/src/continuum/mcp/install.py
@@ -1,0 +1,369 @@
+"""Register the MCP server with a host so the host can actually spawn it (issue #834).
+
+``.mcp.json`` declares the server by bare command name, and that name resolves only
+when the *host's* PATH contains the environment CONTINUUM was installed into. On
+Windows this fails by construction: ``CreateProcess`` resolves a bare command name
+against the calling process's own PATH, never the environment it passes to the child,
+and a venv's ``Scripts`` directory joins PATH only inside a shell that activated it.
+The host reports the failed spawn as ``CONNECTION_CLOSED``, which reads like a crash
+but describes an executable that was never found (#699). A committed JSON file cannot
+name both ``.venv/bin/continuum-mcp`` and ``.venv\\Scripts\\continuum-mcp.exe``, so no
+static config can fix this for every machine at once.
+
+The fix is to resolve the command *on the machine that will spawn the server*, which
+is what this module does: ``continuum mcp install`` resolves the real entry point
+(the ``continuum-mcp`` executable, or ``<python> -m continuum.mcp`` when no executable
+is on PATH — the same two-step resolution ``hooks install`` uses for its commands,
+``clienthooks.observe_command``), proves it serves the protocol by driving a real
+``initialize`` handshake over stdio, and only then writes the registration with the
+resolved absolute path baked in.
+
+The handshake probe is what separates this from a PATH lookup: it catches the
+missing-``mcp``-extra state (#697, where the entry point exists but its dependency
+does not), a stale entry point from a moved virtualenv, and a server that starts but
+cannot open storage — all before any configuration is written, so a failed install
+leaves the host's config untouched rather than registering a server known not to
+work.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "MCP_PROFILES",
+    "ProbeError",
+    "SERVER_KEY",
+    "build_registration",
+    "install_server",
+    "probe_server",
+    "remove_server",
+    "resolve_server_command",
+]
+
+#: The server key every host config uses. MCP servers are registered by name, so
+#: unlike hooks (whose entries are anonymous and recognised by command shape,
+#: ``clienthooks._is_managed_hook``) the key *is* the identity: whatever wrote the
+#: entry under this name registered the CONTINUUM server.
+SERVER_KEY = "continuum-mcp"
+
+#: Which client name the authz layer trusts with mutating tools. The committed
+#: ``.mcp.json`` grants ``claude-code``; the installer keeps that default and keys
+#: it to the profile so a future host profile grants its own client name.
+_MUTATING_CLIENTS_ENV = "CONTINUUM_MCP_MUTATING_CLIENTS"
+
+#: Per-host wiring profiles, in the spirit of ``clienthooks.CLIENT_PROFILES``
+#: (#209): everything that differs between hosts is data. A host's config file,
+#: where its scopes live, and whether its "local" scope is per-project (Claude Code
+#: nests local registrations under ``projects[<cwd>].mcpServers`` in the user config)
+#: is all a host needs to describe here for install/remove to work.
+MCP_PROFILES: dict[str, dict[str, Any]] = {
+    "claude-code": {
+        # local and user scopes share ~/.claude.json; project scope is the
+        # committed .mcp.json at the project root.
+        "user_config": "~/.claude.json",
+        "project_config": ".mcp.json",
+        # Claude Code's local scope is stored per project directory inside the
+        # user config (verified against `claude mcp add`: projects[cwd].mcpServers,
+        # with the directory spelled in forward slashes even on Windows).
+        "local_is_per_project": True,
+        "mutating_client": "claude-code",
+    },
+}
+
+
+class ProbeError(Exception):
+    """The server could not be started or did not complete the MCP handshake."""
+
+
+def resolve_server_command() -> list[str]:
+    """The argv that runs the MCP server on this machine, right now.
+
+    Three steps, most desirable first: an executable on PATH (what a wheel, pipx
+    or ``uv tool`` install provides); an executable sitting beside the running
+    ``continuum`` (the common venv case where ``continuum mcp install`` was invoked
+    from inside the environment but PATH resolution is unavailable to the host);
+    and the interpreter-plus-module form, which needs no PATH at all and is what
+    makes editable and unactivated-venv installs work on Windows. The forms match
+    ``clienthooks.observe_command``'s resolution so the two installers cannot
+    disagree about how to reach a CONTINUUM entry point.
+    """
+    direct = shutil.which(SERVER_KEY)
+    if direct:
+        return [direct]
+    sibling_name = f"{SERVER_KEY}.exe" if os.name == "nt" else SERVER_KEY
+    running = shutil.which("continuum")
+    if running:
+        sibling = Path(running).parent / sibling_name
+        if sibling.exists():
+            return [str(sibling)]
+    return [sys.executable, "-u", "-m", "continuum.mcp"]
+
+
+def probe_server(command: Sequence[str], *, timeout: float = 20.0) -> dict[str, Any]:
+    """Prove ``command`` serves MCP by driving a real ``initialize`` handshake.
+
+    Raises :class:`ProbeError` — never writes anything, spawns nothing else — so
+    the caller can refuse to register a server that does not work. The probe's
+    database is a throwaway in the system temporary directory: verifying a
+    registration must not leave ``continuum.db`` files in the project, whose
+    presence the CLI treats as state.
+
+    The environment is inherited rather than minimal: on Windows a child denied
+    ``SystemRoot`` dies during interpreter startup before any CONTINUUM code runs
+    (issue #211).
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="continuum-mcp-probe-"))
+    env = dict(os.environ)
+    env["CONTINUUM_DB"] = str(tmp / "probe.db")
+    errors: list[str] = []
+    stderr_thread: threading.Thread | None = None
+    try:
+        try:
+            proc = subprocess.Popen(  # noqa: SIM115 - cleaned up in finally
+                list(command),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                text=True,
+                bufsize=1,
+            )
+        except OSError as exc:
+            raise ProbeError(
+                f"cannot start the MCP server ({exc}). The registered command must "
+                f"be spawnable by the host; check the installation."
+            ) from exc
+
+        # Drain stderr on a thread so a chatty server cannot deadlock the probe by
+        # filling the pipe buffer while we block reading stdout.
+        def drain_stderr() -> None:
+            assert proc.stderr is not None
+            errors.extend(line.rstrip() for line in proc.stderr)
+
+        stderr_thread = threading.Thread(target=drain_stderr, daemon=True)
+        stderr_thread.start()
+
+        try:
+            assert proc.stdin is not None
+            proc.stdin.write(
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {},
+                            "clientInfo": {"name": "continuum-mcp-install", "version": "0"},
+                        },
+                    }
+                )
+                + "\n"
+            )
+            proc.stdin.flush()
+            line = _readline_with_timeout(proc, timeout)
+            reply: dict[str, Any] = json.loads(line)
+            server: dict[str, Any] = reply.get("result", {}).get("serverInfo", {})
+            if server.get("name") != SERVER_KEY:
+                raise ProbeError(
+                    f"the command answered the handshake as a different server "
+                    f"({server.get('name')!r})"
+                )
+            return server
+        except json.JSONDecodeError as exc:
+            raise ProbeError(
+                f"the server's handshake reply is not JSON ({exc}); it printed to "
+                f"stdout, which the MCP protocol reserves for protocol frames"
+            ) from exc
+        finally:
+            if proc.stdin:
+                proc.stdin.close()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+    except ProbeError as exc:
+        # The server's own stderr is often the actual diagnosis (the missing-extra
+        # message, a storage error), and the host never shows it, so the probe
+        # attaches it rather than summarising it away. The drain thread needs a
+        # moment past process exit to consume the pipe's tail; join briefly
+        # instead of racing it.
+        if stderr_thread is not None:
+            stderr_thread.join(1.0)
+        tail = "\n".join(errors[-5:]).strip()
+        if tail:
+            raise ProbeError(f"{exc}\nThe server reported:\n{tail}") from None
+        raise
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _readline_with_timeout(proc: subprocess.Popen[str], timeout: float) -> str:
+    """Read one stdout line, bounded in time.
+
+    ``select`` cannot wait on Windows pipes, so the read runs on a thread and the
+    join is the deadline. An empty line means the server exited before answering,
+    which is where every cold-start failure (#87, #697) shows up.
+    """
+    assert proc.stdout is not None
+    result: list[str] = []
+
+    def read() -> None:
+        result.append(proc.stdout.readline())  # type: ignore[union-attr]
+
+    reader = threading.Thread(target=read, daemon=True)
+    reader.start()
+    reader.join(timeout)
+    if reader.is_alive():
+        proc.kill()
+        raise ProbeError(
+            f"the MCP server did not complete the initialize handshake within {timeout:.0f}s"
+        )
+    line = result[0]
+    if not line:
+        raise ProbeError("the MCP server exited before answering the handshake")
+    return line
+
+
+def build_registration(
+    command: Sequence[str], *, db: str | None = None, client: str = "claude-code"
+) -> dict[str, Any]:
+    """The ``mcpServers`` entry for ``command``.
+
+    ``db`` defaults to the same ``continuum.db`` the committed ``.mcp.json`` uses:
+    relative, resolved by the host against the project it spawns the server in.
+    That is parity with the shipped configuration, not an oversight — a
+    registration's command path is per-machine (resolved here, baked in), but the
+    database belongs to the project, and an absolute default would point every
+    project at one database. ``--db`` bakes an explicit path for operators who
+    want one.
+    """
+    db_path = db or "continuum.db"
+    if len(command) == 1:
+        resolved_command: str = command[0]
+        args: list[str] = ["--db", db_path]
+    else:
+        resolved_command = command[0]
+        args = [*command[1:], "--db", db_path]
+    return {
+        "type": "stdio",
+        "command": resolved_command,
+        "args": args,
+        "env": {_MUTATING_CLIENTS_ENV: client},
+    }
+
+
+def _load_config(config_path: Path) -> dict[str, Any]:
+    """Read a host config file, refusing to clobber one that is not JSON.
+
+    A file someone edited by hand is a statement of intent; overwriting it to save
+    a typo would destroy work (same contract as ``clienthooks._install_hook``).
+    """
+    if config_path.exists():
+        try:
+            settings: dict[str, Any] = json.loads(config_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"{config_path} is not valid JSON ({exc}); refusing to edit it"
+            ) from exc
+        if not isinstance(settings, dict):
+            raise ValueError(f"{config_path} does not contain a JSON object")
+        return settings
+    return {}
+
+
+def _mcp_servers_for(
+    settings: dict[str, Any], *, scope: str, project_dir: Path, profile: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Navigate to the ``mcpServers`` map a given scope lives in, creating the path.
+
+    Claude Code keeps its per-project "local" scope inside the user config under
+    ``projects[<cwd>].mcpServers`` — with the directory spelled in forward slashes
+    even on Windows, which is how ``claude mcp add`` itself writes it, so this
+    reproduces the host's own layout rather than inventing a parallel one. The
+    "user" scope is the same file's top-level ``mcpServers``; the "project" scope
+    is a different file entirely (``.mcp.json``, chosen by the caller), whose
+    ``mcpServers`` is also top-level.
+    """
+    if scope == "local" and profile["local_is_per_project"]:
+        projects = settings.setdefault("projects", {})
+        if not isinstance(projects, dict):
+            raise ValueError("'projects' is not an object")
+        # as_posix: forward slashes on every platform, matching what the host
+        # itself writes as the project key.
+        project_key = project_dir.resolve().as_posix()
+        project = projects.setdefault(project_key, {})
+        if not isinstance(project, dict):
+            raise ValueError(f"projects[{project_key}] is not an object")
+    elif scope in ("local", "user", "project"):
+        project = settings
+    else:
+        raise ValueError(f"unknown scope {scope!r}")
+    servers = project.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise ValueError("'mcpServers' is not an object")
+    return servers
+
+
+def install_server(
+    config_path: Path,
+    registration: Mapping[str, Any],
+    *,
+    scope: str,
+    project_dir: Path,
+    profile: Mapping[str, Any] | None = None,
+) -> str:
+    """Write ``registration`` under :data:`SERVER_KEY`; returns the change made.
+
+    ``"installed"`` when the key was absent, ``"updated"`` when an existing entry
+    pointed somewhere else (a moved virtualenv — repointed, not duplicated), and
+    ``"present"`` when nothing needed to change, so re-running after an upgrade
+    converges instead of accumulating entries.
+    """
+    profile = profile or MCP_PROFILES["claude-code"]
+    settings = _load_config(config_path)
+    servers = _mcp_servers_for(settings, scope=scope, project_dir=project_dir, profile=profile)
+    existing = servers.get(SERVER_KEY)
+    if existing == dict(registration):
+        return "present"
+    servers[SERVER_KEY] = dict(registration)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    return "updated" if existing is not None else "installed"
+
+
+def remove_server(
+    config_path: Path, *, scope: str, project_dir: Path, profile: Mapping[str, Any] | None = None
+) -> bool:
+    """Drop the :data:`SERVER_KEY` registration. True when anything was removed.
+
+    Only our key is touched: every other server, every other key in the file, and
+    the project entry itself survive, exactly as ``clienthooks._remove_hooks``
+    leaves unrelated hook configuration alone. Empty ``mcpServers`` maps are left
+    in place because the host itself does (verified: ``claude mcp remove`` leaves
+    ``"mcpServers": {}`` behind), so removing cannot make the file a shape the
+    host has never seen.
+    """
+    profile = profile or MCP_PROFILES["claude-code"]
+    settings = _load_config(config_path)
+    if not settings:
+        return False
+    try:
+        servers = _mcp_servers_for(settings, scope=scope, project_dir=project_dir, profile=profile)
+    except ValueError:
+        return False
+    if SERVER_KEY not in servers:
+        return False
+    del servers[SERVER_KEY]
+    config_path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    return True

--- a/tests/test_mcp_entrypoint.py
+++ b/tests/test_mcp_entrypoint.py
@@ -1,0 +1,189 @@
+"""The installed ``continuum-mcp`` entry point, spoken to the way a client speaks to it.
+
+Every other MCP test drives the server in-process (``tests/mcp_helpers.py``) or through
+``sys.executable -m continuum.mcp[.server]`` (``tests/test_reasoning_summary.py``,
+``tests/test_recovery_guidance.py``). Neither exercises what an MCP host actually spawns:
+the ``continuum-mcp`` console script that ``[project.scripts]`` installs unconditionally.
+That gap is why #697 shipped to PyPI (the entry point existed where its dependency did
+not) and why #699 reached users before CI (PATH resolution of the entry point was never
+under test) — the failures live between the entry point and the protocol, a stretch of
+road the suite had never driven.
+
+Three behaviours are pinned here:
+
+1. the console script, spawned by absolute path, completes the ``initialize``
+   handshake and serves ``tools/list`` over real stdio (issue #834's baseline);
+2. on Windows, a bare ``continuum-mcp`` cannot be spawned even when its directory is on
+   the *child's* PATH — ``CreateProcess`` resolves the calling process's PATH, not the
+   environment it passes (the mechanism behind ``CONNECTION_CLOSED``, and the reason
+   registration must bake resolved paths rather than rely on the host's PATH);
+3. ``python -m continuum.mcp`` — the form ``continuum mcp install`` falls back to when
+   no executable is on PATH — completes the same handshake.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PROTOCOL_VERSION = "2024-11-05"
+#: Twelve tools: three read-only, nine mutating (``docs/api/mcp.md``).
+TOOL_COUNT = 12
+
+
+def _entrypoint() -> str | None:
+    """The installed ``continuum-mcp`` executable, or ``None`` when absent.
+
+    ``shutil.which`` first, so the test uses whatever the environment would find;
+    the sibling-of-interpreter fallback covers environments where the Scripts
+    directory is not on PATH (GitHub Actions runners, unactivated venvs) — the
+    same two-step resolution ``continuum mcp install`` performs.
+    """
+    found = shutil.which("continuum-mcp")
+    if found:
+        return found
+    name = "continuum-mcp.exe" if os.name == "nt" else "continuum-mcp"
+    sibling = Path(sys.executable).parent / name
+    return str(sibling) if sibling.exists() else None
+
+
+def _spawn(cmd: list[str], db: Path) -> subprocess.Popen[str]:
+    """Start the server exactly as a host would: pipes, no shell, inherited env.
+
+    The environment is a copy of the parent's rather than a minimal block: on
+    Windows a child denied ``SystemRoot`` dies during interpreter startup on
+    ``import _overlapped`` before any CONTINUUM code runs (issue #211).
+    """
+    env = dict(os.environ)
+    env["CONTINUUM_DB"] = str(db)
+    return subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        env=env,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _request(proc: subprocess.Popen[str], payload: dict[str, Any]) -> dict[str, Any]:
+    """Send one JSON-RPC request and return its response."""
+    assert proc.stdin is not None and proc.stdout is not None
+    proc.stdin.write(json.dumps(payload) + "\n")
+    proc.stdin.flush()
+    line = proc.stdout.readline()
+    assert line, "server closed the connection before answering"
+    return json.loads(line)
+
+
+def _stop(proc: subprocess.Popen[str]) -> None:
+    if proc.stdin:
+        proc.stdin.close()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def _handshake(cmd: list[str], db: Path) -> list[dict[str, Any]]:
+    """Drive initialize + tools/list over real stdio; return the listed tools."""
+    proc = _spawn(cmd, db)
+    try:
+        reply = _request(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "entrypoint-test", "version": "0"},
+                },
+            },
+        )
+        server = reply.get("result", {}).get("serverInfo", {})
+        assert server.get("name") == "continuum-mcp", server
+        proc.stdin.write('{"jsonrpc":"2.0","method":"notifications/initialized"}\n')
+        proc.stdin.flush()
+        listed = _request(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+        tools = listed.get("result", {}).get("tools", [])
+        assert len(tools) == TOOL_COUNT, [t.get("name") for t in tools]
+        return tools
+    finally:
+        _stop(proc)
+
+
+def test_console_script_handshake_over_stdio(tmp_path: Any) -> None:
+    """The installed entry point serves the protocol a host consumes (issues #697, #699)."""
+    script = _entrypoint()
+    if script is None:
+        pytest.skip(
+            "no installed continuum-mcp console script (pip install -e '.[dev]' provides one)"
+        )
+    _handshake([script], tmp_path / "entrypoint.db")
+
+
+def test_module_fallback_handshake_over_stdio(tmp_path: Any) -> None:
+    """``python -m continuum.mcp`` — the no-executable fallback ``mcp install`` bakes."""
+    _handshake([sys.executable, "-u", "-m", "continuum.mcp"], tmp_path / "module.db")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="documents Windows CreateProcess resolution")
+def test_bare_name_ignores_child_path_on_windows(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bare command name resolves against the *parent's* PATH, never the child's.
+
+    This is the mechanism behind ``CONNECTION_CLOSED`` (#699): an MCP host passes
+    the server a constructed environment whose PATH may contain the Scripts
+    directory, but ``CreateProcess`` ignores it and searches the calling process's
+    own PATH. A venv that is not activated in the shell that launched the host
+    therefore cannot be reached by bare name — which is why registration must
+    bake an absolute path (issue #834) rather than trust the host's environment.
+    """
+    script = _entrypoint()
+    if script is None:
+        pytest.skip(
+            "no installed continuum-mcp console script (pip install -e '.[dev]' provides one)"
+        )
+    script_dir = Path(script).parent.resolve()
+
+    # Parent PATH: the script's own directory surgically removed, so resolution
+    # has nothing to find. Any *other* continuum-mcp still reachable would make
+    # the constraint untestable here, so that case skips rather than lies.
+    kept = [
+        entry
+        for entry in os.environ.get("PATH", "").split(os.pathsep)
+        if entry and Path(entry).resolve() != script_dir
+    ]
+    monkeypatch.setenv("PATH", os.pathsep.join(kept))
+    if shutil.which("continuum-mcp") is not None:
+        pytest.skip(
+            "another continuum-mcp remains reachable on PATH; cannot isolate the constraint"
+        )
+
+    # Child PATH: the script's directory explicitly present. If resolution
+    # consulted the child's environment this spawn would succeed; on Windows it
+    # does not, and the FileNotFoundError is what a host turns into
+    # CONNECTION_CLOSED.
+    child_env = dict(os.environ)
+    child_env["PATH"] = os.pathsep.join([str(script_dir), *kept])
+    child_env["CONTINUUM_DB"] = str(tmp_path / "bare.db")
+    with pytest.raises(FileNotFoundError):
+        proc = subprocess.Popen(  # noqa: SIM115 - raised before the handle exists
+            ["continuum-mcp"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=child_env,
+        )
+        proc.kill()

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -1,0 +1,323 @@
+"""``continuum mcp install`` — registration resolved on the machine that spawns it (issue #834).
+
+The committed ``.mcp.json`` names the server by bare command, which a Windows host
+cannot resolve from a venv it did not activate (#699), and no committed file can
+carry one path that is right on every machine. The installer is the moving part
+that makes a static file unnecessary: it resolves the entry point here, proves it
+serves the protocol with a real handshake, and bakes the resolved path into the
+host's config.
+
+What is pinned here:
+
+1. the written shape matches what ``claude mcp add`` itself writes (verified against
+   the host), in every scope, with unrelated keys preserved;
+2. idempotency: re-running converges (``present``), a moved venv repoints
+   (``updated``) rather than duplicating;
+3. the handshake gate: a server that does not answer ``initialize`` is refused
+   *before* any config is written, and the server's own stderr surfaces — the
+   diagnosis the host would otherwise swallow;
+4. removal drops only the ``continuum-mcp`` key.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from continuum.cli import ExitCode, main
+from continuum.mcp.install import (
+    MCP_PROFILES,
+    SERVER_KEY,
+    build_registration,
+    install_server,
+    probe_server,
+    remove_server,
+    resolve_server_command,
+)
+
+
+def run(*argv: str) -> tuple[int, str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    code = main(list(argv), out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+def _project_key() -> str:
+    """The key Claude Code files a local-scope registration under: cwd, posix-spelled."""
+    return Path.cwd().resolve().as_posix()
+
+
+def _registered(config: Path, scope: str) -> dict[str, Any]:
+    data = json.loads(config.read_text(encoding="utf-8"))
+    if scope == "local":
+        return data["projects"][_project_key()]["mcpServers"][SERVER_KEY]
+    return data["mcpServers"][SERVER_KEY]
+
+
+def test_install_writes_the_shape_the_host_writes(tmp_path: Path) -> None:
+    """Local scope lands where ``claude mcp add --scope local`` puts it: the user
+    config's ``projects[cwd].mcpServers``, cwd in forward slashes, entry shaped
+    ``{type, command, args, env}``. A shape the host did not write is a shape it
+    may silently ignore."""
+    config = tmp_path / "claude.json"
+    code, out, err = run("--json", "mcp", "install", "--config", str(config))
+    assert code == ExitCode.OK, err
+    entry = _registered(config, "local")
+    assert entry["type"] == "stdio"
+    assert entry["env"] == {"CONTINUUM_MCP_MUTATING_CLIENTS": "claude-code"}
+    # The default database is the same relative path the committed .mcp.json
+    # names, resolved by the host per project — not an absolute path that would
+    # point every project at one database.
+    assert entry["args"][-2:] == ["--db", "continuum.db"]
+    payload = json.loads(out)
+    assert payload["status"] == "installed"
+    assert payload["verified"]["name"] == SERVER_KEY
+
+
+def test_install_user_scope_writes_top_level(tmp_path: Path) -> None:
+    """User scope registers the server for every project: top-level
+    ``mcpServers`` in the same config file."""
+    config = tmp_path / "claude.json"
+    code, _, err = run("--json", "mcp", "install", "--scope", "user", "--config", str(config))
+    assert code == ExitCode.OK, err
+    entry = _registered(config, "user")
+    assert entry["type"] == "stdio"
+    # User scope must not fabricate a per-project entry on its way past.
+    data = json.loads(config.read_text(encoding="utf-8"))
+    assert "projects" not in data
+
+
+def test_install_project_scope_writes_mcp_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Project scope targets the ``.mcp.json`` at the project root — the file the
+    repo already ships — and the report says it is machine-specific, because a
+    baked absolute path in a committed file is exactly the trap #699 fell into."""
+    monkeypatch.chdir(tmp_path)
+    code, out, err = run("--json", "mcp", "install", "--scope", "project")
+    assert code == ExitCode.OK, err
+    entry = json.loads((tmp_path / ".mcp.json").read_text(encoding="utf-8"))["mcpServers"][
+        SERVER_KEY
+    ]
+    assert entry["type"] == "stdio"
+    assert "specific to this machine" in out
+
+
+def test_reinstall_converges_and_repoints(tmp_path: Path) -> None:
+    """Three installs leave one entry: the second is ``present`` (an upgrade that
+    rewrote nothing), and a changed database repoints to ``updated`` — the
+    moved-venv case, repointed rather than duplicated (#484's lesson, applied to
+    a keyed store where it is simpler: the name *is* the identity)."""
+    config = tmp_path / "claude.json"
+    code, out, err = run("--json", "mcp", "install", "--config", str(config))
+    assert code == ExitCode.OK, err
+    assert json.loads(out)["status"] == "installed"
+
+    code, out, err = run("--json", "mcp", "install", "--config", str(config))
+    assert code == ExitCode.OK, err
+    assert json.loads(out)["status"] == "present"
+
+    code, out, err = run("--json", "mcp", "install", "--db", "other.db", "--config", str(config))
+    assert code == ExitCode.OK, err
+    assert json.loads(out)["status"] == "updated"
+    assert _registered(config, "local")["args"][-1] == "other.db"
+
+
+def test_install_preserves_unrelated_keys(tmp_path: Path) -> None:
+    """The installer edits a file the host owns, in a section other tools share.
+    Another server in the same ``mcpServers``, another project in ``projects``,
+    and a top-level key must all survive byte-for-byte in value."""
+    other_project = "C:/somewhere/else" if os.name == "nt" else "/somewhere/else"
+    preexisting = {
+        "numStartups": 42,
+        "mcpServers": {"someone-elses-server": {"type": "stdio", "command": "other"}},
+        "projects": {other_project: {"mcpServers": {"another": {"command": "x"}}}},
+    }
+    config = tmp_path / "claude.json"
+    config.write_text(json.dumps(preexisting), encoding="utf-8")
+
+    code, _, err = run("--json", "mcp", "install", "--scope", "user", "--config", str(config))
+    assert code == ExitCode.OK, err
+    data = json.loads(config.read_text(encoding="utf-8"))
+    assert data["numStartups"] == 42
+    assert data["mcpServers"]["someone-elses-server"]["command"] == "other"
+    assert data["projects"][other_project]["mcpServers"]["another"]["command"] == "x"
+    assert SERVER_KEY in data["mcpServers"]
+
+
+def test_failed_probe_leaves_the_host_config_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The handshake gate's whole point: a server that does not answer is never
+    registered. #697 shipped because an entry point existed where its dependency
+    did not; here that state fails the probe and the config file is not created."""
+    from continuum.mcp import install as install_module
+
+    def refuses(command: Any, **_: Any) -> dict[str, Any]:
+        raise install_module.ProbeError("simulated: mcp extra not installed")
+
+    monkeypatch.setattr(install_module, "probe_server", refuses)
+    config = tmp_path / "claude.json"
+    code, _, err = run("--json", "mcp", "install", "--config", str(config))
+    assert code == ExitCode.ERROR
+    assert "refusing to register" in err
+    assert not config.exists()
+
+
+def test_probe_surfaces_the_servers_own_stderr() -> None:
+    """The host never shows a stdio server's stderr, so the probe has to: a child
+    that exits with a remediation line on stderr must deliver that line to the
+    operator, not a generic startup failure."""
+    from continuum.mcp.install import ProbeError
+
+    with pytest.raises(ProbeError) as excinfo:
+        probe_server(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stderr.write('install continuum-agent[mcp]\\n'); sys.exit(1)",
+            ]
+        )
+    assert "continuum-agent[mcp]" in str(excinfo.value)
+
+
+def test_probe_rejects_non_json_stdout() -> None:
+    """stdout belongs to the protocol; a server that prints anything else there
+    is unregistrable no matter how healthy it looks."""
+    from continuum.mcp.install import ProbeError
+
+    with pytest.raises(ProbeError):
+        probe_server([sys.executable, "-c", "print('hello from a chatty server')"])
+
+
+def test_probe_rejects_a_foreign_server() -> None:
+    """A command that answers the handshake as some other server would register
+    the wrong tool; the probe checks the name it was promised."""
+    from continuum.mcp.install import ProbeError
+
+    responder = (
+        "import json,sys;"
+        "print(json.dumps({'jsonrpc':'2.0','id':1,'result':{'serverInfo':"
+        "{'name':'someone-elses-server','version':'1'}}}))"
+    )
+    with pytest.raises(ProbeError, match="different server"):
+        probe_server([sys.executable, "-c", responder])
+
+
+def test_probe_accepts_the_real_server() -> None:
+    """The interpreter fallback form — what a fresh clone without an activated
+    venv resolves to on Windows — passes the probe, answering as continuum-mcp."""
+    server = probe_server([sys.executable, "-u", "-m", "continuum.mcp"])
+    assert server["name"] == SERVER_KEY
+
+
+def test_install_refuses_to_clobber_invalid_json(tmp_path: Path) -> None:
+    """A config someone hand-edited into invalid JSON is a statement of intent;
+    the installer refuses to touch it rather than overwrite it (the
+    ``clienthooks._install_hook`` contract, same situation)."""
+    config = tmp_path / "claude.json"
+    config.write_text("{not json", encoding="utf-8")
+    code, _, err = run("--json", "mcp", "install", "--config", str(config))
+    assert code == ExitCode.ERROR
+    assert config.read_text(encoding="utf-8") == "{not json"
+
+
+def test_remove_drops_only_our_key(tmp_path: Path) -> None:
+    """Removal is scoped to ``continuum-mcp``: another server in the same map,
+    and the project entry around it, survive — the mirror of install's
+    preservation, and the same discipline ``clienthooks._remove_hooks`` keeps."""
+    other_project = "C:/somewhere/else" if os.name == "nt" else "/somewhere/else"
+    profile = MCP_PROFILES["claude-code"]
+    config = tmp_path / "claude.json"
+    registration = build_registration([r"C:\venv\continuum-mcp.exe"], client="claude-code")
+    install_server(config, registration, scope="local", project_dir=Path.cwd(), profile=profile)
+    data = json.loads(config.read_text(encoding="utf-8"))
+    data["mcpServers"] = {"someone-elses-server": {"command": "other"}}
+    data["projects"][other_project] = {"allowedTools": ["Bash"]}
+    config.write_text(json.dumps(data), encoding="utf-8")
+
+    assert remove_server(config, scope="local", project_dir=Path.cwd(), profile=profile) is True
+    data = json.loads(config.read_text(encoding="utf-8"))
+    assert SERVER_KEY not in data["projects"][_project_key()]["mcpServers"]
+    assert data["projects"][_project_key()]["mcpServers"] == {}
+    assert data["mcpServers"]["someone-elses-server"]["command"] == "other"
+    assert data["projects"][other_project]["allowedTools"] == ["Bash"]
+
+    # Nothing left to remove: quiet no-op, not an error (an operator uninstalling
+    # twice must not be told the second attempt failed).
+    assert remove_server(config, scope="local", project_dir=Path.cwd(), profile=profile) is False
+
+
+def test_remove_via_cli_reports_the_same_file_install_wrote(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The #580 lesson: uninstall must resolve the same file install wrote, or
+    install is a one-way door. Here both sides take ``--config``; remove must
+    also work without it (the project-scope default is the cwd's .mcp.json)."""
+    monkeypatch.chdir(tmp_path)
+    code, _, err = run("--json", "mcp", "install", "--scope", "project")
+    assert code == ExitCode.OK, err
+    code, out, err = run("--json", "mcp", "remove", "--scope", "project")
+    assert code == ExitCode.OK, err
+    payload = json.loads(out)
+    assert payload["removed"] is True
+    # Relative, like the hooks installer's settings path: resolved against the
+    # cwd the operator ran from.
+    assert Path(payload["config"]) == Path(".mcp.json")
+    assert (tmp_path / ".mcp.json").exists()
+    assert (
+        SERVER_KEY
+        not in json.loads((tmp_path / ".mcp.json").read_text(encoding="utf-8"))["mcpServers"]
+    )
+
+
+def test_registration_forms() -> None:
+    """Both resolved command shapes produce spawnable entries: an executable
+    carries only the database flag; the interpreter form keeps its own argv
+    (module flags before the database flag, in spawn order)."""
+    exe = build_registration([r"C:\venv\Scripts\continuum-mcp.exe"])
+    assert exe == {
+        "type": "stdio",
+        "command": r"C:\venv\Scripts\continuum-mcp.exe",
+        "args": ["--db", "continuum.db"],
+        "env": {"CONTINUUM_MCP_MUTATING_CLIENTS": "claude-code"},
+    }
+    module = build_registration(
+        [sys.executable, "-u", "-m", "continuum.mcp"], db="state/ledger.db", client="gemini"
+    )
+    assert module["command"] == sys.executable
+    assert module["args"] == ["-u", "-m", "continuum.mcp", "--db", "state/ledger.db"]
+    assert module["env"]["CONTINUUM_MCP_MUTATING_CLIENTS"] == "gemini"
+
+
+def test_resolution_prefers_the_executable_then_the_sibling_then_the_interpreter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Three-step resolution, most host-friendly first: an executable on PATH
+    needs no environment; failing that, one beside the running ``continuum``
+    (the unactivated-venv case); failing that, the interpreter form that needs
+    no PATH at all — the only form that works for a fresh clone on Windows."""
+    fake_exe = tmp_path / ("continuum-mcp.exe" if os.name == "nt" else "continuum-mcp")
+    monkeypatch.setattr(
+        "continuum.mcp.install.shutil.which",
+        lambda name: str(fake_exe) if name == SERVER_KEY else None,
+    )
+    assert resolve_server_command() == [str(fake_exe)]
+
+    running = tmp_path / ("continuum.exe" if os.name == "nt" else "continuum")
+    running.write_text("", encoding="utf-8")
+    fake_exe.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        "continuum.mcp.install.shutil.which",
+        lambda name: str(running) if name == "continuum" else None,
+    )
+    assert resolve_server_command() == [str(fake_exe)]
+
+    monkeypatch.setattr("continuum.mcp.install.shutil.which", lambda name: None)
+    assert resolve_server_command() == [sys.executable, "-u", "-m", "continuum.mcp"]


### PR DESCRIPTION
## Summary

Closes #834. Follow-up to #699/#700 (that fix is POSIX-only) and #697.

A bare `continuum-mcp` in `.mcp.json` only resolves when the host's own PATH
contains the install environment. On Windows this fails by construction:
`CreateProcess` resolves a bare command name against the calling process's
PATH, never the environment it passes to the child, and a committed JSON file
cannot name both `.venv/bin/continuum-mcp` and `.venv/Scripts/continuum-mcp.exe`.
The registration therefore has to be written on the machine that spawns the
server.

`continuum mcp install` does for MCP what `hooks install` does for hooks
(#580's pattern):

- **resolve** the entry point: executable on PATH → sibling of the running
  `continuum` → `python -m continuum.mcp` (matches
  `clienthooks.observe_command`, so the two installers cannot disagree);
- **verify** by driving a real `initialize` handshake over stdio — a
  throwaway temp DB, never the project's. This catches the #697 state (entry
  point without the `mcp` extra), a stale entry point from a moved venv, and
  a server that cannot open storage, all *before* any config is written: a
  failed install leaves the host's config untouched. The server's own stderr
  is surfaced in the error, since the host never shows it;
- **register** with the resolved absolute path baked in, in the shape the
  host itself writes (verified against `claude mcp add`): local scope
  (default) under `projects[cwd].mcpServers` in `~/.claude.json` with the
  project key posix-spelled, user scope top-level, project scope the
  committed `.mcp.json` (reported as machine-specific, since that file is
  usually committed).

Idempotent by key: re-running converges (`present`), a moved venv repoints
(`updated`). `mcp remove` drops only the `continuum-mcp` key, leaving every
other server and project entry alone. Invalid host JSON is refused, not
clobbered (the `clienthooks._install_hook` contract). `mcp` bypasses storage
so config edits create no `continuum.db`.

### One deliberate deviation from the issue text

`--db` defaults to the same relative `continuum.db` the committed
`.mcp.json` names, resolved by the host per project — not an absolute path.
An absolute default cannot be right from a per-user config: it would point
every project at one database. `--db` bakes an explicit path for operators
who want one.

## Testing

`tests/test_mcp_install.py` — 15 tests: per-scope shapes, idempotency and
repointing, unrelated-key preservation, probe refusal leaving config
untouched, stderr surfacing, foreign-server rejection, remove-only-our-key,
three-step resolution. Full suite: 2,130 collected, only the environmental
Postgres test fails locally (no local server; fails identically at base).
Ruff and mypy clean. Live smoke-tested on Windows 11 (install → present →
updated → remove → not-found).

Stacked on #843 (the entry-point regression tests); docs count figures
re-synced to 2,130 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)