### PR TITLE
fix(core): add omitted public names to __all__ across five modules (#913)

### DIFF
--- a/src/continuum/actions/ledger.py
+++ b/src/continuum/actions/ledger.py
@@ -108,6 +108,7 @@ __all__ = [
     "LedgerError",
     "DuplicateAction",
     "ClaimLockError",
+    "fold_action_events",
     "forensic_join_across_runs",
 ]
 

--- a/src/continuum/gate.py
+++ b/src/continuum/gate.py
@@ -41,6 +41,7 @@ from continuum.events import EventType
 __all__ = [
     "DEFAULT_GATE_CONFIG_PATH",
     "Decision",
+    "GateConfigError",
     "MEMORY_KEY_PREFIX",
     "MEMORY_REQUIRED_FIELDS",
     "is_memory_template",

--- a/src/continuum/pinning.py
+++ b/src/continuum/pinning.py
@@ -15,7 +15,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-__all__ = ["ALLOWED_PINNING_KEYS", "normalize_pinning", "pinning_drift"]
+__all__ = [
+    "ALLOWED_PINNING_KEYS",
+    "latest_pinning",
+    "normalize_pinning",
+    "pinning_drift",
+]
 
 ALLOWED_PINNING_KEYS = (
     "prompt_sha256",

--- a/src/continuum/recovery/contract.py
+++ b/src/continuum/recovery/contract.py
@@ -33,7 +33,12 @@ from continuum.recovery.planner import RepairPlan
 from continuum.security.hashing import stable_hash
 from continuum.state.validator import ValidationOutcome
 
-__all__ = ["build_contract", "seal_contract", "verify_contract"]
+__all__ = [
+    "build_contract",
+    "render_contract",
+    "seal_contract",
+    "verify_contract",
+]
 
 
 def _identifier(component: Component, component_id: str | None) -> str:

--- a/src/continuum/recovery/gate.py
+++ b/src/continuum/recovery/gate.py
@@ -59,6 +59,7 @@ __all__ = [
     "enforce",
     "render_preserved_summary",
     "render_refusal_text",
+    "stamp_lineage",
     "summary_payload",
 ]
 

--- a/tests/test_module_all_exports.py
+++ b/tests/test_module_all_exports.py
@@ -1,0 +1,72 @@
+"""Tests for public module export surfaces (__all__) (issue #913)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import continuum.actions.ledger as action_ledger
+import continuum.gate as gate
+import continuum.pinning as pinning
+import continuum.recovery.contract as recovery_contract
+import continuum.recovery.gate as recovery_gate
+
+
+def test_action_ledger_exports_fold_action_events() -> None:
+    assert "fold_action_events" in action_ledger.__all__
+    assert callable(action_ledger.fold_action_events)
+
+
+def test_recovery_contract_exports_render_contract() -> None:
+    assert "render_contract" in recovery_contract.__all__
+    assert callable(recovery_contract.render_contract)
+
+
+def test_gate_exports_gate_config_error() -> None:
+    assert "GateConfigError" in gate.__all__
+    assert issubclass(gate.GateConfigError, Exception)
+
+
+def test_pinning_exports_latest_pinning() -> None:
+    assert "latest_pinning" in pinning.__all__
+    assert callable(pinning.latest_pinning)
+
+
+def test_recovery_gate_exports_stamp_lineage() -> None:
+    assert "stamp_lineage" in recovery_gate.__all__
+    assert callable(recovery_gate.stamp_lineage)
+
+
+def test_all_symbols_exist_on_modules() -> None:
+    modules = [
+        action_ledger,
+        recovery_contract,
+        gate,
+        pinning,
+        recovery_gate,
+    ]
+    for mod in modules:
+        for name in mod.__all__:
+            assert hasattr(mod, name), (
+                f"{mod.__name__} missing attribute {name!r} listed in __all__"
+            )
+
+
+def test_star_import_execution() -> None:
+    code = """
+from continuum.actions.ledger import *
+from continuum.recovery.contract import *
+from continuum.gate import *
+from continuum.pinning import *
+from continuum.recovery.gate import *
+
+assert callable(fold_action_events)
+assert callable(render_contract)
+assert issubclass(GateConfigError, Exception)
+assert callable(latest_pinning)
+assert callable(stamp_lineage)
+"""
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, (
+        f"Star import failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+    )


### PR DESCRIPTION
﻿## Description

Follow-up to #903: adds omitted public names to `__all__` across five modules where the symbols are already used externally:
- `src/continuum/actions/ledger.py`: adds `fold_action_events`
- `src/continuum/recovery/contract.py`: adds `render_contract`
- `src/continuum/gate.py`: adds `GateConfigError`
- `src/continuum/pinning.py`: adds `latest_pinning`
- `src/continuum/recovery/gate.py`: adds `stamp_lineage`

Also adds comprehensive unit tests in `tests/test_module_all_exports.py` verifying that each module defines the symbol, includes it in `__all__`, and correctly exports it via `from <module> import *`.

## Related issues

Fixes #913

## Types of changes

- Type: `bugfix`

## Breaking changes

No

## How has this been tested?

- `uv run pytest tests/test_module_all_exports.py`: 7 passed
- `uv run pytest tests/test_pinning.py tests/test_contract_observations.py tests/test_cli_gate.py`: 48 passed
- `uv run ruff check`: All checks passed
- `uv run ruff format --check`: 6 files formatted / clean

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the public API with additional action, recovery, gate, and pinning utilities.
  * Added access to configuration errors and lineage, contract, event-folding, and latest-pinning helpers.

* **Tests**
  * Added coverage verifying public exports, valid attributes, callable utilities, exception types, and successful wildcard imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->