### PR TITLE
fix(devcontainer): forward the dashboard port, document the default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,9 @@
       ]
     }
   },
-  "forwardPorts": [8765],
+  "forwardPorts": [8000],
   "portsAttributes": {
-    "8765": {
+    "8000": {
       "label": "continuum dashboard",
       "onAutoForward": "notify"
     }

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -52,7 +52,7 @@ continuum --json <command>                    # machine-readable output
 | `attest <run_id>` | Sign a run's event chain into an attestation document. |
 | `attest-verify <run_id> --attest <file>` | Verify a signed attestation against the live chain. |
 | `serve` | Run the Tier 0 newline-delimited JSON sidecar (no MCP dependency). |
-| `dashboard` | Serve the dashboard (presentation over run data). |
+| `dashboard` | Serve the dashboard (presentation over run data). Listens on port 8000 by default (`--port`). |
 | `tui [--refresh <seconds>]` | Full-screen terminal dashboard: monitor and control runs, read-only until an action is confirmed (`q` quits). |
 | `export-evidence` | Export evidence as content-addressed JSON lines. Read-only. |
 | `forget` | Enumerate and tombstone memory records for a tenant. Mutates unless --dry-run. |


### PR DESCRIPTION
## Description

The devcontainer forwarded port 8765 labeled continuum dashboard, but 8765 is the gateway port; the dashboard serves 8000 by default. This forwards 8000 with the dashboard label and states the default in the CLI reference dashboard row.

## Related issues

Fixes #755

## Types of changes

- Type: `bugfix`

## Breaking changes

No

## How has this been tested?

```console
$ python -c "from continuum.cli.main import build_parser; ns, _ = build_parser().parse_known_args(['dashboard']); print(ns.port)"
8000
$ python -c "import json; print(json.load(open('.devcontainer/devcontainer.json'))['forwardPorts'])"
[8000]
$ git diff --check
(clean)
```

Verified the parser default is 8000, the JSON parses, and the forwarded port and label match. Markdownlint reports no issues on the touched docs file.