### PR TITLE
docs(citation): remove placeholder all-zeros ORCID

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,6 @@ authors:
   - family-names: Shaji
     given-names: Anandhu P
     alias: Cyrax321
-    orcid: https://orcid.org/0009-0000-0000-0000
     website: https://github.com/Cyrax321
     affiliation: "CONTINUUM — Verifiable semantic recovery for long-running AI agents"
 repository-code: https://github.com/Cyrax321/CONTINUUM


### PR DESCRIPTION
## Description

Remove the placeholder `https://orcid.org/0009-0000-0000-0000` identifier from `CITATION.cff`. If the author has a real ORCID to include, it can be provided during review or in a subsequent update.

## Related issues

Fixes #792

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

- Validated `CITATION.cff` syntax using `yaml-lint`:
  `npx --yes yaml-lint CITATION.cff` (successful, exit code 0).
- Confirmed file structure and schema compliance for CFF 1.2.0.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

None