### PR TITLE
docs(actions): add docstrings for ActionOutcome and ActionLedger read surface in ledger.py

### DIFF
--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -283,6 +283,7 @@ def _single_writer(
 
     @wraps(method)
     def wrapper(self: ActionLedger, /, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+        """Acquire the ledger lease lock before invoking the mutating method."""
         with self._locked():
             return method(self, *args, **kwargs)
 
@@ -303,14 +304,17 @@ class ActionOutcome:
 
     @property
     def already_completed(self) -> bool:
+        """True when the claim hit an existing already-completed action."""
         return not self.fresh and self.action.status is ActionStatus.COMPLETED
 
     @property
     def result(self) -> Mapping[str, Any] | None:
+        """The recorded result dictionary from the underlying action, if any."""
         return self.action.result
 
     @property
     def external_id(self) -> str | None:
+        """The external system identifier associated with the action, if known."""
         return self.action.external_id
 
 
@@ -563,6 +567,7 @@ class ActionLedger:
         return found
 
     def get(self, key: str) -> Action | None:
+        """Return the current action state for ``key``, or ``None`` if unclaimed."""
         return self._replay().get(key)
 
     def resolve_key(self, identifier: str) -> str | None:
@@ -701,6 +706,7 @@ class ActionLedger:
         return None
 
     def all(self) -> Sequence[Action]:
+        """Return all action records currently in the folded ledger."""
         return list(self._replay().values())
 
     def pending(self) -> Sequence[Action]:


### PR DESCRIPTION
## Description

Adds docstrings to the 6 public and wrapper names in `src/continuum/actions/ledger.py`:
- `wrapper` (in `_single_writer`): acquires the ledger lease lock before invoking mutating methods.
- `ActionOutcome.already_completed`: returns True when the claim hit an existing already-completed action.
- `ActionOutcome.result`: returns the recorded result dictionary from the underlying action, if any.
- `ActionOutcome.external_id`: returns the external system identifier associated with the action, if known.
- `ActionLedger.get`: returns the current action state for a key, or None if unclaimed.
- `ActionLedger.all`: returns all action records currently in the folded ledger.

No runtime change.

## Related issues

Fixes #805

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in actions/ledger.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/actions/ledger.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/actions/ledger.py
-> All checks passed!

ruff format --check src/continuum/actions/ledger.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_action_ledger.py
-> 85 passed in 0.67s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
