### PR TITLE
docs(zh): add notebook zero-setup rows to Quick Start

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,9 +64,11 @@ CONTINUUM 提出一个更窄但更难的问题：智能体能否从任务状态�
 | 通过 Docker 使用 CLI | `docker run --rm ghcr.io/cyrax321/continuum continuum --help` |
 | 无需克隆即可运行 CLI | `uvx --from git+https://github.com/Cyrax321/CONTINUUM.git continuum --help` |
 | Windows PowerShell（在克隆中） | `powershell -ExecutionPolicy Bypass -File .\try-it.ps1` 或 `powershell -ExecutionPolicy Bypass -File .\try-it.ps1 cli --help` |
+| 在笔记本中观看同样的恢复过程 | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Cyrax321/CONTINUUM/blob/main/examples/demo.ipynb) |
+| 同样的笔记本，在 Binder 上运行 | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Cyrax321/CONTINUUM/HEAD?labpath=examples%2Fdemo.ipynb) |
 | 浏览器中的完整开发环境 | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Cyrax321/CONTINUUM?quickstart=1) |
 
-Docker 镜像由 CI 在每次推送到 `main` 和每个发布标签时发布到 GHCR（`.github/workflows/docker-publish.yml`）。Codespace 在 `.devcontainer/` 中定义。
+Docker 镜像由 CI 在每次推送到 `main` 和每个发布标签时发布到 GHCR（`.github/workflows/docker-publish.yml`）。Codespace 在 `.devcontainer/` 中定义。该笔记本是 [examples/demo.ipynb](examples/demo.ipynb)：其首个单元格仅在导入失败时安装 CONTINUUM，因此单个文件即可在 Colab、Binder 和本地克隆三种环境中运行。
 
 ```bash
 git clone https://github.com/Cyrax321/CONTINUUM.git


### PR DESCRIPTION
## Description

Adds the two missing notebook rows (Colab, Binder) and the demo.ipynb paragraph to the Simplified Chinese Quick Start table, mirroring the English README exactly. Badge markdown kept identical; only labels and prose translated, matching the file's existing style.

## Related issues

Fixes #752

## Types of changes

- Type: docs

## Breaking changes

No.

## How has this been tested?

- Verified the gap first: zero Colab/Binder/ipynb matches in README.zh-CN.md on current main, while en/es/ja/ko/pt-BR all carry the rows.
- markdownlint-cli2 on the file: 0 issues.
- Row order and links are byte-identical in structure to the English table.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Completes the last remaining item of #752 (ja/ko/pt-BR/es already carry the rows).