### PR TITLE
docs(interchange): document evidence primitives

### DIFF
--- a/src/continuum/interchange/evidence.py
+++ b/src/continuum/interchange/evidence.py
@@ -66,6 +66,7 @@ class EvidencePrimitive(BaseModel):
     signature_inputs: dict[str, Any]
 
     def content(self) -> dict[str, Any]:
+        """Return the primitive content used to compute its digest."""
         return {
             "kind": self.kind,
             "run_id": self.run_id,
@@ -78,16 +79,21 @@ class EvidencePrimitive(BaseModel):
         }
 
     def digest(self) -> str:
+        """Compute the stable hash of this primitive's content."""
         return stable_hash(self.content())
 
 
 class Transition(EvidencePrimitive):
+    """An event-appended state movement in a run."""
+
     kind: Literal["transition"] = "transition"
     event_id: str
     event_type: str
 
 
 class Observation(EvidencePrimitive):
+    """An environment validation or diff observed during a run."""
+
     kind: Literal["observation"] = "observation"
     event_id: str
     event_type: str
@@ -95,6 +101,8 @@ class Observation(EvidencePrimitive):
 
 
 class Relation(EvidencePrimitive):
+    """A dependency edge between run components."""
+
     kind: Literal["relation"] = "relation"
     event_id: str
     event_type: str
@@ -103,6 +111,8 @@ class Relation(EvidencePrimitive):
 
 
 class Checkpoint(EvidencePrimitive):
+    """A checkpoint record exported from a run."""
+
     kind: Literal["checkpoint"] = "checkpoint"
     checkpoint_id: str
     version: int


### PR DESCRIPTION
<!--
Thank you for contributing to CONTINUUM.

Please fill out each section below. Sections left empty may delay review.
The PR title should follow conventional commits, for example:
feat: add recovery validator for partial checkpoints

-->

## Description

Adds caller-facing docstrings for the interchange evidence primitive subclasses and their `content` and `digest` methods. The wording identifies what each exported primitive carries and what the two base methods return, with no runtime changes.

## Related issues

Fixes #964

## Types of changes

- Type: `docs`

## Breaking changes

No.

## How has this been tested?

Windows 11, Python 3.11.15:

```text
python <issue AST reproduction script>  # []
pytest tests/test_interchange_evidence.py --no-cov --tb=short  # 10 passed
ruff 0.16.5 check src/ tests/ examples/  # All checks passed
ruff 0.16.5 format --check src/ tests/ examples/  # 308 files already formatted
mypy src/continuum  # Success: no issues found in 125 source files
```

## Checklist

Tests added or updated for the changed behaviour: not applicable; this is a docstring-only change and the existing interchange evidence tests pass. Documentation updated where the change affects user-facing behaviour: yes. CI passes on the latest commit: pending. Security-relevant changes state known limitations explicitly in this description: not applicable.

## Additional context

The diff contains only the six docstrings requested by the issue. The branch is rooted at the commit that introduced the evidence export file so its upstream diff stays focused while the fork's default branch catches up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
