### PR TITLE
docs(cli): add docstrings for Palette helpers in colour.py

### DIFF
--- a/src/continuum/cli/colour.py
+++ b/src/continuum/cli/colour.py
@@ -76,6 +76,7 @@ class Palette:
 
     @classmethod
     def for_stream(cls, stream: Any, *, force: bool | None = None) -> Palette:
+        """Construct a palette enabled or suppressed for ``stream``."""
         return cls(should_colour(stream, force=force))
 
     def _wrap(self, text: str, code: str) -> str:
@@ -84,30 +85,39 @@ class Palette:
         return f"{code}{text}{_RESET}"
 
     def red(self, text: str) -> str:
+        """Wrap text in red ANSI escape codes when colour is enabled."""
         return self._wrap(text, _CODES["red"])
 
     def green(self, text: str) -> str:
+        """Wrap text in green ANSI escape codes when colour is enabled."""
         return self._wrap(text, _CODES["green"])
 
     def yellow(self, text: str) -> str:
+        """Wrap text in yellow ANSI escape codes when colour is enabled."""
         return self._wrap(text, _CODES["yellow"])
 
     def blue(self, text: str) -> str:
+        """Wrap text in blue ANSI escape codes when colour is enabled."""
         return self._wrap(text, _CODES["blue"])
 
     def cyan(self, text: str) -> str:
+        """Wrap text in cyan ANSI escape codes when colour is enabled."""
         return self._wrap(text, _CODES["cyan"])
 
     def grey(self, text: str) -> str:
+        """Wrap text in grey ANSI escape codes when colour is enabled."""
         return self._wrap(text, _CODES["grey"])
 
     def bold(self, text: str) -> str:
+        """Wrap text in bold ANSI escape codes when colour is enabled."""
         return self._wrap(text, _CODES["bold"])
 
     def dim(self, text: str) -> str:
+        """Wrap text in dim ANSI escape codes when colour is enabled."""
         return self._wrap(text, _CODES["dim"])
 
     def heading(self, text: str) -> str:
+        """Wrap text in bold cyan ANSI escape codes for section headings."""
         return self._wrap(text, _CODES["bold"] + _CODES["cyan"])
 
     # -- domain-aware helpers -------------------------------------------- #


### PR DESCRIPTION
## Description

Adds missing one-line docstrings for the 10 public methods on `Palette` in `src/continuum/cli/colour.py`: `for_stream`, `red`, `green`, `yellow`, `blue`, `cyan`, `grey`, `bold`, `dim`, and `heading`.

Docs-only change, no runtime or behavioural modifications.

## Related issues

Fixes #787

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

AST check verifying zero undocumented public names remain:
```bash
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/cli/colour.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
```
Output:
```
[]
```

Linter and type check:
```bash
ruff check src/continuum/cli/colour.py
ruff format --check src/continuum/cli/colour.py
mypy src/continuum/cli/colour.py
```
Output:
```
All checks passed!
1 file already formatted
Success: no issues found in 1 source file
```

Pytest:
```bash
pytest tests/test_cli_colour.py
```
Output:
```
34 passed in 3.02s
```

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Follows #607 and resolves diff-scoped docstring coverage gaps in `src/continuum/cli/colour.py`.
