### PR TITLE
docs: document provenance graph mutators

### DIFF
--- a/src/continuum/provenance/graph.py
+++ b/src/continuum/provenance/graph.py
@@ -81,6 +81,8 @@ class ProvenanceGraph:
         self.reverse_edges.setdefault(node.event_id, [])
 
     def add_edge(self, parent_id: str, child_id: str) -> None:
+        """Link two known nodes, ignoring edges with an unknown endpoint."""
+
         if parent_id not in self.nodes or child_id not in self.nodes:
             return
         if child_id not in self.edges.get(parent_id, []):

--- a/src/continuum/provenance/graph.py
+++ b/src/continuum/provenance/graph.py
@@ -74,6 +74,8 @@ class ProvenanceGraph:
     reverse_edges: dict[str, list[str]] = field(default_factory=dict)
 
     def add_node(self, node: ProvenanceNode) -> None:
+        """Insert or replace a node and initialise its adjacency lists."""
+
         self.nodes[node.event_id] = node
         self.edges.setdefault(node.event_id, [])
         self.reverse_edges.setdefault(node.event_id, [])


### PR DESCRIPTION
## Summary
- document `ProvenanceGraph.add_node` and its adjacency initialization
- document `ProvenanceGraph.add_edge` and its unknown-endpoint behavior
- keep the provenance graph change documentation-only

Closes #909

## Validation
- `./.venv/bin/pytest -q tests/test_provenance_graph.py tests/test_provenance.py` — 18 passed
- public-name AST audit reports no undocumented public classes or functions
- `./.venv/bin/ruff check src/continuum/provenance/graph.py`
- `./.venv/bin/ruff format --check src/continuum/provenance/graph.py`
- `./.venv/bin/mypy src/continuum/provenance/graph.py`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)