### PR TITLE
fix(tests): make the suite Windows-portable and cwd-independent (#837)

### DIFF
--- a/tests/test_benchmark_counters.py
+++ b/tests/test_benchmark_counters.py
@@ -17,6 +17,10 @@ from pathlib import Path
 
 from continuum.benchmark import METHODS, SCENARIOS, MethodResult, run_benchmark
 
+#: The repo root, so the file reads below work no matter where pytest runs
+#: from (issue #837: relative paths only passed from the repo root).
+ROOT = Path(__file__).resolve().parents[1]
+
 
 def test_method_result_has_byte_count_fields() -> None:
     r = MethodResult(
@@ -101,12 +105,12 @@ def test_byte_counts_are_deterministic() -> None:
 
 
 def test_deterministic_tokenizer_note_documented() -> None:
-    text = Path("src/continuum/benchmark/__init__.py").read_text(encoding="utf-8")
+    text = (ROOT / "src/continuum/benchmark/__init__.py").read_text(encoding="utf-8")
     assert "Deterministic tokenizer" in text
     assert "estimate_tokens" in text
     assert "No vendor tokenizer" in text
     # Also check benchmarks/run.py documents it
-    run_text = Path("benchmarks/run.py").read_text(encoding="utf-8")
+    run_text = (ROOT / "benchmarks/run.py").read_text(encoding="utf-8")
     assert "checkpoint_bytes_written" in run_text
     assert "estimate_tokens" in run_text or "deterministic" in run_text.lower()
 
@@ -165,5 +169,5 @@ def test_no_em_dash_in_harness() -> None:
         "benchmarks/run.py",
         "tests/test_benchmark_counters.py",
     ):
-        content = Path(path).read_text(encoding="utf-8")
+        content = (ROOT / path).read_text(encoding="utf-8")
         assert "\u2014" not in content, f"em dash found in {path}"

--- a/tests/test_cli_observe.py
+++ b/tests/test_cli_observe.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -259,16 +260,33 @@ def test_installed_command_actually_records_through_the_real_entrypoint(
     (project / ".claude").mkdir(parents=True)
     monkeypatch.chdir(project)
 
-    subprocess.run([sys.executable, "-m", "continuum.cli", "init"], check=True, capture_output=True)
+    # Prepend the worktree's src so every subprocess below (including the
+    # shell-run baked command, whose interpreter fallback resolves `continuum`
+    # through PYTHONPATH) imports the tree under test, not an installed copy
+    # (issue #837).
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            filter(
+                None,
+                [str(Path(__file__).resolve().parents[1] / "src"), os.environ.get("PYTHONPATH")],
+            )
+        ),
+    }
+    subprocess.run(
+        [sys.executable, "-m", "continuum.cli", "init"], check=True, capture_output=True, env=env
+    )
     subprocess.run(
         [sys.executable, "-m", "continuum.cli", "start", "demo", "--goal", "write things"],
         check=True,
         capture_output=True,
+        env=env,
     )
     subprocess.run(
         [sys.executable, "-m", "continuum.cli", "hooks", "install", "claude-code"],
         check=True,
         capture_output=True,
+        env=env,
     )
     artifact = project / "out.txt"
     artifact.write_text("done")
@@ -278,7 +296,9 @@ def test_installed_command_actually_records_through_the_real_entrypoint(
     settings = json.loads((project / ".claude" / "settings.json").read_text())
     command = settings["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
     hook_input = json.dumps(payload_for(artifact))
-    result = subprocess.run(command, input=hook_input, capture_output=True, text=True, shell=True)
+    result = subprocess.run(
+        command, input=hook_input, capture_output=True, text=True, shell=True, env=env
+    )
     assert result.returncode == ExitCode.OK, result.stderr
 
     with SQLiteStorage(str(project / "continuum.db")) as store:

--- a/tests/test_client_installers.py
+++ b/tests/test_client_installers.py
@@ -136,16 +136,29 @@ def test_codex_install_hints_when_feature_flag_commented_out(
 def test_gemini_payload_shape_matches_the_observation_contract() -> None:
     """Gemini AfterTool payloads carry the same tool_name/tool_input fields;
     prove `continuum observe` accepts one verbatim through the real CLI."""
+    import os
     import tempfile
 
     project = Path(tempfile.mkdtemp())
+    # The worktree's src comes first on PYTHONPATH so the subprocesses import
+    # the tree under test, not an installed continuum (issue #837).
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            filter(
+                None,
+                [str(Path(__file__).resolve().parents[1] / "src"), os.environ.get("PYTHONPATH")],
+            )
+        ),
+    }
     subprocess.run(
-        [sys.executable, "-m", "continuum.cli", "init"], cwd=project, capture_output=True
+        [sys.executable, "-m", "continuum.cli", "init"], cwd=project, capture_output=True, env=env
     )
     subprocess.run(
         [sys.executable, "-m", "continuum.cli", "start", "g", "--goal", "gemini"],
         cwd=project,
         capture_output=True,
+        env=env,
     )
     artifact = project / "out.txt"
     artifact.write_text("written by gemini")
@@ -162,6 +175,7 @@ def test_gemini_payload_shape_matches_the_observation_contract() -> None:
         capture_output=True,
         text=True,
         cwd=project,
+        env=env,
     )
     assert result.returncode == ExitCode.OK, result.stderr
 

