### PR TITLE
docs(adapters): document generic lifecycle API

### DIFF
--- a/src/continuum/adapters/generic.py
+++ b/src/continuum/adapters/generic.py
@@ -74,6 +74,7 @@ class GenericAgentAdapter(AgentAdapter):
         environment: EnvironmentSnapshot | None = None,
         reason: str = "",
     ) -> StateCheckpoint:
+        """Create and store a semantic state checkpoint for a run."""
         # A snapshot alone cannot invalidate a checkpoint: the validator decides
         # staleness per declared dependency and returns early when a state has
         # none, so a checkpoint carrying only a snapshot would report
@@ -139,6 +140,7 @@ class GenericAgentAdapter(AgentAdapter):
         *,
         replay: bool = True,
     ) -> SemanticState:
+        """Restore the latest semantic state for a run."""
         restored = self.manager.restore(run_id, replay=replay)
         return restored.state
 
@@ -253,6 +255,7 @@ class GenericAgentAdapter(AgentAdapter):
         expected_model: str | None = None,
         replay: bool = True,
     ) -> RecoveryDecision:
+        """Assess recovery safety and return a recovery decision for a run."""
         return self.engine.assess(
             run_id,
             current_environment=current_environment,


### PR DESCRIPTION
<!--
Thank you for contributing to CONTINUUM.

Please fill out each section below. Sections left empty may delay review.
The PR title should follow conventional commits, for example:
feat: add recovery validator for partial checkpoints

-->

## Description

Adds caller-facing docstrings to the generic adapter's `capture_state`, `restore_state`, and `resume` lifecycle methods. Each docstring states the operation and returned contract without changing runtime behavior.

## Related issues

Fixes #966

## Types of changes

- Type: `docs`

## Breaking changes

No.

## How has this been tested?

Windows 11, Python 3.11.15:

```text
python <issue AST reproduction script>  # []
pytest tests/test_adapters.py --no-cov --tb=short  # 11 passed
ruff 0.16.5 check src/ tests/ examples/  # All checks passed
ruff 0.16.5 format --check src/ tests/ examples/  # 308 files already formatted
mypy src/continuum  # Success: no issues found in 125 source files
```

## Checklist

Tests added or updated for the changed behaviour: not applicable; this is a docstring-only change and existing generic adapter tests pass. Documentation updated where the change affects user-facing behaviour: yes. CI passes on the latest commit: pending. Security-relevant changes state known limitations explicitly in this description: not applicable.

## Additional context

The diff contains only the three docstrings requested by the issue. The branch is rooted at the latest commit touching this adapter before the fork diverged so its upstream diff stays focused while the fork's default branch catches up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
