### PR TITLE
fix(docs): sync README module-map command count and guard it

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ CONTINUUM is one library (`src/continuum`, 124 modules) plus a large test suite 
 | `mcp/` | 12 stdio tools plus authz `authz.py` token auth, allowlist, confirmation token |
 | `serve/` | Sidecar stdio JSON wire + HTTP `CONTINUUM_SERVE_TOKEN` |
 | `dashboard/` | Web dashboard `app.py` `hitl.py` with HITL buttons confirm/reconcile/complete, prefix trust advisory, pins |
-| `cli/` | 38 argparse commands, exit codes as verdict: `runs, start, inspect, resume, verify, health, tree, benchmark, attest, dashboard` |
+| `cli/` | 45 argparse commands, exit codes as verdict: `runs, start, inspect, resume, verify, health, tree, benchmark, attest, dashboard` |
 | `otel.py` | OpenTelemetry span processor bridge |
 | `benchmark/` | CONTINUUM-Bench harness: 5 crash scenarios + argument drift + 12 scenario recovery suite |
 

--- a/tests/test_cli_docs.py
+++ b/tests/test_cli_docs.py
@@ -68,3 +68,20 @@ def test_hooks_section_names_every_client_profile() -> None:
             elif value not in section:
                 missing.append(f"{profile}.{key}={value}")
     assert not missing, f"hooks section omits CLIENT_PROFILES entries: {missing}"
+
+
+def test_readme_module_map_command_count_matches_parser() -> None:
+    """The README module map `cli/` row must state the live command count (#754).
+
+    The row read 38 while the parser built 44. The figure rots with every
+    new subcommand, so the guard compares the documented number against the
+    parser instead of pinning a literal.
+    """
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text(encoding="utf-8")
+    match = re.search(r"^\|\s*`cli/`\s*\|\s*(\d+) argparse commands", readme, re.MULTILINE)
+    assert match, "README module map has no `cli/` argparse-commands count to guard"
+    documented = int(match.group(1))
+    live = len(build_parser()._subparsers._group_actions[0].choices)
+    assert documented == live, (
+        f"README module map says {documented} argparse commands but the parser builds {live}"
+    )


### PR DESCRIPTION
## Description

The README module map `cli/` row said 38 argparse commands while the parser builds 45. Updates the figure and adds `test_readme_module_map_command_count_matches_parser` comparing the documented count against the live parser.

## Related issues

Fixes #754

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

```console
pytest tests/test_cli_docs.py -q  # 4 passed (3 existing + 1 new)
ruff check tests/test_cli_docs.py  # clean
ruff format --check tests/test_cli_docs.py  # clean
git diff --check  # clean
```

The new guard initially failed against my first edit (44 vs live 45, the `tui` command), which confirmed it detects drift; the row now reads 45.