--- a/tests/test_forget.py
+++ b/tests/test_forget.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -15,17 +16,13 @@ from continuum.storage import SQLiteStorage
 
 def _run_cli(args: list[str], db: str) -> tuple[int, str, str]:
     """Run CLI main with given args, capturing output."""
-    import os
-
     # Ensure we import from the worktree's src, not installed package
     env = os.environ.copy()
     # Use the current worktree's src if available, else fallback
     # The test file lives in the worktree, so its parent is the worktree root
     worktree_root = Path(__file__).resolve().parents[1]
     src_path = str(worktree_root / "src")
-    env["PYTHONPATH"] = src_path + (
-        ":" + env.get("PYTHONPATH", "") if env.get("PYTHONPATH") else ""
-    )
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [src_path, env.get("PYTHONPATH")]))
     cmd = [sys.executable, "-m", "continuum.cli", "--db", db, *args]
     result = subprocess.run(cmd, capture_output=True, text=True, env=env)
     return result.returncode, result.stdout, result.stderr

--- a/tests/test_horizon_benchmark.py
+++ b/tests/test_horizon_benchmark.py
@@ -101,8 +101,12 @@ def test_table_regenerates_from_runner_no_invented_numbers(tmp_path: Path) -> No
     lines1 = [line for line in md1.splitlines() if not line.startswith("Generated:")]
     lines2 = [line for line in md2.splitlines() if not line.startswith("Generated:")]
     assert lines1 == lines2
-    # Also test README regeneration
-    readme = Path("README.md")
+    # Also test README regeneration. Anchor to the repo root: a relative
+    # README.md only resolves when pytest runs from the root, and the
+    # regeneration subprocess needs the anchored script path and cwd alike
+    # (issue #837).
+    root = Path(__file__).resolve().parents[1]
+    readme = root / "README.md"
     if readme.exists():
         original = readme.read_text(encoding="utf-8")
         # Simulate deleting the bench section
@@ -111,15 +115,22 @@ def test_table_regenerates_from_runner_no_invented_numbers(tmp_path: Path) -> No
             import subprocess
             import sys
 
-            result = subprocess.run(
-                [sys.executable, "benchmarks/run.py"], capture_output=True, text=True, timeout=60
-            )
-            assert result.returncode == 0
-            regenerated = readme.read_text(encoding="utf-8")
-            assert "<!-- BENCH:START -->" in regenerated
-            assert "<!-- BENCH:END -->" in regenerated
-            # Restore original to avoid dirtying working tree in test
-            readme.write_text(original, encoding="utf-8")
+            try:
+                result = subprocess.run(
+                    [sys.executable, str(root / "benchmarks/run.py")],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                    cwd=root,
+                )
+                assert result.returncode == 0, result.stderr
+                regenerated = readme.read_text(encoding="utf-8")
+                assert "<!-- BENCH:START -->" in regenerated
+                assert "<!-- BENCH:END -->" in regenerated
+            finally:
+                # Restore the tracked file even when an assertion above fails,
+                # so a red test never leaves the working tree dirty.
+                readme.write_text(original, encoding="utf-8")
 
 
 def test_shared_emitter_schema_with_fault_injection() -> None:

--- a/tests/test_interchange_evidence.py
+++ b/tests/test_interchange_evidence.py
@@ -217,7 +217,7 @@ def test_zero_new_dependencies() -> None:
     import ast
     from pathlib import Path
 
-    path = Path("src/continuum/interchange/evidence.py")
+    path = Path(__file__).resolve().parents[1] / "src/continuum/interchange/evidence.py"
     tree = ast.parse(path.read_text(encoding="utf-8"))
     imports: list[str] = []
     for node in ast.walk(tree):

