### PR TITLE
fix(windows): shell-portable run_shell, reserved-char run ids, drive-…

### DIFF
--- a/docs/guides/authority-probes.md
+++ b/docs/guides/authority-probes.md
@@ -33,6 +33,12 @@ stdin: `authority_id`, `consumer_run_id`, `via_action_id`, `consumed_at`, and
 `sequence`. A probe that needs no context can ignore stdin entirely. For this
 walkthrough any command printing a verdict will do:
 
+> The command string runs through the platform shell (`cmd.exe /c` on Windows,
+> `/bin/sh -c` elsewhere), so its syntax is shell-family-specific: a registry
+> written on one platform fails on the other, and the authority then stays
+> blocked, fail-closed, until the probe is fixed. Prefer an executable plus
+> arguments both shells resolve identically, or keep one registry per platform.
+
 ```bash
 mkdir -p /tmp/probe-demo
 export DB=/tmp/probe-demo/g.db

--- a/src/continuum/adapters/filesystem.py
+++ b/src/continuum/adapters/filesystem.py
@@ -34,14 +34,29 @@ class FilesystemSandboxAdapter(GenericAgentAdapter):
         self.sandbox_dir.mkdir(parents=True, exist_ok=True)
 
     def run_shell(
-        self, run_id: str, command: str, *, dep_scope: str | None = None
+        self,
+        run_id: str,
+        command: str | list[str],
+        *,
+        dep_scope: str | None = None,
     ) -> AdapterResult:
-        """Run ``command`` inside the sandbox dir, recorded as an action."""
+        """Run ``command`` inside the sandbox dir, recorded as an action.
+
+        A string command runs through the platform shell, ``cmd.exe /c`` on
+        Windows and ``/bin/sh -c`` elsewhere, so its syntax is silently
+        shell-family-specific: redirections, quoting, and builtins written
+        for one family fail on the other (#842). Pass an argv list to run
+        without a shell, which is portable across platforms and free of
+        quoting pitfalls; the string form is kept for callers that want the
+        shell, with the caveat that such a command only works where the
+        shell family it was written for is the one running it.
+
+        """
 
         def _run() -> str:
             completed = subprocess.run(
                 command,
-                shell=True,
+                shell=isinstance(command, str),
                 cwd=str(self.sandbox_dir),
                 capture_output=True,
                 text=True,

--- a/src/continuum/reconcilers.py
+++ b/src/continuum/reconcilers.py
@@ -141,6 +141,14 @@ def probe_verdict(
     The verdict is True, False, None (probe ran but could not tell) or the
     string ``"error"`` (probe itself failed). ``detail`` carries whatever a
     human would want to see next to the outcome.
+
+    ``spec["command"]`` runs through the platform shell, ``cmd.exe /c`` on
+    Windows and ``/bin/sh -c`` elsewhere, so a probe string is silently
+    shell-family-specific: a registry written on one platform (redirections,
+    quoting, builtins) fails on the other, and the run then refuses to
+    resume, fail-closed, until the probe is fixed (#842). Prefer an
+    executable plus arguments that both shells resolve identically, or keep
+    one registry per platform.
     """
     try:
         completed = subprocess.run(  # noqa: S602 - operator-configured command
@@ -281,7 +289,13 @@ def _parse_authority_verdict(text: str) -> bool | None | Literal["unknown"]:
 def probe_authority_verdict(
     spec: Mapping[str, Any], payload: Mapping[str, Any]
 ) -> tuple[bool | None | Literal["error"], str]:
-    """Run one authority probe. Returns (verdict, detail)."""
+    """Run one authority probe. Returns (verdict, detail).
+
+    ``spec["command"]`` runs through the platform shell, so the same
+    shell-family caveat as :func:`probe_verdict` applies: a command string
+    written for one shell family fails on another and the authority stays
+    blocked, fail-closed (#842).
+    """
     try:
         completed = subprocess.run(  # noqa: S602 - operator-configured command
             spec["command"],

--- a/src/continuum/recovery/ledger.py
+++ b/src/continuum/recovery/ledger.py
@@ -156,6 +156,35 @@ class MemoryLedgerBackend(LedgerBackend):
         self._store[run_id] = list(entries)
 
 
+#: Every character a Windows filename forbids, separators included. POSIX
+#: forbids none of the extras, so replacing them all on every platform costs
+#: nothing and keeps a caller-supplied run id usable as a filename on both
+#: families (issue #842: only "/" and "\" were replaced, so run ids carrying
+#: ":*?<>"|" produced unopenable ledger files on Windows).
+_UNSAFE_FILENAME_CHARS = '/\\:*?"<>|'
+
+#: Windows reserves these device names as filenames with any extension, so a
+#: sanitized id whose stem is one of them still cannot open there.
+_RESERVED_DEVICE_NAMES = frozenset(
+    {"AUX", "CON", "NUL", "PRN"}
+    | {f"COM{i}" for i in range(1, 10)}
+    | {f"LPT{i}" for i in range(1, 10)}
+)
+
+
+def _sanitize_run_id(run_id: str) -> str:
+    """Turn a caller-supplied run id into a safe filename component.
+
+    The result keeps every character that is legal on both platform families
+    and substitutes an underscore for the rest, so the same run id maps to
+    the same file everywhere.
+    """
+    safe = "".join("_" if char in _UNSAFE_FILENAME_CHARS else char for char in run_id)
+    if safe.split(".", 1)[0].upper() in _RESERVED_DEVICE_NAMES:
+        safe = f"_{safe}"
+    return safe
+
+
 class FileLedgerBackend(LedgerBackend):
     """One JSONL file per run. Each line is one entry record."""
 
@@ -163,8 +192,7 @@ class FileLedgerBackend(LedgerBackend):
         self._directory = directory
 
     def _path(self, run_id: str) -> str:
-        safe = run_id.replace("/", "_").replace("\\", "_")
-        return os.path.join(self._directory, f"ledger-{safe}.jsonl")
+        return os.path.join(self._directory, f"ledger-{_sanitize_run_id(run_id)}.jsonl")
 
     def _ensure_directory(self) -> None:
         os.makedirs(self._directory, exist_ok=True)

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -71,7 +71,10 @@ def _resolve_path(url_or_path: str | Path) -> str:
 
     ``sqlite:///`` is the conventional form: the third slash begins an absolute
     path. Stripping it blindly would turn ``/var/db`` into ``var/db`` and open a
-    file in the wrong place, so the leading slash is preserved.
+    file in the wrong place, so the leading slash is preserved. The exception is
+    a Windows drive letter: ``sqlite:///C:/db`` is the three-slash absolute form
+    of ``C:/db``, and the leftover slash would leave a path (``/C:/db``) that
+    sqlite3 rejects on Windows, so it is dropped (#842).
     """
     raw = str(url_or_path)
     if raw.startswith("sqlite://"):
@@ -79,6 +82,10 @@ def _resolve_path(url_or_path: str | Path) -> str:
         # sqlite://a.db -> a.db (relative). Stripping the third slash too would
         # silently turn an absolute path into a relative one.
         raw = raw[len("sqlite://") :]
+        if len(raw) >= 3 and raw[0] == "/" and raw[1].isalpha() and raw[2] == ":":
+            # A drive letter follows the third slash: that slash is the URL
+            # grammar, not the filesystem. sqlite:///C:/db -> C:/db.
+            raw = raw[1:]
     if raw in ("", "/"):
         return ":memory:"
     return raw

--- a/tests/test_filesystem_adapter.py
+++ b/tests/test_filesystem_adapter.py
@@ -30,3 +30,21 @@ def test_run_shell_passes_dep_scope(tmp_path) -> None:
     adapter.run_shell("run_1", "echo x", dep_scope="numpy")
     recorded = ActionLedger(storage, "run_1").all()
     assert recorded[0].dep_scope == "numpy"
+
+
+def test_run_shell_accepts_an_argv_list_without_a_shell(tmp_path) -> None:
+    """The argv form is shell-free, so it runs identically on every platform.
+
+    ``echo`` only happens to work under both shell families; a command like
+    ``python -c "print(1)"`` or any redirection is family-specific, which is
+    why the list form exists (#842).
+    """
+    import sys
+
+    adapter, storage = _adapter(tmp_path)
+    result = adapter.run_shell("run_1", [sys.executable, "-c", "print('argv ok')"])
+    assert result.status == "completed"
+    assert result.output.strip() == "argv ok"
+    recorded = ActionLedger(storage, "run_1").all()
+    assert recorded[0].action_type == "shell"
+    assert recorded[0].arguments["command"] == [sys.executable, "-c", "print('argv ok')"]

--- a/tests/test_recovery_ledger.py
+++ b/tests/test_recovery_ledger.py
@@ -132,6 +132,40 @@ def test_file_backend_round_trips(tmp_path) -> None:  # type: ignore[no-untyped-
     assert reopened.verify("run_1")[0] is True
 
 
+def test_file_backend_sanitizes_windows_reserved_characters(tmp_path) -> None:
+    """A run id may carry characters Windows forbids in filenames (#842).
+
+    Only the separators were replaced, so a caller-supplied id like
+    ``run:1<2026>?`` produced a ledger file that could not be opened on
+    Windows at all. Every forbidden character must round-trip through a
+    name that opens on both platform families.
+    """
+    hostile = 'run:1<2026>?"*|/x\\y'
+    backend = FileLedgerBackend(str(tmp_path))
+    RecoveryLedger(backend).append_decision(hostile, _contract(0))
+
+    reopened = RecoveryLedger(backend)
+    assert len(reopened.entries(hostile)) == 1
+    assert reopened.verify(hostile)[0] is True
+
+
+def test_file_backend_sanitizes_windows_reserved_device_names(tmp_path) -> None:
+    """``CON`` and friends are reserved as filenames with any extension.
+
+    The ``ledger-`` prefix already shields the real filename, but the
+    sanitizer must not become a trap the day the prefix changes (#842).
+    """
+    from continuum.recovery.ledger import _sanitize_run_id
+
+    assert _sanitize_run_id("CON") == "_CON"
+    assert _sanitize_run_id("nul.backup") == "_nul.backup"
+    assert _sanitize_run_id("com1") == "_com1"
+    # Ordinary ids, including ones that merely contain the substring, pass.
+    assert _sanitize_run_id("run_1") == "run_1"
+    assert _sanitize_run_id("connection") == "connection"
+    assert _sanitize_run_id("a/b\\c:d") == "a_b_c_d"
+
+
 def test_pending_gate_survives_prior_approval(ledger: RecoveryLedger) -> None:
     # Regression for #176: an approval for an earlier decision must not clear
     # the gate of a later gate-required decision.

--- a/tests/test_storage_edges.py
+++ b/tests/test_storage_edges.py
@@ -191,6 +191,37 @@ def test_an_absolute_path_is_not_mangled_into_a_relative_one() -> None:
     assert _resolve_path("/plain/abs.db") == "/plain/abs.db"
 
 
+def test_a_drive_letter_survives_the_three_slash_form() -> None:
+    """``sqlite:///C:/db`` is the absolute form of ``C:/db`` on Windows (#842).
+
+    The leftover third slash produced ``/C:/db``, which sqlite3 rejects on
+    Windows, so the URL grammar's slash is dropped and the drive letter kept.
+    POSIX absolute paths must keep theirs, which the sibling assertions pin.
+    """
+    from continuum.storage.sqlite import _resolve_path
+
+    assert _resolve_path("sqlite:///C:/data/agent.db") == "C:/data/agent.db"
+    assert _resolve_path("sqlite:///d:/agent.db") == "d:/agent.db"
+    # A plain drive-letter path was already fine and stays untouched.
+    assert _resolve_path("C:/data/agent.db") == "C:/data/agent.db"
+    # POSIX forms regress to nothing: the slash before a non-drive stem stays.
+    assert _resolve_path("sqlite:///var/db/agent.db") == "/var/db/agent.db"
+    assert _resolve_path("sqlite:////var/db/agent.db") == "//var/db/agent.db"
+
+
+def test_a_drive_letter_url_opens_on_windows(tmp_path: Path) -> None:
+    """End to end: the three-slash drive form must open a real database.
+
+    Runs on every platform so the POSIX green path is pinned too; the
+    interesting failure (sqlite3 rejecting ``/C:/...``) only existed on
+    Windows.
+    """
+    db = tmp_path / "agent.db"
+    with open_storage(f"sqlite:///{db.as_posix()}") as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+    assert db.exists(), "database was created somewhere other than the requested path"
+
+
 def test_the_absolute_url_form_writes_where_it_says(tmp_path: Path) -> None:
     db = tmp_path / "agent.db"
     with open_storage(f"sqlite://{db}") as store:


### PR DESCRIPTION
…letter sqlite URLs (#842)

Four runtime Windows defects found during the installation/MCP audit, fixed separately from that work so the reviews stay focused:

- FilesystemSandboxAdapter.run_shell accepted only command strings, which run through the platform shell (cmd.exe /c vs /bin/sh -c) and are silently shell-family-specific. The docstring now states the contract, and an argv list runs shell-free and portably; the string form is kept for compatibility with the caveat documented.
- The reconciler and authority probes run operator-configured strings with shell=True, so a registry written on one platform fails (fail-closed) on another. Documented on both probe functions and in the authority-probes guide, with the portable-form guidance.
- FileLedgerBackend replaced only / and \ in run ids, so caller-supplied ids carrying :*?"<>| produced unopenable ledger files on Windows. Sanitization now covers every Windows-forbidden character and the reserved device names; POSIX loses nothing.
- sqlite:///C:/path parsed to /C:/path, which sqlite3 rejects on Windows. A drive letter after the third slash is now recognized as the URL grammar's slash and dropped; POSIX absolute forms are pinned unchanged by tests.

<!--
Thank you for contributing to CONTINUUM.

Please fill out each section below. Sections left empty may delay review.
The PR title should follow conventional commits, for example:
feat: add recovery validator for partial checkpoints

-->

## Description

<!-- Describe what this PR changes. Explain the approach where the approach itself is non-obvious. -->

## Related issues

<!--
Link the issue this PR addresses.
Use "Fixes #N" if merging this PR fully resolves the issue,
otherwise use "Addresses #N" or "Refs #N".
If there is no related issue, explain why here.
-->

## Types of changes

<!-- Keep the one that applies, delete the rest. -->

- Type: `bugfix` | `feature` | `refactor` | `performance` | `docs` | `tests` | `build` | `ci`

## Breaking changes

<!-- State Yes or No. If Yes, describe the impact and the migration path for users. -->

## How has this been tested?

<!-- Describe the tests you ran to verify your changes. Include the exact commands and note the environment. For example:

pytest tests/test_recovery.py --tb=short -q
ruff check src/ tests/
mypy src/continuum

Mention any configuration or environment details relevant to reproducing the run.
-->

## Checklist

<!-- Reviewers will check these during review. Confirm them before requesting review. -->

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

<!-- Anything else reviewers should know: benchmarks, design tradeoffs, alternatives considered. -->
