### PR TITLE
fix(packaging): reconcile the declared version with the v0.1.2 tag (#…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -504,6 +504,21 @@ All notable changes to this project are documented here. The format follows
   callable), and the existing answers for genuinely malformed JSON are
   unchanged.
 
+## [0.1.2] - 2026-08-31
+
+### Fixed
+
+- **Version reconciliation after `v0.1.2` was tagged without the version bump
+  (#838).** The `v0.1.2` tag and its GitHub Release (67 commits over
+  `v0.1.0`: the `tree --limit` fix #544, the rewind carry-forward passthrough
+  #531, the hook-installer refactor #536, and docs) shipped while
+  `pyproject.toml` and `src/continuum/__init__.py` still declared `0.1.0`, so
+  every artifact built from the tag self-reported as 0.1.0. This section and
+  the version bump align the declared version with the newest tag, and the
+  release checklist now compares `pyproject.toml`, the tag, and PyPI so the
+  drift cannot recur silently. PyPI still serves 0.1.0 until the maintainer
+  publishes the reconciling 0.1.2 build.
+
 ## [0.1.0] - 2026-08-27
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM python:3.12-slim
 
 COPY . /opt/continuum
-RUN pip install --no-cache-dir /opt/continuum \
+# The [mcp] extra ships the SDK behind the continuum-mcp console script, so
+# the published image can serve MCP clients too; without it the entry point
+# exists but dies on the missing dependency (#838).
+RUN pip install --no-cache-dir '/opt/continuum[mcp]' \
     && useradd --create-home continuum
 
 # Default working directory is writable so the demo and CLI can create continuum.db.
@@ -10,4 +13,5 @@ USER continuum
 
 # No command given: run the crash-recovery demo end to end.
 # Override it to use the CLI: docker run --rm ghcr.io/cyrax321/continuum continuum --help
+# The MCP server likewise: docker run --rm ghcr.io/cyrax321/continuum continuum-mcp --help
 CMD ["python", "/opt/continuum/examples/crash_recovery_agent.py"]

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -42,6 +42,12 @@ grep -E "^## \[0\.1\.0\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md
 # Each prints its line; exits nonzero on any other value.
 grep -E '^version = "0\.1\.0"$' pyproject.toml
 grep -E '^__version__ = "0\.1\.0"$' src/continuum/__init__.py
+
+# The version being cut must be strictly newer than the newest existing tag.
+# Prints the newest tag; if it equals the version above, the bump was skipped
+# (this is exactly how the v0.1.2 drift happened, #838: the tag shipped while
+# both files still read 0.1.0, so every artifact built from it misreported).
+git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1
 ```
 
 Passing looks like:
@@ -53,6 +59,9 @@ Passing looks like:
 - `pyproject.toml` and `src/continuum/__init__.py` read the same version, and
   the tag about to be cut is that version prefixed with `v`: `0.1.0` becomes
   `v0.1.0`.
+- The newest existing tag sorts strictly below the version being cut. An equal
+  or newer tag means the release process was entered from the wrong end:
+  reconcile on `main` first (#838) instead of tagging over the drift.
 
 If any check fails, stop and reconcile on `main` through a reviewed PR before
 continuing. Do not edit files ad hoc during the cut.
@@ -141,6 +150,20 @@ you want to exercise the tip rather than the cut.)
   release workflow skips PyPI until trusted publishing is switched on
   (`PUBLISH_PYPI` repository variable set to `true`). While #215 is pending, a
   missing PyPI package does not mean the release failed.
+- **Version agreement across PyPI, the tag, and `pyproject.toml`:** once the
+  publish lands, all three must read the same version. `v0.1.2` was tagged
+  while `pyproject.toml` still read `0.1.0` and PyPI never received a 0.1.2 at
+  all (#838); this check is what makes that drift visible instead of silent.
+
+  ```bash
+  # Prints PyPI's latest version for continuum-agent. It must equal the
+  # version declared in pyproject.toml and the tag just cut.
+  curl -s https://pypi.org/pypi/continuum-agent/json \
+    | python -c "import json, sys; print(json.load(sys.stdin)['info']['version'])"
+  ```
+
+  If it disagrees, do not retag or republish the same number: PyPI never
+  reuses a version. Cut the next patch release through this same checklist.
 - **Launch assets:** the orientation table, regenerable crash-recovery visual,
   and research page belong to #400. This checklist deliberately carries no
   steps for them; link them from the GitHub Release description when they land.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "continuum-agent"
-version = "0.1.0"
+version = "0.1.2"
 description = "Verifiable semantic recovery layer for long-running AI agents."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/continuum/__init__.py
+++ b/src/continuum/__init__.py
@@ -164,7 +164,7 @@ from continuum.storage import (
     open_storage,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.2"
 
 # Framework-adapter names resolve lazily (PEP 562, issue #214): importing the
 # package must not pay for openai/langgraph/langchain, because every entry


### PR DESCRIPTION
…838)

The v0.1.2 tag and its GitHub Release shipped while pyproject.toml and src/continuum/__init__.py still declared 0.1.0, so every artifact built from the tag self-reported as 0.1.0, and PyPI (which only ever received 0.1.0) went stale against the newest release. A user installing latest did not get the newest tagged code.

- Bump pyproject.toml and __version__ to 0.1.2, matching the newest tag. Publishing the reconciling 0.1.2 build to PyPI remains the maintainer step (PUBLISH_PYPI gate, #215).
- Add a CHANGELOG [0.1.2] section recording the reconciliation and what the tag actually carried.
- Release checklist: the cut step now compares the version being cut against the newest existing tag (an equal tag means the bump was skipped, which is exactly how this drift happened), and the post-tag step verifies pyproject == tag == PyPI once the publish lands.
- Dockerfile: install with the [mcp] extra so the published image can run continuum-mcp instead of shipping an entry point that dies on the missing SDK.

<!--
Thank you for contributing to CONTINUUM.

Please fill out each section below. Sections left empty may delay review.
The PR title should follow conventional commits, for example:
feat: add recovery validator for partial checkpoints

-->

## Description

<!-- Describe what this PR changes. Explain the approach where the approach itself is non-obvious. -->

## Related issues

<!--
Link the issue this PR addresses.
Use "Fixes #N" if merging this PR fully resolves the issue,
otherwise use "Addresses #N" or "Refs #N".
If there is no related issue, explain why here.
-->

## Types of changes

<!-- Keep the one that applies, delete the rest. -->

- Type: `bugfix` | `feature` | `refactor` | `performance` | `docs` | `tests` | `build` | `ci`

## Breaking changes

<!-- State Yes or No. If Yes, describe the impact and the migration path for users. -->

## How has this been tested?

<!-- Describe the tests you ran to verify your changes. Include the exact commands and note the environment. For example:

pytest tests/test_recovery.py --tb=short -q
ruff check src/ tests/
mypy src/continuum

Mention any configuration or environment details relevant to reproducing the run.
-->

## Checklist

<!-- Reviewers will check these during review. Confirm them before requesting review. -->

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

<!-- Anything else reviewers should know: benchmarks, design tradeoffs, alternatives considered. -->
