### PR TITLE
docs(recovery): add docstrings for attempt lesson functions in summary.py

### DIFF
--- a/src/continuum/recovery/summary.py
+++ b/src/continuum/recovery/summary.py
@@ -246,6 +246,15 @@ def build_attempt_lesson(
     ledger_entries: Any | None = None,
     now: Any | None = None,
 ) -> Any:
+    """Build a bounded AttemptLesson capturing why an attempt failed.
+
+    Derives the attempt ID deterministically from the decision rationale,
+    uncertain action scars, and ledger length. Extracts the falsified
+    premise, environment delta, avoidance rules, and supporting evidence
+    from validation statuses. Enforces per-field character limits and a
+    total size budget of 2048 bytes, progressively trimming fields if
+    necessary to prevent context bloating.
+    """
     from continuum.security.hashing import stable_hash
 
     run_id = getattr(decision, "run_id", "unknown")
@@ -335,6 +344,13 @@ def build_attempt_lesson(
 
 
 def render_attempt_lesson(lesson: Any) -> list[str]:
+    """Format an AttemptLesson into human-readable summary lines.
+
+    Accepts an AttemptLesson model instance or a raw dictionary and returns
+    concise lines summarizing the attempt identifier, falsified rationale,
+    environment changes, uncertain action scars, avoidance rules, and
+    supporting evidence items.
+    """
     if isinstance(lesson, dict):
         attempt_id = str(lesson.get("attempt_id", ""))
         falsified = str(lesson.get("falsified", ""))
@@ -373,6 +389,12 @@ def record_attempt_lesson(
     uncertain_actions: Any | None = None,
     ledger_entries: Any | None = None,
 ) -> Any:
+    """Build and append an ATTEMPT_LESSON event to the run log.
+
+    Constructs an AttemptLesson via :func:`build_attempt_lesson` and commits
+    it to ``storage`` as an ``EventType.ATTEMPT_LESSON`` event signed with
+    ``Origin.DETERMINISTIC``. Returns the created lesson instance.
+    """
     lesson = build_attempt_lesson(
         decision, uncertain_actions=uncertain_actions, ledger_entries=ledger_entries
     )


### PR DESCRIPTION
## Description

Adds docstrings to the three public attempt-lesson functions in `src/continuum/recovery/summary.py`:
- `build_attempt_lesson`: derives deterministic attempt IDs and extracts failure rationales, environmental deltas, avoidance rules, and evidence into an `AttemptLesson`, enforcing per-field limits and a 2048-byte total budget.
- `render_attempt_lesson`: formats an `AttemptLesson` into concise, readable summary lines for logging, CLI output, and context injection.
- `record_attempt_lesson`: constructs and appends an `EventType.ATTEMPT_LESSON` event signed with `Origin.DETERMINISTIC` to the event log.

No runtime change.

## Related issues

Fixes #826

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# Reproduction AST check
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/recovery/summary.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Lint and formatting
ruff check src/continuum/recovery/summary.py
-> All checks passed!

ruff format --check src/continuum/recovery/summary.py
-> 1 file already formatted

mypy src/continuum/recovery/summary.py
-> Success: no issues found in 1 source file

# Unit tests
pytest tests/test_attempt_lesson.py
-> 8 passed in 0.47s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
