### PR TITLE
docs: complete uncovered API contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -734,7 +734,7 @@ All notable changes to this project are documented here. The format follows
   Framework Integration documents the CrewAI/AutoGen/Pydantic-AI thin hooks
   and the gateway/OTel fallback seams; the Roadmap marks the dashboard and
   the enforced-durability work complete; test counts are current
-  (~2,163 collected, ~2,030 passed, ~23 skipped on a minimal env).
+  (~2,195 collected, ~2,030 passed, ~23 skipped on a minimal env).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
 
 - **Gateway hardening and docs refresh.** The enforcing proxy now refuses

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Verify:
 ```bash
 continuum --help                 # CLI entrypoint
 continuum-mcp --help             # MCP server entrypoint (needs [mcp] or [dev])
-pytest -q                        # ~2,163 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
+pytest -q                        # ~2,195 collected, ~2,030 passed, ~23 skipped on a minimal env (exact counts vary)
 ruff check src/ tests/ examples/ && ruff format --check src/ tests/ examples/
 mypy src/continuum               # the three gates CI enforces
 ```
@@ -232,7 +232,7 @@ CONTINUUM is verified against real LLM agents, live protocol boundaries, and har
 - **Third-party clients**: Gemini CLI and Kilo Code connected over stdio JSON-RPC against the live SQLite store, validating multi-agent co-existence and authorization isolation.
 - **Protocol compliance**: driven end to end with `@modelcontextprotocol/inspector --cli` across process deaths; mutating tools deny by default behind `CONTINUUM_MCP_MUTATING_CLIENTS`; external claims degrade to `REQUIRES_REVIEW` (`safe: false`).
 - **Self-healing**: hard-killed servers recover from orphaned SQLite `-wal`/`-shm` sidecars via single-retry cleanup at startup.
-- **Scale**: roughly 2,163 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 14-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions, and an 8-fault risk-injection suite (`benchmarks/fault_injection/`) grades failure handling.
+- **Scale**: roughly 2,195 tests collected (~2,030 passing; the rest skip without optional services) on Python 3.11, 3.12, and 3.13 (unit, `hypothesis` property-based, concurrency, adversarial). CONTINUUM-Bench runs five crash scenarios plus a dedicated argument-drift scenario, measuring 0 duplicate work and 0 duplicate side effects for CONTINUUM against full duplication for naive replay; a separate 14-scenario recovery-correctness suite (`continuum.benchmark.phase6`) encodes the crash points from the durable-execution survey as executable assertions, and an 8-fault risk-injection suite (`benchmarks/fault_injection/`) grades failure handling.
 - **Adversarial audit**: the full MCP surface was audited over the live protocol; three defects were found and fixed. Method and reproduction steps in [test.md](test.md).
 
 <!-- BENCH:START -->
@@ -425,7 +425,7 @@ Schema v6. SQLite is primary, Postgres is CI verified. One log, many projections
 
 ### Module map: one library, many surfaces
 
-CONTINUUM is one library (`src/continuum`, 124 modules) plus a large test suite (161 test files, ~2,163 tests). All modules append to and replay one hash chained event log:
+CONTINUUM is one library (`src/continuum`, 124 modules) plus a large test suite (161 test files, ~2,195 tests). All modules append to and replay one hash chained event log:
 
 | Module | Role |
 |:--|:--|

--- a/docs/CONTRIBUTING_ONBOARDING.md
+++ b/docs/CONTRIBUTING_ONBOARDING.md
@@ -28,7 +28,7 @@ Install once with `uv sync --extra dev` (or `pip install -e ".[dev]"`).
 
 - Recommended: install the [pre-commit hooks](../CONTRIBUTING.md#pre-commit-hooks-optional-but-recommended) before committing.
 - Run all tests: `uv run pytest` or `pytest -q`. Expect `~2,030 passed, ~23 skipped`
-  on main at this writing (`~2,163` collected).
+  on main at this writing (`~2,195` collected).
   <!-- generated via: pytest --collect-only -q; pytest -q -->
   Skips are environmental (Postgres without `CONTINUUM_TEST_POSTGRES_DSN`, adapter tests without `langgraph` or `openai-agents`).
 - Run a single area: `uv run pytest tests/test_checkpoint_phase4.py -v`

--- a/src/continuum/adapters/generic.py
+++ b/src/continuum/adapters/generic.py
@@ -74,6 +74,7 @@ class GenericAgentAdapter(AgentAdapter):
         environment: EnvironmentSnapshot | None = None,
         reason: str = "",
     ) -> StateCheckpoint:
+        """Capture semantic state and optionally pin its environment."""
         # A snapshot alone cannot invalidate a checkpoint: the validator decides
         # staleness per declared dependency and returns early when a state has
         # none, so a checkpoint carrying only a snapshot would report
@@ -139,6 +140,7 @@ class GenericAgentAdapter(AgentAdapter):
         *,
         replay: bool = True,
     ) -> SemanticState:
+        """Restore the latest checkpointed semantic state for a run."""
         restored = self.manager.restore(run_id, replay=replay)
         return restored.state
 
