### PR TITLE
fix: replace unsafe tempfile.mktemp with mkstemp

### DIFF
--- a/examples/plan_milestones.py
+++ b/examples/plan_milestones.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 
 from continuum.events import EventType
@@ -11,7 +12,8 @@ from continuum.storage import SQLiteStorage
 
 
 def main() -> None:
-    db = tempfile.mktemp(suffix=".db")
+    fd, db = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
     storage = SQLiteStorage(db)
     run_id = "plan-run-1"
     storage.create_run(Run(run_id=run_id, goal="5 milestones"))

--- a/tests/test_trajectory_report.py
+++ b/tests/test_trajectory_report.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import os
-
 import json
+import os
 
 from continuum.analysis.trajectory_report import (
     build_trajectory_report,

--- a/tests/test_trajectory_report.py
+++ b/tests/test_trajectory_report.py
@@ -1,3 +1,4 @@
+import os
 """Sleep-time trajectory reports (issue #393)."""
 
 from __future__ import annotations
@@ -267,7 +268,8 @@ def test_digest_auditable_and_briefing_consumption() -> None:
 
         from continuum.cli.main import main as cli_main
 
-        tmp = tempfile.mktemp(suffix=".sqlite")
+        fd, tmp = tempfile.mkstemp(suffix=".sqlite")
+        os.close(fd)
         file_storage = SQLiteStorage(tmp)
         try:
             file_storage.create_run(Run(run_id=run_id, goal="g"))

--- a/tests/test_trajectory_report.py
+++ b/tests/test_trajectory_report.py
@@ -1,7 +1,8 @@
-import os
 """Sleep-time trajectory reports (issue #393)."""
 
 from __future__ import annotations
+
+import os
 
 import json
 


### PR DESCRIPTION
## Summary
\`tempfile.mktemp\` only reserved a filename without creating it, leaving a TOCTOU race.

## Changes
- \`examples/plan_milestones.py\` and \`tests/test_trajectory_report.py\`: use \`tempfile.mkstemp\` + \`os.close(fd)\` for throwaway SQLite paths

Closes #950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary database setup in examples and command-line tests by using safer temporary file creation.
  * Ensured temporary file descriptors are closed before SQLite databases are opened.
  * Reduced the risk of file conflicts and unsafe access during temporary database setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->