### PR TITLE
docs(benchmark): document phase6 harness APIs

### DIFF
--- a/src/continuum/benchmark/phase6/harness.py
+++ b/src/continuum/benchmark/phase6/harness.py
@@ -38,11 +38,13 @@ class ScenarioContext:
     _failed: bool = False
 
     def fail(self, message: str) -> None:
+        """Mark the scenario failed and record the reason."""
         self.notes.append(f"FAIL: {message}")
         self._failed = True
 
 
 def run_scenario(name: str, fn: ScenarioFn) -> ScenarioResult:
+    """Run one scenario and return its timed result without propagating failures."""
     ctx = ScenarioContext()
     start = time.perf_counter()
     try:
@@ -64,6 +66,7 @@ def run_scenario(name: str, fn: ScenarioFn) -> ScenarioResult:
 
 
 def run_benchmark(scenarios: list[tuple[str, ScenarioFn]]) -> BenchmarkReport:
+    """Run named scenarios and return their aggregate benchmark report."""
     return BenchmarkReport(
         generated_at=datetime.now(),
         results=[run_scenario(name, fn) for name, fn in scenarios],

--- a/src/continuum/benchmark/phase6/metrics.py
+++ b/src/continuum/benchmark/phase6/metrics.py
@@ -19,6 +19,8 @@ from pydantic import BaseModel, Field
 
 
 class RecoveryOutcome(StrEnum):
+    """Possible correctness outcomes for a recovery scenario."""
+
     PASS = "pass"
     FAIL = "fail"
     ESCALATED = "escalated"
@@ -44,6 +46,7 @@ class BenchmarkReport(BaseModel):
     results: list[ScenarioResult] = Field(default_factory=list)
 
     def summary(self) -> dict[str, Any]:
+        """Return total, pass/fail, and per-outcome counts for the report."""
         passed = sum(1 for r in self.results if r.passed)
         by_outcome: dict[str, int] = {}
         for r in self.results:


### PR DESCRIPTION
<!--
Thank you for contributing to CONTINUUM.

Please fill out each section below. Sections left empty may delay review.
The PR title should follow conventional commits, for example:
feat: add recovery validator for partial checkpoints

-->

## Description

Adds caller-facing docstrings for the Phase 6 benchmark outcome enum, scenario failure helper, scenario and benchmark runners, and aggregate summary method. The new contracts describe return shapes and failure handling without changing runtime behavior.

## Related issues

Fixes #965

## Types of changes

- Type: `docs`

## Breaking changes

No.

## How has this been tested?

Windows 11, Python 3.11.15:

```text
python <issue AST reproduction script>  # no undocumented public names
pytest tests/test_phase6.py --no-cov --tb=short  # 17 passed
ruff 0.16.5 check src/ tests/ examples/  # All checks passed
ruff 0.16.5 format --check src/ tests/ examples/  # 308 files already formatted
mypy src/continuum  # Success: no issues found in 125 source files
```

## Checklist

Tests added or updated for the changed behaviour: not applicable; this is a docstring-only change and the Phase 6 tests pass. Documentation updated where the change affects user-facing behaviour: yes. CI passes on the latest commit: pending. Security-relevant changes state known limitations explicitly in this description: not applicable.

## Additional context

The diff contains only the five docstrings requested by the issue; there are no runtime or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
