### PR TITLE
docs: document MCP authorization flags

### DIFF
--- a/src/continuum/mcp/authz.py
+++ b/src/continuum/mcp/authz.py
@@ -131,6 +131,8 @@ class AuthPolicy:
 
     @property
     def disabled(self) -> bool:
+        """Whether authentication is disabled because no secret is configured."""
+
         # Only an absent secret disables authentication. An explicit empty
         # secret is a misconfiguration and must refuse, not open the door.
         return self.expected is None and not self.tokens
@@ -345,6 +347,8 @@ class AuthorizationPolicy:
 
     @property
     def denies_everything(self) -> bool:
+        """Whether the empty allow-list refuses every mutating caller."""
+
         return not self.allowed
 
     def permits(self, caller: str | None) -> bool:


### PR DESCRIPTION
## Summary
- document when `AuthPolicy.disabled` disables authentication
- document when `AuthorizationPolicy.denies_everything` refuses all mutating callers
- keep the security-boundary change documentation-only

Closes #910

## Validation
- `./.venv/bin/pytest -q tests/test_mcp_authz.py` — 65 passed
- public-name AST audit reports no undocumented public classes or functions
- `./.venv/bin/ruff check src/continuum/mcp/authz.py`
- `./.venv/bin/ruff format --check src/continuum/mcp/authz.py`
- `./.venv/bin/mypy src/continuum/mcp/authz.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)