### PR TITLE
fix(docs): add notebook zero-setup rows to ja, ko, pt-BR READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -65,9 +65,11 @@ PyPI に `continuum-agent` 0.1.0 として公開。`pip install continuum-agent`
 | Docker 経由で CLI を使う | `docker run --rm ghcr.io/cyrax321/continuum continuum --help` |
 | クローンせずに CLI を実行 | `uvx --from git+https://github.com/Cyrax321/CONTINUUM.git continuum --help` |
 | Windows PowerShell（クローン内） | `powershell -ExecutionPolicy Bypass -File .\try-it.ps1` または `powershell -ExecutionPolicy Bypass -File .\try-it.ps1 cli --help` |
+| ノートブックで同じリカバリを見る | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Cyrax321/CONTINUUM/blob/main/examples/demo.ipynb) |
+| 同じノートブックを Binder で | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Cyrax321/CONTINUUM/HEAD?labpath=examples%2Fdemo.ipynb) |
 | ブラウザで完全な開発環境 | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Cyrax321/CONTINUUM?quickstart=1) |
 
-Docker イメージは CI によって `main` への各 push と各リリースタグで GHCR に公開される（`.github/workflows/docker-publish.yml`）。Codespace は `.devcontainer/` で定義される。
+Docker イメージは CI によって `main` への各 push と各リリースタグで GHCR に公開される（`.github/workflows/docker-publish.yml`）。Codespace は `.devcontainer/` で定義される。ノートブックは [examples/demo.ipynb](examples/demo.ipynb) です。最初のセルはインポート失敗時にのみ CONTINUUM をインストールするため、1つのファイルが Colab、Binder、クローンのいずれでも動作します。
 
 ```bash
 git clone https://github.com/Cyrax321/CONTINUUM.git

--- a/README.ko.md
+++ b/README.ko.md
@@ -65,9 +65,11 @@ PyPI에 `continuum-agent` 0.1.0으로 게시됨. `pip install continuum-agent` �
 | Docker를 통해 CLI 사용 | `docker run --rm ghcr.io/cyrax321/continuum continuum --help` |
 | 클론 없이 CLI 실행 | `uvx --from git+https://github.com/Cyrax321/CONTINUUM.git continuum --help` |
 | Windows PowerShell (클론 내부) | `powershell -ExecutionPolicy Bypass -File .\try-it.ps1` 또는 `powershell -ExecutionPolicy Bypass -File .\try-it.ps1 cli --help` |
+| 노트북에서 동일한 복구 보기 | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Cyrax321/CONTINUUM/blob/main/examples/demo.ipynb) |
+| 동일한 노트북, Binder에서 | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Cyrax321/CONTINUUM/HEAD?labpath=examples%2Fdemo.ipynb) |
 | 브라우저에서 완전한 개발 환경 | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Cyrax321/CONTINUUM?quickstart=1) |
 
-Docker 이미지는 CI가 `main`에 대한 각 push와 각 릴리스 태그마다 GHCR에 게시한다 (`.github/workflows/docker-publish.yml`). Codespace는 `.devcontainer/`에 정의되어 있다.
+Docker 이미지는 CI가 `main`에 대한 각 push와 각 릴리스 태그마다 GHCR에 게시한다 (`.github/workflows/docker-publish.yml`). Codespace는 `.devcontainer/`에 정의되어 있다. 노트북은 [examples/demo.ipynb](examples/demo.ipynb)이다. 첫 셀은 가져오기에 실패할 때만 CONTINUUM을 설치하므로, 하나의 파일이 Colab, Binder, 클론에서 모두 실행된다.
 
 ```bash
 git clone https://github.com/Cyrax321/CONTINUUM.git

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -66,9 +66,11 @@ Caminhos sem configuração (sem clonar, sem instalar, sem publicar nada):
 | Usar a CLI via Docker | `docker run --rm ghcr.io/cyrax321/continuum continuum --help` |
 | Executar a CLI sem clonar | `uvx --from git+https://github.com/Cyrax321/CONTINUUM.git continuum --help` |
 | Windows PowerShell (de um clone) | `powershell -ExecutionPolicy Bypass -File .\try-it.ps1` ou `powershell -ExecutionPolicy Bypass -File .\try-it.ps1 cli --help` |
+| Ver a mesma recuperação em um caderno | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Cyrax321/CONTINUUM/blob/main/examples/demo.ipynb) |
+| O mesmo caderno, no Binder | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Cyrax321/CONTINUUM/HEAD?labpath=examples%2Fdemo.ipynb) |
 | Ambiente de desenvolvimento completo no navegador | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Cyrax321/CONTINUUM?quickstart=1) |
 
-A imagem Docker é publicada no GHCR pelo CI a cada push para `main` e a cada tag de release (`.github/workflows/docker-publish.yml`). O Codespace é definido em `.devcontainer/`.
+A imagem Docker é publicada no GHCR pelo CI a cada push para `main` e a cada tag de release (`.github/workflows/docker-publish.yml`). O Codespace é definido em `.devcontainer/`. O caderno é [examples/demo.ipynb](examples/demo.ipynb): sua primeira célula instala o CONTINUUM somente quando a importação falha, de modo que o mesmo arquivo roda no Colab, no Binder e a partir de um clone.
 
 ```bash
 git clone https://github.com/Cyrax321/CONTINUUM.git


### PR DESCRIPTION
## Description

Mirrors the Colab/Binder badge rows and the notebook sentence into the Japanese, Korean, and Brazilian Portuguese Quick Start tables (English, Spanish, and Chinese already have them).

## Related issues

Refs #752 (zh-CN half lands via #875; this covers the other three)

## Types of changes

- Type: `docs`

## Breaking changes

No

## How has this been tested?

```console
for L in ja ko pt-BR; do grep -c "Colab" README.$L.md; done  # 1 each (was 0)
git diff --check  # clean
```