### PR TITLE
docs(dashboard): add docstrings for human-in-the-loop actions in hitl.py

### DIFF
--- a/src/continuum/dashboard/hitl.py
+++ b/src/continuum/dashboard/hitl.py
@@ -42,6 +42,12 @@ class HitlUnauthorized(Exception):
 
 
 def authorize_hitl(token_from_request: str | None) -> None:
+    """Verify the request token matches ``CONTINUUM_DASHBOARD_TOKEN``.
+
+    Fails closed: raises ``HitlUnauthorized`` if the environment variable is
+    unset or empty, or if ``token_from_request`` is missing or does not match
+    the expected token.
+    """
     import os
 
     expected = os.environ.get(DEFAULT_HITL_TOKEN_ENV)
@@ -52,6 +58,13 @@ def authorize_hitl(token_from_request: str | None) -> None:
 
 
 def confirm_run(storage: Storage, run_id: str) -> None:
+    """Record an operator review confirmation for a run.
+
+    Appends a ``REVIEW_CONFIRMED`` event with ``Origin.HUMAN`` provenance
+    covering goal and progress components, clearing self-certification gates
+    with audit parity to the CLI. Raises ``RunNotFound`` if ``run_id`` is
+    missing from storage.
+    """
     storage.get_run(run_id)
     storage.append_event(
         run_id,
@@ -62,6 +75,13 @@ def confirm_run(storage: Storage, run_id: str) -> None:
 
 
 def complete_run(storage: Storage, run_id: str, summary: str = "") -> None:
+    """Mark a run as completed by a human operator from the dashboard.
+
+    Appends a ``RUN_COMPLETED`` event with ``Origin.HUMAN`` provenance,
+    attaches an optional summary note, and transitions the run row to
+    ``RunStatus.COMPLETED``. Raises ``RunNotFound`` if ``run_id`` is missing
+    from storage.
+    """
     run = storage.get_run(run_id)
     note = {"closed_by": "dashboard"}
     if summary:
@@ -78,6 +98,13 @@ def reconcile_action(
     occurred: bool,
     external_id: str | None = None,
 ) -> None:
+    """Settle an uncertain side effect in the action ledger from operator evidence.
+
+    Dispatches through ``ActionLedger.reconcile``, updating the action to
+    ``COMPLETED`` (if ``occurred=True``) or ``FAILED`` (if ``occurred=False``)
+    and recording an ``ACTION_RECONCILED`` event with provenance. Raises
+    ``KeyError`` if ``ledger_key`` is not found in the ledger.
+    """
     ActionLedger(storage, run_id).reconcile(
         ledger_key,
         occurred=occurred,


### PR DESCRIPTION
## Description

Adds docstrings for the 4 public human-in-the-loop action functions in `src/continuum/dashboard/hitl.py`:
- `authorize_hitl`: documents authorization against `CONTINUUM_DASHBOARD_TOKEN` and fail-closed posture (`HitlUnauthorized`).
- `confirm_run`: documents operator review confirmation, `REVIEW_CONFIRMED` event provenance (`Origin.HUMAN`), CLI parity, and `RunNotFound` failure mode.
- `complete_run`: documents operator completion, `RUN_COMPLETED` event provenance (`Origin.HUMAN`), status transition to `RunStatus.COMPLETED`, and `RunNotFound` failure mode.
- `reconcile_action`: documents evidence-based reconciliation of uncertain side effects through `ActionLedger.reconcile`, event/status transitions, and `KeyError` failure mode.

Docs-only change, no runtime or behavioural modifications.

## Related issues

Fixes #786

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

AST check verifying zero undocumented public names remain:
```bash
python -c "import ast; from pathlib import Path; tree = ast.parse(Path('src/continuum/dashboard/hitl.py').read_text(encoding='utf-8')); print([n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and not n.name.startswith('_') and ast.get_docstring(n) is None])"
```
Output:
```
[]
```

Linter and type check:
```bash
ruff check src/continuum/dashboard/hitl.py
ruff format --check src/continuum/dashboard/hitl.py
mypy src/continuum/dashboard/hitl.py
```
Output:
```
All checks passed!
1 file already formatted
Success: no issues found in 1 source file
```

Pytest:
```bash
pytest tests/test_dashboard_hitl.py
```
Output:
```
9 passed in 5.08s
```

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Follows #607 and covers operator-facing behavior for dashboard HITL actions.
