### PR TITLE
docs(environment): add docstrings for provider capture methods in snapshot.py

### DIFF
--- a/src/continuum/environment/snapshot.py
+++ b/src/continuum/environment/snapshot.py
@@ -67,6 +67,7 @@ class StaticProvider(EnvironmentProvider):
         self._resources = captured
 
     def capture(self) -> Mapping[str, EnvResource]:
+        """Return a copy of the fixed resources supplied at initialization."""
         return dict(self._resources)
 
 
@@ -79,6 +80,12 @@ class ValueProvider(EnvironmentProvider):
         self._values = values
 
     def capture(self) -> Mapping[str, EnvResource]:
+        """Compute content fingerprints for configured in-memory values.
+
+        Calculates a deterministic hash for each value using :func:`stable_hash`.
+        Values that fail serialization or hashing report :data:`UNKNOWN_VERSION`
+        with the error in metadata rather than raising.
+        """
         captured: dict[str, EnvResource] = {}
         for key, value in self._values.items():
             try:
@@ -119,6 +126,12 @@ class FileProvider(EnvironmentProvider):
         self.max_bytes = max_bytes
 
     def capture(self) -> Mapping[str, EnvResource]:
+        """Fingerprint tracked files by streaming SHA-256 content checksums.
+
+        Files exceeding ``max_bytes`` or causing an :class:`OSError` report
+        :data:`UNKNOWN_VERSION` with diagnostic metadata. Missing files are
+        omitted so environment diffing classifies them as removed.
+        """
         captured: dict[str, EnvResource] = {}
         for path in self.paths:
             key = str(path)
@@ -179,6 +192,12 @@ class CallableProvider(EnvironmentProvider):
         self._kind = kind
 
     def capture(self) -> Mapping[str, EnvResource]:
+        """Execute registered probe callables and capture their results.
+
+        Wraps return values into :class:`~continuum.models.EnvResource` records.
+        Probes that raise an exception report :data:`UNKNOWN_VERSION` with the
+        exception details in metadata rather than propagating the failure.
+        """
         captured: dict[str, EnvResource] = {}
         for key, probe in self._probes.items():
             try:
@@ -259,6 +278,12 @@ class GitProvider(EnvironmentProvider):
         self.path = Path(path)
 
     def capture(self) -> Mapping[str, EnvResource]:
+        """Inspect the current git commit HEAD for the configured repository.
+
+        Executes ``git rev-parse HEAD`` under the repository path. If the command
+        fails, times out, or reports a non-zero exit status, returns
+        :data:`UNKNOWN_VERSION` with error details in metadata.
+        """
         key = f"git:{self.path}"
         try:
             result = subprocess.run(


### PR DESCRIPTION
## Description

Adds docstrings to the 5 provider `capture` methods in `src/continuum/environment/snapshot.py`:
- `StaticProvider.capture`: returns a copy of the fixed dictionary of resources supplied at initialization.
- `ValueProvider.capture`: computes deterministic content fingerprints for in-memory values via `stable_hash`, reporting `UNKNOWN_VERSION` on serialization errors.
- `FileProvider.capture`: fingerprints tracked files via streaming SHA-256 checksums, emitting `UNKNOWN_VERSION` on errors or byte size cap breaches, and omitting missing files.
- `CallableProvider.capture`: executes registered probe callables, catching exceptions and reporting `UNKNOWN_VERSION` so failures are treated as findings.
- `GitProvider.capture`: inspects the current git commit HEAD via `git rev-parse HEAD`, returning `UNKNOWN_VERSION` if the command fails or path is not a git repository.

No runtime change.

## Related issues

Fixes #850

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in environment/snapshot.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/environment/snapshot.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/environment/snapshot.py
-> All checks passed!

ruff format --check src/continuum/environment/snapshot.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_environment.py
-> 28 passed in 0.30s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
