### PR TITLE
docs(analysis): add docstrings for trajectory report helpers and builders

### DIFF
--- a/src/continuum/analysis/trajectory_report.py
+++ b/src/continuum/analysis/trajectory_report.py
@@ -46,6 +46,7 @@ def _window_events(storage: Storage, run_id: str, start: int, end: int) -> list[
 
 
 def is_quiet_window(events: list[Event]) -> bool:
+    """Return True if the event window contains no progress or decision events."""
     for ev in events:
         if ev.type is EventType.WORK_COMPLETED:
             try:
@@ -178,6 +179,7 @@ def build_trajectory_report(
     *,
     now: datetime | None = None,
 ) -> TrajectoryReport:
+    """Distill metrics and failure patterns across an event window into a report."""
     from continuum.security.hashing import stable_hash
 
     events = _window_events(storage, run_id, window_start, window_end)
@@ -234,6 +236,7 @@ def build_trajectory_report(
 def record_trajectory_report(
     storage: Storage, run_id: str, report: TrajectoryReport
 ) -> TrajectoryReport:
+    """Persist a trajectory report event to storage if not already recorded."""
     try:
         existing_events = list(storage.read_events(run_id)) + list(
             storage.read_archived_events(run_id)
@@ -299,6 +302,7 @@ def maybe_generate_trajectory_report(
     window_start: int | None = None,
     window_end: int | None = None,
 ) -> TrajectoryReport | None:
+    """Generate and record a trajectory report if the target window is quiet."""
     if window_start is None or window_end is None:
         window = _last_compaction_window(storage, run_id)
         if window is None:
@@ -331,6 +335,7 @@ def maybe_generate_trajectory_report(
 def health_maybe_generate_trajectory_report(
     storage: Storage, run_id: str
 ) -> TrajectoryReport | None:
+    """Generate a trajectory report for the latest anchored compaction window."""
     window = _last_compaction_window(storage, run_id, require_anchor=True)
     if window is None:
         return None
@@ -341,6 +346,7 @@ def health_maybe_generate_trajectory_report(
 
 
 def render_trajectory_report(report: TrajectoryReport) -> list[str]:
+    """Format a trajectory report into human-readable lines for display."""
     label = (
         "unverified (derived)"
         if report.derived_origin in ("external_agent", "llm")


### PR DESCRIPTION
## Description

Adds docstrings to the 6 public functions in `src/continuum/analysis/trajectory_report.py`:
- `is_quiet_window`: returns True if the event window contains no progress or decision events.
- `build_trajectory_report`: distills metrics and failure patterns across an event window into a report.
- `record_trajectory_report`: persists a trajectory report event to storage if not already recorded.
- `maybe_generate_trajectory_report`: generates and records a trajectory report if the target window is quiet.
- `health_maybe_generate_trajectory_report`: generates a trajectory report for the latest anchored compaction window.
- `render_trajectory_report`: formats a trajectory report into human-readable lines for display.

No runtime change.

## Related issues

Fixes #798

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in trajectory_report.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/analysis/trajectory_report.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/analysis/trajectory_report.py
-> All checks passed!

ruff format --check src/continuum/analysis/trajectory_report.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_trajectory_report.py
-> 8 passed in 1.19s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
