### PR TITLE
fix(provenance): stamp remote ledger writes external-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project are documented here. The format follows
 
 ### Fixed
 
+- **MCP and sidecar ledger writes now carry `EXTERNAL_AGENT` (#653).**
+  `ContinuumMCP.ledger` and `SidecarServer._ledger` construct their
+  `ActionLedger` with `source=AGENT_SOURCE`, matching the `EXTERNAL_AGENT`
+  stamp both servers already put on their direct appends and widening the
+  #612 thin-adapter fix to the remote-agent surfaces. Agent-asserted effects
+  reported over MCP or the sidecar no longer self-certify as trusted local
+  work: recovery verdicts for affected runs lean toward human review.
+  `tests/test_mcp_sidecar_provenance.py` pins the new derivation; both tests
+  fail on the old default. The bare `ActionLedger` default stays
+  `DETERMINISTIC`, so local writers are unchanged.
+
 - **Cleared the `noqa` backlog flagged by RUF100 (#951).** Removed 42 unused
   `# noqa` directives (rules not enabled in the repo's ruff `select`) from
   `src/`, `tests/`, and `examples/`, while keeping the ~26 that still suppress

--- a/src/continuum/mcp/server.py
+++ b/src/continuum/mcp/server.py
@@ -513,7 +513,7 @@ class ContinuumMCP:
         return run
 
     def ledger(self, run_id: str) -> ActionLedger:
-        return ActionLedger(self.storage, run_id)
+        return ActionLedger(self.storage, run_id, source=AGENT_SOURCE)
 
 
 def build_server(

--- a/src/continuum/serve/server.py
+++ b/src/continuum/serve/server.py
@@ -280,7 +280,7 @@ class SidecarServer:
         return run
 
     def _ledger(self, run_id: str) -> ActionLedger:
-        return ActionLedger(self.storage, run_id)
+        return ActionLedger(self.storage, run_id, source=AGENT_SOURCE)
 
     def dispatch(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         """Authenticate, then route to the handler for ``method``.

--- a/tests/test_mcp_sidecar_provenance.py
+++ b/tests/test_mcp_sidecar_provenance.py
@@ -1,0 +1,67 @@
+"""Remote-agent ledger writes must not self-certify as deterministic (#653)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from continuum.events import EventType
+from continuum.models import Run
+from continuum.storage import SQLiteStorage
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    path = str(tmp_path / "remote.db")
+    with SQLiteStorage(path) as store:
+        store.create_run(Run(run_id="run_1", goal="g"))
+        store.append_event("run_1", EventType.RUN_STARTED, {"goal": "g"})
+    yield path
+
+
+def _assert_external(action_run_events: list, run_id: str, db_path: str) -> None:
+    from continuum.models import Origin
+    from continuum.provenance_map import derived_provenance_for_events
+
+    assert action_run_events, "surface must record action events"
+    assert {e.source for e in action_run_events} == {Origin.EXTERNAL_AGENT}
+    with SQLiteStorage(db_path) as store:
+        derived = derived_provenance_for_events(store.read_events(run_id))
+    assert derived is Origin.EXTERNAL_AGENT
+
+
+def test_mcp_ledger_writes_carry_external_agent(db: str) -> None:
+    """MCP-asserted effects must derive external_agent, not deterministic (#653)."""
+    from continuum.mcp.server import ContinuumMCP
+
+    mcp = ContinuumMCP(storage=SQLiteStorage(db))
+    try:
+        ledger = mcp.ledger("run_1")
+        outcome = ledger.claim("notify.customer", {"order_id": "O-9"})
+        ledger.complete(outcome.key)
+        with SQLiteStorage(db) as store:
+            action_events = [
+                e for e in store.read_events("run_1") if e.type is EventType.ACTION_RECORDED
+            ]
+    finally:
+        mcp.close()
+    _assert_external(action_events, "run_1", db)
+
+
+def test_sidecar_ledger_writes_carry_external_agent(db: str) -> None:
+    """Sidecar-asserted effects must derive external_agent, not deterministic (#653)."""
+    from continuum.serve.server import SidecarServer
+
+    server = SidecarServer(storage=SQLiteStorage(db))
+    try:
+        ledger = server._ledger("run_1")
+        outcome = ledger.claim("notify.customer", {"order_id": "O-9"})
+        ledger.complete(outcome.key)
+        with SQLiteStorage(db) as store:
+            action_events = [
+                e for e in store.read_events("run_1") if e.type is EventType.ACTION_RECORDED
+            ]
+    finally:
+        server.close()
+    _assert_external(action_events, "run_1", db)


### PR DESCRIPTION
## Description

Widens the #612 thin-adapter fix to the two remote-agent surfaces. MCP ctx.ledger and the sidecar _ledger constructed ActionLedger with the deterministic default while both servers stamp their direct appends EXTERNAL_AGENT, so agent-asserted effects self-certified as trusted local work. Both constructors now pass source=AGENT_SOURCE. Two-line behavior change plus regression tests and a CHANGELOG entry.

## Related issues

Fixes #653

## Types of changes

- Type: bugfix

## Breaking changes

No API break, but deliberate behavior change as #653 anticipates: recovery verdicts for MCP/sidecar-driven runs lean toward human review where ledger actions previously derived deterministic. The bare ActionLedger default stays DETERMINISTIC, so local writers are unchanged.

## How has this been tested?

- New tests/test_mcp_sidecar_provenance.py (2 tests, mirroring the #612 proof): shown failing on the old code and passing on the new.
- Related suites green: test_mcp_server, test_mcp_authz, test_serve_http, test_serve, test_adapters_thin, test_provenance_non_amplification, test_provenance_graph, test_action_index, test_contract_observations, test_recovery_engine.
- ruff check src/ tests/: pass. ruff format --check on touched files: pass. mypy src/continuum (strict, 125 files): pass.
- Full suite not rerun here: test_dashboard_bind fails in this environment with Address already in use (machine ports busy, unrelated).

Python 3.13, macOS, from source at origin/main.

## Checklist

Tests added or updated for the changed behaviour. Documentation updated where the change affects user-facing behaviour. CI passes on the latest commit. Security-relevant changes state known limitations explicitly in this description.

## Additional context

Takes decision option A from #653 (widen with test plus CHANGELOG) over option B (document the default).