### PR TITLE
fix(dashboard): keep archived actions visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,11 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **Dashboard HITL actions remain visible after compaction (#809).** The dashboard
+  now folds the full archived and live event history when listing uncertain
+  actions, so an operator can still see and reconcile a claim whose action
+  events moved into the archive.
+
 - **`reconcile --auto` settles archived actions and probes authorities with
   full consumption context after compaction (#647).**
   `ActionLedger.pending` folds archived plus live events, but

--- a/src/continuum/dashboard/hitl.py
+++ b/src/continuum/dashboard/hitl.py
@@ -90,7 +90,7 @@ def pending_actions_with_keys(storage: Storage, run_id: str) -> list[tuple[str, 
     """Uncertain actions paired with their full ledger key (for buttons)."""
     from continuum.actions.ledger import fold_action_events
 
-    folded = fold_action_events(storage.read_events(run_id))
+    folded = fold_action_events(storage.read_all_events(run_id))
     out: list[tuple[str, Any]] = []
     for key, action in folded.items():
         if action.status in (ActionStatus.STARTED, ActionStatus.UNKNOWN):

--- a/tests/test_dashboard_hitl.py
+++ b/tests/test_dashboard_hitl.py
@@ -172,6 +172,23 @@ def test_reconcile_true_settles_uncertain_action(db: str, addr: str) -> None:
     assert "completed" in fold_statuses(db)
 
 
+def test_archived_uncertain_action_remains_visible_after_compaction(db: str) -> None:
+    from continuum.dashboard.hitl import pending_actions_with_keys
+
+    key = seed_uncertain(db, key="invoice:H-archived")
+    with SQLiteStorage(db) as store:
+        store.compact_run("run_1")
+        assert not any(
+            event.type is EventType.ACTION_RECORDED for event in store.read_events("run_1")
+        )
+
+        pending = pending_actions_with_keys(store, "run_1")
+
+    assert [(ledger_key, action.status.value) for ledger_key, action in pending] == [
+        (key, "started")
+    ]
+
+
 def test_reconcile_false_frees_the_action_for_retry(db: str, addr: str) -> None:
     seed_uncertain(db, key="invoice:H-2")
     status, _ = post(


### PR DESCRIPTION
## Description

The dashboard's human-in-the-loop action list folded only the live event tail. After compaction moved an uncertain claim's action events into the archive, the dashboard no longer displayed that claim even though the archive-aware action ledger still considered it pending.

This change builds the dashboard action list from `Storage.read_all_events`, preserving archived and live history. A compact-then-read regression test verifies that the archived uncertain action remains visible with its original ledger key.

## Related issues

Fixes #809

## Types of changes

- Type: `bugfix`

## Breaking changes

No.

## How has this been tested?

Environment: Windows 11, Python 3.11.15, Ruff 0.16.4, mypy 2.3.1.

- `pytest tests/test_dashboard_hitl.py -o addopts="" -q` (9 passed before the latest main refresh)
- `pytest tests/test_dashboard.py tests/test_dashboard_bind.py tests/test_dashboard_escaping.py tests/test_dashboard_hitl.py -o addopts="" -q` (26 passed before the latest main refresh)
- `pytest tests/test_dashboard_hitl.py tests/test_compaction.py -o addopts="" -q` (26 passed after the latest main refresh)
- `pytest tests -o addopts="" -q` (2086 passed, 37 skipped after the latest main refresh)
- `ruff check src/continuum/dashboard/hitl.py tests/test_dashboard_hitl.py` (passed)
- `ruff format --check src/ tests/ examples/` (298 files already formatted)
- `mypy src/continuum` (success, no issues in 124 source files)

The repository-wide `ruff check src/ tests/ examples/` is currently blocked by a pre-existing unsorted import block in `tests/test_tui.py`; the changed Python files pass Ruff lint and formatting.

## Checklist

Tests added for the changed behaviour. The changelog documents the user-visible fix. The full local test suite, format check, and strict type check pass. The only local lint failure is the unrelated existing `tests/test_tui.py` import order described above.

## Additional context

The regression test first confirms that compaction removed all `ACTION_RECORDED` rows from the live tail. It then asserts that the dashboard helper still returns the archived action as `started`, proving the test exercises the original failure rather than a non-compacted path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Uncertain actions remain visible in the dashboard after event-history compaction.
  - Archived action history is now included when displaying and reconciling uncertain actions, preserving their status and ledger details.

- **Documentation**
  - Updated the unreleased changelog to document the improved handling of archived and live event history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->