### PR TITLE
docs(cli): add missing subcommands to references/cli.md and guard test

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -1,11 +1,14 @@
 ### CLI
 
 Standard library only - a recovery tool must not fail to import when you most need it.
+For the complete command reference with detailed options and tables, see [docs/api/cli.md](../docs/api/cli.md).
 
 ```bash
 continuum init                                   # create storage
 continuum runs                                   # list runs
+continuum start <run_id> --goal "..."            # create a run with a goal. mutates
 continuum inspect <run_id> [--version 17]        # semantic state, now or at a version
+continuum status <run_id>                        # show run status
 continuum history <run_id>                       # version and checkpoint history
 continuum events <run_id> [--after N --upto M]   # raw event log
 continuum diff <run_id> <from> <to>              # semantic diff between versions
@@ -19,18 +22,41 @@ continuum replay <run_id> [--upto N]             # re-derive state from events
 continuum reconcile <run_id> [--dry-run]         # settle uncertain effects with probes
 continuum confirm <run_id>                       # human blessing for self-reported state
 continuum complete <run_id> [--summary "..."]    # close a run as done. mutates
-continuum observe                                # record one tool completion (hook)
+continuum budget <run_id>                        # retry-budget usage per action type
+continuum tree <run_id> [--limit N]              # show parent run and child runs
+continuum fork <run_id> --reason "..."           # approve divergent child continuation. mutates
+continuum merge <run_id> --reason "..."          # merge child run into parent at anchor. mutates
+continuum restore <run_id> --reason "..."        # restore run to anchor checkpoint. mutates
+continuum compact <run_id>                       # archive pre-anchor log prefix. mutates
+continuum precompact <run_id>                    # checkpoint before context compaction. mutates
+continuum rewind <run_id> --to <checkpoint>      # revert workspace and projection [--force] [--dry-run]
+continuum observe                                # record one tool completion (hook). mutates
 continuum gate                                   # pre-tool-use verdict: allow or deny
 continuum briefing                               # session-start context injection
-continuum gateway --port 8765                    # enforcing proxy for registered upstreams
+continuum gateway --port 8765                    # enforcing proxy for registered upstreams. mutates
 continuum hooks install <client> [--with-gate]   # wire a coding CLI (claude-code, gemini, codex)
-continuum rewind <run_id> --to <checkpoint>      # revert workspace and projection to checkpoint [--force] [--dry-run]
+continuum health <run_id>                        # advisory prefix-trust health check
+continuum impact <run_id> --evidence <id>        # downstream impact of an evidence item
+continuum provenance <run_id>                    # show provenance DAG
+continuum record-plan <run_id> --plan-id <id>    # record structured plan upsert. mutates
+continuum export-evidence <run_id>               # export evidence as JSON lines
+continuum forget --tenant <id> [--dry-run]       # tombstone memory records for a tenant. mutates
+continuum watch <run_id>                         # watch run for liveness breach
+continuum serve                                  # run JSON sidecar over stdio
+continuum dashboard [--port 8080]                # serve web dashboard
+continuum tui [--refresh N]                      # full-screen terminal dashboard
+continuum attest-keygen                          # generate Ed25519 signer key pair
+continuum attest <run_id>                        # sign run event-chain attestation
+continuum attest-verify <run_id> --attest <file> # verify signed attestation against live chain
+continuum benchmark [--total N]                  # run CONTINUUM-Bench harness
 ```
 
-Every command accepts `--json`. `inspect`, `history`, `events`, `diff`, `validate`, `resume`,
-`verify`, `actions`, `show-contract`, `replay`, `gate` and `briefing` never write, so they are safe
-against a live database while an agent is mid-run. The mutating commands (`start`, `checkpoint`,
-`confirm`, `complete`, `observe`, `reconcile`, `gateway`, `rewind`) say so in their help.
+Every command accepts `--json`. Read-only commands (`inspect`, `status`, `history`, `events`,
+`diff`, `validate`, `resume`, `verify`, `actions`, `show-contract`, `replay`, `budget`, `tree`,
+`gate`, `briefing`, `health`, `impact`, `provenance`, `export-evidence`, `watch`) never write, so
+they are safe against a live database while an agent is mid-run. Mutating commands (`start`,
+`checkpoint`, `confirm`, `complete`, `fork`, `merge`, `restore`, `compact`, `precompact`, `rewind`,
+`observe`, `reconcile`, `gateway`, `record-plan`, `forget`) say so in their help.
 
 #### Registries are executable configuration
 

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from continuum.cli.main import build_parser
 
 TABLE = Path(__file__).resolve().parents[1] / "docs" / "api" / "cli.md"
