### PR TITLE
docs(checkpoint): add docstrings for policy should_checkpoint methods and helpers in policy.py

### DIFF
--- a/src/continuum/checkpoint/policy.py
+++ b/src/continuum/checkpoint/policy.py
@@ -99,10 +99,12 @@ class CheckpointDecision:
 
     @classmethod
     def no(cls) -> CheckpointDecision:
+        """Return a negative decision indicating no checkpoint should be created."""
         return cls(should=False)
 
     @classmethod
     def yes(cls, trigger: str, reason: str = "") -> CheckpointDecision:
+        """Return an affirmative decision with trigger type and optional reason."""
         return cls(should=True, trigger=trigger, reason=reason)
 
 
@@ -125,7 +127,9 @@ class CheckpointPolicy(ABC):
     name: str = "policy"
 
     @abstractmethod
-    def should_checkpoint(self, context: PolicyContext) -> CheckpointDecision: ...
+    def should_checkpoint(self, context: PolicyContext) -> CheckpointDecision:
+        """Evaluate context and decide whether to trigger a checkpoint."""
+        ...
 
 
 class ManualPolicy(CheckpointPolicy):
@@ -134,6 +138,7 @@ class ManualPolicy(CheckpointPolicy):
     name = "manual"
 
     def should_checkpoint(self, context: PolicyContext) -> CheckpointDecision:
+        """Trigger a checkpoint only when explicitly requested in the context."""
         if context.explicit:
             return CheckpointDecision.yes(CheckpointTrigger.MANUAL, "explicitly requested")
         return CheckpointDecision.no()
@@ -150,6 +155,7 @@ class IntervalPolicy(CheckpointPolicy):
         self.max_interval = timedelta(seconds=max_interval_seconds)
 
     def should_checkpoint(self, context: PolicyContext) -> CheckpointDecision:
+        """Trigger a checkpoint if elapsed time exceeds the configured interval."""
         if context.last_checkpoint_at is None:
             return CheckpointDecision.yes(
                 CheckpointTrigger.INTERVAL, "no checkpoint exists for this run"
@@ -186,6 +192,7 @@ class EventPolicy(CheckpointPolicy):
         self.watched = frozenset(watched)
 
     def should_checkpoint(self, context: PolicyContext) -> CheckpointDecision:
+        """Trigger a checkpoint when new events match watched milestones or side effects."""
         for event in context.new_events:
             if event.type not in self.watched:
                 continue
@@ -216,6 +223,7 @@ class SemanticPolicy(CheckpointPolicy):
         self.progress_stride = progress_stride
 
     def should_checkpoint(self, context: PolicyContext) -> CheckpointDecision:
+        """Trigger a checkpoint on structural state changes or progress milestones."""
         current = context.state
         previous = context.previous_state
 
@@ -246,15 +254,18 @@ class SemanticPolicy(CheckpointPolicy):
         previous: SemanticState, current: SemanticState
     ) -> Sequence[tuple[str, bool]]:
         def invalidated(state: SemanticState) -> int:
+            """Count decisions and findings with terminal invalidation statuses."""
             terminal = {StateStatus.INVALID, StateStatus.STALE, StateStatus.CONFLICTED}
             return sum(1 for d in state.decisions if d.status in terminal) + sum(
                 1 for f in state.findings if f.status in terminal
             )
 
         def dependency_signature(state: SemanticState) -> tuple[tuple[str, str | None], ...]:
+            """Return a canonical sorted tuple of external dependencies and versions."""
             return tuple(sorted((d.resource, d.version) for d in state.external_dependencies))
 
         def approval_signature(state: SemanticState) -> tuple[tuple[str, str], ...]:
+            """Return a canonical sorted tuple of approval identifiers and statuses."""
             return tuple(sorted((a.approval_id, a.status.value) for a in state.approvals))
 
         return (
@@ -290,6 +301,7 @@ class HybridPolicy(CheckpointPolicy):
             raise ValueError("HybridPolicy requires at least one policy")
 
     def should_checkpoint(self, context: PolicyContext) -> CheckpointDecision:
+        """Return the first affirmative decision from constituent policies, or negative."""
         for policy in self.policies:
             decision = policy.should_checkpoint(context)
             if decision.should:
@@ -316,6 +328,7 @@ class ContextPressurePolicy(CheckpointPolicy):
         self.threshold = threshold
 
     def should_checkpoint(self, context: PolicyContext) -> CheckpointDecision:
+        """Trigger a checkpoint when context token consumption crosses threshold."""
         if context.context_tokens is None:
             return CheckpointDecision.no()
         used = context.context_tokens / self.token_budget


### PR DESCRIPTION
## Description

Adds docstrings to the 12 public methods and helper functions in `src/continuum/checkpoint/policy.py`:
- `CheckpointDecision.no`: returns a negative decision indicating no checkpoint should be created.
- `CheckpointDecision.yes`: returns an affirmative decision with trigger type and optional reason.
- `CheckpointPolicy.should_checkpoint`: evaluates context and decides whether to trigger a checkpoint.
- `ManualPolicy.should_checkpoint`: triggers a checkpoint only when explicitly requested in context.
- `IntervalPolicy.should_checkpoint`: triggers a checkpoint if elapsed time exceeds the configured interval.
- `EventPolicy.should_checkpoint`: triggers a checkpoint when new events match watched milestones or side effects.
- `SemanticPolicy.should_checkpoint`: triggers a checkpoint on structural state changes or progress milestones.
- `invalidated` (in `SemanticPolicy._structural_changes`): counts decisions and findings with terminal invalidation statuses.
- `dependency_signature` (in `SemanticPolicy._structural_changes`): returns a canonical sorted tuple of external dependencies and versions.
- `approval_signature` (in `SemanticPolicy._structural_changes`): returns a canonical sorted tuple of approval identifiers and statuses.
- `HybridPolicy.should_checkpoint`: returns the first affirmative decision from constituent policies, or negative.
- `ContextPressurePolicy.should_checkpoint`: triggers a checkpoint when context token consumption crosses threshold.

No runtime change.

## Related issues

Fixes #797

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# AST check confirms zero undocumented public names remaining in policy.py
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/checkpoint/policy.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
-> []

# Linting and formatting
ruff check src/continuum/checkpoint/policy.py
-> All checks passed!

ruff format --check src/continuum/checkpoint/policy.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files

# Unit tests
pytest tests/test_checkpoint_policy.py
-> 29 passed in 0.30s
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Follow-up to #607.