--- a/tests/test_provenance_graph.py
+++ b/tests/test_provenance_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -10,6 +11,12 @@ from continuum.events import EventType
 from continuum.models import Run
 from continuum.provenance.graph import build_provenance_graph, downstream_of
 from continuum.storage.sqlite import SQLiteStorage
+
+#: The worktree's src, so the subprocess imports the tree under test rather
+#: than whatever continuum happens to be installed (the sibling tests that
+#: spawn the CLI all do this; the ones that did not were the portability gaps
+#: called out in issue #837).
+WORKTREE_SRC = str(Path(__file__).resolve().parents[1] / "src")
 
 
 # Use CLI helper from tests
@@ -20,7 +27,11 @@ def _run(*args: str, db: str | None = None):
         if db
         else [sys.executable, "-m", "continuum.cli"] + list(args)
     )
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(filter(None, [WORKTREE_SRC, os.environ.get("PYTHONPATH")])),
+    }
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
     return result.returncode, result.stdout, result.stderr
 
 

--- a/tests/test_rewind_dual_state.py
+++ b/tests/test_rewind_dual_state.py
@@ -241,7 +241,8 @@ os._exit(0)
 
 
 def test_docs_updated() -> None:
-    arch = Path("references/architecture.md").read_text(encoding="utf-8")
-    cli = Path("references/cli.md").read_text(encoding="utf-8")
+    root = Path(__file__).resolve().parents[1]
+    arch = (root / "references/architecture.md").read_text(encoding="utf-8")
+    cli = (root / "references/cli.md").read_text(encoding="utf-8")
     assert "rewind" in arch.lower()
     assert "rewind" in cli.lower()


### PR DESCRIPTION
The CI matrix this issue asks for runs the suite on windows-latest and macos-latest, where four classes of POSIX-only assumptions are red on a clean checkout (this is the suite half of the issue; the ci.yml matrix itself is the workflow half and follows separately):

- test_forget.py joined PYTHONPATH with a hardcoded ':' where every sibling uses os.pathsep, so the worktree's src was unreachable on Windows and the subprocess imported whatever continuum was installed.
- test_provenance_graph.py, test_cli_observe.py and test_client_installers.py spawned the CLI with no PYTHONPATH at all, resolving the installed package instead of the worktree under test.
- test_benchmark_counters.py, test_interchange_evidence.py, test_horizon_benchmark.py and test_rewind_dual_state.py read repo files through relative paths that only resolve when pytest runs from the repo root; elsewhere the reads fail or the assertions skip silently.
- test_horizon_benchmark.py regenerated the tracked README.md with no try/finally, so a failing assertion left the working tree dirty, and spawned benchmarks/run.py by relative path.

All touched tests pass on Windows with PYTHONPATH set in the environment (the issue's acceptance criterion for the os.pathsep fix).

<!--
Thank you for contributing to CONTINUUM.

Please fill out each section below. Sections left empty may delay review.
The PR title should follow conventional commits, for example:
feat: add recovery validator for partial checkpoints

-->

## Description

<!-- Describe what this PR changes. Explain the approach where the approach itself is non-obvious. -->

## Related issues

<!--
Link the issue this PR addresses.
Use "Fixes #N" if merging this PR fully resolves the issue,
otherwise use "Addresses #N" or "Refs #N".
If there is no related issue, explain why here.
-->

## Types of changes

<!-- Keep the one that applies, delete the rest. -->

- Type: `bugfix` | `feature` | `refactor` | `performance` | `docs` | `tests` | `build` | `ci`

## Breaking changes

<!-- State Yes or No. If Yes, describe the impact and the migration path for users. -->

## How has this been tested?

<!-- Describe the tests you ran to verify your changes. Include the exact commands and note the environment. For example:

pytest tests/test_recovery.py --tb=short -q
ruff check src/ tests/
mypy src/continuum

Mention any configuration or environment details relevant to reproducing the run.
-->

## Checklist

<!-- Reviewers will check these during review. Confirm them before requesting review. -->

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

<!-- Anything else reviewers should know: benchmarks, design tradeoffs, alternatives considered. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability across different working directories and environments.
  * Ensured command-line tests consistently run against the source code under test.
  * Added safeguards for benchmark execution, including timeouts, failure reporting, and cleanup after interrupted runs.
  * Improved path handling for documentation, benchmark, and evidence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->