### PR TITLE
docs: document recovery derived helpers

### DIFF
--- a/src/continuum/recovery/derived.py
+++ b/src/continuum/recovery/derived.py
@@ -12,6 +12,7 @@ __all__ = ["is_derived_unverified", "derived_label", "stamp_derived"]
 
 
 def stamp_derived(payload: dict[str, Any], source_events: list[Event]) -> dict[str, Any]:
+    """Stamp a payload with provenance derived from its source events."""
     derived = derived_provenance_for_events(source_events)
     stamped = dict(payload)
     stamped["derived_origin"] = derived.value
@@ -19,6 +20,7 @@ def stamp_derived(payload: dict[str, Any], source_events: list[Event]) -> dict[s
 
 
 def derived_label(payload: dict[str, Any]) -> str:
+    """Render the human-readable provenance label for a derived payload."""
     raw = payload.get("derived_origin")
     if raw is None:
         return "unverified (derived from unverified sources)"
@@ -32,6 +34,7 @@ def derived_label(payload: dict[str, Any]) -> str:
 
 
 def is_derived_unverified(payload: dict[str, Any]) -> bool:
+    """Report whether a derived payload has an unverified origin."""
     raw = payload.get("derived_origin")
     if raw is None:
         return True


### PR DESCRIPTION
## Summary
- document all three public helpers in `recovery/derived.py`
- clarify provenance stamping, label rendering, and unverified-origin detection

Documentation-only change; runtime behavior is unchanged.

## Validation
- `19 passed` across `tests/test_provenance_non_amplification.py` and `tests/test_provenance.py`
- public-name docstring audit passed
- Ruff check passed
- Ruff format check passed
- Mypy passed
- `git diff --check` passed

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)