### PR TITLE
docs: purge the installation-doc contradictions and pin them with tes…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,16 +148,18 @@ To run it manually against all files:
 pre-commit run --all-files
 ```
 
-The ruff version lives in three places that must move together in one PR.
+The ruff version lives in four places that must move together in one PR.
 `tests/test_precommit_config.py` fails any PR where they drift, which is how a
 dependabot `pip` bump surfaces (as a red test, not a version skew, so read a
 failure there as drift before anything else):
 
 1. the `ruff==` pin in the `dev` extra of `pyproject.toml`,
-2. `rev:` in `.pre-commit-config.yaml`, and
+2. `rev:` in `.pre-commit-config.yaml`,
 3. the `rev:` quoted in the yaml block above. This file is itself one of the
    pins, which is easy to miss because you are editing prose, not
    configuration.
+4. the `ruff==` row in the dependency table in `references/install.md` (#840:
+   this one drifted two releases before anything watched it).
 
 A hook running a different ruff than CI is how a locally formatted file still
 fails `ruff format --check` on the PR.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ CONTINUUM asks a narrower, harder question: can an agent resume from a compact s
 
 Published to PyPI as `continuum-agent` 0.1.0: `pip install continuum-agent` (`pip install continuum-agent==0.1.0` to pin). Release tags additionally ship built wheels attached to [GitHub Releases](https://github.com/Cyrax321/CONTINUUM/releases).
 
-Zero-setup paths (no clone, no install, nothing published anywhere):
+Paths that need no clone and no local install:
 
 | Path | How |
 |:--|:--|
@@ -192,7 +192,7 @@ Full walkthrough with code is in `docs/recovery_walkthrough.md` (`examples/recov
 | Environment revalidation | Every checkpoint component verified against the current world before resume |
 | Provenance-aware state | Agent-reported progress is marked `REQUIRES_REVIEW`, never self-certifying |
 | Recovery engine | Seven recovery modes with a deterministic, sealed next-action contract |
-| Deny-by-default MCP server | Eleven tools, read-only/mutating split, caller allowlist |
+| Deny-by-default MCP server | Twelve tools, read-only/mutating split, caller allowlist |
 | Framework adapters | Generic Python, OpenAI Agents SDK, LangGraph, and LangChain integrations |
 | Secure planning loop | Two-signal observation verification escalates high-risk branches to REQUIRES_REVIEW |
 | Periodic revalidation | Environment re-checked on a schedule, catching mid-run drift within one cycle |
