### PR TITLE
docs(provenance): document graph add_node and add_edge

### DIFF
--- a/src/continuum/provenance/graph.py
+++ b/src/continuum/provenance/graph.py
@@ -74,11 +74,13 @@ class ProvenanceGraph:
     reverse_edges: dict[str, list[str]] = field(default_factory=dict)
 
     def add_node(self, node: ProvenanceNode) -> None:
+        """Insert a node, initializing its edge lists."""
         self.nodes[node.event_id] = node
         self.edges.setdefault(node.event_id, [])
         self.reverse_edges.setdefault(node.event_id, [])
 
     def add_edge(self, parent_id: str, child_id: str) -> None:
+        """Link parent to child; unknown ids are ignored."""
         if parent_id not in self.nodes or child_id not in self.nodes:
             return
         if child_id not in self.edges.get(parent_id, []):


### PR DESCRIPTION
## Description

Two docstrings in provenance/graph.py. Docstrings only.

## Related issues

Fixes #909

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

```console
python AST check  # [] missing
ruff check, ruff format --check, mypy  # clean
pytest tests/test_provenance.py  # pass
```