+REF_CLI = Path(__file__).resolve().parents[1] / "references" / "cli.md"
 
 
 def _row_pattern(name: str) -> re.Pattern[str]:
@@ -27,6 +28,19 @@ def test_every_subcommand_has_a_table_row() -> None:
     assert subs, "parser exposes no subcommands"
     missing = [name for name in subs if not _row_pattern(name).search(table)]
     assert not missing, f"subcommands without a docs/api/cli.md row: {missing}"
+
+
+def test_references_cli_names_every_subcommand() -> None:
+    """Every CLI subcommand must appear in references/cli.md (#795)."""
+    text = REF_CLI.read_text(encoding="utf-8")
+    subs = sorted(build_parser()._subparsers._group_actions[0].choices.keys())
+    assert subs, "parser exposes no subcommands"
+    missing = [
+        name
+        for name in subs
+        if not re.search(r"^continuum " + re.escape(name) + r"\b", text, re.MULTILINE)
+    ]
+    assert not missing, f"subcommands omitted from references/cli.md: {missing}"
 
 
 def _hooks_section() -> str:


### PR DESCRIPTION
## Description

Updates `references/cli.md` and adds a documentation guard test:
- Adds the missing subcommands (`watch`, `health`, `precompact`, `forget`, `budget`, `serve`, `dashboard`, `start`, `status`, `tree`, `fork`, `merge`, `restore`, `compact`, `export-evidence`, `impact`, `provenance`, `record-plan`, `tui`, `attest-keygen`, `attest`, `attest-verify`, `benchmark`) to the command list in `references/cli.md`, ensuring all 45 subcommands are documented.
- Explicitly links to `docs/api/cli.md` at the top of `references/cli.md` as the canonical reference for full option tables and details.
- Updates the list of read-only and mutating commands in `references/cli.md`.
- Adds `test_references_cli_names_every_subcommand` to `tests/test_cli_docs.py` to prevent `references/cli.md` from drifting behind the CLI parser in future PRs.

## Related issues

Fixes #795

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

Exact commands run locally:

```console
# Reproduction check confirms previously missing subcommands are now present in references/cli.md
python -c "from pathlib import Path; ref = Path('references/cli.md').read_text(encoding='utf-8'); [print(s + ': ' + str(ref.count('continuum ' + s))) for s in ['watch', 'health', 'precompact', 'forget', 'budget', 'serve', 'dashboard']]"
-> watch: 1
-> health: 1
-> precompact: 1
-> forget: 1
-> budget: 1
-> serve: 1
-> dashboard: 1

# AST/parser check confirms zero missing subcommands across all 45 choices
python -c "import re; from pathlib import Path; from continuum.cli.main import build_parser; ref = Path('references/cli.md').read_text(encoding='utf-8'); subs = sorted(build_parser()._subparsers._group_actions[0].choices.keys()); missing = [name for name in subs if not re.search(r'^continuum ' + re.escape(name) + r'\b', ref, re.MULTILINE)]; print('Missing count:', len(missing))"
-> Missing count: 0

# Guard unit tests
pytest tests/test_cli_docs.py tests/test_rewind_dual_state.py
-> 3 passed in 0.38s
-> 6 passed in 0.87s

# Linting
ruff check tests/test_cli_docs.py
-> All checks passed!

ruff format --check tests/test_cli_docs.py
-> 1 file already formatted

mypy src/continuum
-> Success: no issues found in 124 source files
```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit.

## Additional context

Keeps `references/cli.md` and `docs/api/cli.md` aligned with the parser.
