### PR TITLE
docs(actions): add docstrings for reconcile methods and render in reconciliation.py

### DIFF
--- a/src/continuum/actions/reconciliation.py
+++ b/src/continuum/actions/reconciliation.py
@@ -86,6 +86,12 @@ class ProbeReconciler(Reconciler):
         self.last_error: Exception | None = None
 
     def resolve(self, action: Action) -> Resolution | None:
+        """Query the external system for evidence of ``action``.
+
+        Invokes the configured probe callable. If the probe raises an exception,
+        records it in :attr:`last_error` and returns ``None`` so an unreachable
+        probe is treated as uncertain rather than evidence of absence.
+        """
         try:
             return self._probe(action)
         except Exception as exc:  # noqa: BLE001 - an unreachable probe is not evidence
@@ -111,6 +117,11 @@ class AssumeNotOccurredReconciler(Reconciler):
             )
 
     def resolve(self, action: Action) -> Resolution:
+        """Resolve ``action`` by assuming it did not occur to allow a retry.
+
+        Returns a :class:`Resolution` with ``occurred=False``, relying on the
+        explicit assertion that the underlying operation is idempotent.
+        """
         return Resolution(
             occurred=False,
             note="assumed not to have occurred (operation declared idempotent)",
@@ -126,6 +137,11 @@ class ManualReconciler(Reconciler):
         self.reason = reason
 
     def resolve(self, action: Action) -> None:
+        """Defer resolution of ``action`` to human review.
+
+        Always returns ``None`` so the action remains unresolved and flagged
+        for manual inspection.
+        """
         return None
 
 
@@ -143,6 +159,12 @@ class ReconciliationReport:
         return not self.unresolved
 
     def render(self) -> str:
+        """Render a human-readable text summary of the reconciliation outcome.
+
+        Lists actions confirmed as performed, confirmed as not performed, and
+        those still unresolved that require human review. Returns
+        ``"nothing to reconcile"`` when no actions were processed.
+        """
         lines = []
         if self.resolved_completed:
             lines.append(f"confirmed as performed: {', '.join(self.resolved_completed)}")


### PR DESCRIPTION
## Description

Adds docstrings to the 4 public names in `src/continuum/actions/reconciliation.py`:
- `ProbeReconciler.resolve`: queries the external system for evidence of an action, catching probe exceptions and recording them in `last_error` so an unreachable probe is treated as uncertain rather than evidence of absence.
- `AssumeNotOccurredReconciler.resolve`: resolves an action by assuming it did not occur to permit a retry, relying on the assertion that the operation is idempotent.
- `ManualReconciler.resolve`: defers resolution to human review by returning `None`, ensuring the action remains unresolved and flagged for inspection.
- `ReconciliationReport.render`: formats a human-readable summary of confirmed performed, confirmed not performed, and unresolved actions.

No runtime change.

## Related issues

Fixes #853

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in actions/reconciliation.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/actions/reconciliation.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/actions/reconciliation.py
-> All checks passed!

ruff format --check src/continuum/actions/reconciliation.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_reconciliation.py tests/test_reconcilers.py
-> 44 passed in 2.60s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
