### PR TITLE
feat(smoke): spawn the console script by default, report the wire fra…

### DIFF
--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -174,3 +174,26 @@ in use. Do not resolve it with `claude mcp remove continuum-mcp -s project`, whi
 edits the committed `.mcp.json` and unregisters the server for everyone who clones
 the repository. Leave the diagnostic in place, or drop the local entry with
 `-s local` once the environment is on `PATH`.
+
+### Windows: response frames end with `\r\n`
+
+On Windows the MCP Python SDK terminates its stdio frames with CRLF instead of
+the LF the JSON-RPC-over-stdio transport specifies (upstream
+[modelcontextprotocol/python-sdk#2433](https://github.com/modelcontextprotocol/python-sdk/issues/2433);
+confirmed against this server, every response line ends `b"\r\n"`). Lenient
+clients, Claude Code among them, absorb the extra byte. Strict NDJSON clients
+reject every frame, so the same install works in one client and reports a
+protocol error in another, on Windows only, which is why it lands in
+troubleshooting rather than in a release note.
+
+The defect is upstream, so CONTINUUM neither patches nor vendors it. What the
+repository does instead:
+
+- `scripts/mcp_smoke.py` reads the wire with `newline=""` (universal newlines
+  would rewrite the bytes and hide the difference) and states the observed
+  framing in its output: a Windows run reports `CRLF (\r\n)`, a Linux run
+  reports `LF (\n)`. Run it when a Windows client fails in a way a Linux one
+  does not.
+- A strict client has to tolerate both terminators or fail everywhere on
+  Windows; if yours does not, that is the client side of the upstream issue,
+  not a CONTINUUM configuration.

--- a/references/e2e.md
+++ b/references/e2e.md
@@ -30,6 +30,12 @@ revalidation - it does not silently assume the switch is safe.
 `mcp_smoke.py` drives the MCP server as a subprocess over stdio and prints every
 JSON-RPC frame as it crosses the wire. It asserts, rather than reports, that the
 same action intercepted twice returns `proceed: false` with the prior result.
+By default it spawns the installed `continuum-mcp` console script (PATH
+resolution being the most common real-world failure, issue #839), falling back
+to `python -m continuum.mcp` against the worktree source when the script is not
+on PATH; `--entry-point module` or `--entry-point console-script` forces either
+form. Its output also states the observed wire framing of the response frames,
+`\r\n` on Windows or `\n` elsewhere (see the MCP doc's troubleshooting section).
 
 Both exit non-zero if their guarantees fail.
 

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -2,10 +2,25 @@
 """Drive the CONTINUUM MCP server live over stdio and print the protocol traffic.
 
     python scripts/mcp_smoke.py
+    python scripts/mcp_smoke.py --entry-point module
 
 Starts the real server as a subprocess and speaks raw JSON-RPC to it: no test
 harness, no in-process shortcut. Every frame sent and received is printed as it
 happens, so what you see is the wire, not a summary of it.
+
+By default the smoke test spawns the installed ``continuum-mcp`` console
+script, because PATH resolution of that entry point is the single most common
+way a real installation fails while every module-form test still passes
+(issue #839). When the script is not on PATH it falls back to
+``python -m continuum.mcp`` against the worktree's ``src`` and says so; pass
+``--entry-point console-script`` to refuse the fallback, or
+``--entry-point module`` to force it.
+
+The transcript also reports the observed wire framing of the response frames
+(``\\n`` or ``\\r\\n``): on Windows the MCP SDK terminates stdio frames with
+CRLF (modelcontextprotocol/python-sdk#2433), which lenient clients absorb and
+strict NDJSON clients reject, so the smoke output states which one this server
+actually produced.
 
 The point of the transcript is step 7. The same action is intercepted twice with
 identical arguments; the second call must answer ``proceed: false`` and hand back
@@ -19,6 +34,7 @@ else.
 
 from __future__ import annotations
 
+import argparse
 import io
 import json
 import os
@@ -71,10 +87,38 @@ def note(text: str, colour: str = YELLOW) -> None:
     print(paint(f"    {text}", colour), flush=True)
 
 
+#: The console script a real MCP host spawns; also the name ``.mcp.json``
+#: declares, resolved by the host through PATH.
+CONSOLE_SCRIPT = "continuum-mcp"
+
+
+def _resolve_command(choice: str) -> tuple[list[str], bool]:
+    """Return the argv to spawn and whether the module fallback was used.
+
+    The console script is resolved through PATH because PATH resolution is
+    the failure mode this smoke test exists to cover (#839): a bare command
+    name in ``.mcp.json`` is looked up by the host, so the smoke test must
+    look it up the same way instead of bypassing it with ``python -m``.
+    """
+    if choice == "module":
+        return [sys.executable, "-u", "-m", "continuum.mcp"], False
+    resolved = shutil.which(CONSOLE_SCRIPT)
+    if resolved:
+        return [resolved], False
+    if choice == "console-script":
+        raise SystemExit(
+            f"error: {CONSOLE_SCRIPT} is not on PATH. Install it (pip install "
+            '"continuum-agent[mcp]") or pass --entry-point module to smoke-test '
+            "the worktree source instead."
+        )
+    return [sys.executable, "-u", "-m", "continuum.mcp"], True
+
+
 class MCPClient:
     """A minimal JSON-RPC client over the server's stdin/stdout."""
 
-    def __init__(self, db_path: str) -> None:
+    def __init__(self, db_path: str, entry_point: str = "auto") -> None:
+        cmd, self.fell_back = _resolve_command(entry_point)
         env = dict(os.environ)
         env["CONTINUUM_DB"] = db_path
         # Mutating tools deny unlisted callers by default, so the demo grants
@@ -82,21 +126,33 @@ class MCPClient:
         # server is read-only and step 2 onward is refused, which is the
         # intended posture for an unconfigured server, not a bug.
         env["CONTINUUM_MCP_ALLOW"] = "mcp-smoke"
-        src = Path(__file__).resolve().parents[1] / "src"
-        if src.is_dir():
-            existing = env.get("PYTHONPATH")
-            env["PYTHONPATH"] = f"{src}{os.pathsep}{existing}" if existing else str(src)
+        # The PYTHONPATH injection belongs to the module form only: against
+        # the worktree's src it is how a source-tree run works, but pointed at
+        # the console script it would shadow the very install under test.
+        if "-m" in cmd:
+            src = Path(__file__).resolve().parents[1] / "src"
+            if src.is_dir():
+                existing = env.get("PYTHONPATH")
+                env["PYTHONPATH"] = f"{src}{os.pathsep}{existing}" if existing else str(src)
 
+        # Binary pipes wrapped by hand: Popen's text=True would enable
+        # universal newlines and silently rewrite \r\n to \n, hiding the wire
+        # framing this script reports (#839). newline="" preserves what the
+        # server actually wrote; newline="\n" keeps what we send as LF.
         self.proc = subprocess.Popen(
-            [sys.executable, "-u", "-m", "continuum.mcp"],
+            cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=env,
-            text=True,
-            bufsize=1,  # line buffered: frames appear as they are written
         )
+        assert self.proc.stdin is not None and self.proc.stdout is not None
+        self._stdin = io.TextIOWrapper(self.proc.stdin, encoding="utf-8", newline="\n")
+        self._stdout = io.TextIOWrapper(self.proc.stdout, encoding="utf-8", newline="")
         self._id = 0
+        #: The terminator observed on response frames so far: "CRLF (\r\n)",
+        #: "LF (\n)", or None before the first frame arrives.
+        self.wire_framing: str | None = None
         # Drain stderr on a thread so a chatty server cannot deadlock us by
         # filling the pipe buffer while we block reading stdout.
         self._errors: list[str] = []
@@ -104,24 +160,31 @@ class MCPClient:
 
     def _drain_stderr(self) -> None:
         assert self.proc.stderr is not None
-        for line in self.proc.stderr:
-            self._errors.append(line.rstrip())
+        for raw in self.proc.stderr:
+            self._errors.append(raw.decode("utf-8", errors="replace").rstrip())
 
     def _send(self, payload: dict[str, Any]) -> None:
-        assert self.proc.stdin is not None
         raw = json.dumps(payload)
         print(paint("  --> ", GREEN) + paint(raw, DIM), flush=True)
-        self.proc.stdin.write(raw + "\n")
-        self.proc.stdin.flush()
+        self._stdin.write(raw + "\n")
+        self._stdin.flush()
 
     def _read(self) -> dict[str, Any]:
-        assert self.proc.stdout is not None
-        line = self.proc.stdout.readline()
+        line = self._stdout.readline()
         if not line:
             errors = "\n".join(self._errors[-20:])
             raise RuntimeError(f"server closed the connection.\nstderr:\n{errors}")
+        self._observe_framing(line)
         print(paint("  <-- ", CYAN) + paint(line.rstrip(), DIM), flush=True)
         return json.loads(line)
+
+    def _observe_framing(self, line: str) -> None:
+        ending = "CRLF (\\r\\n)" if line.endswith("\r\n") else "LF (\\n)"
+        if self.wire_framing is None:
+            self.wire_framing = ending
+        elif ending not in self.wire_framing:
+            print(paint(f"    note: frame terminator changed to {ending}", YELLOW), flush=True)
+            self.wire_framing = f"mixed, last seen {ending}"
 
     def request(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         self._id += 1
@@ -141,8 +204,7 @@ class MCPClient:
         return json.loads(content[0]["text"])
 
     def close(self) -> None:
-        if self.proc.stdin:
-            self.proc.stdin.close()
+        self._stdin.close()
         try:
             self.proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
@@ -157,6 +219,20 @@ def show(payload: dict[str, Any], *, indent: str = "    ") -> None:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Drive the CONTINUUM MCP server live over stdio and print the protocol traffic."
+    )
+    parser.add_argument(
+        "--entry-point",
+        choices=("auto", "console-script", "module"),
+        default="auto",
+        help=(
+            "how to spawn the server: the installed console script (auto uses it when "
+            "on PATH), or python -m against the worktree source"
+        ),
+    )
+    args = parser.parse_args()
+
     if Path(DB_PATH).exists():
         Path(DB_PATH).unlink()
     for suffix in ("-wal", "-shm"):
@@ -166,9 +242,16 @@ def main() -> int:
 
     print(paint("CONTINUUM MCP: live stdio smoke test", BOLD))
     print(paint(f"database: {DB_PATH} (fresh)", DIM))
-    print(paint(f"server:   {sys.executable} -m continuum.mcp", DIM))
-
-    client = MCPClient(DB_PATH)
+    client = MCPClient(DB_PATH, entry_point=args.entry_point)
+    print(paint(f"server:   {' '.join(client.proc.args)}", DIM))
+    if client.fell_back:
+        print(
+            paint(
+                f"note:     {CONSOLE_SCRIPT} is not on PATH, so the module form runs against "
+                "the worktree source. This covers the code, not the installation.",
+                YELLOW,
+            )
+        )
     run_id = "run_demo_1"
     action_args = {"to": "team@example.com"}
     failures: list[str] = []
@@ -186,6 +269,7 @@ def main() -> int:
         )
         server_info = response.get("result", {}).get("serverInfo", {})
         note(f"connected to {server_info.get('name')} ({server_info.get('title')})", GREEN)
+        note(f"response frames end with {client.wire_framing}", GREEN)
         client.notify("notifications/initialized")
 
         banner("1b", "tools/list")
@@ -311,6 +395,7 @@ def main() -> int:
             return 1
         print(paint("  SMOKE TEST PASSED", BOLD + GREEN))
         print(paint(f"    handshake ok · {len(tools)} tools · progress durable ·", GREEN))
+        print(paint(f"    wire framing {client.wire_framing} ·", GREEN))
         print(paint("    side effect performed exactly once ·", GREEN))
         print(paint("    agent-reported state correctly withheld from 'resume'", GREEN))
         return 0


### PR DESCRIPTION
…ming (#839)

The smoke test was advertised as proof the MCP server works, but it launched python -m continuum.mcp with src prepended to PYTHONPATH, so it bypassed the continuum-mcp console script and the PATH resolution that docs/api/mcp.md identifies as the single most common failure. It could pass while the user-facing installation was broken.

- --entry-point {auto,console-script,module}: auto (the default) spawns the installed continuum-mcp resolved through PATH, exactly as a host does, and falls back to the module form with a clear notice when the script is not installed; the explicit modes refuse or force the fallback. The PYTHONPATH injection now applies only to the module form, so the console-script run cannot shadow the install under test.
- Read the wire through binary pipes wrapped with newline="": Popen's text mode would rewrite \r\n to \n and hide the framing. The output now states what the server actually sent, CRLF (\r\n) on Windows (confirmed live against this server, upstream SDK issue modelcontextprotocol/python-sdk#2433) and LF (\n) elsewhere, at the handshake and in the pass summary.
- Document the Windows CRLF defect in docs/api/mcp.md's troubleshooting with the upstream reference, so strict-NDJSON client failures on Windows are diagnosable, and describe the new flags in references/e2e.md.

Verified on Windows in all three modes: auto falls back with the notice, console-script drives the installed .EXE end to end, module drives the worktree source; all pass and report CRLF.

<!--
Thank you for contributing to CONTINUUM.

Please fill out each section below. Sections left empty may delay review.
The PR title should follow conventional commits, for example:
feat: add recovery validator for partial checkpoints

-->

## Description

<!-- Describe what this PR changes. Explain the approach where the approach itself is non-obvious. -->

## Related issues

<!--
Link the issue this PR addresses.
Use "Fixes #N" if merging this PR fully resolves the issue,
otherwise use "Addresses #N" or "Refs #N".
If there is no related issue, explain why here.
-->

## Types of changes

<!-- Keep the one that applies, delete the rest. -->

- Type: `bugfix` | `feature` | `refactor` | `performance` | `docs` | `tests` | `build` | `ci`

## Breaking changes

<!-- State Yes or No. If Yes, describe the impact and the migration path for users. -->

## How has this been tested?

<!-- Describe the tests you ran to verify your changes. Include the exact commands and note the environment. For example:

pytest tests/test_recovery.py --tb=short -q
ruff check src/ tests/
mypy src/continuum

Mention any configuration or environment details relevant to reproducing the run.
-->

## Checklist

<!-- Reviewers will check these during review. Confirm them before requesting review. -->

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

<!-- Anything else reviewers should know: benchmarks, design tradeoffs, alternatives considered. -->
