### PR TITLE
docs(checkpoint): document restore status and history

### DIFF
--- a/src/continuum/checkpoint/manager.py
+++ b/src/continuum/checkpoint/manager.py
@@ -75,6 +75,7 @@ class RestoredRun:
 
     @property
     def from_checkpoint(self) -> bool:
+        """True when the restore started from a checkpoint rather than replay."""
         return self.checkpoint is not None
 
 
@@ -306,6 +307,7 @@ class CheckpointManager:
         )
 
     def history(self, run_id: str) -> Sequence[StateCheckpoint]:
+        """Every checkpoint for the run in creation order, via storage."""
         return self.storage.list_checkpoints(run_id)
 
     # -- recovery anchors ------------------------------------------------- #


### PR DESCRIPTION
## Description

Two docstrings in checkpoint/manager.py. Docstrings only.

## Related issues

Fixes #900

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

```console
python AST check  # [] missing
ruff check, ruff format --check, mypy  # clean
```