### PR TITLE
test: cover file snapshot edge cases

### DIFF
--- a/tests/test_file_snapshot_edges.py
+++ b/tests/test_file_snapshot_edges.py
@@ -1,0 +1,44 @@
+"""Direct tests for file snapshot boundary behavior (issue #902)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import continuum.environment.file_snapshot as file_snapshot
+
+
+def test_snapshot_file_returns_none_for_missing_source(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setattr(file_snapshot, "_SNAPSHOT_DIR", tmp_path / "snapshots")
+
+    assert file_snapshot.snapshot_file(tmp_path / "missing.txt") is None
+
+
+def test_snapshot_file_returns_none_without_writing_oversized_source(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    snapshot_dir = tmp_path / "snapshots"
+    monkeypatch.setattr(file_snapshot, "_SNAPSHOT_DIR", snapshot_dir)
+    monkeypatch.setattr(file_snapshot, "MAX_SNAPSHOT_BYTES", 3)
+    source = tmp_path / "large.txt"
+    source.write_bytes(b"1234")
+
+    assert file_snapshot.snapshot_file(source) is None
+    assert not snapshot_dir.exists()
+
+
+def test_restore_file_returns_false_for_absent_snapshot(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setattr(file_snapshot, "_SNAPSHOT_DIR", tmp_path / "snapshots")
+
+    assert file_snapshot.restore_file(tmp_path / "restored.txt", "missing-sha") is False
+
+
+def test_file_digest_returns_none_for_missing_source(tmp_path: Path) -> None:
+    assert file_snapshot.file_digest(tmp_path / "missing.txt") is None
+
+
+def test_snapshot_path_uses_file_snapshot_directory(tmp_path: Path, monkeypatch: Any) -> None:
+    snapshot_dir = tmp_path / ".continuum" / "file-snapshots"
+    monkeypatch.setattr(file_snapshot, "_SNAPSHOT_DIR", snapshot_dir)
+
+    assert file_snapshot.snapshot_path("abc123") == snapshot_dir / "abc123"


### PR DESCRIPTION
## Summary
- add direct tests for missing snapshot sources
- cover oversized source refusal without creating a snapshot directory
- cover absent restores, missing-file digests, and snapshot path construction

Closes #902

## Validation
- `./.venv/bin/pytest -q tests/test_file_snapshot_edges.py tests/test_rewind_dual_state.py` — 11 passed
- `./.venv/bin/ruff check tests/test_file_snapshot_edges.py`
- `./.venv/bin/ruff format --check tests/test_file_snapshot_edges.py`
- `./.venv/bin/mypy src/continuum/environment/file_snapshot.py tests/test_file_snapshot_edges.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)