### PR TITLE
docs(validator): add docstrings for ValidationOutcome and StateValidator methods in validator.py

### DIFF
--- a/src/continuum/state/validator.py
+++ b/src/continuum/state/validator.py
@@ -194,13 +194,16 @@ class ValidationOutcome:
 
     @property
     def safe(self) -> bool:
+        """True when all validated components permit resuming without repair."""
         return self.report.safe_to_resume
 
     @property
     def downgraded(self) -> tuple[ComponentValidationEntry, ...]:
+        """All component entries whose status was degraded away from valid."""
         return tuple(e for e in self.report.statuses if e.status is not StateStatus.VALID)
 
     def render(self) -> str:
+        """Render a human-readable summary of the validation report."""
         lines = [f"Run: {self.report.run_id}", f"Checkpoint: v{self.report.checkpoint_version}", ""]
         symbols = {StateStatus.VALID: "[ok]"}
         for entry in self.report.statuses:
@@ -256,6 +259,14 @@ class StateValidator:
         scope: Iterable[str] | None = None,
         events: Iterable[Event] | None = None,
     ) -> ValidationOutcome:
+        """Validate semantic state against environment diff and causal history.
+
+        Compares ``checkpoint_environment`` and ``current_environment``,
+        propagating staleness through dependencies, evidence, findings, and
+        decisions. Checks plan topology, approvals, model alignment, and
+        optional causal events. Returns a :class:`ValidationOutcome` with
+        the revised state and detailed component statuses.
+        """
         if isinstance(confirmed, bool):
             self.confirmed = {"goal", "progress"} if confirmed else set()
         else:
@@ -585,6 +596,7 @@ class StateValidator:
         visited_dfs: set[str] = set()
 
         def dfs(node: str, stack: set[str]) -> bool:
+            """Detect cycles in downstream causal event paths using DFS."""
             if node in stack:
                 return True
             if node in visited_dfs:
@@ -811,6 +823,7 @@ class StateValidator:
         cycle: list[str] | None = None
 
         def dfs(node: str) -> bool:
+            """Detect dependency cycles within plan steps using DFS."""
             nonlocal cycle
             if node in visited:
                 return False


### PR DESCRIPTION
## Description

Adds docstrings to the 6 public and inner helper names in `src/continuum/state/validator.py`:
- `ValidationOutcome.safe`: indicates whether all validated components permit resuming without repair.
- `ValidationOutcome.downgraded`: returns all component entries whose status was degraded away from valid.
- `ValidationOutcome.render`: renders a human-readable text summary of the validation report.
- `StateValidator.validate`: validates semantic state against environment diff and causal history, propagating staleness through dependencies and decisions.
- `dfs` (in `_propagate_caused_by`): traverses downstream causal event paths to detect cycles.
- `dfs` (in `_check_plan`): traverses plan step dependencies to detect circular dependencies.

No runtime change.

## Related issues

Fixes #824

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in state/validator.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/state/validator.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/state/validator.py
-> All checks passed!

ruff format --check src/continuum/state/validator.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_validator.py
-> 35 passed in 0.31s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