@@ -244,7 +244,16 @@ uv pip install -e ".[mcp]"
 CONTINUUM_MCP_MUTATING_CLIENTS=your-client-name continuum-mcp
 ```
 
-Eleven tools over stdio. Three are read-only (`continuum_validate`, `continuum_resume`, `continuum_list_actions`); eight mutate. Side effects are two-phase (claim, perform, complete), and mutating tools deny by default behind an allowlist. Agent-reported state is recorded with `Origin.EXTERNAL_AGENT` provenance and marked `REQUIRES_REVIEW`.
+On Windows, the env-prefix form has no PowerShell equivalent, so set the
+variable first:
+
+```powershell
+uv pip install -e ".[mcp]"
+$env:CONTINUUM_MCP_MUTATING_CLIENTS = "your-client-name"
+continuum-mcp
+```
+
+Twelve tools over stdio. Three are read-only (`continuum_validate`, `continuum_resume`, `continuum_list_actions`); nine mutate. Side effects are two-phase (claim, perform, complete), and mutating tools deny by default behind an allowlist. Agent-reported state is recorded with `Origin.EXTERNAL_AGENT` provenance and marked `REQUIRES_REVIEW`.
 
 Verification details, including crash recovery at startup and the end to end Claude Code test, are in [references/mcp.md](references/mcp.md). If a registered server reports `CONNECTION_CLOSED`, the cause is almost always `PATH` resolution rather than the server itself: [docs/api/mcp.md](docs/api/mcp.md#troubleshooting) has the diagnosis and two remedies.
 
@@ -332,7 +341,7 @@ Any harness plugs into the same hash chained log. The same run can be written by
 | Seam | How to connect | What it gives you |
 |:--|:--|:--|
 | 1 In-process | `GenericAgentAdapter.intercept_action(...)` and `wrap_tool(key_fn=...)` on LangChain, LangGraph, OpenAI Agents SDK | Python frameworks, trusted writes |
-| 2 MCP server | `continuum-mcp` 12 tools over stdio (`continuum_record_progress`, `continuum_intercept_action`, `continuum_complete_action`, etc.) | Any MCP capable client, 3 read only + 8 mutating, allowlist `CONTINUUM_MCP_MUTATING_CLIENTS` |
+| 2 MCP server | `continuum-mcp` 12 tools over stdio (`continuum_record_progress`, `continuum_intercept_action`, `continuum_complete_action`, etc.) | Any MCP capable client, 3 read-only + 9 mutating, allowlist `CONTINUUM_MCP_MUTATING_CLIENTS` |
 | 3 CLI lifecycle hooks | `continuum hooks install claude-code --with-gate` also `gemini` and `codex` | Coding CLIs: `SessionStart briefing`, `PostToolUse observe`, `PreToolUse gate`; no CLAUDE.md needed |
 | 4 Enforcing HTTP gateway | `continuum gateway --port 8765` with `.continuum/gateway.json` | Any language, any outbound HTTP must have a claim, gateway settles from real status code |
 | 5 OpenTelemetry bridge | `make_span_processor(storage)` | Any traced app, spans become `TOOL_COMPLETED` evidence |
@@ -461,7 +470,7 @@ All wiring is host-side; the model's cooperation is optional:
 continuum hooks install claude-code --with-gate   # coding CLIs: evidence, briefing, gate
 continuum gateway --port 8765                     # enforcing HTTP proxy for everything else
 provider.add_span_processor(continuum.otel.make_span_processor(storage))  # OTel to evidence
-continuum-mcp                                     # anything MCP-capable: the eleven-tool server
+continuum-mcp                                     # anything MCP-capable: the twelve-tool server
 continuum briefing                                # session-start context injection
 continuum budget <run_id>                         # retry-budget usage report
 continuum tree <parent_run_id>                    # multi-agent hierarchy view

--- a/docs/ARCHITECTURE_EVOLUTION.md
+++ b/docs/ARCHITECTURE_EVOLUTION.md
@@ -27,7 +27,7 @@ and replays one append-only, hash-chained event log per run.
 | Checkpoint | `checkpoint/` | `CheckpointManager`, policy stack (`policy.py`), `build_recovery_context` |
 | Recovery | `recovery/` | `RecoveryEngine.assess()`, `planner.py` (repair plan), `contract.py` |
 | Adapters | `adapters/` | `AgentAdapter` base + Generic / LangChain / LangGraph / OpenAI |
-| MCP | `mcp/` | `server.py` (10 stdio tools), `authz.py` (allowlist + shared secret) |
+| MCP | `mcp/` | `server.py` (12 stdio tools), `authz.py` (allowlist + shared secret) |
 | Serve | `serve/` | newline-JSON sidecar mirroring the MCP surface |
 | CLI | `cli/` | `argparse` commands, exit codes as verdict |
 | Environment | `environment/` | `EnvironmentProvider` ABC + File/Git/Value/Callable/Static providers |

--- a/docs/UPGRADE_SPEC.md
+++ b/docs/UPGRADE_SPEC.md
@@ -48,7 +48,7 @@ Core invariant: every fact carries its origin, and trust is earned, never assume
 Five integration seams, all funneling into `GenericAgentAdapter`:
 
 * Seam 1: in-process adapters (generic, LangChain, LangGraph, OpenAI)
-* Seam 2: MCP server (11 tools over stdio, 3 read-only, 8 mutating)
+* Seam 2: MCP server (12 tools over stdio, 3 read-only, 9 mutating)
 * Seam 3: CLI lifecycle hooks (`continuum hooks install`, `continuum observe`, `continuum gate`, `continuum briefing`)
 * Seam 4: enforcing HTTP gateway (`continuum gateway`)
 * Seam 5: OpenTelemetry bridge (`make_span_processor`)
@@ -424,7 +424,7 @@ Reviewers: check that no section invents a number that is not cited, that every 
 
 ## 19. Appendix C: file inventory for reviewers
 
-Core: 60 files in `src/continuum` as listed in section 3.2. Entry points: `continuum.cli.main:main`, `continuum.mcp.server:main`. Tests: 99 files. Examples: `crash_recovery_agent.py`, `context_compaction.py`, `model_switch.py`, `recovery_walkthrough.py`, plus real-LLM crash harnesses. Docs: `README.md` (11 tools, 33 commands, 5 seams), `docs/*` research notes, `references/*` specs.
+Core: 60 files in `src/continuum` as listed in section 3.2. Entry points: `continuum.cli.main:main`, `continuum.mcp.server:main`. Tests: 99 files. Examples: `crash_recovery_agent.py`, `context_compaction.py`, `model_switch.py`, `recovery_walkthrough.py`, plus real-LLM crash harnesses. Docs: `README.md` (12 tools, 33 commands, 5 seams), `docs/*` research notes, `references/*` specs.
 
 ---
 

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -68,6 +68,28 @@ Twelve tools: three read-only, nine mutating.
 Read-only responses `continuum_resume` and `continuum_validate` include a
 `constraint_pins` block: per-pin status (`present`, `absent`, `unverifiable`), grace deadline, and flagged set derived from reconstruction accounting (hash-tagged markers in the recovery context, issue #419). The CLI renders flagged pins prominently with TTY-aware colour while piped output stays byte-identical modulo colour codes. No gating changes live here; strict escalation remains in the accounting layer.
 
+## Environment variables
+
+`CONTINUUM_MCP_ALLOW`
+: The primary authorization variable: a comma-separated list of client names
+allowed to call mutating tools (for example
+`CONTINUUM_MCP_ALLOW=claude-code,cline`). Everything else is denied, and the
+read-only tools above stay open to every caller.
+
+`CONTINUUM_MCP_MUTATING_CLIENTS`
+: An older alias for `CONTINUUM_MCP_ALLOW`, kept from PR #3. It states what is
+being allowed more explicitly, so it wins when both are set; otherwise the two
+behave identically.
+
+Either variable takes precedence over `.continuum/mcp-policy.json`, and an
+explicit `allow` passed by an API caller takes precedence over both; each
+source replaces the ones below it rather than merging, so `policy.source`
+always names exactly where a grant came from.
+
+`CONTINUUM_DB`
+: The database path the server opens when `--db` is not passed on the command
+line (default `./continuum.db`).
+
 ## build_server
 
 `continuum.mcp.server.build_server(database=None, *, policy=None, auth=None) -> tuple[Server, Storage]`

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -74,7 +74,7 @@
   <rect class="tierSDK" x="60" y="268" width="960" height="300" rx="16" filter="url(#shadow)"/>
   <text x="80" y="294" class="sdk" font-size="13">CONTINUUM SDK</text>
   <rect x="560" y="278" width="450" height="26" rx="13" fill="#07131E"/>
-  <text x="574" y="295" fill="#FFFFFF" font-size="11" font-weight="600">MCP server: deny by default, 11 tools (3 read-only / 8 mutating)</text>
+  <text x="574" y="295" fill="#FFFFFF" font-size="11" font-weight="600">MCP server: deny by default, 12 tools (3 read-only / 9 mutating)</text>
 
   <!-- Pipeline nodes -->
   <rect class="card"  x="80"  y="330" width="156" height="120" rx="10"/>

--- a/docs/cloud_api.md
+++ b/docs/cloud_api.md
@@ -16,7 +16,7 @@ This is an optional, additive layer. The system remains fully runnable locally w
 
 - Default install is `SQLiteStorage` in the project directory, no server required.
 - `uv run pytest` passes with no Postgres and no S3.
-- The cloud services are built as an extra, for example `uv pip install -e ".[cloud]"`, and are not imported at library import time.
+- The cloud services are built as optional installs and are not imported at library import time. The durable store rides the existing `[postgres]` extra; no `cloud` extra exists in `pyproject.toml` (#840).
 
 ## Deployment
 

--- a/docs/guides/embed-claude-code.md
+++ b/docs/guides/embed-claude-code.md
@@ -276,6 +276,23 @@ continuum --db /tmp/embed-claude-demo.db --json resume hardkill-demo | python -m
 echo "exit code: $?"
 ```
 
+The same test on Windows (PowerShell), with the platform temporary directory
+and no heredoc: save the Python block above to a file, point its `db` variable
+at `$db`, and run it with `python` between the two `continuum` calls.
+
+```powershell
+# fresh DB for the demo
+$db = "$env:TEMP\embed-claude-demo.db"
+Remove-Item -ErrorAction SilentlyContinue "$db", "$db-wal", "$db-shm"
+continuum --db $db start hardkill-demo --goal "Demo task for embed test"
+
+# ... run the saved Python block here (same simulation) ...
+
+# fresh session resumes (new process, same DB, no prompt needed)
+continuum --db $db --json resume hardkill-demo | python -m json.tool
+"exit code: $LASTEXITCODE"
+```
+
 Expected contract (real output from this repo, ids vary per run):
 
 ```json
@@ -324,7 +341,7 @@ A newcomer with only this guide should have crash recovery inside ten minutes. S
 2. `continuum start my-task --goal "trial"` (1s)
 3. `continuum hooks install claude-code` (1s)
 4. Do any work (write a file, claim an action via adapter, checkpoint)
-5. `kill -9` the agent (or `os._exit(9)` in the example) (instant)
+5. `kill -9` the agent (or `os._exit(9)` in the example; `Stop-Process -Id <pid> -Force` on Windows) (instant)
 6. New shell: `continuum --json resume my-task` shows correct mode and next steps (under 1s)
 
 Gap list as of this doc (honest): LangChain/LangGraph/Codex adapters require their optional dependency (`pip install "continuum-agent[langchain]"` etc.) which adds install time but stays inside ten minutes on a warm cache. No gap found for generic adapter path.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CONTINUUM: Verifiable Semantic Recovery for AI Agents</title>
-  <meta name="description" content="Framework-agnostic semantic recovery layer for long-running AI agents. 9 MCP tools, 14 CLI commands, 675 tests.">
+  <meta name="description" content="Framework-agnostic semantic recovery layer for long-running AI agents. 12 MCP tools, deny-by-default, crash-recovery proven.">
   <link rel="stylesheet" href="styles.css">
   <link rel="icon" type="image/png" href="assets/favicon.png">
 </head>
@@ -225,7 +225,7 @@
     </div>
 
     <div class="bottom-copy bottom-right">
-      <div>9 MCP TOOLS</div>
+      <div>12 MCP TOOLS</div>
       <div class="muted">deny-by-default auth</div>
     </div>
 
@@ -375,7 +375,7 @@
   <!-- MCP SERVER INTRO -->
   <section class="what-we-make-section" id="mcp-intro">
     <div class="what-we-make-container">
-      <p class="what-we-make-eyebra">eleven tools, one protocol</p>
+      <p class="what-we-make-eyebra">twelve tools, one protocol</p>
       <h2 class="what-we-make-title">DENY BY DEFAULT. WORKS WITH CLAUDE CODE.</h2>
       <div class="what-we-make-note">Route external side effects through the ledger without embedding the library.</div>
     </div>
@@ -387,7 +387,7 @@
       <div class="mcp-top">
         <div class="mcp-top-left">
           <span class="mcp-eyebrow">MCP SERVER</span>
-          <h2 class="mcp-headline">11 tools. Deny-by-default.<br>Works with Claude Code.</h2>
+          <h2 class="mcp-headline">12 tools. Deny-by-default.<br>Works with Claude Code.</h2>
           <p class="mcp-desc">Route external side effects through the ledger without embedding the library.</p>
         </div>
         <div class="mcp-preview">
@@ -495,7 +495,7 @@
       <div class="quickstart-header">
         <p class="quickstart-eyebra">start building</p>
         <h2 class="quickstart-title">Up and running in minutes</h2>
-        <p class="quickstart-note">Not on PyPI yet, install from a clone. The core library and CLI use only the standard library, the <code>mcp</code> extra adds the server.</p>
+        <p class="quickstart-note">On PyPI as <code>continuum-agent</code>, or install from a clone. The core library depends only on <code>pydantic</code>; the <code>mcp</code> extra adds the server.</p>
       </div>
 
       <div class="quickstart-grid">
@@ -556,7 +556,7 @@ continuum validate run_4821</code></pre></div>
             <span class="metric-label">CLI COMMANDS</span>
           </div>
           <div class="metric-row">
-            <span class="metric-value">9</span>
+            <span class="metric-value">12</span>
             <span class="metric-label">MCP TOOLS</span>
           </div>
         </div>
@@ -629,7 +629,7 @@ continuum validate run_4821</code></pre></div>
           </div>
           <div class="faq-answer" id="faq-answer-4">
             <span class="answer-label">ANSWER</span>
-            <p class="answer-text">It is framework-agnostic. There are adapters for generic Python, the OpenAI Agents SDK, LangGraph, and LangChain, plus a deny-by-default MCP server (11 tools) that lets Claude Code and other MCP clients route side effects through the ledger without embedding the library.</p>
+            <p class="answer-text">It is framework-agnostic. There are adapters for generic Python, the OpenAI Agents SDK, LangGraph, and LangChain, plus a deny-by-default MCP server (12 tools) that lets Claude Code and other MCP clients route side effects through the ledger without embedding the library.</p>
           </div>
         </div>
         <div class="faq-item">

--- a/docs/recipes/claude-code.md
+++ b/docs/recipes/claude-code.md
@@ -54,7 +54,10 @@ instead if you want the compaction boundary to report without writing:
 }
 ```
 
-Replace `/absolute/path/to/.venv/bin/continuum` with `which continuum`.
+Replace `/absolute/path/to/.venv/bin/continuum` with the resolved path:
+`which continuum` on macOS/Linux, `where.exe continuum` on Windows, where
+the executable lives under `.venv\Scripts\continuum.exe` rather than
+`.venv/bin/continuum`.
 
 For an explicit `--json resume` variant (pairs with #394):
 

--- a/docs/recipes/codex.md
+++ b/docs/recipes/codex.md
@@ -56,6 +56,10 @@ cat .codex/hooks.json | python -m json.tool
 }
 ```
 
+Replace `/absolute/path/to/.venv/bin/continuum` with the resolved path:
+`which continuum` on macOS/Linux, `where.exe continuum` on Windows, where the
+executable lives under `.venv\Scripts\continuum.exe`.
+
 ```bash
 continuum --json resume | python -m json.tool | grep -q "pins"
 ```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -27,7 +27,7 @@ behind a deny-by-default MCP server.
 
 - **Recovery as a sealed contract** - `RecoveryEngine.assess` reduces three signals to one `RecoveryMode` (max-severity, `RESUME < ... < ABORT`) and returns a hash-sealed `RecoveryContract` with `evidence` / `reason` / `next_allowed_action` / `human_steps` (`src/continuum/recovery/`).
 
-- **Deny-by-default surfaces** - MCP server (11 tools, read-only/mutating split, allowlist + token auth in `src/continuum/mcp/authz.py`), CLI with exit-code contract (`src/continuum/cli/main.py`), enforcing HTTP gateway (`src/continuum/gateway.py`), OTel bridge (`src/continuum/otel.py`), observation hooks + briefing (`src/continuum/hooks.py`, `src/continuum/clienthooks.py`).
+- **Deny-by-default surfaces** - MCP server (12 tools, read-only/mutating split, allowlist + token auth in `src/continuum/mcp/authz.py`), CLI with exit-code contract (`src/continuum/cli/main.py`), enforcing HTTP gateway (`src/continuum/gateway.py`), OTel bridge (`src/continuum/otel.py`), observation hooks + briefing (`src/continuum/hooks.py`, `src/continuum/clienthooks.py`).
 
 - **Adapters and thin hooks** - nine class-based adapters in `src/continuum/adapters/` plus thin hook surfaces `src/continuum/adapters/thin.py` (CrewAI, AutoGen, Pydantic AI) and `make_continuum_checkpointer` for LangGraph native persistence. See `references/adapters.md` and `docs/recipes/`.
 

--- a/docs/research/token_floor.md
+++ b/docs/research/token_floor.md
@@ -1,10 +1,10 @@
 # Reduce Per Session Token Floor
 
-Every session pays for the system prompt plus the schemas of all eleven MCP tools, regardless of how little work is done. For a short resume check this dominates cost.
+Every session pays for the system prompt plus the schemas of all twelve MCP tools, regardless of how little work is done. For a short resume check this dominates cost.
 
 ## Current cost
 
-The MCP server exposes eleven tools via `tools/list`. Each schema is sent as part of the model context. The system prompt in `CLAUDE.md` plus eleven schemas is the floor before any user message.
+The MCP server exposes twelve tools via `tools/list`. Each schema is sent as part of the model context. The system prompt in `CLAUDE.md` plus twelve schemas is the floor before any user message.
 
 ## Proposal
 

--- a/references/architecture-data.md
+++ b/references/architecture-data.md
@@ -46,7 +46,7 @@ Optional installs. An agent may also call the SDK or MCP server directly.
 
 ## 4. MCP server (stdio, deny by default) `src/continuum/mcp/`
 
-Server name: `continuum` (`server.py`). Eleven tools, all names prefixed,
+Server name: `continuum-mcp` (`server.py`). Twelve tools, all names prefixed,
 recounted from the tool registrations on 2026-08-24.
 
 | Tool (exact name) | Kind | Source |
@@ -324,7 +324,7 @@ Vertical, tiered. Group boxes by the tiers in section 1.
   - Row 2: State Engine, Checkpoint Manager, Environment
   - Row 3: Validator, Recovery Engine, Security
   - Pill at top-right of the SDK container:
-    "MCP server: deny by default, 11 tools (3 read-only, 8 mutating)".
+    "MCP server: deny by default, 12 tools (3 read-only, 9 mutating)".
 - Fourth tier: two boxes side by side: "Durable Storage (SQLite, WAL)" and
   "External Systems (GitHub, email, APIs)".
 - Bottom tier: one centered box "Resume (bounded recovery context)".

--- a/references/architecture-drawing-prompt.md
+++ b/references/architecture-drawing-prompt.md
@@ -84,7 +84,7 @@ Row 3:
 - Security (subtitle: canonical hashing, provenance)
 
 MCP pill (small rounded bar at the top-right inside the SDK container):
-- Text: "MCP server: deny by default, 11 tools (3 read-only, 8 mutating)"
+- Text: "MCP server: deny by default, 12 tools (3 read-only, 9 mutating)"
 
 ### Tier 4: two cards side by side
 Left card:

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -460,7 +460,7 @@ continuum/
 |       |   +-- contract.py          Sealed, gated next action
 |       +-- mcp/
 |       |   +-- __init__.py
-|       |   +-- server.py            9 stdio tools, read-only/mutating split, auth gate
+|       |   +-- server.py            12 stdio tools, read-only/mutating split, auth gate
 |       +-- adapters/
 |       |   +-- __init__.py          AgentAdapter contract
 |       |   +-- base.py              Shared adapter plumbing

--- a/references/auto-resume-integration.md
+++ b/references/auto-resume-integration.md
@@ -71,7 +71,7 @@ Registered in `.mcp.json` (project root):
 ```json
 {
   "mcpServers": {
-    "continuum": {
+    "continuum-mcp": {
       "command": "continuum-mcp",
       "args": ["--db", "continuum.db"],
       "env": { "CONTINUUM_MCP_MUTATING_CLIENTS": "claude-code" }
@@ -82,7 +82,7 @@ Registered in `.mcp.json` (project root):
 
 - Spawns as a stdio MCP server; it opens `continuum.db` in the current working
   directory.
-- **Eleven tools**, split read-only vs mutating:
+- **Twelve tools**, split read-only vs mutating:
   `continuum_record_progress`, `continuum_checkpoint`,
   `continuum_record_summary`, `continuum_intercept_action`,
   `continuum_complete_action`, `continuum_fail_action`,
@@ -241,7 +241,7 @@ coarser than desired.
 
 ### P7. Per-session token floor
 Every session pays for the system prompt (`CLAUDE.md`) plus the schemas of all
-eleven MCP tools, regardless of how little work is done. For many short
+twelve MCP tools, regardless of how little work is done. For many short
 resume checks this fixed cost dominates.
 
 ---
@@ -327,7 +327,7 @@ continuum --db continuum.db events guide     # the recorded section trail
 
 ## 10. Key files to read
 
-- `src/continuum/mcp/server.py`  -  `build_server`, `ContinuumMCP`, the 11 tools,
+- `src/continuum/mcp/server.py`  -  `build_server`, `ContinuumMCP`, the 12 tools,
   `continuum_resume` (optional `run_id`, returns `goal`).
 - `src/continuum/storage/sqlite.py`  -  `get_active_run`, `list_runs`, run table.
 - `src/continuum/recovery/engine.py`  -  `RecoveryEngine.assess` (mode decision).

--- a/references/install.md
+++ b/references/install.md
@@ -6,7 +6,7 @@ Deep install and dependency material. The [README Quick Start](../README.md#quic
 
 | Requirement | Version / Notes |
 |:--|:--|
-| Python | **3.11+** (3.12 recommended for development; CI tests 3.11 / 3.12 / 3.13) |
+| Python | **3.11+** (3.12 recommended for development; CI tests 3.11 / 3.12 / 3.13). 3.14 works in practice but is not yet in the CI matrix, so it is not part of the support claim. |
 | git | any recent version |
 | uv **or** pip | `uv` is recommended (faster, lockfile-aware). `pip` works with a manual venv. |
 | SQLite | bundled with Python, no extra install (WAL mode is used) |
@@ -26,7 +26,7 @@ uv pip install -e ".[dev]"
 uv pip install -e .
 
 # Composable extras
-uv pip install -e ".[mcp]"           # MCP server (11 stdio tools), requires mcp>=2.0
+uv pip install -e ".[mcp]"           # MCP server (12 stdio tools), requires mcp>=2.0
 uv pip install -e ".[otel]"          # OpenTelemetry bridge, opentelemetry-api>=1.20
 uv pip install -e ".[langgraph]"     # LangGraph adapter
 uv pip install -e ".[openai]"        # OpenAI Agents SDK adapter (also pulls mcp transitively)
@@ -55,7 +55,7 @@ Combine freely: `[dev]` already includes `mcp`, `langgraph`, `langchain`, `opena
 | **Dev / test tooling** (all in `pyproject.toml:33-50` `[dev]`) | | | Only for contributors |
 | `pytest>=8.0`, `pytest-cov>=5.0`, `pytest-asyncio>=0.23` |  | Test runner + coverage + async MCP tests | Dev |
 | `hypothesis>=6.0` |  | Property-based tests (hashing, models) | Dev |
-| `ruff==0.16.3` |  | Lint + format (CI enforces `ruff check` + `ruff format --check`) | Dev |
+| `ruff==0.16.5` |  | Lint + format (CI enforces `ruff check` + `ruff format --check`) | Dev |
 | `mypy>=1.13` + `pydantic.mypy` |  | Strict type-check (CI runs `mypy src/continuum`) | Dev |
 
 No other runtime dependencies. The CLI, storage, recovery engine, and checkpointing use only the Python standard library.

--- a/references/mcp.md
+++ b/references/mcp.md
@@ -28,7 +28,7 @@ help, and the re-raise when there is nothing to clear. Recorded in CHANGELOG.md
 under Fixed.
 
 **The server is verified usable through Claude Code.** Registered as an MCP
-server, it reports `✔ Connected`, exposes all eleven tools with the correct
+server, it reports `✔ Connected`, exposes all twelve tools with the correct
 read-only/mutating split, and the full `continuum_record_progress` to
 `continuum_checkpoint` to `continuum_intercept_action` to
 `continuum_complete_action` to `continuum_resume` cycle returns correct,

--- a/references/quickstart.md
+++ b/references/quickstart.md
@@ -1,6 +1,7 @@
 ## Quick Start
 
-> Not published to PyPI yet. Install from a clone:
+> Published to PyPI as `continuum-agent` (`pip install continuum-agent`), or
+> install from a clone:
 >
 > ```bash
 > uv venv
@@ -9,8 +10,8 @@
 > ```
 >
 > Two entrypoints are installed: `continuum` (the CLI) and `continuum-mcp`
-> (the MCP server). The core library and CLI use only the standard library -
-> the `mcp` extra is required solely for the server.
+> (the MCP server). The core library depends only on `pydantic`; the `mcp`
+> extra is required solely for the server.
 
 What runs today (Phases 1–11): record events, project state, checkpoint, survive a crash, validate against the current environment, never duplicate an external side effect, decide how it is safe to resume, expose a stdio MCP server, and plug into agent frameworks.
 

--- a/references/testing.md
+++ b/references/testing.md
@@ -138,7 +138,7 @@ continuum attest-verify <run_id> --attest <file>
 | 1 | pytest/ruff/format/mypy clean |
 | 2 | benchmark shows 0 duplicates; verify ok; crash examples print resumed state |
 | 3 | fresh session briefs unprompted; observations `[verified]`; gate denials teach then pass |
-| 4 | inspector lists eleven tools; mutating calls honour the allowlist |
+| 4 | inspector lists twelve tools; mutating calls honour the allowlist |
 | 5 | exactly-once holds across soft resume and hard crash for every adapter |
 | 6 | tool spans appear in `continuum events` with `via: otel` |
 | 7 | 403 -> claim -> forward -> settled, all visible in the event chain |

--- a/tests/test_docs_counts.py
+++ b/tests/test_docs_counts.py
@@ -70,3 +70,38 @@ def test_documented_count_matches_suite() -> None:
         "re-sync README.md, docs/CONTRIBUTING_ONBOARDING.md, and CHANGELOG.md "
         "(pytest --collect-only -q; pytest -q)"
     )
+
+
+def test_documented_extras_exist_in_pyproject() -> None:
+    """No doc installs an extra that pyproject.toml does not declare.
+
+    ``docs/cloud_api.md`` taught ``uv pip install -e ".[cloud]"`` for an extra
+    that never existed (#840): a reader following it got an error from pip and
+    nowhere to turn. Every extras bracket in an install context, both the
+    ``continuum-agent[x]`` and the editable ``.[x]`` spelling, is checked
+    against the declared optional-dependencies.
+    """
+    import tomllib
+
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    declared = set(data["project"]["optional-dependencies"])
+
+    scanned = [
+        ROOT / "README.md",
+        *sorted(ROOT.joinpath("docs").rglob("*.md")),
+        *sorted(ROOT.joinpath("references").rglob("*.md")),
+    ]
+    for path in scanned:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            # Only install-command lines carry extras, and the bracket must
+            # sit directly on `continuum-agent` or the editable `.` target;
+            # anything else (Codex's `[features]` toml section, markdown
+            # links, regex examples) is not a pip extra.
+            if "install" not in line.lower():
+                continue
+            for group in re.findall(r"(?:continuum-agent|\.)\[([\w,-]+)\]", line):
+                for extra in group.split(","):
+                    assert extra in declared, (
+                        f"{path} installs the [{extra}] extra, but pyproject.toml "
+                        f"declares only {sorted(declared)}"
+                    )

--- a/tests/test_mcp_docs.py
+++ b/tests/test_mcp_docs.py
@@ -95,3 +95,72 @@ async def test_the_audit_coverage_table_lists_every_served_tool(server: Any) -> 
 def test_the_page_carries_no_em_dashes() -> None:
     """House style forbids them (issue #266) and one had reached the table."""
     assert EM_DASH not in MCP_DOC.read_text(encoding="utf-8")
+
+
+#: The repo root, for scanning the docs that state the MCP tool count.
+ROOT = Path(__file__).resolve().parents[1]
+
+#: Prose and tables that state how many tools the MCP server serves: the
+#: markdown docs, the marketing page, and the architecture drawing's text.
+TOOL_COUNT_DOCS = [
+    ROOT / "README.md",
+    *sorted((ROOT / "docs").rglob("*.md")),
+    *sorted((ROOT / "docs").rglob("*.html")),
+    *sorted((ROOT / "docs").rglob("*.svg")),
+    *sorted((ROOT / "references").rglob("*.md")),
+]
+
+#: A tool-count claim: "12 tools", "eleven tools", "12 stdio tools",
+#: "twelve MCP tools", "the twelve-tool server". The number may be digits or
+#: a word up to thirteen, and up to one adjective may sit before "tools".
+_TOOL_COUNT_CLAIM = re.compile(
+    r"\b(\d+|eleven|twelve|thirteen)[-\s]+(?:stdio\s+|MCP\s+)?tools\b", re.IGNORECASE
+)
+_WORD_TO_NUM = {"eleven": 11, "twelve": 12, "thirteen": 13}
+
+#: The mutating half of the same claim: "9 mutating", "8 mutating".
+_MUTATING_CLAIM = re.compile(r"\b(\d+)\s+mutating\b", re.IGNORECASE)
+
+#: A claim only counts when it is about this server, not a surveyed external
+#: system (the research notes describe benchmarks with their own tool counts),
+#: so the window around the claim must name the server or its transport.
+_ABOUT_US = re.compile(r"mcp|continuum|stdio|inspector", re.IGNORECASE)
+
+
+def _claims_about_us(text: str, match: re.Match[str]) -> bool:
+    window = text[max(0, match.start() - 200) : match.end() + 200]
+    return bool(_ABOUT_US.search(window))
+
+
+@pytest.mark.asyncio
+async def test_documented_tool_counts_match_the_server(server: Any) -> None:
+    """Every tool-count claim in the docs equals what ``tools/list`` serves.
+
+    The count drifted twice (#271, #759): tools were added and the prose kept
+    saying eleven, in ten files at once (#840). The server is the only
+    authority, so every claim about it is compared against it, digits and
+    words alike, including the read-only/mutating split. Claims about other
+    systems' tools (the research surveys) are left alone.
+    """
+    tools = await server.list_tools()
+    served = len(tools)
+    mutating = sum(
+        1 for tool in tools if not (tool.annotations and tool.annotations.read_only_hint)
+    )
+    for path in TOOL_COUNT_DOCS:
+        text = path.read_text(encoding="utf-8")
+        for match in _TOOL_COUNT_CLAIM.finditer(text):
+            if not _claims_about_us(text, match):
+                continue
+            claim = _WORD_TO_NUM.get(match.group(1).lower())
+            if claim is None:
+                claim = int(match.group(1))
+            assert claim == served, (
+                f"{path} claims {match.group(0)!r} but tools/list serves {served}"
+            )
+        for match in _MUTATING_CLAIM.finditer(text):
+            if not _claims_about_us(text, match):
+                continue
+            assert int(match.group(1)) == mutating, (
+                f"{path} claims {match.group(0)!r} but {mutating} tools mutate"
+            )

--- a/tests/test_precommit_config.py
+++ b/tests/test_precommit_config.py
@@ -98,6 +98,23 @@ def test_precommit_pins_the_ruff_version_from_the_dev_extra() -> None:
     )
 
 
+def test_install_reference_pins_the_same_ruff() -> None:
+    """The dependency table in references/install.md is a fourth ruff pin.
+
+    It read ``ruff==0.16.3`` for two releases after the other three pins moved
+    to 0.16.5 (#840), because no test watched it, so a contributor following
+    the install reference installed a different ruff than CI enforced.
+    """
+    expected = _pinned_ruff_version()
+    text = (REPO_ROOT / "references" / "install.md").read_text(encoding="utf-8")
+    pins = re.findall(r"ruff==([0-9.]+)", text)
+    assert pins == [expected], (
+        f"references/install.md pins ruff=={pins}, but pyproject's dev extra "
+        f"pins ruff=={expected}. Bump all four pins in the same PR; the "
+        "lockstep note in CONTRIBUTING.md lists them."
+    )
+
+
 def test_dependabot_does_not_watch_the_pre_commit_ecosystem() -> None:
     """The pre-commit ecosystem is deliberately absent from dependabot (#689).
 

--- a/try-it.sh
+++ b/try-it.sh
@@ -2,11 +2,15 @@
 # CONTINUUM - one-command demo. Run:  ./try-it.sh
 cd "$(dirname "$0")" || exit 1
 
-# macOS re-hides uv's .pth files, which makes Python 3.14 skip them.
-# A symlink into site-packages is immune to that.
-SP=".venv/lib/python3.14/site-packages"
-[ -d "$SP" ] && [ ! -e "$SP/continuum" ] && ln -sfn "$PWD/src/continuum" "$SP/continuum"
-chflags nohidden "$SP"/*.pth 2>/dev/null
+# macOS re-hides uv's .pth files, which makes the venv's Python skip them.
+# A symlink into site-packages is immune to that. The venv's layout names its
+# Python version, so every site-packages is handled rather than one pinned
+# version (#840: 3.14 was hardcoded while the support matrix is 3.11-3.13).
+for SP in .venv/lib/python3*/site-packages; do
+  [ -d "$SP" ] || continue
+  [ -e "$SP/continuum" ] || ln -sfn "$PWD/src/continuum" "$SP/continuum"
+  chflags nohidden "$SP"/*.pth 2>/dev/null
+done
 
 export PATH="$PWD/.venv/bin:$PATH"
 export PYTHONPATH="$PWD/src"


### PR DESCRIPTION
…ts (#840)

Nine classes of drift had accumulated across many doc PRs with no single-owner install page. All fixed at their cited locations:

- Published status: quickstart.md and docs/index.html still said 'not on PyPI yet' beside a README that installs from PyPI, and the README's own table claimed 'nothing published anywhere' one line after its PyPI row. All three now agree; the stale 'core uses only the standard library' claim (it depends on pydantic) is corrected in the same lines.
- Tool count: the server serves 12 tools; twelve files still said 11, 10, or 9 (README, index.html including its meta description and metrics, the architecture svg/data/prompt/spec set, UPGRADE_SPEC, release notes, research notes, install/mcp/testing references). All now read 12, with the 3 read-only + 9 mutating split corrected.
- Phantom extra: cloud_api.md taught a [cloud] extra that does not exist; it now points at the real [postgres] extra.
- Fourth ruff pin: references/install.md pinned 0.16.3 while the other three pins said 0.16.5; CONTRIBUTING's lockstep note now lists all four and a test watches the fourth.
- POSIX-only guidance: PowerShell equivalents added for the README env-prefix example, the recipes' hook paths (Scripts\ vs bin/), and the embed guide's hard-kill test; kill -9 gets its Windows spelling.
- Python versions: install.md documents the policy (3.11-3.13 in CI, 3.14 works but unsupported) and try-it.sh no longer hardcodes python3.14 in the site-packages workaround.
- Env vars: CONTINUUM_MCP_ALLOW (primary), its alias, and CONTINUUM_DB are now documented in docs/api/mcp.md.
- Stale .mcp.json copy: references/auto-resume-integration.md used the pre-rename 'continuum' server key; now 'continuum-mcp'.

Three guards keep it from rotting: every documented tool count (and mutating split) is compared against a live tools/list, every install-command extra is checked against pyproject.toml's declared extras, and the install reference's ruff pin against the dev extra.

<!--
Thank you for contributing to CONTINUUM.

Please fill out each section below. Sections left empty may delay review.
The PR title should follow conventional commits, for example:
feat: add recovery validator for partial checkpoints

-->

## Description

<!-- Describe what this PR changes. Explain the approach where the approach itself is non-obvious. -->

## Related issues

<!--
Link the issue this PR addresses.
Use "Fixes #N" if merging this PR fully resolves the issue,
otherwise use "Addresses #N" or "Refs #N".
If there is no related issue, explain why here.
-->

## Types of changes

<!-- Keep the one that applies, delete the rest. -->

- Type: `bugfix` | `feature` | `refactor` | `performance` | `docs` | `tests` | `build` | `ci`

## Breaking changes

<!-- State Yes or No. If Yes, describe the impact and the migration path for users. -->

## How has this been tested?

<!-- Describe the tests you ran to verify your changes. Include the exact commands and note the environment. For example:

pytest tests/test_recovery.py --tb=short -q
ruff check src/ tests/
mypy src/continuum

Mention any configuration or environment details relevant to reproducing the run.
-->

## Checklist

<!-- Reviewers will check these during review. Confirm them before requesting review. -->

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

<!-- Anything else reviewers should know: benchmarks, design tradeoffs, alternatives considered. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP server documentation now reflects 12 tools, including 3 read-only and 9 mutating tools.
  - Added Windows PowerShell setup and recovery instructions for MCP and Claude Code integrations.
  - Documented MCP environment variables, client allowlists, policy precedence, and default database behavior.
  - Quick-start guides now include PyPI installation for `continuum-agent`.

- **Documentation**
  - Clarified installation extras, Python support, executable paths, and cloud service setup.
  - Updated architecture, integration, testing, and release references for consistency.

- **Bug Fixes**
  - Improved macOS environment detection across supported Python versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->