### PR TITLE
docs(mcp): quote extras everywhere, record the [mcp] extra decision (#836)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -38,11 +38,14 @@ may resume. The integration points, in order of most to least common, are:
 ## Install
 
 ```bash
-pip install continuum-agent          # core, no optional dependencies
-pip install continuum-agent[attest]  # adds cryptographic attestation
-pip install continuum-agent[mcp]     # adds the MCP server
-pip install continuum-agent[langgraph]  # adds the LangGraph adapter
-pip install continuum-agent[openai]  # adds the OpenAI Agents SDK adapter
+pip install continuum-agent              # core, no optional dependencies
+pip install "continuum-agent[attest]"    # adds cryptographic attestation
+pip install "continuum-agent[mcp]"       # adds the MCP server
+pip install "continuum-agent[langgraph]" # adds the LangGraph adapter
+pip install "continuum-agent[openai]"    # adds the OpenAI Agents SDK adapter
 ```
+
+The extras are quoted because unquoted brackets are a glob in zsh, where the
+command either fails or silently expands to something else.
 
 All imports below assume `import continuum` and the relevant submodule.

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -13,6 +13,37 @@ continuum-mcp --transport sse
 continuum-mcp --transport streamable-http
 ```
 
+## Installation
+
+The `continuum-mcp` console script ships with the base package, but the SDK it
+serves with is the optional `[mcp]` extra. An install without the extra is a
+supported state, not a broken one: the entry point reports the missing extra
+with the command to run on stderr and exits 1 instead of raising a traceback
+the client can only report as `CONNECTION_CLOSED`.
+
+```bash
+pip install "continuum-agent[mcp]"   # from PyPI
+
+# GitHub or fork installs must use the PEP 508 direct-reference form, quoted:
+pip install "continuum-agent[mcp] @ git+https://github.com/<you>/CONTINUUM.git"
+
+# A bare VCS URL cannot carry an extra, so it installs the core only and the
+# entry point will report the missing SDK on first run:
+pip install git+https://github.com/Cyrax321/CONTINUUM.git
+```
+
+Quote the extra in every form. Unquoted `[mcp]` is a glob in zsh, where the
+command either fails or silently expands; the same rule covers the editable
+form, `pip install -e ".[mcp]"`.
+
+The split is deliberate. The core library and CLI must import with only
+`pydantic` (stated in `pyproject.toml` and the module docstrings), and
+packaging has no mechanism to condition an entry point on an extra, so the
+choice is between an unconditional entry point with a clear missing-dependency
+error and moving the SDK into core dependencies. The second was rejected
+because it violates that architecture; the first is the contract documented
+here and exercised by the missing-SDK tests in `tests/test_mcp_server.py`.
+
 ## Registration
 
 Claude Code discovers the server from the project's `.mcp.json`, which declares

--- a/tests/test_mcp_docs.py
+++ b/tests/test_mcp_docs.py
@@ -37,6 +37,27 @@ AUDIT_TOOL = re.compile(r"^\| `(continuum_\w+)` \|", re.MULTILINE)
 #: The character house style bans, by code point so this file carries none.
 EM_DASH = chr(0x2014)
 
+#: Files whose shell commands document how to install the package, so the
+#: extras are spelled and quoted the same way in each of them.
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_DOCS = [
+    ROOT / "docs" / "api" / "README.md",
+    ROOT / "docs" / "api" / "mcp.md",
+    ROOT / "README.md",
+    ROOT / "references" / "install.md",
+    ROOT / "references" / "adapters.md",
+    ROOT / "references" / "quickstart.md",
+]
+
+#: An install command and its first non-flag argument: the target an extra
+#: appears in, if one appears at all.
+INSTALL_COMMAND = re.compile(r"(?:pip|uv pip) install\s+(?:-\S+\s+)*(\S+)")
+
+
+def _extras_targets(text: str) -> list[str]:
+    """Every install target in ``text`` that carries an extras bracket."""
+    return [target for target in INSTALL_COMMAND.findall(text) if "[" in target]
+
 
 @pytest.fixture
 def store() -> Iterator[SQLiteStorage]:
@@ -95,3 +116,32 @@ async def test_the_audit_coverage_table_lists_every_served_tool(server: Any) -> 
 def test_the_page_carries_no_em_dashes() -> None:
     """House style forbids them (issue #266) and one had reached the table."""
     assert EM_DASH not in MCP_DOC.read_text(encoding="utf-8")
+
+
+def test_documented_extras_name_the_real_package() -> None:
+    """No install command teaches ``continuum[...]``, the wrong package.
+
+    A real PyPI package exists under the bare name ``continuum``, so a doc
+    that sends the operator to it installs something unrelated instead of the
+    extra (issue #836, the bug the remediation message shipped with until
+    #719). Removing every legitimate ``continuum-agent[`` first leaves only
+    the wrong spellings behind.
+    """
+    for path in INSTALL_DOCS:
+        text = path.read_text(encoding="utf-8")
+        assert "continuum[" not in text.replace("continuum-agent[", ""), (
+            f"{path} teaches an install of the wrong package"
+        )
+
+
+def test_documented_extras_are_quoted() -> None:
+    """Every extras-bearing install target is quoted.
+
+    Unquoted brackets are a glob in zsh, where ``pip install continuum-agent[
+    mcp]`` either fails or silently expands to the files that happen to match
+    (issue #836). Quoting is the documented house form in every context, so
+    the guard scans the target of every install command that carries one.
+    """
+    for path in INSTALL_DOCS:
+        for target in _extras_targets(path.read_text(encoding="utf-8")):
+            assert target.startswith('"'), f"{path}: unquoted extras in {target}"


### PR DESCRIPTION
Closes #836.

## What

The remediation string and its test assertion were already corrected by #719; this PR is the docs half the issue still asks for:

- `docs/api/README.md` taught five **unquoted** extras (`pip install continuum-agent[mcp]`), which is a glob in zsh — it either fails or silently expands. All quoted now, with the rule stated.
- `docs/api/mcp.md` gains an **Installation** section: the PEP 508 direct-reference form for GitHub/fork installs (`pip install "continuum-agent[mcp] @ git+https://..."`), the note that a bare VCS URL cannot carry an extra, and the **decision record** — the entry point stays unconditional, the SDK stays an extra, and moving `mcp` into core dependencies was rejected as a violation of the dependency-free-core architecture.
- Two guards in `tests/test_mcp_docs.py`: no documented install names the unrelated `continuum` PyPI package (the bug that shipped until #719), and every extras-bearing install target is quoted.

## Out of scope (per the issue)

- The `mcp install` / `mcp doctor` verification hooks depend on #834/#835 (open PRs #844/#845).

## Verification

`pytest tests/test_mcp_docs.py tests/test_mcp_server.py` green locally; `ruff check` + `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)