### PR TITLE
docs(observability): add docstrings for metrics helpers in observability.py

### DIFF
--- a/src/continuum/observability.py
+++ b/src/continuum/observability.py
@@ -74,22 +74,49 @@ class Metrics:
     gauges: dict[str, float] = field(default_factory=dict)
 
     def increment(self, name: str, by: int = 1) -> None:
+        """Increment a monotonic counter by ``by``.
+
+        Counters are initialized to zero on first use. Raises
+        :class:`ValueError` if ``by`` is negative, preserving counter
+        monotonicity.
+        """
         if by < 0:
             raise ValueError("counters may only increase")
         self.counters[name] = self.counters.get(name, 0) + by
 
     def set_gauge(self, name: str, value: float) -> None:
+        """Set the instantaneous value of the named gauge.
+
+        Unlike monotonic counters, gauges record point-in-time values that
+        can fluctuate across updates.
+        """
         self.gauges[name] = value
 
     def record_time(self, name: str, seconds: float) -> None:
+        """Accumulate elapsed duration in seconds for ``name``.
+
+        Adds ``seconds`` to the named timer. Raises :class:`ValueError`
+        if ``seconds`` is negative.
+        """
         if seconds < 0:
             raise ValueError("elapsed time may not be negative")
         self.timers[name] = self.timers.get(name, 0.0) + seconds
 
     def timer(self, name: str) -> _Timer:
+        """Return a context manager that measures and records elapsed duration.
+
+        Measures wall-clock time using :func:`time.perf_counter` while the
+        block executes, adding the elapsed seconds to ``name`` upon exit.
+        """
         return _Timer(self, name)
 
     def snapshot(self) -> dict[str, Any]:
+        """Return a point-in-time copy of all recorded metrics.
+
+        Returns a dictionary with shallow copies of ``counters``,
+        ``timers``, and ``gauges`` so callers can inspect or serialize
+        metrics without mutating internal state.
+        """
         return {
             "counters": dict(self.counters),
             "timers": dict(self.timers),
@@ -97,6 +124,7 @@ class Metrics:
         }
 
     def reset(self) -> None:
+        """Clear all recorded counters, timers, and gauges in place."""
         self.counters.clear()
         self.timers.clear()
         self.gauges.clear()


### PR DESCRIPTION
## Description

Adds docstrings to the 6 public metrics helper methods on `Metrics` in `src/continuum/observability.py`:
- `increment`: increments a monotonic counter, enforcing non-negative increments.
- `set_gauge`: sets the instantaneous value of a named gauge.
- `record_time`: accumulates elapsed duration in seconds, enforcing non-negative duration.
- `timer`: returns a context manager measuring wall-clock duration via `time.perf_counter`.
- `snapshot`: returns an isolated, point-in-time dictionary copy of all recorded metrics.
- `reset`: clears all counters, timers, and gauges in place.

No runtime change.

## Related issues

Fixes #854

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in observability.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/observability.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/observability.py
-> All checks passed!

ruff format --check src/continuum/observability.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_observability.py
-> 7 passed in 0.39s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation for metrics tracking and timing operations.
  - Clarified how metric snapshots and resets work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->