### PR TITLE
docs(environment): document file snapshot helpers

### DIFF
--- a/src/continuum/environment/file_snapshot.py
+++ b/src/continuum/environment/file_snapshot.py
@@ -14,10 +14,12 @@ _SNAPSHOT_DIR = Path(".continuum/file-snapshots")
 
 
 def snapshot_path(sha256: str) -> Path:
+    """Return the content-addressed snapshot path for a SHA-256 digest."""
     return _SNAPSHOT_DIR / sha256
 
 
 def snapshot_file(path: str | Path, *, sha256: str | None = None) -> Path | None:
+    """Snapshot a file, or return ``None`` when it is missing, oversized, or unreadable."""
     src = Path(path)
     try:
         stat = src.stat()
@@ -56,6 +58,7 @@ def snapshot_file(path: str | Path, *, sha256: str | None = None) -> Path | None
 
 
 def restore_file(path: str | Path, sha256: str) -> bool:
+    """Restore a snapshot atomically, returning ``False`` when restoration fails."""
     src = snapshot_path(sha256)
     if not src.exists():
         return False
@@ -71,6 +74,7 @@ def restore_file(path: str | Path, sha256: str) -> bool:
 
 
 def file_digest(path: str | Path) -> str | None:
+    """Return a file's SHA-256 digest, or ``None`` when it cannot be read."""
     try:
         digest = hashlib.sha256()
         with Path(path).open("rb") as f:


### PR DESCRIPTION
## Description

Document the four remaining public file snapshot helpers in `src/continuum/environment/file_snapshot.py`:

- `snapshot_path` returns the content-addressed location for a SHA-256 digest.
- `snapshot_file` documents the `None` result for missing, oversized, or unreadable files.
- `restore_file` documents its atomic restore and `False` failure contract.
- `file_digest` documents its SHA-256 result and `None` result for unreadable files.

This is a documentation-only change with no runtime behavior changes.

## Related issues

Fixes #952

## Types of changes

- Type: `docs`

## Breaking changes

No.

## How has this been tested?

Windows 11, Python 3.11:

```console
pytest tests/test_file_snapshot_edges.py tests/test_rewind_dual_state.py --tb=short -q
# 11 passed

pytest --tb=short -q
# Full suite passed (platform-dependent skips)

ruff check src/ tests/ examples/
# All checks passed!

ruff format --check src/ tests/ examples/
# 308 files already formatted

mypy src/continuum
# Success: no issues found in 125 source files
```

The issue's AST audit now returns `[]` instead of `['snapshot_path', 'snapshot_file', 'restore_file', 'file_digest']`.

## Checklist

Tests added or updated for the changed behaviour: N/A, docstrings only; the existing file snapshot edge and dual-state rewind tests pass. Documentation updated where the change affects user-facing behaviour: these public helper contracts are now documented. CI passes on the latest commit: pending. Security-relevant changes state known limitations explicitly in this description: N/A, not security-relevant.

## Additional context

No dependencies, exports, signatures, or runtime logic changed. The branch merges cleanly with current `main`.
