### PR TITLE
docs(security): document confirmation-token flow

### DIFF
--- a/docs/api/security.md
+++ b/docs/api/security.md
@@ -81,3 +81,62 @@ may use mutating tools; read-only tools stay open.
 
 The policy object and the errors raised when a caller is not permitted, did not
 identify itself, or failed authentication.
+
+## Confirmation token flow
+
+Runs created or updated via MCP carry `Origin.EXTERNAL_AGENT`, meaning their
+goal and progress are self-reported. To uphold the anti-self-certification
+guarantee, `continuum_resume` marks these runs with `REQUIRES_REVIEW`
+(`mode="request_human"`). While progress recording and checkpointing continue
+to operate normally, the run cannot resume without review. Confirming records a
+`REVIEW_CONFIRMED` event, clearing the review requirement.
+
+### Host CLI fallback
+
+By default, confirmation over MCP is disabled and fail-closed. Calling
+`continuum_confirm` over MCP refuses every caller with `NotAuthenticated`. The
+default and recommended workflow is human-driven out-of-band: an operator
+confirms the run on the host machine using the CLI:
+
+```bash
+continuum confirm <run_id>
+```
+
+This writes a `REVIEW_CONFIRMED` event with `Origin.HUMAN`, attesting the run
+without exposing confirmation credentials over MCP. Operators can also confirm
+only specific components using `--scope goal` or `--scope progress`.
+
+### `CONTINUUM_MCP_CONFIRM_TOKEN`
+
+To permit confirmation over MCP, an operator must explicitly set the
+`CONTINUUM_MCP_CONFIRM_TOKEN` environment variable.
+
+When configured:
+
+- The calling client must be included in the mutating allowlist
+  (`CONTINUUM_MCP_MUTATING_CLIENTS` or `.continuum/mcp-policy.json`).
+- The caller must present this exact token in the handshake's
+  `_meta.authToken`.
+- **Disjoint credential requirement**: The confirmation secret must be
+  distinct from all mutating credentials. At server startup,
+  `_reject_reused_confirmation_secret` verifies that
+  `CONTINUUM_MCP_CONFIRM_TOKEN` does not match `CONTINUUM_MCP_TOKEN` or any
+  entry in `CONTINUUM_MCP_CLIENT_TOKENS`. If an overlap is found, startup
+  raises `ValueError`. An agent trusted to record progress must never also
+  hold the secret required to confirm that progress.
+
+### `load_confirm(expected=None, *, env=None) -> ConfirmPolicy`
+
+Resolve the confirmation policy. Precedence: explicit `expected` argument,
+then the `CONTINUUM_MCP_CONFIRM_TOKEN` environment variable, then the refusing
+default. Unlike `load_auth`, an unset variable refuses every caller rather than
+leaving the tool open.
+
+### `ConfirmPolicy(expected=None, *, source="default (refusing)")`
+
+Gates `continuum_confirm` behind a dedicated secret. When no secret is
+configured, `disabled` is `True` and `verify(token)` raises
+`NotAuthenticated`, instructing the operator to run
+`continuum confirm <run_id>` on the host. When configured, `verify(token)`
+raises `NotAuthenticated` unless `token` matches the configured secret.
+


### PR DESCRIPTION
## Description

Add documentation for the confirmation-token flow in `docs/api/security.md`.

This documents:
- Why confirmation is required: runs created or updated via MCP carry `Origin.EXTERNAL_AGENT`, requiring review (`mode="request_human"`) to prevent self-certification exploits.
- Host CLI fallback: `continuum confirm <run_id>` as the default out-of-band human confirmation flow.
- Opt-in MCP confirmation via `CONTINUUM_MCP_CONFIRM_TOKEN`, allowlist enforcement, and the startup validation rule ensuring confirmation secrets are disjoint from mutating session secrets.
- Reference signatures for `load_confirm` and `ConfirmPolicy`.

## Related issues

Fixes #791

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

- Formatted and linted with markdownlint-cli2:
  ```powershell
  npx --yes markdownlint-cli2 docs/api/security.md
  ```
  Result: `Summary: 0 issues in 0 files`
- Checked line lengths (<= 80 characters for added content).
- Checked for absence of em dashes:
  ```powershell
  powershell -Command "Get-Content docs\api\security.md | Select-String '[\u2013\u2014]'"
  ```
- Verified terms presence:
  ```powershell
  git grep -ci "continuum_confirm" docs/api/security.md
  git grep -ci "CONTINUUM_MCP_CONFIRM_TOKEN" docs/api/security.md
  ```

## Checklist

Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

None.