@@ -253,6 +255,7 @@ class GenericAgentAdapter(AgentAdapter):
         expected_model: str | None = None,
         replay: bool = True,
     ) -> RecoveryDecision:
+        """Assess whether a run may safely resume under current conditions."""
         return self.engine.assess(
             run_id,
             current_environment=current_environment,

--- a/src/continuum/interchange/evidence.py
+++ b/src/continuum/interchange/evidence.py
@@ -66,6 +66,7 @@ class EvidencePrimitive(BaseModel):
     signature_inputs: dict[str, Any]
 
     def content(self) -> dict[str, Any]:
+        """Return the canonical fields represented by this primitive."""
         return {
             "kind": self.kind,
             "run_id": self.run_id,
@@ -78,16 +79,21 @@ class EvidencePrimitive(BaseModel):
         }
 
     def digest(self) -> str:
+        """Return the stable hash of this primitive's canonical content."""
         return stable_hash(self.content())
 
 
 class Transition(EvidencePrimitive):
+    """Represent an event-backed state transition."""
+
     kind: Literal["transition"] = "transition"
     event_id: str
     event_type: str
 
 
 class Observation(EvidencePrimitive):
+    """Represent an environment or tool observation."""
+
     kind: Literal["observation"] = "observation"
     event_id: str
     event_type: str
@@ -95,6 +101,8 @@ class Observation(EvidencePrimitive):
 
 
 class Relation(EvidencePrimitive):
+    """Represent a dependency or derivation relation between items."""
+
     kind: Literal["relation"] = "relation"
     event_id: str
     event_type: str
@@ -103,6 +111,8 @@ class Relation(EvidencePrimitive):
 
 
 class Checkpoint(EvidencePrimitive):
+    """Represent a persisted semantic-state checkpoint."""
+
     kind: Literal["checkpoint"] = "checkpoint"
     checkpoint_id: str
     version: int

--- a/src/continuum/recovery/impact.py
+++ b/src/continuum/recovery/impact.py
@@ -36,6 +36,7 @@ class ImpactedSet:
 
     @property
     def empty(self) -> bool:
+        """Return whether no evidence, finding, or decision is impacted."""
         return not (self.evidence or self.findings or self.decisions)
 
     @property

--- a/tests/test_issue967_impacted_set.py
+++ b/tests/test_issue967_impacted_set.py
@@ -1,0 +1,31 @@
+"""Direct contracts for the dependency impact set (issue #967)."""
+
+from __future__ import annotations
+
+from continuum.recovery.impact import ImpactedSet
+
+
+def test_impacted_set_is_empty_without_impacted_items() -> None:
+    impacted = ImpactedSet(resources=frozenset())
+
+    assert impacted.empty is True
+    assert impacted.all_items == frozenset()
+
+
+def test_impacted_set_is_nonempty_for_each_item_kind() -> None:
+    for field in ("evidence", "findings", "decisions"):
+        impacted = ImpactedSet(resources=frozenset(), **{field: frozenset({field})})
+
+        assert impacted.empty is False
+        assert impacted.all_items == frozenset({field})
+
+
+def test_impacted_set_all_items_unites_every_kind() -> None:
+    impacted = ImpactedSet(
+        resources=frozenset({"dataset"}),
+        evidence=frozenset({"ev-1"}),
+        findings=frozenset({"finding-1"}),
+        decisions=frozenset({"decision-1"}),
+    )
+
+    assert impacted.all_items == frozenset({"ev-1", "finding-1", "decision-1"})


### PR DESCRIPTION
## Description

Completes the three bounded contract gaps selected from the open issue list:

- Adds caller-facing docstrings for `GenericAgentAdapter.capture_state`, `restore_state`, and `resume` (#966).
- Documents all six public interchange evidence primitive contracts (#964), including canonical `content()` and `digest()` methods.
- Adds direct regression tests for the `ImpactedSet.empty` and `all_items` contracts (#967).

No runtime behavior changes are introduced.

## Related issues

Fixes #964
Fixes #966
Fixes #967

## Types of changes

- Type: `docs`
- Type: `tests`

## Breaking changes

No.

## How has this been tested?

- `pytest tests/test_issue967_impacted_set.py tests/test_interchange_evidence.py tests/test_adapters.py -q --no-cov` — 24 passed
- `ruff check src/continuum/adapters/generic.py src/continuum/interchange/evidence.py src/continuum/recovery/impact.py tests/test_issue967_impacted_set.py` — all checks passed
- `ruff format --check ...` — 4 files already formatted
- `mypy src/continuum` — success, no issues found in 125 source files
- `python3 -m compileall ...` — passed
- AST public-docstring audit — no undocumented public names in the three selected modules
- `git diff --check` — passed

## Additional context

Issue #963 was not included because open PR #968 already implements it. Issue #965 was not included because open PR #969 already implements it. Issue #305 was not included because merged PRs #674, #690–#694 already provide the requested webhook capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer documentation for agent state management, evidence records, transitions, observations, relationships, checkpoints, and impact tracking.

* **Tests**
  * Added coverage confirming impacted sets correctly report empty and non-empty states and aggregate all impacted item types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->