### PR TITLE
docs(checkpoint): add docstrings for context render and estimated_tokens

### DIFF
--- a/src/continuum/checkpoint/context.py
+++ b/src/continuum/checkpoint/context.py
@@ -72,6 +72,11 @@ class ContextSection:
     """Lower is more important; high-priority sections survive truncation."""
 
     def render(self) -> str:
+        """Format the section as a titled text block with indented lines.
+
+        Returns an empty string if ``lines`` is empty, otherwise returns the
+        title followed by each line indented by two spaces.
+        """
         if not self.lines:
             return ""
         body = "\n".join(f"  {line}" for line in self.lines)
@@ -79,6 +84,11 @@ class ContextSection:
 
     @property
     def estimated_tokens(self) -> int:
+        """Approximate token count for the rendered section.
+
+        Uses the characters-per-token heuristic from :func:`estimate_tokens`
+        for budget calculations without requiring an external tokenizer.
+        """
         return estimate_tokens(self.render())
 
 
@@ -93,6 +103,12 @@ class RecoveryContext:
     notes: tuple[str, ...] = field(default=())
 
     def render(self) -> str:
+        """Render the complete briefing text across all populated sections.
+
+        Joins non-empty rendered sections with double newlines. If sections were
+        omitted to satisfy a token budget, appends a truncation notice naming
+        the dropped section titles.
+        """
         blocks = [section.render() for section in self.sections if section.lines]
         text = "\n\n".join(blocks)
         if self.truncated:
@@ -102,6 +118,11 @@ class RecoveryContext:
 
     @property
     def estimated_tokens(self) -> int:
+        """Approximate token count for the complete rendered briefing.
+
+        Evaluates the full rendered text against the characters-per-token
+        heuristic to check compliance with context-window budgets.
+        """
         return estimate_tokens(self.render())
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Description

Adds docstrings to the 4 public methods in `src/continuum/checkpoint/context.py` covering context rendering and token estimation:
- `ContextSection.render`: formats a titled text block with 2-space indented lines, returning an empty string if lines are empty.
- `ContextSection.estimated_tokens`: calculates an approximate token count for the section using the characters-per-token heuristic.
- `RecoveryContext.render`: joins populated sections with double newlines and appends a truncation trailer when sections are dropped to fit a budget.
- `RecoveryContext.estimated_tokens`: calculates an approximate token count for the complete briefing to check context-window budget limits.

No runtime change.

## Related issues

Fixes #827

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# Reproduction AST check
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/checkpoint/context.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Lint and formatting
ruff check src/continuum/checkpoint/context.py
-> All checks passed!

ruff format --check src/continuum/checkpoint/context.py
-> 1 file already formatted

mypy src/continuum/checkpoint/context.py
-> Success: no issues found in 1 source file

# Unit tests
pytest tests/test_recovery_context.py
-> 23 passed in 0.44s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
