### PR TITLE
docs(adapters): document AdapterRegistry names and all

### DIFF
--- a/src/continuum/adapters/registry.py
+++ b/src/continuum/adapters/registry.py
@@ -43,9 +43,11 @@ class AdapterRegistry:
         return factory()
 
     def names(self) -> list[str]:
+        """Sorted names of all registered adapters."""
         return sorted(self._factories)
 
     def all(self) -> Mapping[str, type]:
+        """Instantiate every registered adapter, keyed by name."""
         return {name: self.get(name) for name in self.names()}
 
 


### PR DESCRIPTION
## Description

Two docstrings in adapters/registry.py. Docstrings only.

## Related issues

Fixes #899

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

```console
python AST check  # [] missing
ruff check, ruff format --check, mypy  # clean
```