### PR TITLE
docs: sync Level 1 test count to current main

### DIFF
--- a/references/testing.md
+++ b/references/testing.md
@@ -14,7 +14,7 @@ ruff format --check src/ tests/ examples/
 mypy src/continuum                     # strict type check
 ```
 
-On the current main branch, collection reports approximately 2,058 tests; the
+On the current main branch, collection reports approximately 2,160 tests; the
 exact count and pass/skip totals vary with Python version, platform, optional
 dependencies, and external services.
 


### PR DESCRIPTION
## Description

Updates the Level 1 test-count figure in references/testing.md from approximately 2,058 to approximately 2,160. Commands in the same section already match CI exactly, so the count was the only stale part.

## Related issues

Fixes #757

## Types of changes

- Type: docs

## Breaking changes

No.

## How has this been tested?

Count verified two ways on current main:

- ubuntu-latest Python 3.12 CI run 34685274568 (head 121d378, green): 2,160 collected, 26 skipped, counted from the job log progress output.
- Local macOS collection on origin/main: 2,189 collected (platform variance, covered by the doc existing approximately wording).

Markdown-only change; full gate unaffected.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the testing guide to reflect the approximate current test collection count: roughly 2,160 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->