### PR TITLE
docs(state): add docstrings for VersionEntry and VersionChain properties in versioning.py

### DIFF
--- a/src/continuum/state/versioning.py
+++ b/src/continuum/state/versioning.py
@@ -63,6 +63,14 @@ def canonical_state_json(state: SemanticState) -> str:
 
 
 class VersionEntry(BaseModel):
+    """An immutable, content-addressed node in a run's state version chain.
+
+    Carries the full :class:`~continuum.models.SemanticState` snapshot at
+    a specific version index, its cryptographic content fingerprint, the
+    parent version's fingerprint, an optional commit reason, and a UTC
+    timestamp.
+    """
+
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     version: int
@@ -88,14 +96,20 @@ class VersionChain:
 
     @property
     def entries(self) -> tuple[VersionEntry, ...]:
+        """Return all committed version entries in ascending sequence order.
+
+        Returns an immutable tuple snapshot of the internal version chain.
+        """
         return tuple(self._entries)
 
     @property
     def head(self) -> VersionEntry | None:
+        """Return the newest committed version entry, or ``None`` if empty."""
         return self._entries[-1] if self._entries else None
 
     @property
     def current(self) -> SemanticState | None:
+        """Return the latest semantic state in the chain, or ``None`` if empty."""
         head = self.head
         return head.state if head else None
 
@@ -125,6 +139,11 @@ class VersionChain:
         return entry
 
     def at(self, version: int) -> VersionEntry:
+        """Retrieve the version entry at sequence index ``version``.
+
+        Raises :class:`KeyError` if no entry with that version number exists
+        in this chain.
+        """
         for entry in self._entries:
             if entry.version == version:
                 return entry


### PR DESCRIPTION
## Description

Adds docstrings to the 5 public names in `src/continuum/state/versioning.py`:
- `VersionEntry`: an immutable, content-addressed node in a run's state version chain carrying snapshot state, content fingerprint, parent fingerprint, reason, and timestamp.
- `VersionChain.entries`: returns an immutable tuple snapshot of all committed version entries in ascending sequence order.
- `VersionChain.head`: returns the newest committed version entry, or `None` if empty.
- `VersionChain.current`: returns the latest semantic state in the chain, or `None` if empty.
- `VersionChain.at`: retrieves the version entry at sequence index `version`, raising `KeyError` if absent.

No runtime change.

## Related issues

Fixes #852

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in state/versioning.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/state/versioning.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/state/versioning.py
-> All checks passed!

ruff format --check src/continuum/state/versioning.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_versioning.py
-> 10 passed in 0.41s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
