### PR TITLE
docs(events): add docstrings for IntegrityViolation and EventLog query methods

### DIFF
--- a/src/continuum/events.py
+++ b/src/continuum/events.py
@@ -234,6 +234,12 @@ class Event(BaseModel):
 
 
 class IntegrityViolation(BaseModel):
+    """Description of a single integrity failure discovered during chain audit.
+
+    Records the failure classification, run identifier, and optional event
+    metadata (sequence number and event ID) along with explanatory detail.
+    """
+
     model_config = ConfigDict(frozen=True, extra="forbid")
 
     kind: str
@@ -339,20 +345,29 @@ class EventLog:
     # -- reading ---------------------------------------------------------- #
 
     def runs(self) -> tuple[str, ...]:
+        """Return all distinct run identifiers present in the log."""
         return tuple(self._by_run)
 
     def events(self, run_id: str, *, after_sequence: int = 0) -> tuple[Event, ...]:
+        """Return recorded events for a run in sequence order.
+
+        Optionally filters for events whose sequence number is strictly greater
+        than ``after_sequence``.
+        """
         chain = self._by_run.get(run_id, ())
         return tuple(e for e in chain if e.sequence > after_sequence)
 
     def by_type(self, run_id: str, type: EventType) -> tuple[Event, ...]:
+        """Return all events for a run matching the specified event type."""
         return tuple(e for e in self._by_run.get(run_id, ()) if e.type is type)
 
     def head(self, run_id: str) -> Event | None:
+        """Return the most recent event appended for a run, or None if empty."""
         chain = self._by_run.get(run_id)
         return chain[-1] if chain else None
 
     def last_sequence(self, run_id: str) -> int:
+        """Return the highest sequence number recorded for a run, or 0 if empty."""
         return len(self._by_run.get(run_id, ()))
 
     def __iter__(self) -> Iterator[Event]:
@@ -385,6 +400,7 @@ class EventLog:
         truncated = False
 
         def record(kind: str, rid: str, event: Event, detail: str) -> None:
+            """Record an integrity violation if under the maximum violation limit."""
             nonlocal truncated
             if len(violations) >= max_violations:
                 truncated = True


### PR DESCRIPTION
## Description

Adds docstrings to the 7 public and helper names in `src/continuum/events.py`:
- `IntegrityViolation`: description of a single integrity failure discovered during chain audit.
- `EventLog.runs`: returns all distinct run identifiers present in the log.
- `EventLog.events`: returns recorded events for a run in sequence order, optionally starting after a sequence number.
- `EventLog.by_type`: returns all events for a run matching the specified event type.
- `EventLog.head`: returns the most recent event appended for a run, or None if empty.
- `EventLog.last_sequence`: returns the highest sequence number recorded for a run, or 0 if empty.
- `record` (in `EventLog.verify`): records an integrity violation if under the maximum violation limit.

No runtime change.

## Related issues

Fixes #804

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in events.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/events.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/events.py
-> All checks passed!

ruff format --check src/continuum/events.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_events.py tests/test_liveness_events.py
-> 29 passed in 1.01s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
