### PR TITLE
fix(docs): cover new signals on the API reference pages

### DIFF
--- a/docs/api/checkpoints.md
+++ b/docs/api/checkpoints.md
@@ -57,3 +57,11 @@ after it.
 The default `CheckpointPolicy` honors triggers (manual, interval, event,
 semantic, context-pressure, hybrid). Supply a custom `policy` to `CheckpointManager`
 to tune when checkpoints are taken.
+
+## Pre-compaction checkpoint
+
+Context compaction destroys unrecorded reasoning, so the boundary gets its
+own checkpoint. The `precompact` command checkpoints at the compaction
+boundary and is wired as a PreCompact hook by `hooks install`, resolving the
+current run at install time so one hook serves every run. See the
+`precompact` row in `docs/api/cli.md`.

--- a/docs/api/ledger.md
+++ b/docs/api/ledger.md
@@ -121,3 +121,14 @@ The value returned by `claim`. `fresh` is `True` when the effect should still be
 performed; `False` when the ledger already has a recorded outcome and
 `action` carries it. `key` is the idempotency key to pass to `complete`, `fail`,
 or `reconcile`.
+
+## Authority consumption
+
+One-time authorities (credentials, approval tokens) are tracked so a replay
+never resurrects a spent grant. `record_authority_consumed` in
+`src/continuum/actions/authority.py` appends a hash-chained
+`AUTHORITY_CONSUMED` event that never deduplicates, and the gate refuses reuse
+of a consumed authority until a reconciler probe settles it with
+`AUTHORITY_RECONCILED` (`src/continuum/reconcilers.py`). The ledger's retry
+path checks the same events so a live retry under a reused key cannot slip
+past (`src/continuum/actions/ledger.py`).

--- a/docs/api/recovery.md
+++ b/docs/api/recovery.md
@@ -57,3 +57,16 @@ printing or handing to an operator.
 The underlying `ValidationOutcome`, the `RestoredRun`, any actions whose outcome
 is unknown, the repair `RepairPlan`, the `RecoveryContract`, and the textual
 reasons for the decision.
+
+## Liveness and risk signals
+
+Beyond validation, the engine weighs two live signals. A liveness advisory
+from `continuum.recovery.health` reports whether the run has gone quiet past
+its cadence contract (`LIVENESS_SILENCE_DETECTED` events in the log, evaluated
+by `continuum watch`), and
+`triggering_risks` carries any external risks mapped through
+`.continuum/risk-policy.json` (`src/continuum/recovery/risk.py`). Both are
+advisory: silence and risk inform the verdict without replacing validation,
+gate, or ledger evidence. See `src/continuum/recovery/engine.py` for how the
+signals combine, and the operator guides `docs/guides/liveness-watch.md` and
+`docs/guides/risk-policy.md` for the workflows.

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -45,3 +45,12 @@ current environment: which resources changed, and how.
 ### `render() -> str`
 
 A human-readable validation report.
+
+## Restore-point admissibility
+
+Validation also answers whether a checkpoint is safe to resume from at all.
+`check_admissibility` in `src/continuum/state/validator.py` takes the
+checkpoint and the downstream actions and reports inadmissible when a
+completed action consumed inputs produced after the checkpoint. The engine
+refuses plain resume on an inadmissible anchor instead of resuming into a
+commitment the log contradicts.


### PR DESCRIPTION
## Description

Short sections on recovery.md (liveness, risk), ledger.md (authority consumption), validation.md (admissibility), and checkpoints.md (pre-compaction), each citing its implementing module.

## Related issues

Fixes #685

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

```console
for t in liveness risk admissibility AUTHORITY watch precompact; do grep -rli "$t" docs/api/recovery.md docs/api/ledger.md docs/api/validation.md docs/api/checkpoints.md | wc -l; done
# all nonzero (was all 0)
git diff --check  # clean
```