### PR TITLE
docs(storage): document every public name in base, sqlite, postgres

### DIFF
--- a/src/continuum/storage/base.py
+++ b/src/continuum/storage/base.py
@@ -187,7 +187,9 @@ class Storage(ABC):
     # -- lifecycle -------------------------------------------------------- #
 
     @abstractmethod
-    def close(self) -> None: ...
+    def close(self) -> None:
+        """Release the backing store. Idempotent; safe to call twice."""
+        ...
 
     def __enter__(self) -> Storage:
         return self
@@ -225,7 +227,9 @@ class Storage(ABC):
             )
 
     @abstractmethod
-    def create_run(self, run: Run) -> Run: ...
+    def create_run(self, run: Run) -> Run:
+        """Persist a new run row. Raises when the id already exists."""
+        ...
 
     @abstractmethod
     def create_run_started(self, run: Run, *, source: Origin = Origin.DETERMINISTIC) -> Run:
@@ -239,13 +243,19 @@ class Storage(ABC):
         """
 
     @abstractmethod
-    def get_run(self, run_id: str) -> Run: ...
+    def get_run(self, run_id: str) -> Run:
+        """Return the run row. Raises RunNotFound for a run that was never created."""
+        ...
 
     @abstractmethod
-    def update_run(self, run: Run) -> Run: ...
+    def update_run(self, run: Run) -> Run:
+        """Persist run changes and refresh its timestamp. Raises RunNotFound for a missing row."""
+        ...
 
     @abstractmethod
-    def list_runs(self, *, limit: int | None = None) -> Sequence[Run]: ...
+    def list_runs(self, *, limit: int | None = None) -> Sequence[Run]:
+        """Most recently created runs first, at most ``limit`` when given."""
+        ...
 
     @abstractmethod
     def get_active_run(self) -> Run | None:
@@ -285,13 +295,19 @@ class Storage(ABC):
         *,
         after_sequence: int = 0,
         upto: int | None = None,
-    ) -> Sequence[Event]: ...
+    ) -> Sequence[Event]:
+        """Live (unarchived) events in sequence order, windowed by ``after_sequence``/``upto``."""
+        ...
 
     @abstractmethod
-    def last_sequence(self, run_id: str) -> int: ...
+    def last_sequence(self, run_id: str) -> int:
+        """Highest live sequence number; 0 when the run has no events yet."""
+        ...
 
     @abstractmethod
-    def verify_events(self, run_id: str) -> IntegrityReport: ...
+    def verify_events(self, run_id: str) -> IntegrityReport:
+        """Recompute the hash chain and report whether it is intact."""
+        ...
 
     # -- state versions --------------------------------------------------- #
 
@@ -300,27 +316,41 @@ class Storage(ABC):
         """Persist a state version. Returns the assigned version number."""
 
     @abstractmethod
-    def get_version(self, run_id: str, version: int) -> SemanticState: ...
+    def get_version(self, run_id: str, version: int) -> SemanticState:
+        """Return one persisted state version. Raises for an unknown version."""
+        ...
 
     @abstractmethod
-    def latest_version(self, run_id: str) -> SemanticState | None: ...
+    def latest_version(self, run_id: str) -> SemanticState | None:
+        """Newest persisted state, or None when nothing was stored yet."""
+        ...
 
     @abstractmethod
-    def list_versions(self, run_id: str) -> Sequence[int]: ...
+    def list_versions(self, run_id: str) -> Sequence[int]:
+        """Persisted state version numbers in ascending order."""
+        ...
 
     # -- checkpoints ------------------------------------------------------ #
 
     @abstractmethod
-    def put_checkpoint(self, checkpoint: StateCheckpoint) -> StateCheckpoint: ...
+    def put_checkpoint(self, checkpoint: StateCheckpoint) -> StateCheckpoint:
+        """Persist a checkpoint and return it."""
+        ...
 
     @abstractmethod
-    def get_checkpoint(self, checkpoint_id: str) -> StateCheckpoint: ...
+    def get_checkpoint(self, checkpoint_id: str) -> StateCheckpoint:
+        """Return one checkpoint. Raises for an unknown id."""
+        ...
 
     @abstractmethod
-    def latest_checkpoint(self, run_id: str) -> StateCheckpoint | None: ...
+    def latest_checkpoint(self, run_id: str) -> StateCheckpoint | None:
+        """Newest checkpoint for the run, or None when there is none."""
+        ...
 
     @abstractmethod
-    def list_checkpoints(self, run_id: str) -> Sequence[StateCheckpoint]: ...
+    def list_checkpoints(self, run_id: str) -> Sequence[StateCheckpoint]:
+        """Every checkpoint for the run in creation order."""
+        ...
 
     @abstractmethod
     def delete_checkpoint(self, checkpoint_id: str) -> None:

--- a/src/continuum/storage/postgres.py
+++ b/src/continuum/storage/postgres.py
@@ -176,9 +176,10 @@ def _require_psycopg() -> Any:
 
 
 class PostgresStorage(Storage):
+    """Multi-process durable storage backed by PostgreSQL."""
+
     supports_action_index = True
     supports_compaction = True
-    """Multi-process durable storage backed by PostgreSQL."""
 
     def __init__(self, url: str | Any, *, timeout: float = 30.0) -> None:
         psycopg = _require_psycopg()
@@ -255,6 +256,7 @@ class PostgresStorage(Storage):
         return self._lock
 
     def close(self) -> None:
+        """Close the connection. Later use raises from the driver."""
         with self._lock:
             self._connection.close()
 
@@ -267,6 +269,7 @@ class PostgresStorage(Storage):
     # -- runs ------------------------------------------------------------- #
 
     def create_run(self, run: Run) -> Run:
+        """Insert the run row. Raises ConcurrentWriteError when the id exists."""
         self.require_usable_run_id(run)
         with self._write():
             try:
@@ -323,6 +326,7 @@ class PostgresStorage(Storage):
         return run
 
     def get_run(self, run_id: str) -> Run:
+        """Return the run row. Raises RunNotFound for a missing id."""
         with self._read():
             row = self._connection.execute(
                 "SELECT * FROM runs WHERE run_id = %s", (run_id,)
@@ -332,6 +336,7 @@ class PostgresStorage(Storage):
         return self._row_to_run(row)
 
     def update_run(self, run: Run) -> Run:
+        """Persist run changes with a refreshed timestamp. Raises RunNotFound when no row matches."""
         updated = run.touch()
         with self._write():
             cursor = self._connection.execute(
@@ -350,6 +355,7 @@ class PostgresStorage(Storage):
         return updated
 
     def list_runs(self, *, limit: int | None = None) -> Sequence[Run]:
+        """Newest runs first by creation time, at most ``limit`` when given."""
         query = "SELECT * FROM runs ORDER BY created_at DESC, run_id DESC"
         params: tuple[Any, ...] = ()
         if limit is not None:
@@ -360,6 +366,7 @@ class PostgresStorage(Storage):
         return [self._row_to_run(row) for row in rows]
 
     def get_active_run(self) -> Run | None:
+        """Most recently updated non-terminal run, or None when there is none."""
         terminal = (
             RunStatus.COMPLETED.value,
             RunStatus.CRASHED.value,
@@ -400,6 +407,7 @@ class PostgresStorage(Storage):
         expected_sequence: int | None = None,
         source: Origin = Origin.DETERMINISTIC,
     ) -> Event:
+        """Append one chained event in a write transaction and return it."""
         with self._write():
             event = self._append_chained(
                 run_id,
@@ -471,6 +479,7 @@ class PostgresStorage(Storage):
         return event
 
     def append_sealed(self, event: Event) -> Event:
+        """Store a pre-sealed event as-is, preserving its chain."""
         if event.type in CAUSED_BY_TYPES:
             caused_by = event.payload.get("caused_by") if isinstance(event.payload, dict) else None
             if caused_by is not None:
@@ -633,6 +642,7 @@ class PostgresStorage(Storage):
         return {"archived": max(archived, 0)}
 
     def read_archived_events(self, run_id: str) -> Sequence[Event]:
+        """Compacted events from the archive, oldest first."""
         with self._read():
             rows = self._connection.execute(
                 "SELECT * FROM events_archive WHERE run_id = %s ORDER BY sequence ASC", (run_id,)
@@ -736,6 +746,7 @@ class PostgresStorage(Storage):
         after_sequence: int = 0,
         upto: int | None = None,
     ) -> Sequence[Event]:
+        """Live events in sequence order, windowed by ``after_sequence``/``upto``."""
         query = "SELECT * FROM events WHERE run_id = %s AND sequence > %s"
         params: list[Any] = [run_id, after_sequence]
         if upto is not None:
@@ -747,6 +758,7 @@ class PostgresStorage(Storage):
         return [self._row_to_event(row) for row in rows]
 
     def last_sequence(self, run_id: str) -> int:
+        """Highest live sequence number; 0 when the run has no events yet."""
         with self._read():
             row = self._connection.execute(
                 "SELECT MAX(sequence) AS seq FROM events WHERE run_id = %s", (run_id,)
@@ -969,6 +981,7 @@ class PostgresStorage(Storage):
     # -- state versions --------------------------------------------------- #
 
     def put_version(self, state: SemanticState, *, reason: str = "", force: bool = False) -> int:
+        """Persist a state version, reusing the head when the fingerprint is unchanged."""
         fingerprint = state_fingerprint(state)
         with self._write():
             self._require_run(self._connection, state.run_id)
@@ -999,6 +1012,7 @@ class PostgresStorage(Storage):
         return version
 
     def get_version(self, run_id: str, version: int) -> SemanticState:
+        """Return one state version. Raises CheckpointNotFound for an unknown version."""
         with self._read():
             row = self._connection.execute(
                 "SELECT state, fingerprint FROM versions WHERE run_id = %s AND version = %s",
@@ -1009,6 +1023,7 @@ class PostgresStorage(Storage):
         return self._row_to_state(row, run_id, version)
 
     def latest_version(self, run_id: str) -> SemanticState | None:
+        """Newest state version, or None when nothing was stored yet."""
         with self._read():
             row = self._connection.execute(
                 "SELECT state, fingerprint, version FROM versions WHERE run_id = %s "
@@ -1034,6 +1049,7 @@ class PostgresStorage(Storage):
         return state
 
     def list_versions(self, run_id: str) -> Sequence[int]:
+        """Stored state version numbers in ascending order."""
         with self._read():
             rows = self._connection.execute(
                 "SELECT version FROM versions WHERE run_id = %s ORDER BY version ASC", (run_id,)
@@ -1043,6 +1059,7 @@ class PostgresStorage(Storage):
     # -- checkpoints ------------------------------------------------------ #
 
     def put_checkpoint(self, checkpoint: StateCheckpoint) -> StateCheckpoint:
+        """Persist a checkpoint. Raises ConcurrentWriteError when the id exists."""
         sealed = checkpoint if checkpoint.verify() else checkpoint.sealed()
         with self._write():
             self._require_run(self._connection, sealed.run_id)
@@ -1067,6 +1084,7 @@ class PostgresStorage(Storage):
         return sealed
 
     def get_checkpoint(self, checkpoint_id: str) -> StateCheckpoint:
+        """Return one checkpoint. Raises CheckpointNotFound for an unknown id."""
         with self._read():
             row = self._connection.execute(
                 "SELECT body FROM checkpoints WHERE checkpoint_id = %s", (checkpoint_id,)
@@ -1076,6 +1094,7 @@ class PostgresStorage(Storage):
         return self._row_to_checkpoint(row)
 
     def latest_checkpoint(self, run_id: str) -> StateCheckpoint | None:
+        """Newest checkpoint for the run, or None when there is none."""
         with self._read():
             row = self._connection.execute(
                 "SELECT body FROM checkpoints WHERE run_id = %s "
@@ -1085,6 +1104,7 @@ class PostgresStorage(Storage):
         return self._row_to_checkpoint(row) if row else None
 
     def list_checkpoints(self, run_id: str) -> Sequence[StateCheckpoint]:
+        """Every checkpoint for the run in version order."""
         with self._read():
             rows = self._connection.execute(
                 "SELECT body FROM checkpoints WHERE run_id = %s ORDER BY version ASC", (run_id,)
@@ -1092,6 +1112,7 @@ class PostgresStorage(Storage):
         return [self._row_to_checkpoint(row) for row in rows]
 
     def delete_checkpoint(self, checkpoint_id: str) -> None:
+        """Remove a checkpoint by id. Callers must not delete one a decision still depends on."""
         with self._write():
             self._connection.execute(
                 "DELETE FROM checkpoints WHERE checkpoint_id = %s", (checkpoint_id,)

--- a/src/continuum/storage/sqlite.py
+++ b/src/continuum/storage/sqlite.py
@@ -92,9 +92,10 @@ def _resolve_path(url_or_path: str | Path) -> str:
 
 
 class SQLiteStorage(Storage):
+    """Single-host durable storage. Safe for threads and for separate processes."""
+
     supports_action_index = True
     supports_compaction = True
-    """Single-host durable storage. Safe for threads and for separate processes."""
 
     def __init__(self, url: str | Path = ":memory:", *, timeout: float = 30.0) -> None:
         self.path = _resolve_path(url)
@@ -171,6 +172,7 @@ class SQLiteStorage(Storage):
             yield self._live_connection()
 
     def close(self) -> None:
+        """Close the connection. Idempotent; later use raises a clear error."""
         with self._lock:
             conn = getattr(self, "_connection", None)
             if conn is None:
@@ -199,6 +201,7 @@ class SQLiteStorage(Storage):
     # -- runs ------------------------------------------------------------- #
 
     def create_run(self, run: Run) -> Run:
+        """Insert the run row. Raises ConcurrentWriteError when the id exists."""
         self.require_usable_run_id(run)
         with self._write() as conn:
             try:
@@ -253,6 +256,7 @@ class SQLiteStorage(Storage):
         return run
 
     def get_run(self, run_id: str) -> Run:
+        """Return the run row. Raises RunNotFound for a missing id."""
         with self._read() as conn:
             row = conn.execute("SELECT * FROM runs WHERE run_id = ?", (run_id,)).fetchone()
         if row is None:
@@ -260,6 +264,7 @@ class SQLiteStorage(Storage):
         return self._row_to_run(row)
 
     def update_run(self, run: Run) -> Run:
+        """Persist run changes with a refreshed timestamp. Raises RunNotFound when no row matches."""
         updated = run.touch()
         with self._write() as conn:
             cursor = conn.execute(
@@ -278,6 +283,7 @@ class SQLiteStorage(Storage):
         return updated
 
     def list_runs(self, *, limit: int | None = None) -> Sequence[Run]:
+        """Newest runs first by creation time, at most ``limit`` when given."""
         query = "SELECT * FROM runs ORDER BY created_at DESC, run_id DESC"
         params: tuple[Any, ...] = ()
         if limit is not None:
@@ -288,6 +294,7 @@ class SQLiteStorage(Storage):
         return [self._row_to_run(row) for row in rows]
 
     def get_active_run(self) -> Run | None:
+        """Most recently updated non-terminal run, or None when there is none."""
         terminal = (
             RunStatus.COMPLETED.value,
             RunStatus.CRASHED.value,
@@ -329,6 +336,7 @@ class SQLiteStorage(Storage):
         expected_sequence: int | None = None,
         source: Origin = Origin.DETERMINISTIC,
     ) -> Event:
+        """Append one chained event in a write transaction and return it."""
         with self._write() as conn:
             event = self._append_chained(
                 conn,
@@ -402,6 +410,7 @@ class SQLiteStorage(Storage):
         return event
 
     def append_sealed(self, event: Event) -> Event:
+        """Store a pre-sealed event as-is, preserving its chain."""
         if event.type in CAUSED_BY_TYPES:
             caused_by = event.payload.get("caused_by") if isinstance(event.payload, dict) else None
             if caused_by is not None:
@@ -550,6 +559,7 @@ class SQLiteStorage(Storage):
         return {"archived": max(archived, 0)}
 
     def read_archived_events(self, run_id: str) -> Sequence[Event]:
+        """Compacted events from the archive, oldest first."""
         with self._read() as conn:
             rows = conn.execute(
                 "SELECT * FROM events_archive WHERE run_id = ? ORDER BY sequence ASC", (run_id,)
@@ -673,6 +683,7 @@ class SQLiteStorage(Storage):
         after_sequence: int = 0,
         upto: int | None = None,
     ) -> Sequence[Event]:
+        """Live events in sequence order, windowed by ``after_sequence``/``upto``."""
         query = "SELECT * FROM events WHERE run_id = ? AND sequence > ?"
         params: list[Any] = [run_id, after_sequence]
         if upto is not None:
@@ -684,6 +695,7 @@ class SQLiteStorage(Storage):
         return [self._row_to_event(row) for row in rows]
 
     def last_sequence(self, run_id: str) -> int:
+        """Highest live sequence number; 0 when the run has no events yet."""
         with self._read() as conn:
             row = conn.execute(
                 "SELECT MAX(sequence) AS seq FROM events WHERE run_id = ?", (run_id,)
@@ -907,6 +919,7 @@ class SQLiteStorage(Storage):
     # -- versions --------------------------------------------------------- #
 
     def put_version(self, state: SemanticState, *, reason: str = "", force: bool = False) -> int:
+        """Persist a state version, reusing the head when the fingerprint is unchanged."""
         fingerprint = state_fingerprint(state)
         with self._write() as conn:
             self._require_run(conn, state.run_id)
@@ -937,6 +950,7 @@ class SQLiteStorage(Storage):
         return version
 
     def get_version(self, run_id: str, version: int) -> SemanticState:
+        """Return one state version. Raises CheckpointNotFound for an unknown version."""
         with self._read() as conn:
             row = conn.execute(
                 "SELECT state, fingerprint FROM versions WHERE run_id = ? AND version = ?",
@@ -947,6 +961,7 @@ class SQLiteStorage(Storage):
         return self._row_to_state(row, run_id, version)
 
     def latest_version(self, run_id: str) -> SemanticState | None:
+        """Newest state version, or None when nothing was stored yet."""
         with self._read() as conn:
             row = conn.execute(
                 "SELECT state, fingerprint, version FROM versions WHERE run_id = ? "
@@ -972,6 +987,7 @@ class SQLiteStorage(Storage):
         return state
 
     def list_versions(self, run_id: str) -> Sequence[int]:
+        """Stored state version numbers in ascending order."""
         with self._read() as conn:
             rows = conn.execute(
                 "SELECT version FROM versions WHERE run_id = ? ORDER BY version ASC", (run_id,)
@@ -981,6 +997,7 @@ class SQLiteStorage(Storage):
     # -- checkpoints ------------------------------------------------------ #
 
     def put_checkpoint(self, checkpoint: StateCheckpoint) -> StateCheckpoint:
+        """Persist a checkpoint. Raises ConcurrentWriteError when the id exists."""
         sealed = checkpoint if checkpoint.verify() else checkpoint.sealed()
         with self._write() as conn:
             self._require_run(conn, sealed.run_id)
@@ -1005,6 +1022,7 @@ class SQLiteStorage(Storage):
         return sealed
 
     def get_checkpoint(self, checkpoint_id: str) -> StateCheckpoint:
+        """Return one checkpoint. Raises CheckpointNotFound for an unknown id."""
         with self._read() as conn:
             row = conn.execute(
                 "SELECT body FROM checkpoints WHERE checkpoint_id = ?", (checkpoint_id,)
@@ -1014,6 +1032,7 @@ class SQLiteStorage(Storage):
         return self._row_to_checkpoint(row)
 
     def latest_checkpoint(self, run_id: str) -> StateCheckpoint | None:
+        """Newest checkpoint for the run, or None when there is none."""
         with self._read() as conn:
             row = conn.execute(
                 "SELECT body FROM checkpoints WHERE run_id = ? "
@@ -1023,6 +1042,7 @@ class SQLiteStorage(Storage):
         return self._row_to_checkpoint(row) if row else None
 
     def list_checkpoints(self, run_id: str) -> Sequence[StateCheckpoint]:
+        """Every checkpoint for the run in version order."""
         with self._read() as conn:
             rows = conn.execute(
                 "SELECT body FROM checkpoints WHERE run_id = ? ORDER BY version ASC", (run_id,)
@@ -1030,6 +1050,7 @@ class SQLiteStorage(Storage):
         return [self._row_to_checkpoint(row) for row in rows]
 
     def delete_checkpoint(self, checkpoint_id: str) -> None:
+        """Remove a checkpoint by id. Callers must not delete one a decision still depends on."""
         with self._write() as conn:
             conn.execute("DELETE FROM checkpoints WHERE checkpoint_id = ?", (checkpoint_id,))
 


### PR DESCRIPTION
## Description

All 57 public names across storage/base.py (15), sqlite.py (21), and postgres.py (21) now carry docstrings stating the contract a caller needs: ordering, error modes, close idempotency, and the fingerprint-reuse rule. The two class strings sitting below their attributes become real docstrings. Docstrings only, no runtime change.

## Related issues

Fixes #722

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

```console
python AST check  # [] missing in all three files (was 15/21/21)
ruff check src/continuum/storage/  # clean
ruff format --check  # clean
mypy src/continuum/storage/  # strict clean, 6 files
pytest tests/test_storage_edges.py tests/test_compaction.py tests/test_projection_edges.py  # 69 passed
git diff minus docstrings  # only base.py '...' bodies replaced (identical semantics)
```