### PR TITLE
fix(docs): link the orphaned liveness and memory guides

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -55,7 +55,7 @@ continuum --json <command>                    # machine-readable output
 | `dashboard` | Serve the dashboard (presentation over run data). |
 | `tui [--refresh <seconds>]` | Full-screen terminal dashboard: monitor and control runs, read-only until an action is confirmed (`q` quits). |
 | `export-evidence` | Export evidence as content-addressed JSON lines. Read-only. |
-| `forget` | Enumerate and tombstone memory records for a tenant. Mutates unless --dry-run. |
+| `forget` | Enumerate and tombstone memory records for a tenant. Mutates unless --dry-run. See [memory governance](../guides/memory_governance.md). |
 | `health` | Advisory prefix-trust health check. Read-only. |
 | `impact` | Show downstream impact of an evidence item. Read-only. |
 | `merge` | Merge into a run at an anchor. Mutates storage. |
@@ -64,7 +64,7 @@ continuum --json <command>                    # machine-readable output
 | `record-plan` | Record a structured plan upsert. Mutates storage. |
 | `restore` | Restore a run to an anchor checkpoint. Mutates storage. |
 | `rewind` | Rewind workspace and projection to a checkpoint. |
-| `watch` | Watch a run for liveness breach, optionally notify via webhook. |
+| `watch` | Watch a run for liveness breach, optionally notify via webhook. See [liveness watch](../guides/liveness-watch.md). |
 
 ## Examples
 


### PR DESCRIPTION
## Description

The `watch` and `forget` rows in docs/api/cli.md now link to docs/guides/liveness-watch.md and docs/guides/memory_governance.md. Verified inbound counts move from 1/0 to 2/1.

## Related issues

Fixes #751

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

```console
for g in liveness-watch memory_governance; do grep -rln "$g" --include='*.md' . | grep -v "docs/guides/$g.md" | wc -l; done
# 2 and 1 (was 1 and 0; liveness-watch already had the walkthrough link)
git diff --check  # clean
```