### PR TITLE
docs(replayguard): add docstrings for guard types and node wrapper in replayguard.py

### DIFF
--- a/src/continuum/replayguard.py
+++ b/src/continuum/replayguard.py
@@ -46,6 +46,17 @@ RESULT_ENVELOPE_KEY = "__return_value__"
 
 
 class GuardKind(StrEnum):
+    """Enumeration of replay-guard verdicts for intended side effects.
+
+    Classifies an action against the folded ledger into one of:
+    ``ALLOW`` (live claim, proceed with execution),
+    ``SKIP_DUPLICATE`` (already completed, return memoized result),
+    ``DENY_UNCLAIMED`` (no claim registered yet),
+    ``DENY_DUPLICATE`` (explicit duplicate refusal),
+    ``BLOCK_UNCERTAIN`` (outcome in doubt, requires reconciliation), or
+    ``DENY_RECLAIM`` (previous attempt closed, requires new claim).
+    """
+
     ALLOW = "allow"
     SKIP_DUPLICATE = "skip_duplicate"
     DENY_UNCLAIMED = "deny_unclaimed"
@@ -56,6 +67,12 @@ class GuardKind(StrEnum):
 
 @dataclass(frozen=True)
 class GuardDecision:
+    """Verdict and rationale produced by evaluating an action against the ledger.
+
+    Carries the evaluated :class:`GuardKind`, an explanatory human-readable
+    reason, and the optional resolved idempotency key string.
+    """
+
     kind: GuardKind
     reason: str
     key: str | None = None
@@ -214,9 +231,11 @@ def langgraph_protected_node(
     import hashlib
 
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        """Wrap a node function with identity calculation and replay protection."""
         node_name = getattr(fn, "__name__", "node")
 
         def identity(state: dict[str, Any]) -> str:
+            """Compute a stable idempotency key for node execution from state."""
             if key_fields:
                 basis = {k: state.get(k) for k in key_fields}
             else:
@@ -228,6 +247,7 @@ def langgraph_protected_node(
             return f"node:{node_name}:{digest}"
 
         def wrapped(state: dict[str, Any]) -> dict[str, Any]:
+            """Execute or short-circuit node invocation using memoized results."""
             kind, value = protected_call(
                 storage,
                 run_id,


### PR DESCRIPTION
## Description

Adds docstrings to the 5 public names in `src/continuum/replayguard.py`:
- `GuardKind`: enumeration of replay-guard verdicts (`ALLOW`, `SKIP_DUPLICATE`, `DENY_UNCLAIMED`, `DENY_DUPLICATE`, `BLOCK_UNCERTAIN`, `DENY_RECLAIM`).
- `GuardDecision`: frozen dataclass record containing the evaluated `GuardKind`, rationale `reason`, and resolved idempotency `key`.
- `decorator`: decorator wrapping a LangGraph node function with replay protection and stable identity generation.
- `identity`: helper calculating a stable idempotency key digest for node execution from state.
- `wrapped`: execution wrapper invoking `protected_call` and returning replayed markers or fresh outputs.

No runtime change.

## Related issues

Fixes #851

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in replayguard.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/replayguard.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/replayguard.py
-> All checks passed!

ruff format --check src/continuum/replayguard.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_compaction.py
-> 17 passed in 1.61s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
