### PR TITLE
fix(docs): document the scripted bench suites in benchmarks README

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,3 +36,25 @@ the wall-clock ratio.
 ```bash
 PYTHONPATH=src python benchmarks/speedup_demo.py
 ```
+
+## Scripted suites via `run.py`
+
+The phase-6, byte-count, fault-injection, and horizon suites run scripted
+(no LLM, no API key) through one runner. With no arguments it executes every
+suite in order and writes all reports under `benchmarks/out/`; `--list`
+prints the suites and their report paths without running anything:
+
+```bash
+PYTHONPATH=src python benchmarks/run.py --list
+PYTHONPATH=src python benchmarks/run.py
+```
+
+| Suite | What it runs | Report lands in |
+|:--|:--|:--|
+| `phase6` | Recovery-correctness scenarios | `benchmarks/out/report.{json,md}` |
+| `continuum-bench` | Crash-recovery byte counts | Merged into `benchmarks/out/report.json` |
+| `fault-injection` | Chaos suite (#397) | `benchmarks/out/fault_injection_report.{json,md}` |
+| `horizon` | Horizon-scale suite (#398) | `benchmarks/out/horizon_report.{json,md}`; also regenerates the README bench table |
+
+The full run takes minutes. The horizon suite's numbers feed the bench
+table in the top-level README (marked `BENCH:START`/`BENCH:END` there).


### PR DESCRIPTION
## Description

New Scripted suites section in benchmarks/README.md naming the phase6, continuum-bench, fault-injection, and horizon suites with run commands and report paths, taken verbatim from `run.py --list`.

## Related issues

Fixes #725

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

```console
PYTHONPATH=src python benchmarks/run.py --list  # section matches this output
for t in run.py phase6 fault-injection horizon; do grep -c "$t" benchmarks/README.md; done
# 3, 1, 2, 3 (was all 0)
git diff --check  # clean
```