### PR TITLE
docs: document replay similarity API

### DIFF
--- a/src/continuum/replay_similarity.py
+++ b/src/continuum/replay_similarity.py
@@ -37,6 +37,8 @@ __all__ = [
 
 
 class SimilarityKind(StrEnum):
+    """Comparison strategies available to the replay guard."""
+
     EXACT = "exact"
     FUZZY = "fuzzy"
     EMBEDDING = "embedding"
@@ -44,6 +46,8 @@ class SimilarityKind(StrEnum):
 
 @dataclass(frozen=True)
 class SimilarityConfig:
+    """Configure the similarity strategy and replay/fork score thresholds."""
+
     kind: SimilarityKind = SimilarityKind.EXACT
     """Which comparison strategy to use."""
     replay_threshold: float = 0.90
@@ -60,6 +64,8 @@ def token_set(text: str) -> frozenset[str]:
 
 
 def jaccard(a: frozenset[str], b: frozenset[str]) -> float:
+    """Return token-set similarity, treating two empty sets as identical."""
+
     if not a and not b:
         return 1.0
     if not a or not b:


### PR DESCRIPTION
## Summary
- document the replay similarity strategy enum and configuration object
- document Jaccard boundary behavior for empty token sets
- keep the change documentation-only

Closes #911

## Validation
- `./.venv/bin/pytest -q tests/test_replay_similarity.py` — 8 passed
- public-name AST audit reports no undocumented public classes or functions
- `./.venv/bin/ruff check src/continuum/replay_similarity.py`
- `./.venv/bin/ruff format --check src/continuum/replay_similarity.py`
- `./.venv/bin/mypy src/continuum/replay_similarity.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation describing similarity comparison strategies and score thresholds.
  - Clarified that comparing two empty sets with Jaccard similarity returns an identical result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->