### PR TITLE
fix(recovery): remove dead observations_evidence_lines helper

### DIFF
--- a/src/continuum/recovery/observations.py
+++ b/src/continuum/recovery/observations.py
@@ -109,19 +109,3 @@ def collect_observations(
             entries.append({"truncated": True, "omitted": omitted})
             break
     return entries
-
-
-def observations_evidence_lines(observations: list[dict[str, Any]]) -> list[str]:
-    """Render observation rows as contract evidence strings."""
-    lines: list[str] = []
-    for entry in observations:
-        if entry.get("truncated"):
-            lines.append(
-                f"files-changed-since-checkpoint: ... {entry['omitted']} earlier row(s) omitted"
-            )
-            continue
-        lines.append(
-            f"files-changed-since-checkpoint: {entry['status']} "
-            f"{entry['path']} ({entry['tool']}, seq {entry['sequence']})"
-        )
-    return lines


### PR DESCRIPTION
## Description

Deletes the uncalled observations_evidence_lines helper. No behavior change possible: zero references repo-wide.

## Related issues

Fixes #867

## Types of changes

- Type: `refactor`

## Breaking changes

No.

## How has this been tested?

Repo-wide reference search confirms zero callers. ruff check and format clean, strict mypy clean on the file. tests/test_contract_observations.py, tests/test_recovery_engine.py, and tests/test_cli_observe.py pass (65 tests).

## Checklist

No behavior change, so no new tests. No security-relevant changes.

## Additional context

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the formatting of observation entries into `files-changed-since-checkpoint` contract evidence lines.
  - Observation collection continues to return raw observation data, including a possible truncated-row indicator.
  - Existing observation data remains available, but the dedicated contract-line representation is no longer produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->