### PR TITLE
docs: document gateway bound tenant isolation in multi_agent_isolation.md

### DIFF
--- a/docs/multi_agent_isolation.md
+++ b/docs/multi_agent_isolation.md
@@ -58,6 +58,29 @@ ownership model for the state itself.
   lease; without the lease the count can race. The spec requires the lease for
   any run where concurrent recovery is possible.
 
+## Tenant isolation
+
+- **Bound tenant configuration.** The reverse proxy gateway optionally binds to
+  a specific tenant identity via `load_gateway_tenant` (`src/continuum/gateway.py:129`),
+  configured through the `bound_tenant` or `tenant` field in the gateway JSON
+  configuration file passed to `continuum gateway --config <path>` or supplied
+  directly to `GatewayServer`.
+
+- **Key shape and scoping.** Tenant isolation applies to memory-store routes
+  matching the `is_memory_key` predicate (`mem:` prefix, defined in
+  `src/continuum/gate.py:67`). Memory keys follow the canonical template
+  `mem:{store_id}:{tenant}:{record_key}`, where the tenant segment is the third
+  colon-delimited segment (`parts[2]`).
+
+- **Gate-level denial.** When a bound tenant is configured, the gateway checks
+  the key tenant before evaluating ledger claims or storage records (`match_route`
+  in `src/continuum/gateway.py:224`). If the rendered memory key carries a
+  different tenant than `bound_tenant`, the gateway denies the request immediately
+  with `Decision(allow=False, reason="tenant mismatch: bound ... but key ... carries tenant ...")`.
+  Malformed memory keys with fewer than four segments fail closed (`malformed memory key`).
+  This fail-fast denial prevents cross-tenant access at the enforcement boundary
+  even if an action is unclaimed or foreign (`tests/test_memory_forensic.py:211`).
+
 ## What to build next
 
 - Add an integration test that spawns two `RecoveryLedger` instances with a


### PR DESCRIPTION
## Description

Adds a `## Tenant isolation` section to `docs/multi_agent_isolation.md` documenting:
- Gateway bound tenant configuration via `load_gateway_tenant` (`bound_tenant` or `tenant` field in gateway JSON config).
- Memory-store route key shape (`mem:{store_id}:{tenant}:{record_key}`, where tenant is the 3rd colon-delimited segment).
- Gate-level mismatch denial behavior in `match_route` that fails closed prior to evaluating ledger claims.

## Related issues

Fixes #771

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

1. Markdown lint:
`npx -y markdownlint-cli2 docs/multi_agent_isolation.md` passed with 0 issues.
2. Tenant keyword verification:
Confirmed `docs/multi_agent_isolation.md` now covers tenant isolation with 16 mentions of "tenant".
3. Em dash audit:
Verified zero U+2014 characters in `docs/multi_agent_isolation.md`.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Verifiable against `src/continuum/gateway.py` (`load_gateway_tenant`, `match_route`) and `tests/test_memory_forensic.py` (`test_gateway_tenant_deny_before_ledger`).
