### PR TITLE
docs(recovery): add docstrings for repair step and plan methods in planner.py

### DIFF
--- a/src/continuum/recovery/planner.py
+++ b/src/continuum/recovery/planner.py
@@ -103,6 +103,7 @@ class RepairStep(BaseModel):
         return f"{self.kind.value}:{self.target}"
 
     def render(self) -> str:
+        """Render a single-line summary of this repair step."""
         mark = "[human]" if self.requires_human else "[auto] "
         detail = f" - {self.reason}" if self.reason else ""
         return f"{mark} {self.kind.value} {self.target}{detail}"
@@ -123,10 +124,12 @@ class RepairPlan(BaseModel):
 
     @property
     def blocking(self) -> tuple[RepairStep, ...]:
+        """All steps in this plan that block resumption until settled."""
         return tuple(s for s in self.steps if s.blocking)
 
     @property
     def requires_human(self) -> bool:
+        """True if any step in this plan requires human intervention."""
         return any(s.requires_human for s in self.steps)
 
     @property
@@ -135,9 +138,11 @@ class RepairPlan(BaseModel):
         return self.steps[0] if self.steps else None
 
     def of_kind(self, kind: RepairKind) -> tuple[RepairStep, ...]:
+        """Return all steps in this plan matching ``kind``."""
         return tuple(s for s in self.steps if s.kind is kind)
 
     def render(self) -> str:
+        """Render a formatted, numbered multi-line summary of the repair plan."""
         if not self.steps:
             return "No repairs required."
         return "\n".join(f"  {i}. {s.render()}" for i, s in enumerate(self.steps, 1))


### PR DESCRIPTION
## Description

Adds docstrings to the 5 public names in `src/continuum/recovery/planner.py`:
- `RepairStep.render`: renders a single-line summary of a repair step indicating human requirement and details.
- `RepairPlan.blocking`: returns all steps in the plan that block resumption until settled.
- `RepairPlan.requires_human`: returns True if any step in the plan requires human intervention.
- `RepairPlan.of_kind`: filters and returns all steps in the plan matching a given `RepairKind`.
- `RepairPlan.render`: renders a formatted, numbered multi-line summary of the ordered repair plan.

No runtime change.

## Related issues

Fixes #806

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in recovery/planner.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/recovery/planner.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/recovery/planner.py
-> All checks passed!

ruff format --check src/continuum/recovery/planner.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_recovery_planner.py
-> 21 passed in 0.28s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
