### PR TITLE
docs(serve): document sidecar client lifecycle

### DIFF
--- a/src/continuum/serve/__init__.py
+++ b/src/continuum/serve/__init__.py
@@ -56,6 +56,7 @@ class SidecarClient:
         self._next_id = 0
 
     def request(self, method: str, **params: Any) -> dict[str, Any]:
+        """Send one sidecar request and return its result."""
         rid = self._next_id
         self._next_id += 1
         self._out.write(json.dumps({"id": rid, "method": method, "params": params}) + "\n")
@@ -76,6 +77,7 @@ class SidecarClient:
             return cast("dict[str, Any]", msg["result"])
 
     def close(self) -> None:
+        """Close the output stream, suppressing close errors."""
         with contextlib.suppress(Exception):
             self._out.close()
 
@@ -91,6 +93,7 @@ class SubprocessClient:
         return getattr(self._client, name)
 
     def terminate(self) -> None:
+        """Stop the sidecar, killing it if it does not exit within five seconds."""
         self._process.terminate()
         try:
             self._process.wait(timeout=5)

--- a/src/continuum/serve/__init__.py
+++ b/src/continuum/serve/__init__.py
@@ -56,7 +56,11 @@ class SidecarClient:
         self._next_id = 0
 
     def request(self, method: str, **params: Any) -> dict[str, Any]:
-        """Send one sidecar request and return its result."""
+        """Send one JSON-RPC call and return its result.
+
+        Raises:
+            SidecarClientError: If the connection closes or the sidecar returns an error.
+        """
         rid = self._next_id
         self._next_id += 1
         self._out.write(json.dumps({"id": rid, "method": method, "params": params}) + "\n")


### PR DESCRIPTION
## Description

Document the three remaining public sidecar client lifecycle methods in `src/continuum/serve/__init__.py`:

- `SidecarClient.request` sends one JSON-RPC call, returns its result, and documents `SidecarClientError` for connection or server failures.
- `SidecarClient.close` closes the output stream while suppressing close errors.
- `SubprocessClient.terminate` waits five seconds before escalating from terminate to kill.

This is a documentation-only change with no runtime behavior changes.

## Related issues

Fixes #953

## Types of changes

- Type: `docs`

## Breaking changes

No.

## How has this been tested?

Windows 11, Python 3.11:

```console
pytest tests/test_serve.py --tb=short -q
# 42 passed on the initial commit; 40 passed after the latest upstream test layout and docstring refinement

pytest --tb=short -q
# Full suite passed (platform-dependent skips) on the initial commit

ruff check src/ tests/ examples/
# All checks passed!

ruff format --check src/ tests/ examples/
# 307 files already formatted

mypy src/continuum
# Success: no issues found in 125 source files
```

The issue's AST audit now returns `[]` instead of `['request', 'close', 'terminate']`.

## Checklist

Tests added or updated for the changed behaviour: N/A, docstrings only; existing sidecar tests pass. Documentation updated where the change affects user-facing behaviour: N/A, no behaviour change. CI passes on the latest commit: pending after the review refinement; the initial commit passed repository CI except for the unrelated Vercel authorization status. Security-relevant changes state known limitations explicitly in this description: N/A, not security-relevant.

## Additional context

No dependencies, exports, signatures, or runtime logic changed.
