### PR TITLE
docs(benchmark): add docstrings for baseline strategies and helper in baselines.py

### DIFF
--- a/src/continuum/benchmark/baselines.py
+++ b/src/continuum/benchmark/baselines.py
@@ -17,25 +17,35 @@ from continuum.storage import SQLiteStorage
 
 
 class Baseline(Protocol):
+    """Protocol defining the interface for benchmark baseline drivers."""
+
     name: str
 
-    def run(self, storage: SQLiteStorage, run_id: str) -> dict[str, str]: ...
+    def run(self, storage: SQLiteStorage, run_id: str) -> dict[str, str]:
+        """Execute the baseline strategy for a run and return result metrics."""
+        ...
 
 
 @dataclass(frozen=True, slots=True)
 class FullTranscriptReplay:
+    """Baseline strategy that replays the full event log without compression."""
+
     name: str = "full_transcript_replay"
 
     def run(self, storage: SQLiteStorage, run_id: str) -> dict[str, str]:
+        """Read and replay all events for the given run."""
         events = storage.read_events(run_id)
         return {"replayed": str(len(events)), "mode": "replay_all"}
 
 
 @dataclass(frozen=True, slots=True)
 class SimpleConversationSummarization:
+    """Baseline strategy that condenses the event stream into a text summary."""
+
     name: str = "simple_conversation_summarization"
 
     def run(self, storage: SQLiteStorage, run_id: str) -> dict[str, str]:
+        """Summarize all recorded events for the given run."""
         events = storage.read_events(run_id)
         summary = f"summarized {len(events)} events"
         return {"summary": summary, "mode": "summarize"}
@@ -43,9 +53,12 @@ class SimpleConversationSummarization:
 
 @dataclass(frozen=True, slots=True)
 class NaiveCheckpointing:
+    """Baseline strategy that takes unguided checkpoints without recovery logic."""
+
     name: str = "naive_checkpointing"
 
     def run(self, storage: SQLiteStorage, run_id: str) -> dict[str, str]:
+        """Attempt to checkpoint the run, catching and recording any failure."""
         manager = CheckpointManager(storage)
         try:
             checkpoint = manager.checkpoint(run_id)
@@ -56,9 +69,12 @@ class NaiveCheckpointing:
 
 @dataclass(frozen=True, slots=True)
 class StructuredTaskSummary:
+    """Baseline strategy that extracts structured summaries of completed work."""
+
     name: str = "structured_task_summary"
 
     def run(self, storage: SQLiteStorage, run_id: str) -> dict[str, str]:
+        """Extract and count completed work events for the given run."""
         events = storage.read_events(run_id)
         tasks = [e for e in events if e.type == EventType.WORK_COMPLETED]
         return {"tasks": str(len(tasks)), "mode": "structured_summary"}
@@ -66,9 +82,12 @@ class StructuredTaskSummary:
 
 @dataclass(frozen=True, slots=True)
 class ContinuumSemanticCheckpoint:
+    """Baseline driver evaluating CONTINUUM semantic checkpointing."""
+
     name: str = "continuum_semantic_checkpoint"
 
     def run(self, storage: SQLiteStorage, run_id: str) -> dict[str, str]:
+        """Create a semantic checkpoint for the run using CheckpointManager."""
         manager = CheckpointManager(storage)
         checkpoint = manager.checkpoint(run_id)
         return {"checkpoint_id": checkpoint.checkpoint_id, "mode": "continuum"}
@@ -84,6 +103,7 @@ BASELINES: tuple[Baseline, ...] = (  # type: ignore[assignment]
 
 
 def baseline_by_name(name: str) -> Baseline:
+    """Look up a registered baseline driver by its name string."""
     for baseline in BASELINES:
         if baseline.name == name:
             return baseline


### PR DESCRIPTION
## Description

Adds docstrings to the 13 public classes, methods, and functions in `src/continuum/benchmark/baselines.py`:
- `Baseline`: protocol defining the interface for benchmark baseline drivers.
- `Baseline.run`: executes the baseline strategy for a run and returns result metrics.
- `FullTranscriptReplay`: baseline strategy that replays the full event log without compression.
- `FullTranscriptReplay.run`: reads and replays all events for the given run.
- `SimpleConversationSummarization`: baseline strategy that condenses the event stream into a text summary.
- `SimpleConversationSummarization.run`: summarizes all recorded events for the given run.
- `NaiveCheckpointing`: baseline strategy that takes unguided checkpoints without recovery logic.
- `NaiveCheckpointing.run`: attempts to checkpoint the run, catching and recording any failure.
- `StructuredTaskSummary`: baseline strategy that extracts structured summaries of completed work.
- `StructuredTaskSummary.run`: extracts and counts completed work events for the given run.
- `ContinuumSemanticCheckpoint`: baseline driver evaluating CONTINUUM semantic checkpointing.
- `ContinuumSemanticCheckpoint.run`: creates a semantic checkpoint for the run using CheckpointManager.
- `baseline_by_name`: looks up a registered baseline driver by its name string.

No runtime change.

## Related issues

Fixes #799

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in baselines.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/benchmark/baselines.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/benchmark/baselines.py
-> All checks passed!

ruff format --check src/continuum/benchmark/baselines.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_benchmark_baselines.py tests/test_benchmark.py
-> 7 passed in 4.13s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added descriptive documentation for baseline strategies and related methods.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->