### PR TITLE
fix: export gateway route vocabulary

### DIFF
--- a/src/continuum/gateway.py
+++ b/src/continuum/gateway.py
@@ -47,6 +47,9 @@ from continuum.models import Origin
 __all__ = [
     "DEFAULT_GATEWAY_CONFIG_PATH",
     "GatewayConfigError",
+    "Route",
+    "Decision",
+    "render_key",
     "load_gateway_config",
     "load_gateway_tenant",
     "match_route",

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -18,9 +18,12 @@ import pytest
 from continuum.actions import ActionLedger
 from continuum.events import EventType
 from continuum.gateway import (
+    Decision,
     GatewayConfigError,
     GatewayServer,
+    Route,
     load_gateway_config,
+    render_key,
 )
 from continuum.models import ActionStatus, Run
 from continuum.storage import SQLiteStorage
@@ -88,6 +91,15 @@ def claim(db: str, key: str) -> str:
     with SQLiteStorage(db) as store:
         outcome = ActionLedger(store, "run_1").claim("send_invoice", {}, key=key)
     return outcome.key
+
+
+def test_public_gateway_names_are_exported() -> None:
+    namespace: dict[str, object] = {}
+    exec("from continuum.gateway import *", namespace)
+
+    assert namespace["Route"] is Route
+    assert namespace["Decision"] is Decision
+    assert namespace["render_key"] is render_key
 
 
 def test_config_loading_and_validation(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- export `Route`, `Decision`, and `render_key` from `continuum.gateway` via `__all__`
- add a regression test for star-import public API behavior

Closes #903

## Validation
- `./.venv/bin/pytest -q tests/test_gateway.py` — 21 passed
- `./.venv/bin/ruff check src/continuum/gateway.py tests/test_gateway.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Route`, `Decision`, and `render_key` are now available as publicly exported gateway API components, including through wildcard imports.

* **Tests**
  * Added coverage to verify the newly exported gateway components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->