### PR TITLE
solve issue number #806, docs: add missing docstrings to RepairStep and RepairPlan in planner.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,14 +240,14 @@ All notable changes to this project are documented here. The format follows
   keep wrapping durability-only. Docstrings only, no runtime change.
 
 - **`src/continuum/recovery/planner.py` is fully documented (#806).**
-  The planner's `RepairStep` and `RepairPlan` classes carried 4 undocumented
-  (or blank-docstring) public names: `RepairStep.render`, and
+  The planner's `RepairStep` and `RepairPlan` classes carried 5 undocumented
+  (or blank-docstring) public names: `RepairStep.render`, `RepairPlan.render` and
   `RepairPlan.requires_human`, `RepairPlan.blocking`, and `RepairPlan.of_kind`.
   Every docstring says what a caller needs: what `render` formats and how the
   `[auto]`/`[human]` prefix is chosen, what `requires_human` and `blocking`
   filter down to and in what order, and what `of_kind` matches on. Docstrings
   only, no runtime change.
-  
+
 ### Fixed
 
 - **Dashboard HITL actions remain visible after compaction (#809).** The dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,15 @@ All notable changes to this project are documented here. The format follows
   name binds or settles, what it returns, and the pass-through/no-op rules that
   keep wrapping durability-only. Docstrings only, no runtime change.
 
+- **`src/continuum/recovery/planner.py` is fully documented (#806).**
+  The planner's `RepairStep` and `RepairPlan` classes carried 4 undocumented
+  (or blank-docstring) public names: `RepairStep.render`, and
+  `RepairPlan.requires_human`, `RepairPlan.blocking`, and `RepairPlan.of_kind`.
+  Every docstring says what a caller needs: what `render` formats and how the
+  `[auto]`/`[human]` prefix is chosen, what `requires_human` and `blocking`
+  filter down to and in what order, and what `of_kind` matches on. Docstrings
+  only, no runtime change.
+  
 ### Fixed
 
 - **Dashboard HITL actions remain visible after compaction (#809).** The dashboard

--- a/src/continuum/recovery/planner.py
+++ b/src/continuum/recovery/planner.py
@@ -138,12 +138,14 @@ class RepairPlan(BaseModel):
         return self.steps[0] if self.steps else None
 
     def of_kind(self, kind: RepairKind) -> tuple[RepairStep, ...]:
-        """Get only the steps that match a specific kind in ReapirKind Enum.
+        """Get only the steps that match a specific RepairKind.
+
             Args:
                 kind: The RepairKind to filter by.
+
             Returns:
                 All steps where step.kind is the given kind, in original order.
-            """
+        """
         return tuple(s for s in self.steps if s.kind is kind)
 
     def render(self) -> str:

--- a/src/continuum/recovery/planner.py
+++ b/src/continuum/recovery/planner.py
@@ -103,7 +103,7 @@ class RepairStep(BaseModel):
         return f"{self.kind.value}:{self.target}"
 
     def render(self) -> str:
-        """Format the step as a single human-readable status line"""
+        """Render this step as a single human-readable status line, prefixed with [human] when human action is required, else [auto]."""
         mark = "[human]" if self.requires_human else "[auto] "
         detail = f" - {self.reason}" if self.reason else ""
         return f"{mark} {self.kind.value} {self.target}{detail}"
@@ -149,7 +149,7 @@ class RepairPlan(BaseModel):
         return tuple(s for s in self.steps if s.kind is kind)
 
     def render(self) -> str:
-        """The function return steps in serial order with description if present else no repairs required"""
+        """Render every step as a numbered list, or "No repairs required." when the plan is empty."""
         if not self.steps:
             return "No repairs required."
         return "\n".join(f"  {i}. {s.render()}" for i, s in enumerate(self.steps, 1))

--- a/src/continuum/recovery/planner.py
+++ b/src/continuum/recovery/planner.py
@@ -103,6 +103,7 @@ class RepairStep(BaseModel):
         return f"{self.kind.value}:{self.target}"
 
     def render(self) -> str:
+        """Format the step as a single human-readable status line"""
         mark = "[human]" if self.requires_human else "[auto] "
         detail = f" - {self.reason}" if self.reason else ""
         return f"{mark} {self.kind.value} {self.target}{detail}"
@@ -123,10 +124,12 @@ class RepairPlan(BaseModel):
 
     @property
     def blocking(self) -> tuple[RepairStep, ...]:
+        """The function return tuple of blocking steps in original order"""
         return tuple(s for s in self.steps if s.blocking)
 
     @property
     def requires_human(self) -> bool:
+        """Check if any step in this plan needs a person to step in. Returns True if at least one step has requires_human=True."""
         return any(s.requires_human for s in self.steps)
 
     @property
@@ -135,9 +138,16 @@ class RepairPlan(BaseModel):
         return self.steps[0] if self.steps else None
 
     def of_kind(self, kind: RepairKind) -> tuple[RepairStep, ...]:
+        """Get only the steps that match a specific kind in ReapirKind Enum.
+            Args:
+                kind: The RepairKind to filter by.
+            Returns:
+                All steps where step.kind is the given kind, in original order.
+            """
         return tuple(s for s in self.steps if s.kind is kind)
 
     def render(self) -> str:
+        """The function return steps in serial order with descreption if present else no repairs required"""
         if not self.steps:
             return "No repairs required."
         return "\n".join(f"  {i}. {s.render()}" for i, s in enumerate(self.steps, 1))

--- a/src/continuum/recovery/planner.py
+++ b/src/continuum/recovery/planner.py
@@ -124,7 +124,7 @@ class RepairPlan(BaseModel):
 
     @property
     def blocking(self) -> tuple[RepairStep, ...]:
-        """The function return tuple of blocking steps in original order"""
+        """The blocking steps, in original order."""
         return tuple(s for s in self.steps if s.blocking)
 
     @property
@@ -140,16 +140,16 @@ class RepairPlan(BaseModel):
     def of_kind(self, kind: RepairKind) -> tuple[RepairStep, ...]:
         """Get only the steps that match a specific RepairKind.
 
-            Args:
-                kind: The RepairKind to filter by.
+        Args:
+            kind: The RepairKind to filter by.
 
-            Returns:
-                All steps where step.kind is the given kind, in original order.
+        Returns:
+            All steps where step.kind is the given kind, in original order.
         """
         return tuple(s for s in self.steps if s.kind is kind)
 
     def render(self) -> str:
-        """The function return steps in serial order with descreption if present else no repairs required"""
+        """The function return steps in serial order with description if present else no repairs required"""
         if not self.steps:
             return "No repairs required."
         return "\n".join(f"  {i}. {s.render()}" for i, s in enumerate(self.steps, 1))


### PR DESCRIPTION
## Description

Adds missing docstrings to `RepairStep` and related methods in
`src/continuum/recovery/planner.py`. Four public names were undocumented or
carried blank docstrings: `RepairStep.render()`, `RepairPlan.requires_human`
(property), `RepairPlan.blocking` (property), and `RepairPlan.of_kind()`.
Each docstring now explains what a caller needs: what value the method or
property returns, what it filters on, and (for `render`) how the
`[auto]`/`[human]` prefix is chosen. No logic was touched.

## Related issues

Fixes #806

## Types of changes

- Type: `docs`

## Breaking changes

No.

## How has this been tested?

No behavior changed, so no new tests were added. Verified existing tests
still pass and docstrings render correctly:

<!-- Describe the tests you ran to verify your changes. Include the exact commands and note the environment.:

pytest tests/ --tb=short -q
ruff check src/continuum/recovery/planner.py
mypy src/continuum/recovery/planner.py

## Checklist

- [x] Documentation updated where the change affects user-facing behaviour.
- [x] CI passes on the latest commit.
- [ ] Tests added or updated for the changed behaviour. *(not applicable — docs only)*
- [ ] Security-relevant changes state known limitations explicitly. *(not applicable)*

## Additional context

Docstrings follow the existing style used elsewhere in the codebase (e.g.
`src/continuum/adapters/thin.py`, #680): a plain-English summary of what the
method returns or does, followed by `Args:`/`Returns:` sections only where
the method takes parameters or the return value's meaning/format isn't
obvious from the signature alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved documentation for recovery planning and repair-step rendering.
  - Clarified descriptions of repair-plan methods, including human-required, blocking, and matching steps.
  - Documented the repair plan rendering capability in the changelog.
  - Corrected wording and formatting for clearer guidance.
  - No runtime behavior or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->